### PR TITLE
Prepare 0.3.1 release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,9 +26,8 @@ CLAUDE.md
 .vscode/
 .idea/
 
-# Lockfiles (not needed in image)
-requirements.lock
-requirements-dev.lock
+# Lockfiles not needed in compose-lint image but kept in context
+# because the ClusterFuzzLite Dockerfile (COPY .) needs requirements.lock
 
 # Misc
 .env

--- a/.dockerignore
+++ b/.dockerignore
@@ -14,7 +14,6 @@ build/
 # Dev/test files
 tests/
 fuzz/
-.clusterfuzzlite/
 .mypy_cache/
 .pytest_cache/
 .ruff_cache/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,36 +1,19 @@
-# Git and CI
-.git
-.github
-.gitignore
+# Shared by the compose-lint Dockerfile and the ClusterFuzzLite Dockerfile.
+# Keep this minimal — the compose-lint Dockerfile already COPYs only the
+# paths it needs; the fuzz Dockerfile uses COPY . and needs most of the repo.
 
-# Python artifacts
+.git
 __pycache__
 *.pyc
 *.pyo
 *.egg-info
 dist/
 build/
-
-# Dev/test files
-tests/
-fuzz/
 .mypy_cache/
 .pytest_cache/
 .ruff_cache/
 htmlcov/
-
-# Agent/IDE config
-AGENTS.md
-CLAUDE.md
 .claude/
 .vscode/
 .idea/
-
-# Lockfiles not needed in compose-lint image but kept in context
-# because the ClusterFuzzLite Dockerfile (COPY .) needs requirements.lock
-
-# Misc
 .env
-*.md
-!README.md
-!LICENSE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-04-12
+
+### Added
+
+- Docker Hub image (`composelint/compose-lint`) — multi-stage build on
+  `python:3.13-alpine`, multi-arch (`linux/amd64`, `linux/arm64`), runs as
+  non-root, signed with cosign (Sigstore keyless).
+- Docker usage section in README.
+- README rules table now lists all 19 rules (CL-0011–CL-0019 were missing).
+- Automated TestPyPI smoke test in publish workflow — installs from TestPyPI,
+  verifies `--version`, runs fixture tests. Real PyPI publish is gated on it.
+- Automated post-push verification in Docker publish workflow — pulls by
+  digest, verifies cosign signature, checks version output.
+
 ## [0.3.0] - 2026-04-12
 
 ### Added
@@ -80,5 +94,6 @@ First public release.
   inputs through `env:` rather than direct `${{ }}` interpolation to prevent
   shell injection.
 
+[0.3.1]: https://github.com/tmatens/compose-lint/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/tmatens/compose-lint/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/tmatens/compose-lint/releases/tag/v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "compose-lint"
-version = "0.3.0"
+version = "0.3.1"
 description = "A security-focused linter for Docker Compose files"
 readme = "README.md"
 license = "MIT"

--- a/src/compose_lint/__init__.py
+++ b/src/compose_lint/__init__.py
@@ -1,3 +1,3 @@
 """A security-focused linter for Docker Compose files."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,7 +26,9 @@ class TestCLI:
         result = run_cli("--version")
         assert result.returncode == 0
         assert "compose-lint" in result.stdout
-        assert "0.3.0" in result.stdout
+        from compose_lint import __version__
+
+        assert __version__ in result.stdout
 
     def test_no_args_no_compose_file(self) -> None:
         result = run_cli()


### PR DESCRIPTION
## Summary
- Bump version to 0.3.1 in `pyproject.toml` and `__init__.py`
- Add changelog entry for Docker Hub image, README updates, and automated smoke tests

## Test plan
- [ ] CI green
- [ ] After merge: tag `v0.3.1`, push tag, verify full pipeline (TestPyPI smoke -> PyPI -> Docker build/test/push/sign/verify)