### PR TITLE
Pin ad-hoc pip installs in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
-      - run: pip install ruff
+      - run: pip install ruff==0.15.10
       - run: ruff check src/ tests/
       - run: ruff format --check src/ tests/
 
@@ -74,10 +74,13 @@ jobs:
       - name: Install scan tools
         # Upgrade pip first so pip-audit doesn't flag CVEs in the
         # runner-bundled pip itself (those are out of scope for this
-        # project's supply chain).
+        # project's supply chain). The pip upgrade is deliberately
+        # unpinned per the "always-latest for the bootstrap" exception
+        # noted above; bandit and pip-audit are pinned to exact
+        # versions per AGENTS.md "Dependency pinning → CI tool installs".
         run: |
           python -m pip install --upgrade pip
-          pip install -e . bandit pip-audit
+          pip install -e . bandit==1.9.4 pip-audit==2.10.0
       - name: Bandit (source SAST)
         run: bandit -r src/ -ll
       - name: pip-audit (dependency CVEs)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,11 +20,11 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
-      - run: pip install build
+      - run: pip install build==1.4.3
       - run: python -m build
       - name: Verify dist contents
         run: |
-          pip install twine
+          pip install twine==6.2.0
           twine check dist/*
           # Wheel must NOT contain agent config, .env, tests, or .git.
           if unzip -l dist/*.whl | grep -E '(AGENTS\.md|CLAUDE\.md|\.env|/tests/|\.git/)'; then


### PR DESCRIPTION
## Summary

Pins every ad-hoc `pip install <pkg>` line in `ci.yml` and
`publish.yml` to an exact version. Brings the workflows into
compliance with AGENTS.md → "Dependency pinning → CI tool
installs" (added in PR #11).

| Workflow      | Job          | Before                               | After                                            |
| ------------- | ------------ | ------------------------------------ | ------------------------------------------------ |
| `ci.yml`      | lint         | `pip install ruff`                   | `pip install ruff==0.15.10`                      |
| `ci.yml`      | security     | `pip install -e . bandit pip-audit`  | `pip install -e . bandit==1.9.4 pip-audit==2.10.0` |
| `publish.yml` | build        | `pip install build`                  | `pip install build==1.4.3`                       |
| `publish.yml` | verify       | `pip install twine`                  | `pip install twine==6.2.0`                       |

Each version is what currently resolves as latest-stable on PyPI,
so this freezes the status quo rather than changing behavior.

## Why

Unpinned `pip install` lines in CI re-resolve on every run. A
new upstream release can silently change the outcome — a new
ruff rule flips `ruff check` red at 3am; a bandit false-positive
regression blocks PRs — and the diff on the affected PR looks
unrelated. Pinning to an exact version makes those bumps show up
as reviewable PRs (Renovate/Dependabot-driven, once wired up)
instead of invisible CI drift.

The "always-latest for the bootstrap" exception on
`python -m pip install --upgrade pip` in the security job is
preserved — the surrounding comment explains why (upgrading pip
to avoid scoring runner-bundled pip CVEs against the project's
supply chain), and I've extended it to also note that bandit and
pip-audit are now pinned per policy so the contrast is explicit.

### Known gap (follow-up)

**Dependabot does not track inline `pip install X==Y` in workflow
YAML** — only `pyproject.toml` and `requirements*.txt` are
scanned by the `pip` ecosystem. These pins will go stale without
manual attention until they're migrated into a dedicated `[ci]`
or `[publish]` extras group in `pyproject.toml`, at which point
Dependabot picks them up automatically. That migration is
deliberately out of scope here — keeping this PR narrowly scoped
to "pin what's unpinned in workflow YAML" — and will land as a
follow-up after a design pass on the pyproject.toml dev-extras
layout.

### Also deferred

`pip install -e ".[dev]"` in the type-check and test jobs is
**not** touched. Those tools (mypy, pytest, etc.) live in
`pyproject.toml [project.optional-dependencies.dev]`, so pinning
them belongs with a separate dev-deps reproducibility pass (the
AGENTS.md policy's sub-case 3, "Development dependencies"). Not
this PR.

Closes #

## Type of change

- [x] Build / CI / release tooling

## Checklist

- [x] Commits are signed (GitHub shows **Verified**)
- [x] One logical change per commit; no unrelated changes bundled in
- [x] `ruff check`, `ruff format --check`, `mypy src/`, and `pytest` all pass locally (pinning the versions CI already resolves — no behavior change)
- [x] No AI attribution anywhere (commits, comments, docs)

## Test plan

- [ ] CI green on this PR (the lint job should produce identical output since it's pinning `ruff==0.15.10`, the version already resolving today)
- [ ] Confirm the security job still passes (`bandit -r src/ -ll` and `pip-audit --skip-editable` unchanged)
- [ ] Eyeball `publish.yml` changes; no tag push to validate `build==1.4.3` / `twine==6.2.0` end-to-end until the next real release