### PR TITLE
Prepare 0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-04-12
+
+### Added
+
+- 9 new security rules, bringing the total to 19:
+  - **CL-0011**: Dangerous capabilities added — `cap_add` with SYS_ADMIN,
+    SYS_PTRACE, NET_ADMIN, SYS_MODULE, SYS_RAWIO, SYS_TIME, or
+    DAC_READ_SEARCH (HIGH)
+  - **CL-0012**: PIDs cgroup limit disabled — `pids_limit: 0` or `-1` (MEDIUM)
+  - **CL-0013**: Sensitive host paths mounted — bind mounts of `/etc`, `/proc`,
+    `/sys`, `/boot`, or `/root` in short or long syntax (HIGH)
+  - **CL-0014**: Logging driver disabled — `logging.driver: none` (MEDIUM)
+  - **CL-0015**: Healthcheck disabled — `healthcheck.disable: true` (LOW)
+  - **CL-0016**: Dangerous host devices exposed — `/dev/mem`, `/dev/kmem`,
+    `/dev/port`, `/dev/sd*`, `/dev/nvme*`, `/dev/disk/*` (HIGH)
+  - **CL-0017**: Shared mount propagation — `:shared` suffix or
+    `bind.propagation: shared` (MEDIUM)
+  - **CL-0018**: Explicit root user — `user: root` or `user: "0"` overrides
+    image USER instruction (MEDIUM)
+  - **CL-0019**: Image tag without digest — version tag present but no
+    `@sha256:` pin; non-overlapping with CL-0004 (MEDIUM)
+
+### Changed
+
+- **CL-0010** now also detects `uts: host` (CIS 5.21 — sharing the host's UTS
+  namespace lets a container change the host's hostname).
+
 ## [0.2.0] - 2026-04-10
 
 First public release.
@@ -51,4 +78,5 @@ First public release.
   inputs through `env:` rather than direct `${{ }}` interpolation to prevent
   shell injection.
 
+[0.3.0]: https://github.com/tmatens/compose-lint/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/tmatens/compose-lint/releases/tag/v0.2.0

--- a/docs/rules/CL-0010.md
+++ b/docs/rules/CL-0010.md
@@ -7,6 +7,7 @@
 - CIS Docker Benchmark 5.8 — Do not share the host's process namespace
 - CIS Docker Benchmark 5.10 — Do not share the host's IPC namespace
 - CIS Docker Benchmark 5.15 — Do not share the host's user namespace
+- CIS Docker Benchmark 5.21 — Do not share the host's UTS namespace
 
 ## What it detects
 
@@ -14,6 +15,7 @@ Any service with:
 - `pid: host` — shares the host's PID namespace
 - `ipc: host` — shares the host's IPC namespace
 - `userns_mode: host` — disables user namespace remapping
+- `uts: host` — shares the host's UTS namespace
 
 Other values (e.g., `ipc: shareable`) are not flagged.
 
@@ -30,6 +32,9 @@ The container can attach to host shared memory segments, potentially reading sen
 ### `userns_mode: host`
 Disables UID/GID remapping. A process running as root (UID 0) inside the container is also root on the host. This makes container escapes trivially exploitable.
 
+### `uts: host`
+The container shares the host's UTS namespace and can change the host's hostname via `sethostname()`. This can disrupt host identity, break TLS certificate validation, and interfere with services that rely on hostname for configuration.
+
 ## Fix
 
 Remove the namespace sharing directive:
@@ -41,6 +46,7 @@ services:
     image: myapp:1.0
     pid: host
     ipc: host
+    uts: host
 
 # After
 services:

--- a/docs/rules/CL-0011.md
+++ b/docs/rules/CL-0011.md
@@ -1,0 +1,51 @@
+# CL-0011: Dangerous Capabilities Added
+
+**Severity:** HIGH
+
+**References:**
+- [OWASP Docker Security Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3---limit-capabilities-grant-only-specific-capabilities-needed-by-a-container)
+- CIS Docker Benchmark 5.5
+
+## What it detects
+
+Services that add dangerous Linux capabilities via `cap_add`:
+
+| Capability | Risk |
+|-----------|------|
+| `SYS_ADMIN` | Near-root access: mount filesystems, configure namespaces, BPF |
+| `SYS_PTRACE` | Trace/inspect any process, read secrets from memory |
+| `NET_ADMIN` | Modify routing tables, firewall rules, sniff traffic |
+| `SYS_MODULE` | Load/unload kernel modules |
+| `SYS_RAWIO` | Raw I/O port access (iopl/ioperm) |
+| `SYS_TIME` | Change system clock, affecting all containers and the host |
+| `DAC_READ_SEARCH` | Bypass file read permission checks on the host |
+
+Safe capabilities like `NET_BIND_SERVICE` or `CHOWN` are not flagged.
+
+## Why it matters
+
+Linux capabilities split root's privileges into discrete units. Adding dangerous capabilities — especially `SYS_ADMIN` — grants powers that can be chained into container escapes. `SYS_ADMIN` alone enables `mount()`, `unshare()`, and BPF operations that are well-documented escape paths.
+
+## Fix
+
+Remove the dangerous capability and evaluate whether the workload truly requires it:
+
+```yaml
+# Before
+services:
+  app:
+    image: myapp:1.0
+    cap_add:
+      - SYS_ADMIN
+
+# After — drop all, add back only what's needed
+services:
+  app:
+    image: myapp:1.0
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+```
+
+If a dangerous capability is genuinely required (e.g., `SYS_PTRACE` for a debugger sidecar), document the justification and consider running the workload outside a container.

--- a/docs/rules/CL-0012.md
+++ b/docs/rules/CL-0012.md
@@ -1,0 +1,34 @@
+# CL-0012: PIDs Cgroup Limit Disabled
+
+**Severity:** MEDIUM
+
+**References:**
+- CIS Docker Benchmark 5.29 — Ensure the PIDs cgroup limit is set
+
+## What it detects
+
+Services with `pids_limit` set to `0` or `-1`, which disables the process count limit. Services without `pids_limit` set are not flagged — this rule targets explicit opt-outs only.
+
+## Why it matters
+
+Without a PIDs cgroup limit, a single container can create unlimited processes. A fork bomb inside the container will exhaust the host's process table, causing a denial of service that affects all containers and host services.
+
+## Fix
+
+Set a positive `pids_limit` appropriate for your workload:
+
+```yaml
+# Before
+services:
+  app:
+    image: myapp:1.0
+    pids_limit: -1
+
+# After
+services:
+  app:
+    image: myapp:1.0
+    pids_limit: 200
+```
+
+Typical web applications need 100–500 PIDs. Start with a conservative limit and increase if the container hits it during normal operation.

--- a/docs/rules/CL-0013.md
+++ b/docs/rules/CL-0013.md
@@ -1,0 +1,47 @@
+# CL-0013: Sensitive Host Path Mounted
+
+**Severity:** HIGH
+
+**References:**
+- [OWASP Docker Security Rule #8](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-8---set-filesystem-and-volumes-to-read-only)
+- CIS Docker Benchmark 5.5 — Do not mount sensitive host system directories
+
+## What it detects
+
+Services that bind-mount sensitive host directories into a container:
+- `/etc` — host system configuration
+- `/proc` — kernel and process information
+- `/sys` — kernel device and driver interfaces
+- `/boot` — bootloader and kernel images
+- `/root` — root user's home directory
+
+Subpaths (e.g., `/etc/passwd`) are also flagged. Both short syntax (`/etc:/host-etc`) and long syntax (`type: bind, source: /etc`) are checked. Named volumes are not flagged.
+
+## Why it matters
+
+Mounting these paths gives the container read (and potentially write) access to critical host infrastructure:
+- `/etc` contains `shadow`, `sudoers`, `ssh` configs — a writable mount enables full host takeover
+- `/proc` exposes kernel parameters, process environments (secrets), and sysrq triggers
+- `/sys` provides direct interfaces to hardware, cgroups, and kernel modules
+- `/boot` contains the kernel and initramfs — modification enables persistent rootkits
+- `/root` may contain SSH keys, shell history, and credentials
+
+## Fix
+
+Remove the bind mount. If the container needs specific host files, copy them into the image at build time or use a named volume containing only the required data:
+
+```yaml
+# Before
+services:
+  app:
+    image: myapp:1.0
+    volumes:
+      - /etc:/host-etc
+
+# After — use a named volume or COPY in Dockerfile
+services:
+  app:
+    image: myapp:1.0
+    volumes:
+      - app-config:/app/config
+```

--- a/docs/rules/CL-0014.md
+++ b/docs/rules/CL-0014.md
@@ -1,0 +1,39 @@
+# CL-0014: Logging Driver Disabled
+
+**Severity:** MEDIUM
+
+**References:**
+- CIS Docker Benchmark 5.x — Ensure container logging is configured
+
+## What it detects
+
+Services with `logging.driver` set to `none`. Services using any other driver (e.g., `json-file`, `syslog`, `fluentd`) or services without explicit logging configuration are not flagged.
+
+## Why it matters
+
+Disabling the logging driver means no stdout/stderr output from the container is captured anywhere. During an incident, there is no audit trail — you cannot determine what the container did, when it was compromised, or what data was accessed. This violates the principle of non-repudiation and makes forensic analysis impossible.
+
+## Fix
+
+Remove `driver: none` to use the default logging driver, or configure an appropriate one:
+
+```yaml
+# Before
+services:
+  app:
+    image: myapp:1.0
+    logging:
+      driver: none
+
+# After
+services:
+  app:
+    image: myapp:1.0
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: '3'
+```
+
+For centralized logging, use `syslog`, `fluentd`, or `gelf` drivers with appropriate endpoints.

--- a/docs/rules/CL-0015.md
+++ b/docs/rules/CL-0015.md
@@ -1,0 +1,42 @@
+# CL-0015: Healthcheck Disabled
+
+**Severity:** LOW
+
+**References:**
+- CIS Docker Benchmark 4.6 — Add HEALTHCHECK instruction to container images
+- CIS Docker Benchmark 5.27 — Ensure container health is checked at runtime
+
+## What it detects
+
+Services with `healthcheck.disable: true`. Services without a healthcheck configuration or with `disable: false` are not flagged — this rule targets explicit opt-outs only.
+
+## Why it matters
+
+When the healthcheck is explicitly disabled, the orchestrator (Docker Swarm, Compose restart policies) has no way to detect that a container is in a degraded state. A process that is running but unresponsive (deadlocked, out of memory, stuck in a crash loop without exiting) will continue to receive traffic indefinitely.
+
+Disabling a healthcheck also overrides any `HEALTHCHECK` instruction in the Dockerfile, which may have been set by the image author for good reason.
+
+## Fix
+
+Remove `disable: true` and configure an appropriate healthcheck:
+
+```yaml
+# Before
+services:
+  app:
+    image: myapp:1.0
+    healthcheck:
+      disable: true
+
+# After
+services:
+  app:
+    image: myapp:1.0
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+```
+
+If the image already has a `HEALTHCHECK` instruction, simply removing the `healthcheck:` block entirely will restore the image's built-in check.

--- a/docs/rules/CL-0016.md
+++ b/docs/rules/CL-0016.md
@@ -1,0 +1,49 @@
+# CL-0016: Dangerous Host Device Exposed
+
+**Severity:** HIGH
+
+**References:**
+- CIS Docker Benchmark 5.18 — Do not directly expose host devices to containers
+
+## What it detects
+
+Services that expose dangerous host devices via `devices:`:
+
+| Pattern | Risk |
+|---------|------|
+| `/dev/mem` | Raw physical memory access — read/write any address |
+| `/dev/kmem` | Kernel virtual memory — modify running kernel |
+| `/dev/port` | Raw I/O port access — direct hardware control |
+| `/dev/sd*` | SCSI/SATA block devices — raw disk read/write |
+| `/dev/nvme*` | NVMe block devices — raw disk read/write |
+| `/dev/disk/*` | Block device symlinks — same risk as raw devices |
+
+Safe devices like `/dev/net/tun` or `/dev/fuse` are not flagged.
+
+## Why it matters
+
+Exposing raw memory or block devices bypasses all container isolation. A container with access to `/dev/mem` can read any physical memory address, including kernel memory and other containers' data. Block device access enables reading and overwriting the host filesystem directly, bypassing any mount restrictions.
+
+These are equivalent to giving the container full root access to the host.
+
+## Fix
+
+Remove the dangerous device. If you need specific hardware access, consider whether a more constrained approach exists:
+
+```yaml
+# Before
+services:
+  app:
+    image: myapp:1.0
+    devices:
+      - /dev/sda:/dev/sda
+
+# After — use volumes for disk data access
+services:
+  app:
+    image: myapp:1.0
+    volumes:
+      - /data:/app/data:ro
+```
+
+If raw device access is genuinely required (e.g., for disk management tooling), the workload should not run in a container.

--- a/docs/rules/CL-0017.md
+++ b/docs/rules/CL-0017.md
@@ -1,0 +1,65 @@
+# CL-0017: Shared Mount Propagation
+
+**Severity:** MEDIUM
+
+**References:**
+- CIS Docker Benchmark 5.20 — Do not share the host's mount propagation
+
+## What it detects
+
+Services using shared mount propagation in either syntax:
+- Short syntax: `:shared` suffix (e.g., `/data:/app/data:shared`)
+- Long syntax: `bind.propagation: shared`
+
+Other propagation modes (`rprivate`, `rslave`, etc.) and mounts without explicit propagation are not flagged.
+
+## Why it matters
+
+Shared mount propagation means mounts created inside the container are visible on the host, and mounts created on the host are visible inside the container. This breaks mount namespace isolation and can be exploited to:
+- Mount arbitrary filesystems that become visible on the host
+- Access newly mounted host filesystems that were not present when the container started
+- Escape container confinement by creating strategic mount points
+
+## Fix
+
+Remove `:shared` or change the propagation to `rprivate` (the Docker default):
+
+```yaml
+# Before — short syntax
+services:
+  app:
+    image: myapp:1.0
+    volumes:
+      - /data:/app/data:shared
+
+# After
+services:
+  app:
+    image: myapp:1.0
+    volumes:
+      - /data:/app/data
+
+# Before — long syntax
+services:
+  app:
+    image: myapp:1.0
+    volumes:
+      - type: bind
+        source: /data
+        target: /app/data
+        bind:
+          propagation: shared
+
+# After
+services:
+  app:
+    image: myapp:1.0
+    volumes:
+      - type: bind
+        source: /data
+        target: /app/data
+        bind:
+          propagation: rprivate
+```
+
+If your workload requires mount visibility between host and container (e.g., CSI drivers), use `rslave` instead of `shared` — it allows host-to-container propagation without the reverse.

--- a/docs/rules/CL-0018.md
+++ b/docs/rules/CL-0018.md
@@ -1,0 +1,43 @@
+# CL-0018: Explicit Root User
+
+**Severity:** MEDIUM
+
+**References:**
+- [OWASP Docker Security Rule #7](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-7---do-not-use-root-user)
+- CIS Docker Benchmark 5.x — Do not run containers as root
+
+## What it detects
+
+Services that explicitly set the user to root: `user: root`, `user: "0"`, `user: "root:root"`, or `user: "0:0"`. Services without a `user:` directive are not flagged — the absence of `user:` does not imply root, as the image's `USER` instruction determines the UID.
+
+## Why it matters
+
+Many images set a non-root `USER` in their Dockerfile. Explicitly overriding with `user: root` negates that protection. A container running as UID 0:
+- Has full write access to all bind-mounted host paths
+- Can exploit kernel vulnerabilities more easily (many require CAP_SYS_ADMIN or UID 0)
+- Amplifies the impact of every other misconfiguration (e.g., `privileged`, `cap_add`, host mounts)
+
+This rule catches the explicit override case. It does not flag the absence of `user:` — that would be unactionable without knowing the image's intended UID.
+
+## Fix
+
+Remove the `user:` directive to respect the image's built-in `USER` instruction, or set an explicit non-root user:
+
+```yaml
+# Before
+services:
+  app:
+    image: myapp:1.0
+    user: root
+
+# After — let the image decide
+services:
+  app:
+    image: myapp:1.0
+
+# Or — set a specific non-root user
+services:
+  app:
+    image: myapp:1.0
+    user: "1000:1000"
+```

--- a/docs/rules/CL-0019.md
+++ b/docs/rules/CL-0019.md
@@ -1,0 +1,42 @@
+# CL-0019: Image Tag Without Digest
+
+**Severity:** MEDIUM
+
+**References:**
+- [OWASP Docker Security Rule #13](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-13---enhance-supply-chain-security)
+- CIS Docker Benchmark 5.27 — Ensure container images are up to date
+
+## What it detects
+
+Services using a version tag (e.g., `nginx:1.25.3`) without a digest pin (`@sha256:...`). This rule does not overlap with CL-0004:
+
+| Image reference | CL-0004 | CL-0019 |
+|----------------|---------|---------|
+| `nginx` | fires | — |
+| `nginx:latest` | fires | — |
+| `nginx:1.25.3` | — | fires |
+| `nginx:1.25.3@sha256:...` | — | — |
+
+Build-only services (no `image:` key) are skipped.
+
+## Why it matters
+
+Docker tags are mutable pointers. A registry operator, compromised CI pipeline, or supply chain attack can overwrite `nginx:1.25.3` with a different image. Without a digest pin, `docker compose pull` will silently fetch the replacement. You have no cryptographic guarantee that the image you pull today is the same one you tested last week.
+
+## Fix
+
+Add a digest pin. Use `docker inspect --format='{{index .RepoDigests 0}}' <image>` to get the current digest:
+
+```yaml
+# Before
+services:
+  app:
+    image: nginx:1.25.3
+
+# After
+services:
+  app:
+    image: nginx:1.25.3@sha256:6a5af...
+```
+
+Use [Dependabot](https://docs.github.com/en/code-security/dependabot) or [Renovate](https://docs.renovatebot.com/docker/) to automatically update digest pins when new images are published under the same tag.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "compose-lint"
-version = "0.2.0"
+version = "0.3.0"
 description = "A security-focused linter for Docker Compose files"
 readme = "README.md"
 license = "MIT"

--- a/src/compose_lint/__init__.py
+++ b/src/compose_lint/__init__.py
@@ -1,3 +1,3 @@
 """A security-focused linter for Docker Compose files."""
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/src/compose_lint/rules/CL0010_host_namespace.py
+++ b/src/compose_lint/rules/CL0010_host_namespace.py
@@ -35,6 +35,12 @@ _NAMESPACE_CHECKS: list[tuple[str, str, str, str]] = [
         "CIS Docker Benchmark 5.15 — Do not share the host's user namespace",
         "user namespace. UID/GID mapping between container and host is disabled.",
     ),
+    (
+        "uts",
+        "host",
+        "CIS Docker Benchmark 5.21 — Do not share the host's UTS namespace",
+        "UTS namespace. The container can change the host's hostname.",
+    ),
 ]
 
 
@@ -48,14 +54,14 @@ class HostNamespaceRule(BaseRule):
             id="CL-0010",
             name="Host namespace sharing",
             description=(
-                "Sharing host namespaces (PID, IPC, user) breaks container "
+                "Sharing host namespaces (PID, IPC, user, UTS) breaks container "
                 "isolation. The container gains visibility into or control over "
                 "host-level resources."
             ),
             severity=Severity.HIGH,
             references=[
                 OWASP_REF,
-                "CIS Docker Benchmark 5.8, 5.10, 5.15",
+                "CIS Docker Benchmark 5.8, 5.10, 5.15, 5.21",
             ],
         )
 

--- a/src/compose_lint/rules/CL0011_dangerous_cap_add.py
+++ b/src/compose_lint/rules/CL0011_dangerous_cap_add.py
@@ -1,0 +1,79 @@
+"""CL-0011: Dangerous capabilities added."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from compose_lint.models import Finding, RuleMetadata, Severity
+from compose_lint.rules import BaseRule, register_rule
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+OWASP_REF = (
+    "https://cheatsheetseries.owasp.org/cheatsheets/"
+    "Docker_Security_Cheat_Sheet.html#rule-3---limit-capabilities-grant-only-"
+    "specific-capabilities-needed-by-a-container"
+)
+
+CIS_REF = "CIS Docker Benchmark 5.5 — Do not mount sensitive host system directories"
+
+DANGEROUS_CAPS: dict[str, str] = {
+    "SYS_ADMIN": "near-root access: mount filesystems, configure namespaces, BPF",
+    "SYS_PTRACE": "trace/inspect any process, read secrets from memory",
+    "NET_ADMIN": "modify routing tables, firewall rules, sniff traffic",
+    "SYS_MODULE": "load/unload kernel modules",
+    "SYS_RAWIO": "raw I/O port access (iopl/ioperm)",
+    "SYS_TIME": "change system clock, affecting all containers and the host",
+    "DAC_READ_SEARCH": "bypass file read permission checks on the host",
+}
+
+
+@register_rule
+class DangerousCapAddRule(BaseRule):
+    """Detects services adding dangerous Linux capabilities."""
+
+    @property
+    def metadata(self) -> RuleMetadata:
+        return RuleMetadata(
+            id="CL-0011",
+            name="Dangerous capabilities added",
+            description=(
+                "Adding powerful Linux capabilities like SYS_ADMIN or SYS_PTRACE "
+                "significantly weakens container isolation and can enable container "
+                "escapes."
+            ),
+            severity=Severity.HIGH,
+            references=[OWASP_REF, CIS_REF],
+        )
+
+    def check(
+        self,
+        service_name: str,
+        service_config: dict[str, Any],
+        global_config: dict[str, Any],
+        lines: dict[str, int],
+    ) -> Iterator[Finding]:
+        cap_add = service_config.get("cap_add", [])
+        if not isinstance(cap_add, list):
+            return
+
+        for cap in cap_add:
+            cap_upper = str(cap).upper()
+            if cap_upper in DANGEROUS_CAPS:
+                yield Finding(
+                    rule_id="CL-0011",
+                    severity=Severity.HIGH,
+                    service=service_name,
+                    message=(
+                        f"Service adds dangerous capability {cap_upper}: "
+                        f"{DANGEROUS_CAPS[cap_upper]}."
+                    ),
+                    line=lines.get(f"services.{service_name}.cap_add"),
+                    fix=(
+                        f"Remove {cap_upper} from cap_add. If this capability is "
+                        "required, document the justification and consider running "
+                        "the workload outside of a container."
+                    ),
+                    references=[OWASP_REF, CIS_REF],
+                )

--- a/src/compose_lint/rules/CL0012_pids_limit.py
+++ b/src/compose_lint/rules/CL0012_pids_limit.py
@@ -1,0 +1,65 @@
+"""CL-0012: PIDs cgroup limit disabled."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from compose_lint.models import Finding, RuleMetadata, Severity
+from compose_lint.rules import BaseRule, register_rule
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+CIS_REF = "CIS Docker Benchmark 5.29 — Ensure the PIDs cgroup limit is set"
+
+
+@register_rule
+class PidsLimitRule(BaseRule):
+    """Detects services with PIDs cgroup limit explicitly disabled."""
+
+    @property
+    def metadata(self) -> RuleMetadata:
+        return RuleMetadata(
+            id="CL-0012",
+            name="PIDs cgroup limit disabled",
+            description=(
+                "Setting pids_limit to 0 or -1 removes the process count limit, "
+                "allowing a container to fork-bomb the host."
+            ),
+            severity=Severity.MEDIUM,
+            references=[CIS_REF],
+        )
+
+    def check(
+        self,
+        service_name: str,
+        service_config: dict[str, Any],
+        global_config: dict[str, Any],
+        lines: dict[str, int],
+    ) -> Iterator[Finding]:
+        pids_limit = service_config.get("pids_limit")
+        if pids_limit is None:
+            return
+
+        try:
+            value = int(pids_limit)
+        except (TypeError, ValueError):
+            return
+
+        if value <= 0:
+            yield Finding(
+                rule_id="CL-0012",
+                severity=Severity.MEDIUM,
+                service=service_name,
+                message=(
+                    f"PIDs cgroup limit is disabled (pids_limit: {value}). "
+                    "The container can create unlimited processes, enabling "
+                    "fork bomb attacks against the host."
+                ),
+                line=lines.get(f"services.{service_name}.pids_limit"),
+                fix=(
+                    "Set a positive pids_limit appropriate for your workload:\n"
+                    "  pids_limit: 200"
+                ),
+                references=[CIS_REF],
+            )

--- a/src/compose_lint/rules/CL0013_sensitive_mount.py
+++ b/src/compose_lint/rules/CL0013_sensitive_mount.py
@@ -1,0 +1,110 @@
+"""CL-0013: Sensitive host paths mounted."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+from compose_lint.models import Finding, RuleMetadata, Severity
+from compose_lint.rules import BaseRule, register_rule
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+OWASP_REF = (
+    "https://cheatsheetseries.owasp.org/cheatsheets/"
+    "Docker_Security_Cheat_Sheet.html#rule-8---set-filesystem-and-volumes-to-read-only"
+)
+
+CIS_REF = "CIS Docker Benchmark 5.5 — Do not mount sensitive host system directories"
+
+_SENSITIVE_PATHS = ("/etc", "/proc", "/sys", "/boot", "/root")
+
+# Matches host:container or host:container:mode in short syntax
+_SHORT_VOLUME_RE = re.compile(r"^(?P<host>/[^:]+):(?P<container>[^:]+)")
+
+
+def _extract_host_path(volume: Any) -> str | None:
+    """Extract the host path from a short-syntax volume string."""
+    if not isinstance(volume, str):
+        return None
+    m = _SHORT_VOLUME_RE.match(volume)
+    if m:
+        return m.group("host")
+    return None
+
+
+def _is_sensitive(host_path: str) -> str | None:
+    """Return the sensitive prefix if host_path starts with one, else None."""
+    # Normalize trailing slashes for comparison
+    normalized = host_path.rstrip("/")
+    for sensitive in _SENSITIVE_PATHS:
+        if normalized == sensitive or normalized.startswith(sensitive + "/"):
+            return sensitive
+    return None
+
+
+@register_rule
+class SensitiveMountRule(BaseRule):
+    """Detects services mounting sensitive host paths."""
+
+    @property
+    def metadata(self) -> RuleMetadata:
+        return RuleMetadata(
+            id="CL-0013",
+            name="Sensitive host path mounted",
+            description=(
+                "Mounting sensitive host directories like /etc, /proc, /sys, "
+                "/boot, or /root into a container exposes host configuration "
+                "and kernel interfaces."
+            ),
+            severity=Severity.HIGH,
+            references=[OWASP_REF, CIS_REF],
+        )
+
+    def check(
+        self,
+        service_name: str,
+        service_config: dict[str, Any],
+        global_config: dict[str, Any],
+        lines: dict[str, int],
+    ) -> Iterator[Finding]:
+        volumes = service_config.get("volumes", [])
+        if not isinstance(volumes, list):
+            return
+
+        for volume in volumes:
+            # Short syntax: /host/path:/container/path[:mode]
+            host_path = _extract_host_path(volume)
+            if (
+                host_path is None
+                and isinstance(volume, dict)
+                and volume.get("type") == "bind"
+            ):
+                # Long syntax: dict with 'source' key
+                source = volume.get("source")
+                if isinstance(source, str):
+                    host_path = source
+
+            if host_path is None:
+                continue
+
+            sensitive = _is_sensitive(host_path)
+            if sensitive:
+                yield Finding(
+                    rule_id="CL-0013",
+                    severity=Severity.HIGH,
+                    service=service_name,
+                    message=(
+                        f"Service mounts sensitive host path '{host_path}' "
+                        f"(under {sensitive}). This exposes host system files "
+                        "to the container."
+                    ),
+                    line=lines.get(f"services.{service_name}.volumes"),
+                    fix=(
+                        f"Remove the bind mount for {host_path}. If the container "
+                        "needs specific files, copy them into the image at build time "
+                        "or use a named volume with only the required data."
+                    ),
+                    references=[OWASP_REF, CIS_REF],
+                )

--- a/src/compose_lint/rules/CL0014_logging_disabled.py
+++ b/src/compose_lint/rules/CL0014_logging_disabled.py
@@ -1,0 +1,66 @@
+"""CL-0014: Logging driver disabled."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from compose_lint.models import Finding, RuleMetadata, Severity
+from compose_lint.rules import BaseRule, register_rule
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+CIS_REF = "CIS Docker Benchmark 5.x — Ensure container logging is configured"
+
+
+@register_rule
+class LoggingDisabledRule(BaseRule):
+    """Detects services with logging explicitly disabled."""
+
+    @property
+    def metadata(self) -> RuleMetadata:
+        return RuleMetadata(
+            id="CL-0014",
+            name="Logging driver disabled",
+            description=(
+                "Setting the logging driver to 'none' prevents all log "
+                "collection, making incident response and forensics impossible."
+            ),
+            severity=Severity.MEDIUM,
+            references=[CIS_REF],
+        )
+
+    def check(
+        self,
+        service_name: str,
+        service_config: dict[str, Any],
+        global_config: dict[str, Any],
+        lines: dict[str, int],
+    ) -> Iterator[Finding]:
+        logging_config = service_config.get("logging")
+        if not isinstance(logging_config, dict):
+            return
+
+        driver = logging_config.get("driver")
+        if isinstance(driver, str) and driver.lower() == "none":
+            yield Finding(
+                rule_id="CL-0014",
+                severity=Severity.MEDIUM,
+                service=service_name,
+                message=(
+                    "Logging driver is set to 'none'. No logs will be collected "
+                    "from this container, preventing audit trails and incident "
+                    "response."
+                ),
+                line=lines.get(f"services.{service_name}.logging.driver"),
+                fix=(
+                    "Remove 'driver: none' to use the default logging driver, "
+                    "or configure an appropriate driver:\n"
+                    "  logging:\n"
+                    "    driver: json-file\n"
+                    "    options:\n"
+                    "      max-size: 10m\n"
+                    "      max-file: '3'"
+                ),
+                references=[CIS_REF],
+            )

--- a/src/compose_lint/rules/CL0015_healthcheck_disabled.py
+++ b/src/compose_lint/rules/CL0015_healthcheck_disabled.py
@@ -1,0 +1,70 @@
+"""CL-0015: Healthcheck explicitly disabled."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from compose_lint.models import Finding, RuleMetadata, Severity
+from compose_lint.rules import BaseRule, register_rule
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+CIS_REF_46 = (
+    "CIS Docker Benchmark 4.6 — Add HEALTHCHECK instruction to container images"
+)
+CIS_REF_527 = (
+    "CIS Docker Benchmark 5.27 — Ensure container health is checked at runtime"
+)
+
+
+@register_rule
+class HealthcheckDisabledRule(BaseRule):
+    """Detects services with healthcheck explicitly disabled."""
+
+    @property
+    def metadata(self) -> RuleMetadata:
+        return RuleMetadata(
+            id="CL-0015",
+            name="Healthcheck disabled",
+            description=(
+                "Explicitly disabling the healthcheck removes runtime health "
+                "monitoring. Orchestrators cannot detect or restart unhealthy "
+                "containers."
+            ),
+            severity=Severity.LOW,
+            references=[CIS_REF_46, CIS_REF_527],
+        )
+
+    def check(
+        self,
+        service_name: str,
+        service_config: dict[str, Any],
+        global_config: dict[str, Any],
+        lines: dict[str, int],
+    ) -> Iterator[Finding]:
+        healthcheck = service_config.get("healthcheck")
+        if not isinstance(healthcheck, dict):
+            return
+
+        disable = healthcheck.get("disable")
+        if disable is True:
+            yield Finding(
+                rule_id="CL-0015",
+                severity=Severity.LOW,
+                service=service_name,
+                message=(
+                    "Healthcheck is explicitly disabled. The orchestrator cannot "
+                    "detect or automatically restart unhealthy containers."
+                ),
+                line=lines.get(f"services.{service_name}.healthcheck"),
+                fix=(
+                    "Remove 'disable: true' and configure a healthcheck:\n"
+                    "  healthcheck:\n"
+                    '    test: ["CMD", "curl", "-f", "http://localhost/"]\n'
+                    "    interval: 30s\n"
+                    "    timeout: 10s\n"
+                    "    retries: 3"
+                ),
+                references=[CIS_REF_46, CIS_REF_527],
+            )

--- a/src/compose_lint/rules/CL0016_dangerous_devices.py
+++ b/src/compose_lint/rules/CL0016_dangerous_devices.py
@@ -1,0 +1,87 @@
+"""CL-0016: Dangerous host devices exposed."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+from compose_lint.models import Finding, RuleMetadata, Severity
+from compose_lint.rules import BaseRule, register_rule
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+CIS_REF = (
+    "CIS Docker Benchmark 5.18 — Do not directly expose host devices to containers"
+)
+
+_DANGEROUS_DEVICE_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"^/dev/mem$"), "/dev/mem — raw physical memory access"),
+    (re.compile(r"^/dev/kmem$"), "/dev/kmem — kernel virtual memory access"),
+    (re.compile(r"^/dev/port$"), "/dev/port — raw I/O port access"),
+    (re.compile(r"^/dev/sd[a-z]"), "/dev/sd* — SCSI/SATA block device"),
+    (re.compile(r"^/dev/nvme"), "/dev/nvme* — NVMe block device"),
+    (re.compile(r"^/dev/disk/"), "/dev/disk/* — block device symlinks"),
+]
+
+
+def _extract_host_device(device: Any) -> str | None:
+    """Extract the host device path from a device mapping string."""
+    if not isinstance(device, str):
+        return None
+    # Format: /dev/host:/dev/container[:permissions]
+    # or just /dev/host
+    return device.split(":")[0]
+
+
+@register_rule
+class DangerousDevicesRule(BaseRule):
+    """Detects services exposing dangerous host devices."""
+
+    @property
+    def metadata(self) -> RuleMetadata:
+        return RuleMetadata(
+            id="CL-0016",
+            name="Dangerous host device exposed",
+            description=(
+                "Exposing raw memory, I/O ports, or block devices to a container "
+                "enables direct hardware access that bypasses all container isolation."
+            ),
+            severity=Severity.HIGH,
+            references=[CIS_REF],
+        )
+
+    def check(
+        self,
+        service_name: str,
+        service_config: dict[str, Any],
+        global_config: dict[str, Any],
+        lines: dict[str, int],
+    ) -> Iterator[Finding]:
+        devices = service_config.get("devices", [])
+        if not isinstance(devices, list):
+            return
+
+        for device in devices:
+            host_device = _extract_host_device(device)
+            if host_device is None:
+                continue
+
+            for pattern, description in _DANGEROUS_DEVICE_PATTERNS:
+                if pattern.match(host_device):
+                    yield Finding(
+                        rule_id="CL-0016",
+                        severity=Severity.HIGH,
+                        service=service_name,
+                        message=(
+                            f"Service exposes dangerous host device "
+                            f"'{host_device}' ({description})."
+                        ),
+                        line=lines.get(f"services.{service_name}.devices"),
+                        fix=(
+                            f"Remove '{host_device}' from devices. Direct host "
+                            "device access bypasses container isolation entirely."
+                        ),
+                        references=[CIS_REF],
+                    )
+                    break  # One finding per device

