### PR TITLE
Post-release 0.3.0 housekeeping

### DIFF
--- a/.github/workflows/marketplace-smoke.yml
+++ b/.github/workflows/marketplace-smoke.yml
@@ -65,7 +65,7 @@ jobs:
           YAML
 
       - name: Clean fixture should pass
-        uses: tmatens/compose-lint@60c091c7cc8f86c6b0c5954031097364fea0a201 # v0.2.0
+        uses: tmatens/compose-lint@8cffa3497225dd41bacc25f266ff7ec196129072 # v0.3.0
         with:
           files: smoke/clean.yml
           fail-on: high
@@ -73,7 +73,7 @@ jobs:
       - name: Insecure fixture should fail
         id: insecure
         continue-on-error: true
-        uses: tmatens/compose-lint@60c091c7cc8f86c6b0c5954031097364fea0a201 # v0.2.0
+        uses: tmatens/compose-lint@8cffa3497225dd41bacc25f266ff7ec196129072 # v0.3.0
         with:
           files: smoke/insecure.yml
           fail-on: high

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.3.0] - 2026-04-12
 
 ### Added


### PR DESCRIPTION
## Summary

- Bump marketplace-smoke.yml `uses:` pins to v0.3.0 commit SHA (`8cffa34`)
- Add empty `[Unreleased]` section to CHANGELOG.md

## Test plan

- [ ] CI green
- [ ] After merge: trigger Actions > Marketplace smoke test > Run workflow to verify the published action