### PR TITLE
Cosign verify retry + release workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -133,10 +133,18 @@ jobs:
         env:
           DIGEST: ${{ steps.push.outputs.digest }}
         run: |
-          cosign verify \
-            --certificate-identity-regexp="github\.com/tmatens/compose-lint" \
-            --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
-            "composelint/compose-lint@${DIGEST}"
+          for attempt in 1 2 3; do
+            if cosign verify \
+              --certificate-identity-regexp="github\.com/tmatens/compose-lint" \
+              --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+              "composelint/compose-lint@${DIGEST}"; then
+              exit 0
+            fi
+            echo "Attempt ${attempt} failed, waiting 15s for signature propagation..."
+            sleep 15
+          done
+          echo "::error::cosign verify failed after 3 attempts"
+          exit 1
 
       - name: Verify — published image version matches tag
         env:


### PR DESCRIPTION
## Summary
- **cosign verify retry**: adds retry loop (3 attempts, 15s apart) for signature propagation delay
- **release.yml**: new workflow_dispatch to create release tags from the GitHub UI
  - Validates version matches `pyproject.toml`, `__init__.py`, and `CHANGELOG.md`
  - Checks CI passed on main HEAD
  - Creates annotated tag via GitHub API
  - Supports dry-run mode
- **RELEASING.md**: updated to document both UI and local tag creation

## Test plan
- [ ] CI green
- [ ] After merge + version bump: run Release workflow with dry-run to verify validation
- [ ] Run Release workflow for real to create tag and trigger full pipeline