--- a/src/compose_lint/rules/CL0017_shared_mount.py
+++ b/src/compose_lint/rules/CL0017_shared_mount.py
@@ -1,0 +1,96 @@
+"""CL-0017: Shared mount propagation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from compose_lint.models import Finding, RuleMetadata, Severity
+from compose_lint.rules import BaseRule, register_rule
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+CIS_REF = "CIS Docker Benchmark 5.20 — Do not share the host's mount propagation"
+
+
+@register_rule
+class SharedMountRule(BaseRule):
+    """Detects services using shared mount propagation."""
+
+    @property
+    def metadata(self) -> RuleMetadata:
+        return RuleMetadata(
+            id="CL-0017",
+            name="Shared mount propagation",
+            description=(
+                "Shared mount propagation allows mounts created inside a container "
+                "to appear on the host filesystem and vice versa, breaking mount "
+                "namespace isolation."
+            ),
+            severity=Severity.MEDIUM,
+            references=[CIS_REF],
+        )
+
+    def check(
+        self,
+        service_name: str,
+        service_config: dict[str, Any],
+        global_config: dict[str, Any],
+        lines: dict[str, int],
+    ) -> Iterator[Finding]:
+        volumes = service_config.get("volumes", [])
+        if not isinstance(volumes, list):
+            return
+
+        for volume in volumes:
+            if self._is_shared_short_syntax(volume) or self._is_shared_long_syntax(
+                volume
+            ):
+                yield self._make_finding(service_name, lines, str(volume))
+
+    def _is_shared_short_syntax(self, volume: Any) -> bool:
+        """Check for :shared suffix in short-syntax volume strings."""
+        if not isinstance(volume, str):
+            return False
+        # Short syntax options field can contain 'shared'
+        # e.g., /host:/container:shared or /host:/container:ro,shared
+        parts = volume.split(":")
+        if len(parts) >= 3:
+            options = parts[-1].split(",")
+            return "shared" in options
+        return False
+
+    def _is_shared_long_syntax(self, volume: Any) -> bool:
+        """Check for bind.propagation: shared in long-syntax volumes."""
+        if not isinstance(volume, dict):
+            return False
+        bind = volume.get("bind")
+        if not isinstance(bind, dict):
+            return False
+        propagation = bind.get("propagation")
+        return isinstance(propagation, str) and propagation.lower() == "shared"
+
+    def _make_finding(
+        self, service_name: str, lines: dict[str, int], volume_str: str
+    ) -> Finding:
+        return Finding(
+            rule_id="CL-0017",
+            severity=Severity.MEDIUM,
+            service=service_name,
+            message=(
+                "Service uses shared mount propagation. Mounts created inside "
+                "the container will appear on the host and vice versa."
+            ),
+            line=lines.get(f"services.{service_name}.volumes"),
+            fix=(
+                "Remove ':shared' from the volume mount or change "
+                "bind.propagation to 'rprivate' (the default):\n"
+                "  volumes:\n"
+                "    - type: bind\n"
+                "      source: /host/path\n"
+                "      target: /container/path\n"
+                "      bind:\n"
+                "        propagation: rprivate"
+            ),
+            references=[CIS_REF],
+        )

--- a/src/compose_lint/rules/CL0018_explicit_root.py
+++ b/src/compose_lint/rules/CL0018_explicit_root.py
@@ -1,0 +1,70 @@
+"""CL-0018: Explicit root user."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from compose_lint.models import Finding, RuleMetadata, Severity
+from compose_lint.rules import BaseRule, register_rule
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+OWASP_REF = (
+    "https://cheatsheetseries.owasp.org/cheatsheets/"
+    "Docker_Security_Cheat_Sheet.html#rule-7---do-not-use-root-user"
+)
+
+CIS_REF = "CIS Docker Benchmark 5.x — Do not run containers as root"
+
+_ROOT_VALUES = {"root", "0", "root:root", "0:0"}
+
+
+@register_rule
+class ExplicitRootRule(BaseRule):
+    """Detects services explicitly running as root."""
+
+    @property
+    def metadata(self) -> RuleMetadata:
+        return RuleMetadata(
+            id="CL-0018",
+            name="Explicit root user",
+            description=(
+                "Explicitly setting user to root overrides any non-root USER "
+                "instruction in the image, running the container's process as "
+                "UID 0."
+            ),
+            severity=Severity.MEDIUM,
+            references=[OWASP_REF, CIS_REF],
+        )
+
+    def check(
+        self,
+        service_name: str,
+        service_config: dict[str, Any],
+        global_config: dict[str, Any],
+        lines: dict[str, int],
+    ) -> Iterator[Finding]:
+        user = service_config.get("user")
+        if user is None:
+            return
+
+        user_str = str(user).strip().lower()
+        if user_str in _ROOT_VALUES:
+            yield Finding(
+                rule_id="CL-0018",
+                severity=Severity.MEDIUM,
+                service=service_name,
+                message=(
+                    f"Service explicitly runs as root "
+                    f"(user: {service_config['user']}). This overrides any "
+                    "non-root USER instruction in the image."
+                ),
+                line=lines.get(f"services.{service_name}.user"),
+                fix=(
+                    "Remove the 'user:' directive to respect the image's USER "
+                    "instruction, or set a non-root user:\n"
+                    "  user: 1000:1000"
+                ),
+                references=[OWASP_REF, CIS_REF],
+            )

