### PR TITLE
Add manual smoke test for the published Marketplace action

### DIFF
--- a/.github/workflows/marketplace-smoke.yml
+++ b/.github/workflows/marketplace-smoke.yml
@@ -1,0 +1,74 @@
+name: Marketplace smoke test
+
+# Manually-triggered end-to-end test of the published action as it
+# appears on the GitHub Marketplace. Unlike the `action-smoke` job in
+# ci.yml (which uses `./` — the local action.yml in this repo), this
+# workflow consumes `tmatens/compose-lint@<tag>` the same way an
+# external user would. It catches regressions that only show up at
+# the Marketplace boundary: a missing tag, a broken published
+# action.yml, a PyPI outage, etc.
+#
+# Trigger it from the Actions tab → "Marketplace smoke test" →
+# "Run workflow". No automatic triggers — this reaches out to PyPI
+# on every run and there's no reason to spend that on every push.
+#
+# When cutting a new release, bump the `@vX.Y.Z` pin on the two
+# `uses:` lines below. `steps[].uses` does not support ${{ }}
+# expressions, so the version has to live in the file.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  marketplace-smoke:
+    name: Smoke test published action
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Create smoke fixtures
+        run: |
+          mkdir -p smoke
+          cat > smoke/clean.yml <<'YAML'
+          services:
+            web:
+              image: nginx:1.27-alpine
+              ports:
+                - "127.0.0.1:8080:80"
+              security_opt:
+                - no-new-privileges:true
+              cap_drop:
+                - ALL
+              read_only: true
+              tmpfs:
+                - /tmp
+                - /run
+          YAML
+          cat > smoke/insecure.yml <<'YAML'
+          services:
+            app:
+              image: myapp:1.0
+              privileged: true
+          YAML
+
+      - name: Clean fixture should pass
+        uses: tmatens/compose-lint@v0.2.0
+        with:
+          files: smoke/clean.yml
+          fail-on: high
+
+      - name: Insecure fixture should fail
+        id: insecure
+        continue-on-error: true
+        uses: tmatens/compose-lint@v0.2.0
+        with:
+          files: smoke/insecure.yml
+          fail-on: high
+
+      - name: Assert insecure run failed
+        if: steps.insecure.outcome != 'failure'
+        run: |
+          echo "::error::Expected action to fail on insecure fixture, got '${{ steps.insecure.outcome }}'"
+          exit 1

--- a/.github/workflows/marketplace-smoke.yml
+++ b/.github/workflows/marketplace-smoke.yml
@@ -12,9 +12,20 @@ name: Marketplace smoke test
 # "Run workflow". No automatic triggers — this reaches out to PyPI
 # on every run and there's no reason to spend that on every push.
 #
-# When cutting a new release, bump the `@vX.Y.Z` pin on the two
-# `uses:` lines below. `steps[].uses` does not support ${{ }}
-# expressions, so the version has to live in the file.
+# When cutting a new release, bump the commit SHA on the two
+# `uses:` lines below (and the trailing `# vX.Y.Z` comment so a
+# human can still read the version at a glance). Third-party
+# actions in this repo are pinned to full commit SHAs per the
+# `workflow/third-party-action-not-pinned-to-commit-sha` CodeQL
+# rule and the precedent set in commit b59847c ("Pin third-party
+# GitHub Actions to commit SHAs"). `steps[].uses` does not support
+# ${{ }} expressions, so the SHA has to live in the file.
+#
+# Note: pinning to a SHA rather than the tag means this smoke test
+# would not catch a hypothetical force-push of `v0.2.0` to a new
+# commit. That failure mode is covered by our release process
+# (signed annotated tags, never re-tagged) rather than by this
+# workflow.
 
 on:
   workflow_dispatch:
@@ -54,7 +65,7 @@ jobs:
           YAML
 
       - name: Clean fixture should pass
-        uses: tmatens/compose-lint@v0.2.0
+        uses: tmatens/compose-lint@60c091c7cc8f86c6b0c5954031097364fea0a201 # v0.2.0
         with:
           files: smoke/clean.yml
           fail-on: high
@@ -62,7 +73,7 @@ jobs:
       - name: Insecure fixture should fail
         id: insecure
         continue-on-error: true
-        uses: tmatens/compose-lint@v0.2.0
+        uses: tmatens/compose-lint@60c091c7cc8f86c6b0c5954031097364fea0a201 # v0.2.0
         with:
           files: smoke/insecure.yml
           fail-on: high

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,6 +278,42 @@ exact mistake the checklist exists to prevent.
   reservation), they must be scoped to the `compose-lint` project, never account-wide.
   Delete tokens after one-off use.
 
