### PR TITLE
Add smoke-test job for action.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,64 @@ jobs:
         # for the local install path); PyYAML and any future runtime
         # deps are still scanned.
         run: pip-audit --skip-editable
+
+  action-smoke:
+    name: Smoke test action.yml
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      # Fixtures are written inline so the smoke test is self-contained
+      # and doesn't couple to tests/compose_files/ (which may evolve as
+      # rules change). The action installs compose-lint from PyPI, so
+      # behavior here is pinned to the released version below, not the
+      # current source tree.
+      - name: Create smoke fixtures
+        run: |
+          mkdir -p smoke
+          cat > smoke/clean.yml <<'YAML'
+          services:
+            web:
+              image: nginx:1.27-alpine
+              ports:
+                - "127.0.0.1:8080:80"
+              security_opt:
+                - no-new-privileges:true
+              cap_drop:
+                - ALL
+              read_only: true
+              tmpfs:
+                - /tmp
+                - /run
+          YAML
+          cat > smoke/insecure.yml <<'YAML'
+          services:
+            app:
+              image: myapp:1.0
+              privileged: true
+          YAML
+
+      - name: Clean fixture should pass
+        uses: ./
+        with:
+          files: smoke/clean.yml
+          fail-on: high
+          version: "0.2.0"
+
+      - name: Insecure fixture should fail
+        id: insecure
+        continue-on-error: true
+        uses: ./
+        with:
+          files: smoke/insecure.yml
+          fail-on: high
+          version: "0.2.0"
+
+      - name: Assert insecure run failed
+        if: steps.insecure.outcome != 'failure'
+        run: |
+          echo "::error::Expected action to fail on insecure fixture, got '${{ steps.insecure.outcome }}'"
+          exit 1


### PR DESCRIPTION
## Summary

Adds an `action-smoke` job to `ci.yml` that exercises `action.yml`
end-to-end: writes a clean and an insecure Compose fixture inline,
runs `uses: ./` against each (pinned to `compose-lint==0.2.0`), and
asserts the insecure run fails with `fail-on: high`.

## Why

The composite action in `action.yml` has never been exercised in CI.
A regression in the install / find-files / run wiring would only
surface once a user tried `uses: tmatens/compose-lint@vX` — bad
first impression for a public Marketplace listing. This job gives
us a green end-to-end run to point at before publishing the action.

SARIF output is deliberately out of scope. Triggering the
`Upload SARIF` step would push synthetic findings into the repo's
Code Scanning view, and the SARIF formatter itself is already
covered by unit tests.

Closes #

## Type of change

- [x] Build / CI / release tooling

## Checklist

- [x] Commits are signed (GitHub shows **Verified**)
- [x] One logical change per commit; no unrelated changes bundled in
- [x] `ruff check`, `ruff format --check`, `mypy src/`, and `pytest` all pass locally
- [x] No AI attribution anywhere (commits, comments, docs)

## Test plan

- [ ] CI green on this PR (the new `action-smoke` job in particular)
- [ ] `action-smoke` job shows the "Clean fixture should pass" step green and the "Insecure fixture should fail" step with `outcome: failure` (caught by the assertion step)