--- a/src/compose_lint/rules/CL0019_image_no_digest.py
+++ b/src/compose_lint/rules/CL0019_image_no_digest.py
@@ -1,0 +1,86 @@
+"""CL-0019: Image tag without digest."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from compose_lint.models import Finding, RuleMetadata, Severity
+from compose_lint.rules import BaseRule, register_rule
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+OWASP_REF = (
+    "https://cheatsheetseries.owasp.org/cheatsheets/"
+    "Docker_Security_Cheat_Sheet.html#rule-13---enhance-supply-chain-security"
+)
+
+CIS_REF = "CIS Docker Benchmark 5.27 — Ensure container images are up to date"
+
+# Tags that CL-0004 already handles — we skip them to avoid overlap
+_MUTABLE_TAGS = {"latest", "stable", "edge", "nightly", "dev", "test"}
+
+
+@register_rule
+class ImageNoDigestRule(BaseRule):
+    """Detects images pinned to a version tag but not a digest."""
+
+    @property
+    def metadata(self) -> RuleMetadata:
+        return RuleMetadata(
+            id="CL-0019",
+            name="Image tag without digest",
+            description=(
+                "A version tag can be silently overwritten on the registry. "
+                "Without a digest pin, pulls are not guaranteed to return the "
+                "same image."
+            ),
+            severity=Severity.MEDIUM,
+            references=[OWASP_REF, CIS_REF],
+        )
+
+    def check(
+        self,
+        service_name: str,
+        service_config: dict[str, Any],
+        global_config: dict[str, Any],
+        lines: dict[str, int],
+    ) -> Iterator[Finding]:
+        image = service_config.get("image")
+        if image is None:
+            return
+
+        image = str(image)
+
+        # Already digest-pinned — clean
+        if "@sha256:" in image:
+            return
+
+        # Split into name and tag
+        parts = image.rsplit(":", 1)
+        if len(parts) != 2:
+            # No tag at all — CL-0004 handles this
+            return
+
+        tag = parts[1]
+        if tag.lower() in _MUTABLE_TAGS:
+            # Mutable tags are CL-0004's domain
+            return
+
+        # Has a version tag but no digest
+        yield Finding(
+            rule_id="CL-0019",
+            severity=Severity.MEDIUM,
+            service=service_name,
+            message=(
+                f"Image '{image}' is pinned to a tag but not a digest. "
+                "Tags can be overwritten on the registry, so this does not "
+                "guarantee image immutability."
+            ),
+            line=lines.get(f"services.{service_name}.image"),
+            fix=(
+                f"Add a digest pin: image: {image}@sha256:<digest>\n"
+                "Use Dependabot or Renovate to keep digests current."
+            ),
+            references=[OWASP_REF, CIS_REF],
+        )

--- a/tests/compose_files/insecure_cap_add.yml
+++ b/tests/compose_files/insecure_cap_add.yml
@@ -1,0 +1,40 @@
+services:
+  sys_admin:
+    image: nginx:1.27-alpine
+    cap_add:
+      - SYS_ADMIN
+  sys_ptrace:
+    image: nginx:1.27-alpine
+    cap_add:
+      - SYS_PTRACE
+  net_admin:
+    image: nginx:1.27-alpine
+    cap_add:
+      - NET_ADMIN
+  multiple_dangerous:
+    image: nginx:1.27-alpine
+    cap_add:
+      - SYS_ADMIN
+      - SYS_PTRACE
+      - NET_ADMIN
+  safe_caps:
+    image: nginx:1.27-alpine
+    cap_add:
+      - NET_BIND_SERVICE
+      - CHOWN
+  no_cap_add:
+    image: nginx:1.27-alpine
+  lowercase_cap:
+    image: nginx:1.27-alpine
+    cap_add:
+      - sys_module
+  all_dangerous:
+    image: nginx:1.27-alpine
+    cap_add:
+      - SYS_ADMIN
+      - SYS_PTRACE
+      - NET_ADMIN
+      - SYS_MODULE
+      - SYS_RAWIO
+      - SYS_TIME
+      - DAC_READ_SEARCH

--- a/tests/compose_files/insecure_devices.yml
+++ b/tests/compose_files/insecure_devices.yml
@@ -1,0 +1,41 @@
+services:
+  dev_mem:
+    image: nginx:1.27-alpine
+    devices:
+      - /dev/mem:/dev/mem
+  dev_kmem:
+    image: nginx:1.27-alpine
+    devices:
+      - /dev/kmem:/dev/kmem
+  dev_port:
+    image: nginx:1.27-alpine
+    devices:
+      - /dev/port:/dev/port
+  block_sda:
+    image: nginx:1.27-alpine
+    devices:
+      - /dev/sda:/dev/sda
+  block_sda1:
+    image: nginx:1.27-alpine
+    devices:
+      - /dev/sda1:/dev/sda1
+  block_nvme:
+    image: nginx:1.27-alpine
+    devices:
+      - /dev/nvme0n1:/dev/nvme0n1
+  disk_symlink:
+    image: nginx:1.27-alpine
+    devices:
+      - /dev/disk/by-id/ata-drive:/dev/xvda
+  multiple:
+    image: nginx:1.27-alpine
+    devices:
+      - /dev/mem:/dev/mem
+      - /dev/sda:/dev/sda
+  safe_device:
+    image: nginx:1.27-alpine
+    devices:
+      - /dev/net/tun:/dev/net/tun
+      - /dev/fuse:/dev/fuse
+  no_devices:
+    image: nginx:1.27-alpine

--- a/tests/compose_files/insecure_healthcheck.yml
+++ b/tests/compose_files/insecure_healthcheck.yml
@@ -1,0 +1,19 @@
+services:
+  disabled:
+    image: nginx:1.27-alpine
+    healthcheck:
+      disable: true
+  configured:
+    image: nginx:1.27-alpine
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+  no_healthcheck:
+    image: nginx:1.27-alpine
+  disable_false:
+    image: nginx:1.27-alpine
+    healthcheck:
+      disable: false
+      test: ["CMD", "curl", "-f", "http://localhost/"]

--- a/tests/compose_files/insecure_host_namespace.yml
+++ b/tests/compose_files/insecure_host_namespace.yml
@@ -15,6 +15,9 @@ services:
     userns_mode: host
   no_namespace_sharing:
     image: nginx:1.27-alpine
+  uts_host:
+    image: nginx:1.27-alpine
+    uts: host
   ipc_shareable:
     image: nginx:1.27-alpine
     ipc: shareable

--- a/tests/compose_files/insecure_image_no_digest.yml
+++ b/tests/compose_files/insecure_image_no_digest.yml
@@ -1,0 +1,17 @@
+services:
+  version_tag:
+    image: nginx:1.25.3
+  alpine_tag:
+    image: nginx:1.27-alpine
+  registry_tag:
+    image: ghcr.io/org/app:2.0.1
+  digest_pinned:
+    image: nginx:1.25.3@sha256:abcdef1234567890
+  no_tag:
+    image: nginx
+  latest_tag:
+    image: nginx:latest
+  stable_tag:
+    image: nginx:stable
+  build_only:
+    build: .

--- a/tests/compose_files/insecure_logging.yml
+++ b/tests/compose_files/insecure_logging.yml
@@ -1,0 +1,19 @@
+services:
+  logging_none:
+    image: nginx:1.27-alpine
+    logging:
+      driver: none
+  logging_json:
+    image: nginx:1.27-alpine
+    logging:
+      driver: json-file
+  logging_syslog:
+    image: nginx:1.27-alpine
+    logging:
+      driver: syslog
+  no_logging_config:
+    image: nginx:1.27-alpine
+  logging_none_uppercase:
+    image: nginx:1.27-alpine
+    logging:
+      driver: None

--- a/tests/compose_files/insecure_pids_limit.yml
+++ b/tests/compose_files/insecure_pids_limit.yml
@@ -1,0 +1,12 @@
+services:
+  disabled_zero:
+    image: nginx:1.27-alpine
+    pids_limit: 0
+  disabled_negative:
+    image: nginx:1.27-alpine
+    pids_limit: -1
+  positive_limit:
+    image: nginx:1.27-alpine
+    pids_limit: 200
+  no_limit_set:
+    image: nginx:1.27-alpine

--- a/tests/compose_files/insecure_root_user.yml
+++ b/tests/compose_files/insecure_root_user.yml
@@ -1,0 +1,21 @@
+services:
+  root_name:
+    image: nginx:1.27-alpine
+    user: root
+  root_uid:
+    image: nginx:1.27-alpine
+    user: "0"
+  root_with_group:
+    image: nginx:1.27-alpine
+    user: "root:root"
+  root_uid_gid:
+    image: nginx:1.27-alpine
+    user: "0:0"
+  non_root:
+    image: nginx:1.27-alpine
+    user: "1000:1000"
+  named_user:
+    image: nginx:1.27-alpine
+    user: appuser
+  no_user:
+    image: nginx:1.27-alpine

--- a/tests/compose_files/insecure_sensitive_mount.yml
+++ b/tests/compose_files/insecure_sensitive_mount.yml
@@ -1,0 +1,49 @@
+services:
+  mounts_etc:
+    image: nginx:1.27-alpine
+    volumes:
+      - /etc:/host-etc:ro
+  mounts_proc:
+    image: nginx:1.27-alpine
+    volumes:
+      - /proc:/host-proc
+  mounts_sys:
+    image: nginx:1.27-alpine
+    volumes:
+      - /sys:/host-sys
+  mounts_boot:
+    image: nginx:1.27-alpine
+    volumes:
+      - /boot:/host-boot
+  mounts_root:
+    image: nginx:1.27-alpine
+    volumes:
+      - /root:/host-root
+  mounts_etc_subpath:
+    image: nginx:1.27-alpine
+    volumes:
+      - /etc/passwd:/etc/passwd:ro
+  mounts_multiple:
+    image: nginx:1.27-alpine
+    volumes:
+      - /etc:/host-etc
+      - /proc:/host-proc
+  safe_volume:
+    image: nginx:1.27-alpine
+    volumes:
+      - /data:/app/data
+      - myvolume:/app/storage
+  no_volumes:
+    image: nginx:1.27-alpine
+  long_syntax_bind:
+    image: nginx:1.27-alpine
+    volumes:
+      - type: bind
+        source: /etc
+        target: /host-etc
+  long_syntax_named:
+    image: nginx:1.27-alpine
+    volumes:
+      - type: volume
+        source: myvolume
+        target: /app/data

--- a/tests/compose_files/insecure_shared_mount.yml
+++ b/tests/compose_files/insecure_shared_mount.yml
@@ -1,0 +1,35 @@
+services:
+  shared_short:
+    image: nginx:1.27-alpine
+    volumes:
+      - /data:/app/data:shared
+  shared_with_ro:
+    image: nginx:1.27-alpine
+    volumes:
+      - /data:/app/data:ro,shared
+  shared_long:
+    image: nginx:1.27-alpine
+    volumes:
+      - type: bind
+        source: /data
+        target: /app/data
+        bind:
+          propagation: shared
+  rprivate_long:
+    image: nginx:1.27-alpine
+    volumes:
+      - type: bind
+        source: /data
+        target: /app/data
+        bind:
+          propagation: rprivate
+  normal_mount:
+    image: nginx:1.27-alpine
+    volumes:
+      - /data:/app/data
+  rw_mount:
+    image: nginx:1.27-alpine
+    volumes:
+      - /data:/app/data:rw
+  no_volumes:
+    image: nginx:1.27-alpine

--- a/tests/compose_files/valid_basic.yml
+++ b/tests/compose_files/valid_basic.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: nginx:1.27-alpine
+    image: nginx:1.27-alpine@sha256:a1234567890abcdef
     ports:
       - "127.0.0.1:8080:80"
     security_opt:
@@ -12,7 +12,7 @@ services:
       - /tmp
       - /run
   db:
-    image: postgres:16-alpine
+    image: postgres:16-alpine@sha256:b1234567890abcdef
     security_opt:
       - no-new-privileges:true
     cap_drop:

--- a/tests/test_CL0010.py
+++ b/tests/test_CL0010.py
@@ -42,6 +42,14 @@ class TestHostNamespaceRule:
         assert len(findings) == 1
         assert "user namespace" in findings[0].message
 
+    def test_detects_uts_host(self) -> None:
+        data, lines = load_compose(FIXTURES / "insecure_host_namespace.yml")
+        findings = list(
+            self.rule.check("uts_host", data["services"]["uts_host"], data, lines)
+        )
+        assert len(findings) == 1
+        assert "UTS namespace" in findings[0].message
+
     def test_detects_all_three(self) -> None:
         data, lines = load_compose(FIXTURES / "insecure_host_namespace.yml")
         findings = list(

--- a/tests/test_CL0011.py
+++ b/tests/test_CL0011.py
@@ -1,0 +1,74 @@
+"""Tests for CL-0011: Dangerous capabilities added."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from compose_lint.parser import load_compose
+from compose_lint.rules.CL0011_dangerous_cap_add import DangerousCapAddRule
+
+FIXTURES = Path(__file__).parent / "compose_files"
+
+
+class TestDangerousCapAddRule:
+    """Tests for dangerous cap_add detection."""
+
+    def setup_method(self) -> None:
+        self.rule = DangerousCapAddRule()
+
+    def _check(self, service_name: str) -> list:
+        data, lines = load_compose(FIXTURES / "insecure_cap_add.yml")
+        return list(
+            self.rule.check(service_name, data["services"][service_name], data, lines)
+        )
+
+    def test_detects_sys_admin(self) -> None:
+        findings = self._check("sys_admin")
+        assert len(findings) == 1
+        assert findings[0].rule_id == "CL-0011"
+        assert "SYS_ADMIN" in findings[0].message
+
+    def test_detects_sys_ptrace(self) -> None:
+        findings = self._check("sys_ptrace")
+        assert len(findings) == 1
+        assert "SYS_PTRACE" in findings[0].message
+
+    def test_detects_net_admin(self) -> None:
+        findings = self._check("net_admin")
+        assert len(findings) == 1
+        assert "NET_ADMIN" in findings[0].message
+
+    def test_detects_multiple_dangerous(self) -> None:
+        findings = self._check("multiple_dangerous")
+        assert len(findings) == 3
+
+    def test_safe_caps_no_findings(self) -> None:
+        findings = self._check("safe_caps")
+        assert len(findings) == 0
+
+    def test_no_cap_add_no_findings(self) -> None:
+        findings = self._check("no_cap_add")
+        assert len(findings) == 0
+
+    def test_lowercase_normalized(self) -> None:
+        findings = self._check("lowercase_cap")
+        assert len(findings) == 1
+        assert "SYS_MODULE" in findings[0].message
+
+    def test_all_seven_dangerous(self) -> None:
+        findings = self._check("all_dangerous")
+        assert len(findings) == 7
+
+    def test_has_fix_guidance(self) -> None:
+        findings = self._check("sys_admin")
+        assert findings[0].fix is not None
+        assert "SYS_ADMIN" in findings[0].fix
+
+    def test_has_references(self) -> None:
+        findings = self._check("sys_admin")
+        assert len(findings[0].references) > 0
+
+    def test_metadata(self) -> None:
+        meta = self.rule.metadata
+        assert meta.id == "CL-0011"
+        assert meta.severity.value == "high"

