### PR TITLE
Prepare 0.3.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.1] - 2026-04-12
+## [0.3.2] - 2026-04-12
 
 ### Added
 
@@ -94,6 +94,6 @@ First public release.
   inputs through `env:` rather than direct `${{ }}` interpolation to prevent
   shell injection.
 
-[0.3.1]: https://github.com/tmatens/compose-lint/compare/v0.3.0...v0.3.1
+[0.3.2]: https://github.com/tmatens/compose-lint/compare/v0.3.0...v0.3.2
 [0.3.0]: https://github.com/tmatens/compose-lint/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/tmatens/compose-lint/releases/tag/v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "compose-lint"
-version = "0.3.1"
+version = "0.3.2"
 description = "A security-focused linter for Docker Compose files"
 readme = "README.md"
 license = "MIT"

--- a/src/compose_lint/__init__.py
+++ b/src/compose_lint/__init__.py
@@ -1,3 +1,3 @@
 """A security-focused linter for Docker Compose files."""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"


### PR DESCRIPTION
## Summary
- Bump version to 0.3.2 (0.3.1 burned on Docker Hub due to immutable tags + version check bug)
- Same changelog content as 0.3.1 — no code changes, just version number

## Test plan
- [ ] CI green
- [ ] After merge: tag v0.3.2, verify full pipeline end-to-end