### PR TITLE
Exact-pin dev extras in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,10 @@ dependencies = [
 # Focused extras groups exist so Dependabot can track the exact pins
 # (workflow-inline `pip install X==Y` lines aren't scanned). Each
 # extras group maps to one CI job; `dev` is the umbrella developers
-# install locally. Keep the per-group pins exact — these tools pin
-# tightly by policy (AGENTS.md → "Dependency pinning → CI tool
-# installs") — and let Dependabot's weekly pass bump them.
+# install locally. Every pin in every group is exact (`==`) — per
+# AGENTS.md "Dependency pinning → CI tool installs" and
+# "Development dependencies" — and Dependabot's weekly pass bumps
+# them.
 lint = [
     "ruff==0.15.10",
 ]
@@ -50,9 +51,9 @@ publish = [
 dev = [
     # Self-reference so the ruff pin lives only in [lint]; no drift.
     "compose-lint[lint]",
-    "mypy>=1.20.0",
-    "pytest>=9.0.2",
-    "types-pyyaml>=6.0.12",
+    "mypy==1.20.0",
+    "pytest==9.0.3",
+    "types-pyyaml==6.0.12.20260408",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

Converts the three remaining SemVer ranges in
`[project.optional-dependencies.dev]` to exact pins at the
current latest-stable versions:

| Dep             | Before           | After                        |
| --------------- | ---------------- | ---------------------------- |
| `mypy`          | `>=1.20.0`       | `==1.20.0`                   |
| `pytest`        | `>=9.0.2`        | `==9.0.3`                    |
| `types-pyyaml`  | `>=6.0.12`       | `==6.0.12.20260408`          |

Also updates the extras-block header comment so the "every pin
is exact" convention is stated once and applies to all four
groups (`lint`, `security`, `publish`, `dev`).

## Why

This is the last gap in AGENTS.md "Dependency pinning".
Sub-case 3, "Development dependencies," explicitly says dev deps
should be exact-pinned or captured in a lockfile — the
library-vs-app tension that forces ranges on *runtime* deps does
not apply to dev deps, because they aren't consumer-visible.

PR #13 enforced this convention for `[lint]`, `[security]`, and
`[publish]` but left `[dev]` using ranges, so CI reproducibility
depends on whichever `mypy>=1.20.0` or `pytest>=9.0.2` happened
to be latest on the day the runner resolved them. A silent
pytest 9.1 release could change test behavior or start reporting
deprecation warnings as errors — exactly the kind of invisible
CI drift the whole pinning effort is trying to prevent.

Dependabot's `pip` ecosystem already scans `pyproject.toml`, so
these pins will now surface as reviewable PRs on the weekly
pass, same as the CI-tool extras. Renovate/Dependabot absorbs
the bump churn.

### Why exact pins, not a lockfile

AGENTS.md policy recommends a lockfile (`uv.lock` or a
`pip-compile`-generated `requirements-dev.txt`) "ideally," with
exact pins in `pyproject.toml` as the acceptable fallback. I
picked the fallback for three reasons:

1. **Consistency.** `[lint]`, `[security]`, and `[publish]`
   already use exact pins in `pyproject.toml`. One convention
   across all four extras groups is simpler than a split regime.
2. **No new tooling.** A lockfile means adopting `uv` or
   `pip-tools`, committing a new file, documenting the
   update flow, and teaching CI to use it. For a solo-maintainer
   project with four dev deps, that's more ceremony than the
   marginal reproducibility buys.
3. **Upgrade path is open.** Nothing about this PR forecloses a
   lockfile down the line. If a transitive-dep churn ever breaks
   CI — e.g., a pytest plugin dep rev that exact-pinning pytest
   does not protect against — we can move to a lockfile as a
   targeted follow-up without having to undo this PR first.

### Verified locally

- `pip install -e ".[dev]"` resolved and installed
  `pytest-9.0.3` + `types-pyyaml-6.0.12.20260408` (mypy already
  at 1.20.0 so no bump).
- `ruff check src/ tests/` → clean.
- `ruff format --check src/ tests/` → clean.
- `mypy src/` → `no issues found in 22 source files`.
- `pytest` → `168 passed in 1.41s`.

Closes #

## Type of change

- [x] Build / CI / release tooling

## Checklist

- [x] Commits are signed (GitHub shows **Verified**)
- [x] One logical change per commit; no unrelated changes bundled in
- [x] `ruff check`, `ruff format --check`, `mypy src/`, and `pytest` all pass locally
- [x] No AI attribution anywhere (commits, comments, docs)

## Test plan

- [ ] CI green on this PR — in particular, the type-check job (which now installs `mypy==1.20.0` instead of `>=1.20.0`) and the test matrix (which now installs `pytest==9.0.3`)
- [ ] Dependabot's next weekly pass should see the three new exact pins and open a grouped `python` PR if any have newer releases