--- a/tests/test_CL0012.py
+++ b/tests/test_CL0012.py
@@ -1,0 +1,56 @@
+"""Tests for CL-0012: PIDs cgroup limit disabled."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from compose_lint.parser import load_compose
+from compose_lint.rules.CL0012_pids_limit import PidsLimitRule
+
+FIXTURES = Path(__file__).parent / "compose_files"
+
+
+class TestPidsLimitRule:
+    """Tests for PIDs cgroup limit detection."""
+
+    def setup_method(self) -> None:
+        self.rule = PidsLimitRule()
+
+    def _check(self, service_name: str) -> list:
+        data, lines = load_compose(FIXTURES / "insecure_pids_limit.yml")
+        return list(
+            self.rule.check(service_name, data["services"][service_name], data, lines)
+        )
+
+    def test_detects_zero(self) -> None:
+        findings = self._check("disabled_zero")
+        assert len(findings) == 1
+        assert findings[0].rule_id == "CL-0012"
+        assert "pids_limit: 0" in findings[0].message
+
+    def test_detects_negative_one(self) -> None:
+        findings = self._check("disabled_negative")
+        assert len(findings) == 1
+        assert "pids_limit: -1" in findings[0].message
+
+    def test_positive_limit_no_findings(self) -> None:
+        findings = self._check("positive_limit")
+        assert len(findings) == 0
+
+    def test_no_limit_set_no_findings(self) -> None:
+        findings = self._check("no_limit_set")
+        assert len(findings) == 0
+
+    def test_has_fix_guidance(self) -> None:
+        findings = self._check("disabled_zero")
+        assert findings[0].fix is not None
+        assert "200" in findings[0].fix
+
+    def test_has_references(self) -> None:
+        findings = self._check("disabled_zero")
+        assert len(findings[0].references) > 0
+
+    def test_metadata(self) -> None:
+        meta = self.rule.metadata
+        assert meta.id == "CL-0012"
+        assert meta.severity.value == "medium"

--- a/tests/test_CL0013.py
+++ b/tests/test_CL0013.py
@@ -1,0 +1,89 @@
+"""Tests for CL-0013: Sensitive host paths mounted."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from compose_lint.parser import load_compose
+from compose_lint.rules.CL0013_sensitive_mount import SensitiveMountRule
+
+FIXTURES = Path(__file__).parent / "compose_files"
+
+
+class TestSensitiveMountRule:
+    """Tests for sensitive host path mount detection."""
+
+    def setup_method(self) -> None:
+        self.rule = SensitiveMountRule()
+
+    def _check(self, service_name: str) -> list:
+        data, lines = load_compose(FIXTURES / "insecure_sensitive_mount.yml")
+        return list(
+            self.rule.check(service_name, data["services"][service_name], data, lines)
+        )
+
+    def test_detects_etc(self) -> None:
+        findings = self._check("mounts_etc")
+        assert len(findings) == 1
+        assert findings[0].rule_id == "CL-0013"
+        assert "/etc" in findings[0].message
+
+    def test_detects_proc(self) -> None:
+        findings = self._check("mounts_proc")
+        assert len(findings) == 1
+        assert "/proc" in findings[0].message
+
+    def test_detects_sys(self) -> None:
+        findings = self._check("mounts_sys")
+        assert len(findings) == 1
+        assert "/sys" in findings[0].message
+
+    def test_detects_boot(self) -> None:
+        findings = self._check("mounts_boot")
+        assert len(findings) == 1
+        assert "/boot" in findings[0].message
+
+    def test_detects_root(self) -> None:
+        findings = self._check("mounts_root")
+        assert len(findings) == 1
+        assert "/root" in findings[0].message
+
+    def test_detects_etc_subpath(self) -> None:
+        findings = self._check("mounts_etc_subpath")
+        assert len(findings) == 1
+        assert "/etc/passwd" in findings[0].message
+
+    def test_detects_multiple(self) -> None:
+        findings = self._check("mounts_multiple")
+        assert len(findings) == 2
+
+    def test_safe_volume_no_findings(self) -> None:
+        findings = self._check("safe_volume")
+        assert len(findings) == 0
+
+    def test_no_volumes_no_findings(self) -> None:
+        findings = self._check("no_volumes")
+        assert len(findings) == 0
+
+    def test_long_syntax_bind(self) -> None:
+        findings = self._check("long_syntax_bind")
+        assert len(findings) == 1
+        assert "/etc" in findings[0].message
+
+    def test_long_syntax_named_no_findings(self) -> None:
+        findings = self._check("long_syntax_named")
+        assert len(findings) == 0
+
+    def test_has_fix_guidance(self) -> None:
+        findings = self._check("mounts_etc")
+        assert findings[0].fix is not None
+        assert "/etc" in findings[0].fix
+
+    def test_has_references(self) -> None:
+        findings = self._check("mounts_etc")
+        assert len(findings[0].references) > 0
+
+    def test_metadata(self) -> None:
+        meta = self.rule.metadata
+        assert meta.id == "CL-0013"
+        assert meta.severity.value == "high"

