### PR TITLE
Add Docker Hub image, update docs for v0.3.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,38 @@
+# Git and CI
+.git
+.github
+.gitignore
+
+# Python artifacts
+__pycache__
+*.pyc
+*.pyo
+*.egg-info
+dist/
+build/
+
+# Dev/test files
+tests/
+fuzz/
+.clusterfuzzlite/
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+htmlcov/
+
+# Agent/IDE config
+AGENTS.md
+CLAUDE.md
+.claude/
+.vscode/
+.idea/
+
+# Lockfiles (not needed in image)
+requirements.lock
+requirements-dev.lock
+
+# Misc
+.env
+*.md
+!README.md
+!LICENSE

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,123 @@
+name: Docker Publish
+
+on:
+  push:
+    tags:
+      - "v*"
+
+# Default to read-only — individual jobs request what they need.
+permissions:
+  contents: read
+
+jobs:
+  build-test-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: write      # ghcr.io push (optional mirror)
+      id-token: write      # cosign keyless signing via Sigstore OIDC
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: composelint/compose-lint
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+
+      # Build for testing (load into local docker, single platform)
+      - name: Build image for testing
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          load: true
+          tags: composelint/compose-lint:test
+
+      # Smoke test: version check
+      - name: Test — version output matches tag
+        run: |
+          expected="${GITHUB_REF_NAME#v}"
+          actual="$(docker run --rm composelint/compose-lint:test --version)"
+          echo "Expected: ${expected}"
+          echo "Actual:   ${actual}"
+          if [ "${actual}" != "${expected}" ]; then
+            echo "::error::Version mismatch: image reports '${actual}', tag is '${expected}'"
+            exit 1
+          fi
+
+      # Smoke test: lint a clean fixture
+      - name: Test — clean fixture exits 0
+        run: |
+          cat > /tmp/clean.yml <<'YAML'
+          services:
+            web:
+              image: nginx:1.27-alpine
+              ports:
+                - "127.0.0.1:8080:80"
+              security_opt:
+                - no-new-privileges:true
+              cap_drop:
+                - ALL
+              read_only: true
+          YAML
+          docker run --rm -v /tmp/clean.yml:/src/docker-compose.yml composelint/compose-lint:test
+
+      # Smoke test: lint an insecure fixture
+      - name: Test — insecure fixture exits 1
+        run: |
+          cat > /tmp/insecure.yml <<'YAML'
+          services:
+            app:
+              image: myapp:1.0
+              privileged: true
+          YAML
+          exit_code=0
+          docker run --rm -v /tmp/insecure.yml:/src/docker-compose.yml composelint/compose-lint:test || exit_code=$?
+          if [ "${exit_code}" -ne 1 ]; then
+            echo "::error::Expected exit code 1, got ${exit_code}"
+            exit 1
+          fi
+
+      # Smoke test: SARIF output is valid JSON
+      - name: Test — SARIF output is valid JSON
+        run: |
+          cat > /tmp/test.yml <<'YAML'
+          services:
+            db:
+              image: postgres:16
+          YAML
+          docker run --rm -v /tmp/test.yml:/src/docker-compose.yml composelint/compose-lint:test --format sarif --fail-on critical | python3 -c "import sys,json; json.load(sys.stdin); print('Valid SARIF JSON')"
+
+      # All tests passed — build multi-arch and push
+      - name: Build and push (multi-arch)
+        id: push
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # Sign the image with cosign (keyless / Sigstore OIDC)
+      - name: Sign image with cosign
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          cosign sign --yes "composelint/compose-lint@${DIGEST}"

--- a/.github/workflows/marketplace-smoke.yml
+++ b/.github/workflows/marketplace-smoke.yml
@@ -65,7 +65,7 @@ jobs:
           YAML
 
       - name: Clean fixture should pass
-        uses: tmatens/compose-lint@60c091c7cc8f86c6b0c5954031097364fea0a201 # v0.2.0
+        uses: tmatens/compose-lint@8cffa3497225dd41bacc25f266ff7ec196129072 # v0.3.0
         with:
           files: smoke/clean.yml
           fail-on: high
@@ -73,7 +73,7 @@ jobs:
       - name: Insecure fixture should fail
         id: insecure
         continue-on-error: true