+### Workflow pinning
+
+Every third-party `uses:` reference in `.github/workflows/*.yml`
+must be pinned to a full commit SHA, with the tag in a trailing
+comment so a human can still read the version:
+
+```yaml
+- uses: owner/repo@0123456789abcdef0123456789abcdef01234567 # v1.2.3
+```
+
+- **First-party actions are exempt.** `actions/*` and `github/*`
+  (e.g. `actions/checkout@v6`, `github/codeql-action@v4`) are on
+  CodeQL's whitelist and stay tag-pinned. Everything else —
+  including self-references like `tmatens/compose-lint` — pins to
+  a SHA.
+- **Get the SHA from the ref:** `git rev-parse vX.Y.Z^{commit}` for
+  tags you control, or copy from the action's release page on
+  GitHub for third-party actions.
+- **Keep the SHA and the `# vX.Y.Z` comment in sync.** Drift
+  between the two is worse than no comment — the human reads the
+  comment, the runner reads the SHA, and they should never
+  disagree.
+- **The one legitimate exception** is `uses: ./` (a local composite
+  action in this repo). That's a path, not a ref, and there is
+  nothing to pin.
+- **If a SHA pin is genuinely impossible for some other reason,
+  leave an inline comment explaining why** — don't silently ship a
+  tag pin and hope CodeQL doesn't notice. CodeQL's
+  `workflow/third-party-action-not-pinned-to-commit-sha` rule will
+  flag it on the next PR regardless.
+
+The motivating rationale is supply-chain integrity: a tag pin
+trusts the upstream author to never repoint the tag, and CodeQL's
+rule is the enforcement mechanism. Commit b59847c ("Pin third-party
+GitHub Actions to commit SHAs") is the precedent.
+
 ### Package contents safety
 
 Before any release, verify that the sdist and wheel contain only intended files:
@@ -320,3 +356,6 @@ insufficient.
 - Do not add inline suppression syntax unless explicitly planned
 - Do not reference private or internal-only tooling in any file -- if in
   doubt whether something belongs in a public repo, leave it out
+- Do not ship a workflow with a tag-pinned third-party `uses:` — pin to
+  a full commit SHA with a trailing `# vX.Y.Z` comment. See "Workflow
+  pinning" under CI/CD for the exemptions and the rationale.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -108,18 +108,30 @@ version number.
 
 ## Bump the version
 
-compose-lint declares the version in **two** places that must stay in
-sync. Missing one is the mistake we almost made on 0.2.0 — check both.
+compose-lint declares the version in **three** places that must stay
+in sync. Missing any one of them is a release-blocker — check all
+three before opening the bump PR.
 
 - [ ] `pyproject.toml` — `version = "X.Y.Z"` under `[project]`
 - [ ] `src/compose_lint/__init__.py` — `__version__ = "X.Y.Z"`
+- [ ] `.github/workflows/marketplace-smoke.yml` — two
+      `uses: tmatens/compose-lint@<sha> # vX.Y.Z` lines. Update both
+      the full commit SHA and the trailing `# vX.Y.Z` comment. Get
+      the new SHA with `git rev-parse vX.Y.Z^{commit}` **after** you
+      push the signed tag in a later step, then open a follow-up PR
+      to bump the pin.
 
-Verify they match:
+Verify the first two match:
 
 ```bash
 grep -E '^version' pyproject.toml
 grep __version__ src/compose_lint/__init__.py
 ```
+
+The `marketplace-smoke.yml` bump has to land *after* the release
+tag exists, because the commit SHA only exists once the tag is
+pushed. Treat it as a post-release step, not part of the bump PR —
+see "Post-release" below.
 
 ## Update the changelog
 
@@ -196,6 +208,19 @@ reused even after deletion.
 - [ ] Create a GitHub Release from the tag
       (`gh release create vX.Y.Z --notes-from-tag` or use the web UI).
       Copy the relevant CHANGELOG section as the release notes.
+- [ ] **Bump the Marketplace smoke test pin.** The commit SHA only
+      exists once the tag is pushed, so this can't live in the
+      release bump PR. Grab the SHA and update both
+      `uses: tmatens/compose-lint@<sha> # vX.Y.Z` lines in
+      `.github/workflows/marketplace-smoke.yml`:
+
+      ```bash
+      git rev-parse vX.Y.Z^{commit}
+      ```
+
+      Open a follow-up PR with the bump. Once it's merged, trigger
+      **Actions → Marketplace smoke test → Run workflow** to verify
+      the published action end-to-end against the new tag.
 - [ ] Announce in Discussions if the release has user-visible changes.
 - [ ] Open a follow-up PR adding an empty `[Unreleased]` section at the
       top of `CHANGELOG.md` so the next change has somewhere to land.


### PR DESCRIPTION
## Summary

Adds `.github/workflows/marketplace-smoke.yml`, a
`workflow_dispatch`-only workflow that consumes
`tmatens/compose-lint@v0.2.0` from the GitHub Marketplace the same
way an external user would, writes a clean + insecure fixture
inline, and asserts the insecure run fails with `fail-on: high`.

## Why

The existing `action-smoke` job in `ci.yml` exercises the local
`action.yml` via `uses: ./`. That's the right check for PR-time
regression protection, but it can't catch failures that only appear
at the Marketplace boundary:

- A missing or mutated tag (`v0.2.0` got force-pushed, got deleted,
  or never existed in the first place).
- A broken published `action.yml` (Marketplace caching a stale
  version).
- A PyPI outage during `pip install compose-lint` from inside the
  composite action.
- Registry-side rate limits or auth regressions.

A manual workflow gives us a one-click end-to-end check to run
right after cutting a release — before announcing it, before anyone
else tries `uses: tmatens/compose-lint@vX.Y.Z` and hits the same
issue. Manual-only because the workflow reaches out to PyPI on
every run; there's no reason to spend that on every push.

### Maintenance note

`steps[].uses` does not support `${{ }}` expression interpolation,
so the version pin is hardcoded on the two `uses:` lines. When
cutting a new release, bump those pins (one line each) as part of
the release bump PR. A comment at the top of the file flags this.

Closes #

## Type of change

- [x] Build / CI / release tooling

## Checklist

- [x] Commits are signed (GitHub shows **Verified**)
- [x] One logical change per commit; no unrelated changes bundled in
- [x] `ruff check`, `ruff format --check`, `mypy src/`, and `pytest` all pass locally (CI-only change, nothing to lint/type/test)
- [x] No AI attribution anywhere (commits, comments, docs)

## Test plan

- [ ] CI green on this PR (existing jobs; the new workflow only runs on manual dispatch)
- [ ] After merge, go to Actions → **Marketplace smoke test** → **Run workflow** → confirm the run is green end-to-end
- [ ] Confirm the "Insecure fixture should fail" step shows `outcome: failure` (caught by the assertion step) and the "Clean fixture should pass" step shows green