--- a/tests/test_CL0014.py
+++ b/tests/test_CL0014.py
@@ -1,0 +1,59 @@
+"""Tests for CL-0014: Logging driver disabled."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from compose_lint.parser import load_compose
+from compose_lint.rules.CL0014_logging_disabled import LoggingDisabledRule
+
+FIXTURES = Path(__file__).parent / "compose_files"
+
+
+class TestLoggingDisabledRule:
+    """Tests for logging driver disabled detection."""
+
+    def setup_method(self) -> None:
+        self.rule = LoggingDisabledRule()
+
+    def _check(self, service_name: str) -> list:
+        data, lines = load_compose(FIXTURES / "insecure_logging.yml")
+        return list(
+            self.rule.check(service_name, data["services"][service_name], data, lines)
+        )
+
+    def test_detects_driver_none(self) -> None:
+        findings = self._check("logging_none")
+        assert len(findings) == 1
+        assert findings[0].rule_id == "CL-0014"
+        assert "none" in findings[0].message.lower()
+
+    def test_detects_driver_none_case_insensitive(self) -> None:
+        findings = self._check("logging_none_uppercase")
+        assert len(findings) == 1
+
+    def test_json_file_no_findings(self) -> None:
+        findings = self._check("logging_json")
+        assert len(findings) == 0
+
+    def test_syslog_no_findings(self) -> None:
+        findings = self._check("logging_syslog")
+        assert len(findings) == 0
+
+    def test_no_logging_config_no_findings(self) -> None:
+        findings = self._check("no_logging_config")
+        assert len(findings) == 0
+
+    def test_has_fix_guidance(self) -> None:
+        findings = self._check("logging_none")
+        assert findings[0].fix is not None
+        assert "json-file" in findings[0].fix
+
+    def test_has_references(self) -> None:
+        findings = self._check("logging_none")
+        assert len(findings[0].references) > 0
+
+    def test_metadata(self) -> None:
+        meta = self.rule.metadata
+        assert meta.id == "CL-0014"
+        assert meta.severity.value == "medium"

--- a/tests/test_CL0015.py
+++ b/tests/test_CL0015.py
@@ -1,0 +1,55 @@
+"""Tests for CL-0015: Healthcheck explicitly disabled."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from compose_lint.parser import load_compose
+from compose_lint.rules.CL0015_healthcheck_disabled import HealthcheckDisabledRule
+
+FIXTURES = Path(__file__).parent / "compose_files"
+
+
+class TestHealthcheckDisabledRule:
+    """Tests for healthcheck disabled detection."""
+
+    def setup_method(self) -> None:
+        self.rule = HealthcheckDisabledRule()
+
+    def _check(self, service_name: str) -> list:
+        data, lines = load_compose(FIXTURES / "insecure_healthcheck.yml")
+        return list(
+            self.rule.check(service_name, data["services"][service_name], data, lines)
+        )
+
+    def test_detects_disabled(self) -> None:
+        findings = self._check("disabled")
+        assert len(findings) == 1
+        assert findings[0].rule_id == "CL-0015"
+        assert "disabled" in findings[0].message.lower()
+
+    def test_configured_no_findings(self) -> None:
+        findings = self._check("configured")
+        assert len(findings) == 0
+
+    def test_no_healthcheck_no_findings(self) -> None:
+        findings = self._check("no_healthcheck")
+        assert len(findings) == 0
+
+    def test_disable_false_no_findings(self) -> None:
+        findings = self._check("disable_false")
+        assert len(findings) == 0
+
+    def test_has_fix_guidance(self) -> None:
+        findings = self._check("disabled")
+        assert findings[0].fix is not None
+        assert "healthcheck" in findings[0].fix.lower()
+
+    def test_has_references(self) -> None:
+        findings = self._check("disabled")
+        assert len(findings[0].references) == 2
+
+    def test_metadata(self) -> None:
+        meta = self.rule.metadata
+        assert meta.id == "CL-0015"
+        assert meta.severity.value == "low"