-        uses: tmatens/compose-lint@60c091c7cc8f86c6b0c5954031097364fea0a201 # v0.2.0
+        uses: tmatens/compose-lint@8cffa3497225dd41bacc25f266ff7ec196129072 # v0.3.0
         with:
           files: smoke/insecure.yml
           fail-on: high

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.3.0] - 2026-04-12
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1
+# Build: docker build -t composelint/compose-lint .
+# Run:   docker run --rm -v "$(pwd):/src" composelint/compose-lint
+
+# --- build stage: wheel only, no dev deps ---
+FROM python:3.13-alpine@sha256:70dd89363f8665af9a8076ef505bfd8b8bf2fb0b3ab45860cd3494ab7197fe73 AS build
+WORKDIR /build
+COPY pyproject.toml README.md LICENSE ./
+COPY src/ src/
+RUN pip install --no-cache-dir build~=1.0 \
+    && python -m build --wheel --outdir /dist
+
+# --- runtime stage: minimal install ---
+FROM python:3.13-alpine@sha256:70dd89363f8665af9a8076ef505bfd8b8bf2fb0b3ab45860cd3494ab7197fe73
+LABEL org.opencontainers.image.title="compose-lint" \
+      org.opencontainers.image.description="Security-focused linter for Docker Compose files" \
+      org.opencontainers.image.url="https://github.com/tmatens/compose-lint" \
+      org.opencontainers.image.source="https://github.com/tmatens/compose-lint" \
+      org.opencontainers.image.licenses="MIT"
+COPY --from=build /dist /dist
+RUN pip install --no-cache-dir /dist/*.whl \
+    && rm -rf /dist
+# Non-root user; /src is the default working directory for mounted compose files
+RUN adduser -D -h /src linter
+USER linter
+WORKDIR /src
+ENTRYPOINT ["compose-lint"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ When run without arguments, compose-lint automatically finds `compose.yml`, `com
 compose-lint docker-compose.yml docker-compose.prod.yml
 ```
 
+### Docker
+
+```bash
+docker run --rm -v "$(pwd):/src" composelint/compose-lint
+```
+
+Or scan a specific file:
+
+```bash
+docker run --rm -v "$(pwd):/src" composelint/compose-lint docker-compose.prod.yml
+```
+
 ## Example Output
 
 ```
@@ -63,7 +75,16 @@ docker-compose.yml: 1 critical, 1 high
 | [CL-0007](docs/rules/CL-0007.md) | MEDIUM | Filesystem not read-only | [Rule #8](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-8---set-filesystem-and-volumes-to-read-only) | 5.12 |
 | [CL-0008](docs/rules/CL-0008.md) | HIGH | Host network mode | [Rule #5](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-5---be-mindful-of-inter-container-connectivity) | 5.9 |
 | [CL-0009](docs/rules/CL-0009.md) | HIGH | Security profile disabled | [Rule #6](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-6---use-linux-security-module-seccomp-apparmor-or-selinux) | 5.21 |
-| [CL-0010](docs/rules/CL-0010.md) | HIGH | Host namespace sharing | [Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3---limit-capabilities-grant-only-specific-capabilities-needed-by-a-container) | 5.8, 5.15, 5.16 |
+| [CL-0010](docs/rules/CL-0010.md) | HIGH | Host namespace sharing | [Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3---limit-capabilities-grant-only-specific-capabilities-needed-by-a-container) | 5.8, 5.15, 5.16, 5.21 |
+| [CL-0011](docs/rules/CL-0011.md) | HIGH | Dangerous capabilities added | [Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3---limit-capabilities-grant-only-specific-capabilities-needed-by-a-container) | 5.5 |
+| [CL-0012](docs/rules/CL-0012.md) | MEDIUM | PIDs cgroup limit disabled | — | 5.29 |
+| [CL-0013](docs/rules/CL-0013.md) | HIGH | Sensitive host path mounted | [Rule #8](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-8---set-filesystem-and-volumes-to-read-only) | 5.5 |
+| [CL-0014](docs/rules/CL-0014.md) | MEDIUM | Logging driver disabled | — | 5.x |
+| [CL-0015](docs/rules/CL-0015.md) | LOW | Healthcheck disabled | — | 4.6, 5.27 |
+| [CL-0016](docs/rules/CL-0016.md) | HIGH | Dangerous host device exposed | — | 5.18 |
+| [CL-0017](docs/rules/CL-0017.md) | MEDIUM | Shared mount propagation | — | 5.20 |
+| [CL-0018](docs/rules/CL-0018.md) | MEDIUM | Explicit root user | [Rule #7](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-7---do-not-run-containers-with-a-root-user) | 5.x |
+| [CL-0019](docs/rules/CL-0019.md) | MEDIUM | Image tag without digest | [Rule #13](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-13---enhance-supply-chain-security) | 5.27 |
 
 ## Severity Levels
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -203,6 +203,18 @@ reused even after deletion.
 - [ ] The "Build provenance" section on the PyPI page shows the Sigstore
       attestation linked to this repo and the `publish.yml` workflow.
 
+## Approve the Docker Hub publish
+
+The tag push also triggers `.github/workflows/docker-publish.yml`, which
+builds a multi-arch image (`linux/amd64`, `linux/arm64`), runs smoke tests
+(version check, clean/insecure fixtures, SARIF output), pushes to Docker
+Hub as `composelint/compose-lint`, and signs the image with cosign
+(Sigstore keyless).
+
+- [ ] Docker publish workflow completes green.
+- [ ] `docker pull composelint/compose-lint:X.Y.Z` succeeds.
+- [ ] `cosign verify composelint/compose-lint:X.Y.Z --certificate-identity-regexp=github --certificate-oidc-issuer=https://token.actions.githubusercontent.com` passes.
+
 ## Post-release
 
 - [ ] Create a GitHub Release from the tag

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,44 +1,12 @@
 # Roadmap
 
-compose-lint v0.2.0 has a proven core engine — 10 rules, PyPI distribution, SARIF/JSON/text output, pre-commit support. The gap is coverage, distribution reach, and developer experience.
+compose-lint v0.3.0 shipped 19 rules, PyPI distribution, SARIF/JSON/text output, pre-commit support, and a GitHub Action. The gap is distribution reach and developer experience.
 
 ---
 
-## Milestone 1 — Rule Coverage (v0.3)
+## Milestone 1 — Rule Coverage (v0.3) [complete]
 
-The existing 10 rules cover the most critical OWASP/CIS items. This milestone fills the next tier before expanding distribution. More installs means more exposure to false negatives; completeness comes first.
-
-Each candidate was evaluated against three criteria: (1) actionability — is the finding specific enough to fix without guessing?; (2) false positive rate — does the absence of a field have a legitimate default?; (3) right tool — can a Compose linter detect this without image inspection or runtime state?
-
-**New rules (CL-0011 – CL-0017)**
-
-| Rule ID | Check | Severity | Grounding |
-|---------|-------|----------|-----------|
-| CL-0011 | Dangerous `cap_add` values (`SYS_ADMIN`, `SYS_PTRACE`, `NET_ADMIN`, `SYS_MODULE`, `SYS_RAWIO`, `SYS_TIME`, `DAC_READ_SEARCH`) | HIGH | OWASP Rule #3, CIS 5.5 |
-| CL-0012 | PIDs cgroup limit disabled (`pids_limit: 0` or `pids_limit: -1`) | MEDIUM | CIS 5.29 |
-| CL-0013 | Sensitive host paths mounted (`volumes:` containing `/etc`, `/proc`, `/sys`, `/boot`, `/root`) | HIGH | OWASP Rule #8, CIS 5.5 |
-| CL-0014 | Logging driver disabled (`logging.driver: none`) | MEDIUM | CIS 5.x |
-| CL-0015 | Healthcheck explicitly disabled (`healthcheck: {disable: true}`) | LOW | CIS 4.6, 5.27 |
-| CL-0016 | Dangerous host devices exposed (`devices:` matching `/dev/mem`, `/dev/kmem`, `/dev/port`, block devices `/dev/sd*`, `/dev/nvme*`, `/dev/disk/*`) | HIGH | CIS 5.18 |
-| CL-0017 | Shared mount propagation (`:shared` suffix or `bind.propagation: shared`) | MEDIUM | CIS 5.20 |
-| CL-0018 | Explicit root user (`user: root` or `user: "0"`) — overrides a correctly built image's non-root USER instruction | MEDIUM | OWASP Rule #7, CIS 5.x |
-| CL-0019 | Image pinned to tag but not digest (`nginx:1.25.3` without `@sha256:`) — tag can be silently overwritten on the registry | MEDIUM | OWASP Rule #13, CIS 5.27 |
-
-CL-0019 fires only when a version tag is present but no `@sha256:` digest. CL-0004 fires when there is no version tag at all. They are non-overlapping: `nginx` and `nginx:latest` trigger CL-0004 only; `nginx:1.25.3` triggers CL-0019 only; `nginx:1.25.3@sha256:…` triggers neither. Fix guidance should reference Dependabot and Renovate as the practical path for keeping digests current.
-
-**CL-0010 enhancement**: Add `uts: host` to the existing host namespace rule (CIS 5.21 — sharing the UTS namespace lets a container change the host's hostname).
-
-**Rules evaluated and rejected:**
-
-| Candidate | Rejection reason |
-|-----------|-----------------|
-| Hardcoded secrets in `environment:` | Too many false positives — `CONFIG_KEY`, `NEXT_PUBLIC_API_KEY`, `APP_SECRET_NAME` all match naive patterns but are not secrets. Regex on key names erodes trust. |
-| No memory/CPU resource limits | Absence check; fires on every dev Compose file where limits are intentionally omitted. Only explicit opt-outs like `pids_limit: -1` are appropriate. |
-| Service running as root (absence of `user:`) | Wrong tool — absence of `user:` does not imply root; the image's USER instruction determines the UID. Unactionable: "add `user:`" is not a specific fix without knowing the image's intended UID. CL-0018 catches the explicit override case instead. |
-| `restart: always` without failure limit | Fires on virtually every production Compose file; CIS 5.15 concern is system stability, not a security misconfiguration detectable by static analysis. |
-| Ulimit overrides (`ulimits: {nproc: -1}`) | Lower priority — `pids_limit: -1` covers the fork bomb case with higher signal and simpler detection. |
-
-**Section 4 (Container Images) verdict**: Only `healthcheck: {disable: true}` yields a viable rule. All other Section 4 controls require image inspection, Dockerfile analysis, or host-level configuration that a Compose linter cannot access.
+**Shipped in v0.3.0.** Added 9 rules (CL-0011 – CL-0019) plus CL-0010 `uts: host` enhancement, bringing the total to 19 rules. See CHANGELOG.md for details.
 
 ---
 
@@ -46,10 +14,12 @@ CL-0019 fires only when a version tag is present but no `@sha256:` digest. CL-00
 
 Reduce friction from "have Python" to "run one command."
 
-**Docker Hub image** (`composelint/compose-lint`)
-- Minimal image (python:3.13-alpine base, digest-pinned)
+**Docker Hub image** (`composelint/compose-lint`) [complete]
+- Multi-stage build on `python:3.13-alpine` (digest-pinned), ~25 MB final image
+- Multi-arch: `linux/amd64`, `linux/arm64`
 - Enables `docker run --rm -v $(pwd):/src composelint/compose-lint`
-- Published via GitHub Actions OIDC; signed with cosign
+- Published via GitHub Actions on tag push; signed with cosign (Sigstore keyless)
+- Automated smoke tests in CI: version check, clean/insecure fixtures, SARIF output validation
 - Primary audience: teams that distrust pip in CI, or non-Python shops
 
 **Linux packages**
@@ -61,7 +31,7 @@ Reduce friction from "have Python" to "run one command."
 - `brew install tmatens/tap/compose-lint`
 - Widens macOS developer reach beyond pip users
 
-**Implementation note**: The Docker image uses `shiv` to produce a zipapp (works on any Python 3.10+ host without a wheel install). The `.deb`/`.rpm` bundle Python via nfpm. This avoids PyInstaller cross-compilation maintenance.
+**Implementation note**: The Docker image builds a standard wheel in a build stage, then installs it into a clean Alpine runtime stage. The `.deb`/`.rpm` will bundle Python via nfpm. This avoids PyInstaller cross-compilation maintenance.
 
 ---
 
@@ -122,8 +92,8 @@ Pursue based on user demand after v1.0.
 
 | Milestone | Version |
 |-----------|---------|
-| Rule Coverage (19 rules) | v0.3 |
-| Distribution (Docker Hub, packages, Homebrew) | v0.4 |
+| Rule Coverage (19 rules) | v0.3 [complete] |
+| Distribution (Docker Hub, packages, Homebrew) | v0.4 [Docker Hub complete] |
 | Remediation (`--fix`, SARIF fixes, `--explain`) | v0.5 |
 | VS Code extension + GA | v1.0 |
 | Ecosystem integrations, custom rules | v1.x |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,8 @@ exclude = [
     ".clusterfuzzlite/",
     "requirements.lock",
     "requirements-dev.lock",
+    "Dockerfile",
+    ".dockerignore",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -106,4 +108,6 @@ exclude = [
     ".clusterfuzzlite/",
     "requirements.lock",
     "requirements-dev.lock",
+    "Dockerfile",
+    ".dockerignore",
 ]


### PR DESCRIPTION
## Summary
- **Dockerfile**: multi-stage build on `python:3.13-alpine` (digest-pinned), non-root user, ~25 MB final image
- **docker-publish.yml**: fully automated on tag push — builds multi-arch (amd64/arm64), runs 4 smoke tests, pushes to `composelint/compose-lint`, signs with cosign (Sigstore keyless). All actions SHA-pinned.
- **README**: adds Docker usage section, adds CL-0011–CL-0019 to rules table (were missing after v0.3.0)
- **RELEASING.md**: adds Docker Hub verification steps to release checklist
- **ROADMAP.md**: marks milestone 1 complete, Docker Hub complete in milestone 2

## Setup required
`DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repo secrets are already configured.

## Test plan
- [ ] CI passes (lint, type-check, test matrix, security scan)
- [ ] Review Dockerfile for minimal attack surface
- [ ] Review workflow smoke tests cover golden path + failure case
- [ ] On next tag push, verify Docker image builds, tests pass, pushes, and cosign signature verifies