### PR TITLE
Add product roadmap through v1.x

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,514 +1,82 @@
 # compose-lint
 
-## Project Overview
-
-compose-lint is a security-focused linter for Docker Compose files, distributed as a
-Python package on PyPI. It targets the same niche as Hadolint (Dockerfiles) but for
-Compose files: zero-config, opinionated, fast, grounded in OWASP/CIS standards.
-
-This is not a Dockerfile linter, not a runtime security scanner, and not a replacement
-for full-platform tools like KICS or Checkov. It does one thing well: static analysis
-of Compose files for dangerous misconfigurations.
+Security-focused linter for Docker Compose files. Python >=3.10, PyYAML only runtime dep, MIT license.
 
 ## Architecture
 
-- **Language**: Python >=3.10
-- **Build system**: Hatchling (PEP 517)
-- **Package name**: `compose-lint` (PyPI), `compose_lint` (import)
-- **Entry point**: `compose_lint.cli:main`
-- **Single runtime dependency**: PyYAML >=6.0
-- **License**: MIT
-
-### Key design patterns
-
-- YAML parsing uses a custom `LineLoader(yaml.SafeLoader)` that captures line numbers.
-  The parser exposes `load_compose(path) -> (data, lines)`. Rules receive plain dicts,
-  not library-specific types.
-- The parser must handle Compose v2 and v3 schema differences, YAML anchors, merge keys
-  (`<<:`), and extension fields (`x-`). Environment variable interpolation (`${VAR}`)
-  should be left as-is (not resolved by the linter).
-- The parser validates that the input is a valid Compose file, not just valid YAML:
-  - Top-level `services:` key must exist
-  - `services:` must be a mapping, not a list or scalar
-  - Each service entry must be a mapping
-  - Invalid input produces clear error messages (e.g., "Not a valid Compose file:
-    missing 'services' key")
-  - The parser does NOT perform full Compose schema validation — that is Docker's job.
-    Unknown keys are ignored, not rejected. The linter validates security posture, not
-    schema conformance.
-- Each rule is a class inheriting `BaseRule`, registered via decorator. Rules declare
-  their own ID (CL-XXXX), severity, OWASP/CIS references, and a `check()` method that
-  yields findings.
-- Rule IDs use the `CL-` prefix, zero-padded to 4 digits, never reused.
-- Findings are dataclasses (see `models.py`), not dicts.
-- Formatters receive a list of `Finding` objects and produce output. Each formatter is
-  a module in `formatters/` exposing a `format(findings) -> str` function.
-
-### Severity levels
-
-Ordered by rank (see `docs/severity.md` for the full scoring matrix):
-
-- **CRITICAL**: Direct path to host compromise. No chaining required.
-- **HIGH**: Exposed attack surface or requires chaining for cross-container/host impact.
-- **MEDIUM**: Requires chaining for single-container impact, or hardening gap with cross-container scope.
-- **LOW**: Hardening gap contained within a single container.
-
-### Exit code contract
-
-- Exit 0: No findings at or above the failure threshold
-- Exit 1: One or more findings at or above the failure threshold
-- Exit 2: Usage error (invalid arguments, file not found, invalid Compose file)
-- Default threshold: HIGH (medium/low findings alone produce exit 0)
-- Configurable via `--fail-on` flag (`--fail-on low`, `--fail-on critical`)
-
-### CLI interface
-
-```
-compose-lint [OPTIONS] [FILE ...]
-
-Options:
-  --format {text,json,sarif}  Output format (default: text)
-  --fail-on SEVERITY          Minimum severity to trigger exit 1 (default: high)
-  --skip-suppressed           Hide suppressed findings from output
-  --config PATH               Path to .compose-lint.yml config file
-  --version               Show version and exit
-```
-
-### Config file
-
-`.compose-lint.yml` supports per-rule overrides:
-
-```yaml
-rules:
-  CL-0001:
-    enabled: false          # Disable a rule entirely
-  CL-0003:
-    enabled: false
-    reason: "SEC-1234 — Approved by J. Smith"  # Optional exception tracking
-  CL-0005:
-    severity: high          # Override default severity
-```
-
-Disabled rules still run and produce suppressed findings in the output. The optional
-`reason` field records why a rule was disabled (e.g., exception ticket). It flows
-through as `suppression_reason` (JSON), `justification` (SARIF), or is shown after
-the `SUPPRESSED` label (text).
-
-The engine loads config, merges it with defaults, and passes it to the rule runner.
-Inline suppression comments (e.g., `# compose-lint: disable=CL-0001`) are not
-supported -- do not implement unless explicitly planned.
-
-### Source layout
-
-```
-src/compose_lint/       # Package root
-  cli.py                # argparse CLI
-  parser.py             # YAML loading + line number tracking
-  engine.py             # Rule runner + result collection
-  models.py             # Finding, Severity, RuleMetadata dataclasses
-  formatters/           # text, json, sarif output
-  rules/                # One file per rule: CL0001_*.py, CL0002_*.py, etc.
-tests/
-  compose_files/        # YAML fixtures (secure, insecure, mixed)
-  test_CL0001.py        # One test file per rule
-  test_parser.py, test_cli.py, test_engine.py
-docs/
-  adr/                  # Architecture Decision Records -- consult before proposing
-                        # architectural changes
-  rules/                # Per-rule documentation (CL-0001.md, etc.)
-```
+- **Parser**: `LineLoader(yaml.SafeLoader)` captures line numbers. `load_compose(path) -> (data, lines)`. Handles v2/v3, anchors, merge keys (`<<:`), extension fields (`x-`). Leaves `${VAR}` unresolved. Validates `services:` exists and is a mapping. Does NOT do full Compose schema validation.
+- **Rules**: Classes inheriting `BaseRule`, registered via `@register_rule`. IDs are `CL-XXXX`, zero-padded, permanent, never reused. Rules receive plain Python types (`dict`, `list`, `str`, `int`, `bool`), never parser-specific types.
+- **Findings**: Dataclasses in `models.py`, not dicts.
+- **Formatters**: Modules in `formatters/` exposing `format(findings) -> str`.
+- **Engine**: `engine.py` runs rules, collects results, applies config overrides.
 
-## Rule Design Philosophy
+## Severity
 
-### Grounding in authoritative sources
-
-Every rule must be grounded in at least one of:
+CRITICAL > HIGH > MEDIUM > LOW. See `docs/severity.md` for the scoring matrix. Don't inflate severity.
 
-- **OWASP Docker Security Cheat Sheet**: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html
-- **CIS Docker Benchmark**: https://www.cisecurity.org/benchmark/docker
-- **Docker official documentation**: https://docs.docker.com/
+## Exit codes
 
-No opinion-only rules. If a finding cannot be traced to an authoritative source, it
-does not belong in this tool. When a user questions a rule, the reference should end
-the debate.
+- 0: No findings at/above threshold
+- 1: Findings at/above threshold
+- 2: Usage error (bad args, file not found, invalid Compose)
+- Default threshold: HIGH. Configurable via `--fail-on`.
 
-### Every finding must be actionable
-
-A finding is only valuable if the user knows exactly what to do about it. Each rule must
-provide:
-
-1. **Clear description**: What was detected and why it matters (the risk, not just the
-   violation)
-2. **Concise fix guidance**: Specific, copy-pasteable remediation -- not vague advice
-   like "consider securing this." Show the before and after.
-3. **Authoritative references**: Direct links to the OWASP/CIS/Docker docs section that
-   supports the finding. Users should be able to click through and read the full context.
-
-Severity must reflect real-world criticality: how exploitable is this, what is the blast
-radius, and how commonly does this lead to actual incidents? Do not inflate severity to
-make findings seem more important. Do not create findings that waste the user's time
-with noise they cannot act on.
-
-### Severity assignment criteria
-
-Severity is determined by a two-axis matrix (see `docs/severity.md`):
+## Config file (`.compose-lint.yml`)
 
-- **Exploitability**: Direct > Exposed > Requires chaining > Hardening gap
-- **Impact scope**: Host > Cross-container > Single container
-
-The matrix intersection determines the severity. Supply chain rules (e.g., CL-0004) are
-scored by judgment since they don't fit the runtime exploitation model.
-
-## Development
+Disables still produce suppressed findings. `reason` flows to `suppression_reason` (JSON), `justification` (SARIF), or after `SUPPRESSED` (text). No inline suppression comments.
 
-### Setup
-
-```bash
-python -m venv .venv && source .venv/bin/activate
-pip install -e ".[dev]"
-```
+## Quality checks
 
-### Quality checks
-
-```bash
-ruff check src/ tests/          # Linting
-ruff format --check src/ tests/ # Formatting
-mypy src/                       # Type checking (strict mode)
-pytest                          # Tests
-```
-
-All four must pass. CI runs these on every PR.
-
-### Adding a new rule
-
-1. Create `src/compose_lint/rules/CL{NNNN}_{snake_name}.py`
-2. Inherit from `BaseRule`, use the `@register_rule` decorator
-3. Set `id`, `name`, `severity`, `description`, `references` (must cite OWASP or CIS)
-4. Implement `check(service_name, service_config, global_config)` yielding `Finding` objects
-5. Add test file `tests/test_CL{NNNN}.py` with both positive (triggers) and negative (clean) cases
-6. Add fixture YAML files in `tests/compose_files/`
-7. Add rule documentation in `docs/rules/CL-{NNNN}.md`
-8. Ensure fix guidance is specific and actionable -- show the exact YAML change needed
-9. Include direct links to the supporting OWASP/CIS/Docker docs section
-
-### Contributor workflow
-
-[CONTRIBUTING.md](CONTRIBUTING.md) is the source of truth for the commit,
-signing, and PR rules. Everything below is a condensed mirror for agents
-working in this repo — if it ever drifts from CONTRIBUTING.md,
-CONTRIBUTING.md wins.
-
-**Commit conventions**
-
-- One logical change per commit. Rules, features, refactors, and docs each get
-  their own commit. Don't bundle unrelated changes.
-- Imperative subject under 72 characters ("Add CL-0011 rule for X", not
-  "Added CL-0011" or "CL-0011").
-- Explain the *why* in the body, not just the *what*. The diff shows what
-  changed; the message explains the reason.
-- No Conventional Commits prefixes (`feat:`, `fix:`, etc.) — descriptive
-  imperative subjects are preferred.
-- Follow the **No AI authorship attribution** rule in "Things to avoid"
-  below. No `Co-Authored-By` trailers for AI tools, no "Generated by"
-  notices in code, no "built with AI" badges on docs.
-
-**Commit signing**
-
-All commits to `main` must be signed so GitHub shows the "Verified" badge.
-Follow the SSH signing setup in [CONTRIBUTING.md](CONTRIBUTING.md#commit-signing)
-— it uses the SSH key you already push with. Verify locally with
-`git log --show-signature` (each commit should print `Good "git" signature`)
-or `git log --format='%h %G? %s'` (every commit should show `G`, never `N`).
-If a commit lands as `N` (no signature), stop and fix the git config before
-proceeding.
-
-**Pull requests**
-
-All changes to `main` go through a PR — including solo-maintainer changes.
-Direct pushes to `main` are not permitted.
-
-1. Branch from `main` with a descriptive name (`docs/contributor-workflow`,
-   `rules/CL-0011-user-namespaces`, `fix/parser-merge-keys`).
-2. Make small focused commits (above).
-3. Run all four local checks (`ruff check`, `ruff format --check`, `mypy`,
-   `pytest`) before pushing.
-4. Open the PR and fill out `.github/pull_request_template.md`.
-5. Wait for CI to go green.
-6. Squash-merge. `main` stays linear with one commit per logical change; the
-   full PR history is preserved on the PR page.
-
-Keep PRs small. Don't mix refactors with behavior changes — land the refactor
-first, then the behavior change, in separate PRs. The only exception is an
-initial repo-setup PR that bootstraps interconnected files (templates, config,
-docs) that only make sense together.
-
-**Releases**
-
-See [docs/RELEASING.md](docs/RELEASING.md). Do not cut a release without
-working the checklist; in particular, the version string lives in *both*
-`pyproject.toml` and `src/compose_lint/__init__.py`, and missing one is the
-exact mistake the checklist exists to prevent.
-
-## Code Standards
-
-- **Type annotations**: All public functions must have type annotations. `mypy --strict` is enforced.
-- **No unnecessary dependencies**: PyYAML is the only runtime dependency. Dev dependencies (ruff, mypy, pytest) go in optional `[dev]` extras.
-- **Latest stable versions**: When any dependency, library, package, base image, or tool must be used, always use the latest stable version unless there is a specific, documented reason not to (e.g., known incompatibility, alpha/beta status). If the latest stable version cannot be used, state why.
-- **Rules receive plain Python types**: Never leak parser-specific types (ruamel, etc.) into rule code. Rules work on `dict`, `list`, `str`, `int`, `bool`.
-- **Test coverage**: Every rule needs positive and negative test cases. Target 100% rule coverage.
-- **Python 3.10+ compatibility**: Do not use syntax or stdlib features added after 3.10 (e.g., no `type` aliases from 3.12, no `ExceptionGroup` from 3.11 without checking availability).
-
-## CI/CD
-
-- **CI**: GitHub Actions -- ruff + mypy + pytest on every PR (`ci.yml`)
-- **Publishing**: GitHub Actions trusted publisher to PyPI on release tag (`publish.yml`)
-- **Pre-commit**: `.pre-commit-hooks.yaml` for pre-commit framework integration
-
-### Publishing security
-
-- **Trusted Publishers only**: All real PyPI releases must go through GitHub Actions OIDC
-  trusted publishing. No manual `twine upload` to real PyPI. This eliminates stored API
-  tokens entirely — GitHub Actions authenticates directly with PyPI via OIDC, tied to
-  a specific repo + workflow + branch.
-- **Sigstore attestations**: The `publish.yml` workflow must enable build attestations
-  via the `pypa/gh-action-pypi-publish` action's `attestations: true` flag. This gives
-  users cryptographic proof the package was built from this repo.
-- **2FA required**: PyPI and TestPyPI accounts must have 2FA enabled.
-- **Project-scoped tokens only**: If API tokens are ever used (e.g., TestPyPI name
-  reservation), they must be scoped to the `compose-lint` project, never account-wide.
-  Delete tokens after one-off use.
-
-### Dependency pinning
-
-Anything that resolves over the network at build, test, or release
-time must be pinned to an immutable ref. Mutable refs (tags,
-version ranges, `latest`) trust the upstream author to never
-repoint them and make every CI run a roll of the dice. Pin at
-rest; let Renovate or Dependabot bump the pin.
-
-The rule has five sub-cases with different conventions. They're
-all the same principle — pin what you can — but the mechanics
-differ.
-
-#### 1. GitHub Actions workflows
-
-**Every** `uses:` reference in `.github/workflows/*.yml` must be
-pinned to a full commit SHA, with the tag in a trailing comment so a
-human can still read the version. No first-party carve-out:
-`actions/checkout`, `actions/setup-python`, `github/codeql-action`,
-and every other `actions/*` / `github/*` action pins to a SHA, same
-as third-party actions. Self-references like `tmatens/compose-lint`
-pin to a SHA too.
-
-```yaml
-- uses: owner/repo@0123456789abcdef0123456789abcdef01234567 # v1.2.3
-```
-
-- **Get the SHA from the ref:** `git rev-parse vX.Y.Z^{commit}` for
-  tags you control, or resolve via the API for third-party actions:
-  ```bash
-  gh api repos/OWNER/REPO/git/ref/tags/vX.Y.Z -q .object.sha
-  # if that returns a tag object (annotated tag), deref it:
-  gh api repos/OWNER/REPO/git/tags/<that-sha> -q .object.sha
-  ```
-- **Keep the SHA and the `# vX.Y.Z` comment in sync.** Drift
-  between the two is worse than no comment — the human reads the
-  comment, the runner reads the SHA, and they should never
-  disagree. Dependabot/Renovate PRs update both atomically.
-- **The one legitimate exception** is `uses: ./` (a local composite
-  action in this repo). That's a path, not a ref, and there is
-  nothing to pin.
-- **If a SHA pin is genuinely impossible for some other reason,
-  leave an inline comment explaining why** — don't silently ship a
-  tag pin. CodeQL's
-  `workflow/third-party-action-not-pinned-to-commit-sha` rule
-  enforces this for third-party actions, and Scorecard's
-  `Pinned-Dependencies` check enforces it for first-party actions
-  too.
-
-The motivating rationale is supply-chain integrity: a tag pin
-trusts the upstream author to never repoint the tag. The earlier
-first-party exemption here relied on CodeQL's whitelist, but
-Scorecard does not whitelist first-party actions, and uniformity
-("pin everything you consume from a registry") is simpler than
-maintaining a policy seam. Commit b59847c ("Pin third-party GitHub
-Actions to commit SHAs") was the original precedent.
-
-#### 2. Runtime dependencies (`pyproject.toml` `[project] dependencies`)
-
-compose-lint is a **library** published to PyPI, not an application.
-Library runtime deps use SemVer-compatible *ranges*, not exact
-pins. Exact-pinning `PyYAML==6.0.3` would create a resolver
-conflict for anyone who installs compose-lint alongside a different
-PyYAML patch, which is exactly the pain library consumers feel
-when careless upstream maintainers over-pin.
-
-The rule for compose-lint:
-
-- **Lower bound is the minimum version we've actually tested
-  against.** Not a guess, not a copy from the package's README.
-- **No upper bound unless we've observed a break.** A speculative
-  upper cap (`<7`) locks consumers out of versions that may be
-  fine; only add one after a concrete incompatibility.
-- **Never use `*`, unpinned, or `latest`.** Those aren't ranges;
-  they're abdication.
-
-This is the one place the "pin everything" rule bends, and only
-because the cost of over-pinning in a library is paid by every
-downstream user.
-
-#### 3. Development dependencies (`pyproject.toml` `[project.optional-dependencies.dev]`)
-
-Dev deps (ruff, mypy, pytest, and anything else under `[dev]`,
-`[lint]`, `[security]`, `[publish]`) are not consumer-visible, so
-the library-vs-app tension from (2) does not apply. CI must be
-byte-for-byte reproducible: every dev install — local or in a
-workflow — resolves through a hash-pinned lockfile.
-
-The repo ships two lockfiles, both generated with
-`uv pip compile --generate-hashes`:
-
-- `requirements.lock` — runtime deps only (pyyaml). Used by the
-  ClusterFuzzLite build so the fuzzer's instrumented install is
-  reproducible.
-- `requirements-dev.lock` — runtime + every dev/lint/security/publish
-  extra. Used by every CI job in `ci.yml` and `publish.yml`.
-
-`pyproject.toml` still lists each dev dep with an exact `==` pin
-inside the relevant extras group. That declaration is the input to
-`uv pip compile`; the lockfile is the resolved, hash-pinned output
-that CI actually consumes. Both must agree, and Renovate/Dependabot
-bumps the pin in `pyproject.toml`, after which the lockfiles are
-regenerated (see "Regenerating the lockfiles" below).
-
-#### 4. CI tool installs (`pip install` inside workflows)
-
-Every `pip install` in a workflow `run:` block must install through
-a hash-pinned lockfile, never as an ad-hoc package install:
-
-```yaml
-# good — resolves through the lockfile, hashes verified
-- run: |
-    pip install --require-hashes -r requirements-dev.lock
-    pip install --no-deps -e .
-
-# bad — version pin, but no hash verification, no transitive lock
-- run: pip install ruff==0.14.4
-
-# worst — resolves to whatever's newest on PyPI today
-- run: pip install ruff
-```
-
-`--require-hashes` is the enforcement mechanism: pip will refuse to
-install any package whose download doesn't match a hash in the
-lockfile, which closes the window where a compromised PyPI mirror
-or a republished version (PyPI doesn't allow this today, but the
-defense is cheap) could substitute a malicious artifact. The
-`pip install --no-deps -e .` line installs compose-lint itself
-without re-resolving; its deps are already covered by the lockfile.
-
-The one legitimate exception is the **bootstrap pip upgrade** in
-the security-scan job:
-
-```yaml
-- run: python -m pip install --upgrade pip
-```
-
-This runs *before* the lockfile install so that pip-audit doesn't
-flag CVEs in the runner-bundled pip itself (those CVEs are out of
-scope for this project's supply chain — they're GitHub's to patch,
-not ours). It is deliberately unpinned and deliberately unhashed
-because the whole point is "always grab the latest pip security
-fix." If you find yourself reaching for this exception for any
-*other* reason, you're doing it wrong.
-
-##### Regenerating the lockfiles
-
-When a dev dep changes in `pyproject.toml`, regenerate both
-lockfiles in the same commit:
+`ruff check`, `ruff format --check`, `mypy src/` (strict), `pytest`. All four must pass. CI test matrix: Python 3.10–3.13 on ubuntu-latest.
+
+## Adding a rule
+
+See CONTRIBUTING.md for the full checklist. Every rule must cite OWASP, CIS, or Docker docs. Every finding must be actionable with specific fix guidance.
+
+## Contributor workflow
+
+CONTRIBUTING.md is the source of truth for commits, signing, and PRs. Key points:
+- One logical change per commit, imperative subject under 72 chars, no Conventional Commits prefixes
+- All commits signed (SSH). Verify with `git log --format='%h %G? %s'` — every commit shows `G`
+- All changes go through a PR, squash-merge to main
+- Releases: follow `docs/RELEASING.md` checklist — version lives in both `pyproject.toml` and `src/compose_lint/__init__.py`
+
+## Dependency pinning
+
+Pin everything to an immutable ref. Dependabot/Renovate bumps the pins.
+
+- **GitHub Actions**: SHA-pin every `uses:` (including first-party). Tag in trailing comment. Only exception: `uses: ./`.
+- **Runtime deps**: SemVer ranges (this is a library — exact pins break downstream resolvers). Lower bound = tested minimum. No upper bound unless we've observed a break.
+- **Dev deps + CI installs**: Hash-pinned lockfiles. Every `pip install` in CI uses `pip install --require-hashes -r requirements{,-dev}.lock`. No ad-hoc `pip install pkg==X.Y.Z` in workflows. One exception: `python -m pip install --upgrade pip` bootstrap in security-scan job.
+- **Docker base images**: Digest-pin if we ever add a Dockerfile.
+
+### Regenerating lockfiles
 
 ```bash
 uv pip compile pyproject.toml \
   --universal --python-version 3.10 \
-  --generate-hashes \
-  -o requirements.lock
+  --generate-hashes -o requirements.lock
 
 uv pip compile pyproject.toml \
   --extra dev --extra lint --extra security --extra publish \
   --universal --python-version 3.10 \
-  --generate-hashes \
-  -o requirements-dev.lock
+  --generate-hashes -o requirements-dev.lock
 ```
 
-`--universal` emits environment markers so a single lockfile
-works across platforms. `--python-version 3.10` matches
-`requires-python` so conditional backport deps (e.g.,
-`backports.tarfile` for Python <3.12) are included — without
-it, uv resolves against the interpreter version and silently
-drops deps that older Pythons in the test matrix still need.
+`--python-version 3.10` matches `requires-python` so backport deps for older matrix legs are included. Commit lockfiles and `pyproject.toml` together.
 
-Commit `pyproject.toml` and both lockfiles together so the
-declared pins and the resolved hashes never drift apart.
+## Publishing
 
-#### 5. Docker base images
-
-Not applicable to this repo today (compose-lint is a Python
-package, no Dockerfile, no runtime images). If that ever changes,
-base images get **digest-pinned**:
-
-```dockerfile
-FROM python:3.13-slim@sha256:<64-char-digest>
-```
-
-Tag-only references like `python:3.13-slim` are mutable — Docker
-Hub repoints them on every patch rebuild — which defeats the
-purpose. Digest pins + Renovate is the standard pattern.
-
-### Package contents safety
-
-Before any release, verify that the sdist and wheel contain only intended files:
-
-```bash
-tar tzf dist/*.tar.gz
-unzip -l dist/*.whl
-```
-
-The following must **never** appear in published packages:
-
-- `.env` or any secrets/credentials
-- `.git/` directory
-- `AGENTS.md` / `CLAUDE.md` or any agent/AI assistant configuration
-- Memory files, session files, or IDE configuration
-- Test fixtures (these belong in the sdist for `pytest` but not in the wheel)
-
-Use `[tool.hatch.build.targets.wheel]` and `[tool.hatch.build.targets.sdist]` exclude
-patterns in `pyproject.toml` if hatchling's default `.gitignore`-based exclusion is
-insufficient.
+Trusted Publishers (OIDC) only — no manual `twine upload`. Sigstore attestations enabled. Wheel must not contain `.env`, `.git/`, `AGENTS.md`, `CLAUDE.md`, memory/session/IDE files.
 
 ## Things to avoid
 
-- **No AI authorship attribution.** Contributions are attributed to their
-  human author. Do not add `Co-Authored-By` trailers crediting AI tools,
-  "Generated by"-style notices in code or comments, or "built with AI" badges
-  on documentation. The human contributor is accountable for what they
-  submit regardless of how it was produced; AI tools can't sign a CLA,
-  respond to a security advisory, or be held liable for a regression. This
-  rule is about *credit and accountability*, not about the word "AI"
-  appearing — legitimate mentions in security rules, ADRs, or test fixtures
-  are unaffected.
-- Do not add runtime dependencies beyond PyYAML without discussion
-- Do not use ruamel.yaml (see ADR-003 for rationale)
-- Do not reuse or retire rule IDs -- CL-XXXX IDs are permanent
-- Do not add rules without authoritative grounding (OWASP, CIS, Docker docs)
-- Do not create findings that are not actionable -- if you can't tell the user exactly
-  what to change, the finding is not ready
-- Do not inflate severity -- match real-world exploitability and blast radius
-- Do not add inline suppression syntax unless explicitly planned
-- Do not reference private or internal-only tooling in any file -- if in
-  doubt whether something belongs in a public repo, leave it out
-- Do not ship anything that depends on a mutable ref. Workflows pin
-  third-party `uses:` to a full commit SHA; dev deps and CI tool
-  installs pin to exact versions; library runtime deps use SemVer
-  ranges (never `latest` or unpinned); Docker base images pin by
-  digest. See "Dependency pinning" under CI/CD for the full
-  breakdown and the rationale for each sub-case.
+- No AI authorship attribution (no `Co-Authored-By` for AI, no "Generated by" notices, no "built with AI" badges)
+- No runtime deps beyond PyYAML without discussion
+- No ruamel.yaml (see ADR-003)
+- No reusing/retiring rule IDs
+- No rules without authoritative grounding
+- No unactionable findings
+- No inline suppression syntax unless explicitly planned
+- No private/internal tooling references in a public repo
+- No mutable refs in CI (see pinning section above)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,129 @@
+# Roadmap
+
+compose-lint v0.2.0 has a proven core engine — 10 rules, PyPI distribution, SARIF/JSON/text output, pre-commit support. The gap is coverage, distribution reach, and developer experience.
+
+---
+
+## Milestone 1 — Rule Coverage (v0.3)
+
+The existing 10 rules cover the most critical OWASP/CIS items. This milestone fills the next tier before expanding distribution. More installs means more exposure to false negatives; completeness comes first.
+
+Each candidate was evaluated against three criteria: (1) actionability — is the finding specific enough to fix without guessing?; (2) false positive rate — does the absence of a field have a legitimate default?; (3) right tool — can a Compose linter detect this without image inspection or runtime state?
+
+**New rules (CL-0011 – CL-0017)**
+
+| Rule ID | Check | Severity | Grounding |
+|---------|-------|----------|-----------|
+| CL-0011 | Dangerous `cap_add` values (`SYS_ADMIN`, `SYS_PTRACE`, `NET_ADMIN`, `SYS_MODULE`, `SYS_RAWIO`, `SYS_TIME`, `DAC_READ_SEARCH`) | HIGH | OWASP Rule #3, CIS 5.5 |
+| CL-0012 | PIDs cgroup limit disabled (`pids_limit: 0` or `pids_limit: -1`) | MEDIUM | CIS 5.29 |
+| CL-0013 | Sensitive host paths mounted (`volumes:` containing `/etc`, `/proc`, `/sys`, `/boot`, `/root`) | HIGH | OWASP Rule #8, CIS 5.5 |
+| CL-0014 | Logging driver disabled (`logging.driver: none`) | MEDIUM | CIS 5.x |
+| CL-0015 | Healthcheck explicitly disabled (`healthcheck: {disable: true}`) | LOW | CIS 4.6, 5.27 |
+| CL-0016 | Dangerous host devices exposed (`devices:` matching `/dev/mem`, `/dev/kmem`, `/dev/port`, block devices `/dev/sd*`, `/dev/nvme*`, `/dev/disk/*`) | HIGH | CIS 5.18 |
+| CL-0017 | Shared mount propagation (`:shared` suffix or `bind.propagation: shared`) | MEDIUM | CIS 5.20 |
+| CL-0018 | Explicit root user (`user: root` or `user: "0"`) — overrides a correctly built image's non-root USER instruction | MEDIUM | OWASP Rule #7, CIS 5.x |
+| CL-0019 | Image pinned to tag but not digest (`nginx:1.25.3` without `@sha256:`) — tag can be silently overwritten on the registry | MEDIUM | OWASP Rule #13, CIS 5.27 |
+
+CL-0019 fires only when a version tag is present but no `@sha256:` digest. CL-0004 fires when there is no version tag at all. They are non-overlapping: `nginx` and `nginx:latest` trigger CL-0004 only; `nginx:1.25.3` triggers CL-0019 only; `nginx:1.25.3@sha256:…` triggers neither. Fix guidance should reference Dependabot and Renovate as the practical path for keeping digests current.
+
+**CL-0010 enhancement**: Add `uts: host` to the existing host namespace rule (CIS 5.21 — sharing the UTS namespace lets a container change the host's hostname).
+
+**Rules evaluated and rejected:**
+
+| Candidate | Rejection reason |
+|-----------|-----------------|
+| Hardcoded secrets in `environment:` | Too many false positives — `CONFIG_KEY`, `NEXT_PUBLIC_API_KEY`, `APP_SECRET_NAME` all match naive patterns but are not secrets. Regex on key names erodes trust. |
+| No memory/CPU resource limits | Absence check; fires on every dev Compose file where limits are intentionally omitted. Only explicit opt-outs like `pids_limit: -1` are appropriate. |
+| Service running as root (absence of `user:`) | Wrong tool — absence of `user:` does not imply root; the image's USER instruction determines the UID. Unactionable: "add `user:`" is not a specific fix without knowing the image's intended UID. CL-0018 catches the explicit override case instead. |
+| `restart: always` without failure limit | Fires on virtually every production Compose file; CIS 5.15 concern is system stability, not a security misconfiguration detectable by static analysis. |
+| Ulimit overrides (`ulimits: {nproc: -1}`) | Lower priority — `pids_limit: -1` covers the fork bomb case with higher signal and simpler detection. |
+
+**Section 4 (Container Images) verdict**: Only `healthcheck: {disable: true}` yields a viable rule. All other Section 4 controls require image inspection, Dockerfile analysis, or host-level configuration that a Compose linter cannot access.
+
+---
+
+## Milestone 2 — Distribution (v0.4)
+
+Reduce friction from "have Python" to "run one command."
+
+**Docker Hub image** (`composelint/compose-lint`)
+- Minimal image (python:3.13-alpine base, digest-pinned)
+- Enables `docker run --rm -v $(pwd):/src composelint/compose-lint`
+- Published via GitHub Actions OIDC; signed with cosign
+- Primary audience: teams that distrust pip in CI, or non-Python shops
+
+**Linux packages**
+- `.deb` and `.rpm` via `nfpm` — self-contained, no Python required
+- Published to GitHub Releases as build artifacts on every tag
+- Secondary: AUR `compose-lint` PKGBUILD for Arch users
+
+**Homebrew tap**
+- `brew install tmatens/tap/compose-lint`
+- Widens macOS developer reach beyond pip users
+
+**Implementation note**: The Docker image uses `shiv` to produce a zipapp (works on any Python 3.10+ host without a wheel install). The `.deb`/`.rpm` bundle Python via nfpm. This avoids PyInstaller cross-compilation maintenance.
+
+---
+
+## Milestone 3 — Better Remediation (v0.5)
+
+Finding a problem is half the value. Remediation guidance is the differentiator versus KICS, which identifies issues but rarely provides exact Compose-specific fix steps.
+
+**`--fix` mode** — auto-fix for safe, unambiguous rules:
+- CL-0003: inject `no-new-privileges:true` into `security_opt:`
+- CL-0005: prepend `127.0.0.1:` to unbound port mappings
+- CL-0007: add `read_only: true`
+- Dry run by default; `--fix --apply` writes in-place
+- Out of scope for auto-fix: CL-0001 (socket proxy replacement is non-trivial), CL-0016 (correct secret management is context-dependent)
+
+**Remediation snippets in SARIF** — populate `fix.changes[]` objects so GitHub Code Scanning can display a suggested-change diff inline on pull requests.
+
+**`--explain CL-XXXX`** — print the full prose from `docs/rules/CL-XXXX.md` in the terminal, reducing context-switching to the browser during triage.
+
+---
+
+## Milestone 4 — VS Code Extension + GA (v1.0)
+
+**Why VS Code before LSP**: the extension market is where Docker Compose authors spend most of their editing time. LSP can follow after v1.0.
+
+**Architecture**: the extension shells out to `compose-lint --format json` on save. No embedded Python runtime in the extension — this keeps it thin and ensures the user's installed version is always what runs.
+
+- Underlines findings inline with diagnostic severity mapping
+- Hover tooltip shows the `fix:` and `ref:` fields
+- Command palette: `Compose Lint: Fix All Auto-fixable` (requires Milestone 3)
+
+**GA declaration**: v1.0 moves the PyPI classifier from `3 - Alpha` to `5 - Production/Stable`. Prerequisites: 19+ rules, `--fix` mode, VS Code extension, and a documented upgrade/deprecation policy.
+
+---
+
+## Milestone 5 — Ecosystem Integrations (v1.x)
+
+Pursue based on user demand after v1.0.
+
+| Integration | Notes |
+|-------------|-------|
+| GitLab SAST template | SARIF upload to GitLab Security Dashboard |
+| Azure DevOps task | Published to VS Marketplace |
+| JetBrains plugin | Same shell-out pattern as VS Code |
+| Custom rule plugins | `entry_points` hook (`compose_lint.rules` group) for third-party rules |
+| LSP server | Language Server Protocol support — follows VS Code extension post-v1.0 |
+
+---
+
+## Out of Scope
+
+- **Full Compose schema validation** — intentionally excluded; the niche is security, not correctness
+- **Kubernetes/Helm support** — would dilute the zero-config, Compose-specific positioning
+- **SaaS offering** — adds infrastructure, compliance, and billing complexity with no clear moat over the CLI
+
+---
+
+## Summary
+
+| Milestone | Version |
+|-----------|---------|
+| Rule Coverage (19 rules) | v0.3 |
+| Distribution (Docker Hub, packages, Homebrew) | v0.4 |
+| Remediation (`--fix`, SARIF fixes, `--explain`) | v0.5 |
+| VS Code extension + GA | v1.0 |
+| Ecosystem integrations, custom rules | v1.x |


### PR DESCRIPTION
## Summary

- Adds `docs/ROADMAP.md` with five milestones from v0.3 through v1.x
- Milestone 1 (v0.3): 19 rules grounded in CIS Docker Benchmark v1.8.0 sections 4 and 5, OWASP Docker Security Cheat Sheet, and OWASP Docker Top 10
- Each rule candidate evaluated for actionability, false positive rate, and tool fit; rejected candidates documented with reasoning
- Milestones 2–5 cover distribution, remediation UX, VS Code extension + GA, and ecosystem integrations

## Test plan

- [ ] Review rule table accuracy against CIS/OWASP grounding
- [ ] Confirm rejected candidates table is complete
- [ ] Verify rule IDs are sequential and non-overlapping with existing rules