--- a/tests/test_CL0016.py
+++ b/tests/test_CL0016.py
@@ -1,0 +1,85 @@
+"""Tests for CL-0016: Dangerous host devices exposed."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from compose_lint.parser import load_compose
+from compose_lint.rules.CL0016_dangerous_devices import DangerousDevicesRule
+
+FIXTURES = Path(__file__).parent / "compose_files"
+
+
+class TestDangerousDevicesRule:
+    """Tests for dangerous host device detection."""
+
+    def setup_method(self) -> None:
+        self.rule = DangerousDevicesRule()
+
+    def _check(self, service_name: str) -> list:
+        data, lines = load_compose(FIXTURES / "insecure_devices.yml")
+        return list(
+            self.rule.check(service_name, data["services"][service_name], data, lines)
+        )
+
+    def test_detects_dev_mem(self) -> None:
+        findings = self._check("dev_mem")
+        assert len(findings) == 1
+        assert findings[0].rule_id == "CL-0016"
+        assert "/dev/mem" in findings[0].message
+
+    def test_detects_dev_kmem(self) -> None:
+        findings = self._check("dev_kmem")
+        assert len(findings) == 1
+        assert "/dev/kmem" in findings[0].message
+
+    def test_detects_dev_port(self) -> None:
+        findings = self._check("dev_port")
+        assert len(findings) == 1
+        assert "/dev/port" in findings[0].message
+
+    def test_detects_block_sda(self) -> None:
+        findings = self._check("block_sda")
+        assert len(findings) == 1
+        assert "/dev/sda" in findings[0].message
+
+    def test_detects_block_sda_partition(self) -> None:
+        findings = self._check("block_sda1")
+        assert len(findings) == 1
+        assert "/dev/sda1" in findings[0].message
+
+    def test_detects_nvme(self) -> None:
+        findings = self._check("block_nvme")
+        assert len(findings) == 1
+        assert "/dev/nvme" in findings[0].message
+
+    def test_detects_disk_symlink(self) -> None:
+        findings = self._check("disk_symlink")
+        assert len(findings) == 1
+        assert "/dev/disk/" in findings[0].message
+
+    def test_detects_multiple(self) -> None:
+        findings = self._check("multiple")
+        assert len(findings) == 2
+
+    def test_safe_device_no_findings(self) -> None:
+        findings = self._check("safe_device")
+        assert len(findings) == 0
+
+    def test_no_devices_no_findings(self) -> None:
+        findings = self._check("no_devices")
+        assert len(findings) == 0
+
+    def test_has_fix_guidance(self) -> None:
+        findings = self._check("dev_mem")
+        assert findings[0].fix is not None
+        assert "/dev/mem" in findings[0].fix
+
+    def test_has_references(self) -> None:
+        findings = self._check("dev_mem")
+        assert len(findings[0].references) > 0
+
+    def test_metadata(self) -> None:
+        meta = self.rule.metadata
+        assert meta.id == "CL-0016"
+        assert meta.severity.value == "high"

--- a/tests/test_CL0017.py
+++ b/tests/test_CL0017.py
@@ -1,0 +1,67 @@
+"""Tests for CL-0017: Shared mount propagation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from compose_lint.parser import load_compose
+from compose_lint.rules.CL0017_shared_mount import SharedMountRule
+
+FIXTURES = Path(__file__).parent / "compose_files"
+
+
+class TestSharedMountRule:
+    """Tests for shared mount propagation detection."""
+
+    def setup_method(self) -> None:
+        self.rule = SharedMountRule()
+
+    def _check(self, service_name: str) -> list:
+        data, lines = load_compose(FIXTURES / "insecure_shared_mount.yml")
+        return list(
+            self.rule.check(service_name, data["services"][service_name], data, lines)
+        )
+
+    def test_detects_shared_short_syntax(self) -> None:
+        findings = self._check("shared_short")
+        assert len(findings) == 1
+        assert findings[0].rule_id == "CL-0017"
+        assert "shared mount propagation" in findings[0].message.lower()
+
+    def test_detects_shared_with_other_options(self) -> None:
+        findings = self._check("shared_with_ro")
+        assert len(findings) == 1
+
+    def test_detects_shared_long_syntax(self) -> None:
+        findings = self._check("shared_long")
+        assert len(findings) == 1
+
+    def test_rprivate_no_findings(self) -> None:
+        findings = self._check("rprivate_long")
+        assert len(findings) == 0
+
+    def test_normal_mount_no_findings(self) -> None:
+        findings = self._check("normal_mount")
+        assert len(findings) == 0
+
+    def test_rw_mount_no_findings(self) -> None:
+        findings = self._check("rw_mount")
+        assert len(findings) == 0
+
+    def test_no_volumes_no_findings(self) -> None:
+        findings = self._check("no_volumes")
+        assert len(findings) == 0
+
+    def test_has_fix_guidance(self) -> None:
+        findings = self._check("shared_short")
+        assert findings[0].fix is not None
+        assert "rprivate" in findings[0].fix
+
+    def test_has_references(self) -> None:
+        findings = self._check("shared_short")
+        assert len(findings[0].references) > 0
+
+    def test_metadata(self) -> None:
+        meta = self.rule.metadata
+        assert meta.id == "CL-0017"
+        assert meta.severity.value == "medium"

