### PR TITLE
Fix version check to match --version output format

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,12 +52,12 @@ jobs:
       # Smoke test: version check
       - name: Test — version output matches tag
         run: |
-          expected="${GITHUB_REF_NAME#v}"
+          expected="compose-lint ${GITHUB_REF_NAME#v}"
           actual="$(docker run --rm composelint/compose-lint:test --version)"
           echo "Expected: ${expected}"
           echo "Actual:   ${actual}"
           if [ "${actual}" != "${expected}" ]; then
-            echo "::error::Version mismatch: image reports '${actual}', tag is '${expected}'"
+            echo "::error::Version mismatch: image reports '${actual}', expected '${expected}'"
             exit 1
           fi
 
@@ -142,7 +142,7 @@ jobs:
         env:
           DIGEST: ${{ steps.push.outputs.digest }}
         run: |
-          expected="${GITHUB_REF_NAME#v}"
+          expected="compose-lint ${GITHUB_REF_NAME#v}"
           actual="$(docker run --rm "composelint/compose-lint@${DIGEST}" --version)"
           echo "Expected: ${expected}"
           echo "Actual:   ${actual}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,11 +75,12 @@ jobs:
           python-version: "3.13"
       - name: Install from TestPyPI and verify version
         run: |
-          expected="${GITHUB_REF_NAME#v}"
+          version="${GITHUB_REF_NAME#v}"
           pip install \
             -i https://test.pypi.org/simple/ \
             --extra-index-url https://pypi.org/simple/ \
-            "compose-lint==${expected}"
+            "compose-lint==${version}"
+          expected="compose-lint ${version}"
           actual="$(compose-lint --version)"
           echo "Expected: ${expected}"
           echo "Actual:   ${actual}"


### PR DESCRIPTION
## Summary
- Version smoke tests compared against `0.3.1` but `--version` outputs `compose-lint 0.3.1`
- Fixes checks in both `docker-publish.yml` and `publish.yml`

## Test plan
- [ ] CI passes
- [ ] Re-run Docker publish after merge + re-tag