### PR TITLE
Move workflow pip install pins into pyproject.toml extras

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
-      - run: pip install ruff==0.15.10
+      - run: pip install -e ".[lint]"
       - run: ruff check src/ tests/
       - run: ruff format --check src/ tests/
 
@@ -75,12 +75,12 @@ jobs:
         # Upgrade pip first so pip-audit doesn't flag CVEs in the
         # runner-bundled pip itself (those are out of scope for this
         # project's supply chain). The pip upgrade is deliberately
-        # unpinned per the "always-latest for the bootstrap" exception
-        # noted above; bandit and pip-audit are pinned to exact
-        # versions per AGENTS.md "Dependency pinning → CI tool installs".
+        # unpinned per the "always-latest for the bootstrap" exception;
+        # bandit and pip-audit come from the [security] extras group
+        # in pyproject.toml, where Dependabot can track the pins.
         run: |
           python -m pip install --upgrade pip
-          pip install -e . bandit==1.9.4 pip-audit==2.10.0
+          pip install -e ".[security]"
       - name: Bandit (source SAST)
         run: bandit -r src/ -ll
       - name: pip-audit (dependency CVEs)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,11 +20,10 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
-      - run: pip install build==1.4.3
+      - run: pip install -e ".[publish]"
       - run: python -m build
       - name: Verify dist contents
         run: |
-          pip install twine==6.2.0
           twine check dist/*
           # Wheel must NOT contain agent config, .env, tests, or .git.
           if unzip -l dist/*.whl | grep -E '(AGENTS\.md|CLAUDE\.md|\.env|/tests/|\.git/)'; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,26 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Focused extras groups exist so Dependabot can track the exact pins
+# (workflow-inline `pip install X==Y` lines aren't scanned). Each
+# extras group maps to one CI job; `dev` is the umbrella developers
+# install locally. Keep the per-group pins exact — these tools pin
+# tightly by policy (AGENTS.md → "Dependency pinning → CI tool
+# installs") — and let Dependabot's weekly pass bump them.
+lint = [
+    "ruff==0.15.10",
+]
+security = [
+    "bandit==1.9.4",
+    "pip-audit==2.10.0",
+]
+publish = [
+    "build==1.4.3",
+    "twine==6.2.0",
+]
 dev = [
-    "ruff>=0.15.9",
+    # Self-reference so the ruff pin lives only in [lint]; no drift.
+    "compose-lint[lint]",
     "mypy>=1.20.0",
     "pytest>=9.0.2",
     "types-pyyaml>=6.0.12",


### PR DESCRIPTION
## Summary

Migrates the CI tool pins added in PR #12 from inline
`pip install X==Y` lines in workflow YAML into focused
`[project.optional-dependencies]` groups in `pyproject.toml`,
where Dependabot's `pip` ecosystem can actually track them.

| Extras group | Contents                              | Consumed by                  |
| ------------ | ------------------------------------- | ---------------------------- |
| `[lint]`     | `ruff==0.15.10`                       | `ci.yml` lint job            |
| `[security]` | `bandit==1.9.4`, `pip-audit==2.10.0`  | `ci.yml` security job        |
| `[publish]`  | `build==1.4.3`, `twine==6.2.0`        | `publish.yml` build job      |
| `[dev]`      | self-references `compose-lint[lint]`, plus `mypy`, `pytest`, `types-pyyaml` | type-check + test jobs, local dev |

## Why

PR #12 closed the "unpinned `pip install`" gap in workflows, but
the pins landed inline in YAML and **Dependabot's `pip` ecosystem
does not scan workflow files** — only `pyproject.toml`,
`requirements*.txt`, and friends. The pins were correct on the day
PR #12 merged and would have silently gone stale afterwards,
which is the exact "unreviewed CI drift" the policy is trying to
eliminate, just on a slower clock.

Moving the pins into `pyproject.toml` extras groups fixes the
tracking gap. Dependabot's weekly pass now sees them as regular
pip deps and opens a reviewable PR when a new version lands,
just like it does for any other Python dep. No more manual
babysitting.

### Design notes

- **Self-reference in `[dev]`.** `dev` now includes
  `compose-lint[lint]` instead of re-declaring `ruff>=X`. This
  keeps the ruff pin in exactly one place (`[lint]`), eliminates
  the risk of drift between `[lint]` and `[dev]`, and still gives
  contributors running `pip install -e ".[dev]"` everything they
  need locally. Self-referencing extras is supported by pip
  ≥21.2 (2021).
- **`[dev]` still uses ranges for mypy / pytest / types-pyyaml.**
  Tightening those to exact pins (or moving to a lockfile) is a
  separate dev-deps reproducibility pass — out of scope for this
  PR, which is narrowly about the workflow-inline pins that
  PR #12 introduced.
- **`publish.yml` build job now uses one `pip install` instead
  of two.** Previously it installed `build` before running
  `python -m build`, then installed `twine` later before
  `twine check`. With `[publish]` both come in via one install
  at the top of the job.
- **The `[publish]` install is editable (`-e .`) even though the
  build job only needs `build` and `twine`.** Extras inherently
  install the package they're attached to. The overhead is
  ~2–3 seconds of hatchling editable-build time, paid once per
  release — acceptable for the tracking benefit.
- **`python -m pip install --upgrade pip` in the security job
  stays unpinned** per the "always-latest for the bootstrap"
  exception; the surrounding comment still explains why
  (upgrading pip so pip-audit doesn't score runner-bundled pip
  CVEs against this project).

### Verified locally

- `pip install -e ".[dev]"` resolves the self-reference and
  installs `ruff-0.15.10` from `[lint]` (confirmed by
  `ruff --version`).
- `ruff check src/ tests/` → clean.
- `ruff format --check src/ tests/` → clean.
- `mypy src/` → `no issues found in 22 source files`.
- `pytest` → `168 passed in 1.36s`.

Closes #

## Type of change

- [x] Build / CI / release tooling

## Checklist

- [x] Commits are signed (GitHub shows **Verified**)
- [x] One logical change per commit; no unrelated changes bundled in
- [x] `ruff check`, `ruff format --check`, `mypy src/`, and `pytest` all pass locally
- [x] No AI attribution anywhere (commits, comments, docs)

## Test plan

- [ ] CI green on this PR — in particular, the lint and security jobs on `ci.yml` install from `[lint]` and `[security]` extras respectively
- [ ] Confirm `action-smoke` and `marketplace-smoke` jobs are unaffected (they don't touch these extras)
- [ ] No tag push in this PR to exercise `publish.yml` end-to-end — that will happen naturally on the next release cut