--- a/tests/test_CL0018.py
+++ b/tests/test_CL0018.py
@@ -1,0 +1,67 @@
+"""Tests for CL-0018: Explicit root user."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from compose_lint.parser import load_compose
+from compose_lint.rules.CL0018_explicit_root import ExplicitRootRule
+
+FIXTURES = Path(__file__).parent / "compose_files"
+
+
+class TestExplicitRootRule:
+    """Tests for explicit root user detection."""
+
+    def setup_method(self) -> None:
+        self.rule = ExplicitRootRule()
+
+    def _check(self, service_name: str) -> list:
+        data, lines = load_compose(FIXTURES / "insecure_root_user.yml")
+        return list(
+            self.rule.check(service_name, data["services"][service_name], data, lines)
+        )
+
+    def test_detects_root_name(self) -> None:
+        findings = self._check("root_name")
+        assert len(findings) == 1
+        assert findings[0].rule_id == "CL-0018"
+        assert "root" in findings[0].message
+
+    def test_detects_root_uid(self) -> None:
+        findings = self._check("root_uid")
+        assert len(findings) == 1
+
+    def test_detects_root_with_group(self) -> None:
+        findings = self._check("root_with_group")
+        assert len(findings) == 1
+
+    def test_detects_root_uid_gid(self) -> None:
+        findings = self._check("root_uid_gid")
+        assert len(findings) == 1
+
+    def test_non_root_no_findings(self) -> None:
+        findings = self._check("non_root")
+        assert len(findings) == 0
+
+    def test_named_user_no_findings(self) -> None:
+        findings = self._check("named_user")
+        assert len(findings) == 0
+
+    def test_no_user_no_findings(self) -> None:
+        findings = self._check("no_user")
+        assert len(findings) == 0
+
+    def test_has_fix_guidance(self) -> None:
+        findings = self._check("root_name")
+        assert findings[0].fix is not None
+        assert "1000" in findings[0].fix
+
+    def test_has_references(self) -> None:
+        findings = self._check("root_name")
+        assert len(findings[0].references) > 0
+
+    def test_metadata(self) -> None:
+        meta = self.rule.metadata
+        assert meta.id == "CL-0018"
+        assert meta.severity.value == "medium"

--- a/tests/test_CL0019.py
+++ b/tests/test_CL0019.py
@@ -1,0 +1,76 @@
+"""Tests for CL-0019: Image tag without digest."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from compose_lint.parser import load_compose
+from compose_lint.rules.CL0019_image_no_digest import ImageNoDigestRule
+
+FIXTURES = Path(__file__).parent / "compose_files"
+
+
+class TestImageNoDigestRule:
+    """Tests for image tag without digest detection."""
+
+    def setup_method(self) -> None:
+        self.rule = ImageNoDigestRule()
+
+    def _check(self, service_name: str) -> list:
+        data, lines = load_compose(FIXTURES / "insecure_image_no_digest.yml")
+        return list(
+            self.rule.check(service_name, data["services"][service_name], data, lines)
+        )
+
+    def test_detects_version_tag_without_digest(self) -> None:
+        findings = self._check("version_tag")
+        assert len(findings) == 1
+        assert findings[0].rule_id == "CL-0019"
+        assert "nginx:1.25.3" in findings[0].message
+
+    def test_detects_alpine_tag_without_digest(self) -> None:
+        findings = self._check("alpine_tag")
+        assert len(findings) == 1
+        assert "nginx:1.27-alpine" in findings[0].message
+
+    def test_detects_registry_tag_without_digest(self) -> None:
+        findings = self._check("registry_tag")
+        assert len(findings) == 1
+        assert "ghcr.io" in findings[0].message
+
+    def test_digest_pinned_no_findings(self) -> None:
+        findings = self._check("digest_pinned")
+        assert len(findings) == 0
+
+    def test_no_tag_no_findings(self) -> None:
+        """CL-0004 handles missing tags, not CL-0019."""
+        findings = self._check("no_tag")
+        assert len(findings) == 0
+
+    def test_latest_tag_no_findings(self) -> None:
+        """CL-0004 handles mutable tags, not CL-0019."""
+        findings = self._check("latest_tag")
+        assert len(findings) == 0
+
+    def test_stable_tag_no_findings(self) -> None:
+        findings = self._check("stable_tag")
+        assert len(findings) == 0
+
+    def test_build_only_no_findings(self) -> None:
+        findings = self._check("build_only")
+        assert len(findings) == 0
+
+    def test_has_fix_guidance(self) -> None:
+        findings = self._check("version_tag")
+        assert findings[0].fix is not None
+        assert "sha256" in findings[0].fix
+        assert "Dependabot" in findings[0].fix or "Renovate" in findings[0].fix
+
+    def test_has_references(self) -> None:
+        findings = self._check("version_tag")
+        assert len(findings[0].references) > 0
+
+    def test_metadata(self) -> None:
+        meta = self.rule.metadata
+        assert meta.id == "CL-0019"
+        assert meta.severity.value == "medium"

--- a/tests/test_CL0019.py
+++ b/tests/test_CL0019.py
@@ -36,7 +36,7 @@ class TestImageNoDigestRule:
     def test_detects_registry_tag_without_digest(self) -> None:
         findings = self._check("registry_tag")
         assert len(findings) == 1
-        assert "ghcr.io" in findings[0].message
+        assert "ghcr.io/org/app:2.0.1" == findings[0].message.split("'")[1]
 
     def test_digest_pinned_no_findings(self) -> None:
         findings = self._check("digest_pinned")

--- a/tests/test_CL0019.py
+++ b/tests/test_CL0019.py
@@ -36,7 +36,7 @@ class TestImageNoDigestRule:
     def test_detects_registry_tag_without_digest(self) -> None:
         findings = self._check("registry_tag")
         assert len(findings) == 1
-        assert "ghcr.io/org/app:2.0.1" == findings[0].message.split("'")[1]
+        assert findings[0].message.split("'")[1] == "ghcr.io/org/app:2.0.1"
 
     def test_digest_pinned_no_findings(self) -> None:
         findings = self._check("digest_pinned")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,7 +26,7 @@ class TestCLI:
         result = run_cli("--version")
         assert result.returncode == 0
         assert "compose-lint" in result.stdout
-        assert "0.2.0" in result.stdout
+        assert "0.3.0" in result.stdout
 
     def test_no_args_no_compose_file(self) -> None:
         result = run_cli()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -19,7 +19,10 @@ class TestLoadCompose:
         assert "services" in data
         assert "web" in data["services"]
         assert "db" in data["services"]
-        assert data["services"]["web"]["image"] == "nginx:1.27-alpine"
+        assert (
+            data["services"]["web"]["image"]
+            == "nginx:1.27-alpine@sha256:a1234567890abcdef"
+        )
 
     def test_returns_plain_dicts(self) -> None:
         data, _lines = load_compose(FIXTURES / "valid_basic.yml")


### PR DESCRIPTION
## Summary

- Add 9 new security rules (CL-0011 through CL-0019): dangerous cap_add, PIDs cgroup limit, sensitive host mounts, logging disabled, healthcheck disabled, dangerous devices, shared mount propagation, explicit root user, image tag without digest
- Enhance CL-0010 with `uts: host` detection (CIS 5.21)
- Bump version to 0.3.0 in `pyproject.toml` and `__init__.py`
- Update CHANGELOG.md with 0.3.0 section

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/` — clean
- [x] `pytest` — 261 passed
- [x] CI green on this PR
- [ ] After merge: tag `v0.3.0`, approve TestPyPI then PyPI, bump marketplace-smoke SHA