### PR TITLE
Add Docker Scout vuln scan, SBOM attestation, and pre-push signing hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -6,10 +6,10 @@ while read local_ref local_sha remote_ref remote_sha; do
     continue  # branch deletion, skip
   fi
 
-  base="${remote_sha:-$(git rev-list --max-parents=0 HEAD)}"
-  if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
-    base=$(git rev-list --max-parents=0 HEAD)
-  fi
+  # Only check commits unique to this branch — not commits already on main
+  # (including GitHub squash-merge commits which carry GitHub's own key).
+  base=$(git merge-base "$local_sha" origin/main 2>/dev/null \
+    || git rev-list --max-parents=0 HEAD)
 
   while IFS= read -r line; do
     sha="${line%% *}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -175,6 +175,17 @@ jobs:
               image: postgres:16
           YAML
           docker run --rm -v /tmp/test.yml:/src/docker-compose.yml composelint/compose-lint:test --format sarif --fail-on critical | python3 -c "import sys,json; json.load(sys.stdin); print('Valid SARIF JSON')"
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Scan for vulnerabilities (Docker Scout)
+        uses: docker/scout-action@bacf462e8d090c09660de30a6ccc718035f961e3 # v1.20.4
+        with:
+          command: cves
+          image: local://composelint/compose-lint:test
+          only-severities: critical
+          exit-code: true
 
   # Single approval gate — all smoke tests (PyPI + Docker) must pass first.
   # Configure the 'release' GitHub Environment with required reviewers.
@@ -209,7 +220,7 @@ jobs:
   docker-publish:
     needs: release-gate
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     permissions:
       contents: read
       packages: write
@@ -283,3 +294,15 @@ jobs:
             echo "::error::Published image version mismatch: '${actual}' vs tag '${expected}'"
             exit 1
           fi
+      - name: Generate SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: composelint/compose-lint@${{ steps.push.outputs.digest }}
+          format: spdx-json
+          output-file: sbom.spdx.json
+      - name: Attest SBOM to image
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          cosign attest --yes --type spdx --predicate sbom.spdx.json \
+            "composelint/compose-lint@${DIGEST}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,6 +117,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -186,6 +189,13 @@ jobs:
           image: local://composelint/compose-lint:test
           only-severities: critical
           exit-code: true
+          sarif-file: scout-results.sarif
+      - name: Upload Scout results to GitHub Security
+        uses: github/codeql-action/upload-sarif@018511a1aac61b6e92783189d8c0081eb8f69932 # v3.28.13
+        if: always()
+        with:
+          sarif_file: scout-results.sarif
+          category: docker-scout
 
   # Single approval gate — all smoke tests (PyPI + Docker) must pass first.
   # Configure the 'release' GitHub Environment with required reviewers.


### PR DESCRIPTION
## Summary

- **`docker-smoke`**: runs Docker Scout (`docker/scout-action@v1.20.4`) against the local image after smoke tests — fails on CRITICAL CVEs before the release gate
- **`docker-publish`**: generates an SPDX SBOM with `anchore/sbom-action@v0.24.0` and attests it to the published image via `cosign attest`
- **`.githooks/pre-push`**: blocks unsigned commits before push; fixed base SHA calculation so it only checks commits not yet on the remote (not the full branch history)
- **`CONTRIBUTING.md`**: documents `git config core.hooksPath .githooks` as part of dev setup

## Notes

- `aquasecurity/trivy-action` was compromised in March 2026 (tags 0.0.1–0.34.2 affected) — Docker Scout used instead
- Scout uses the same vulnerability data Docker Hub already shows
- SBOM is attested to the image digest via cosign — verifiable with `cosign verify-attestation --type spdx`

## Test plan

- [ ] CI passes
- [ ] On next release: confirm Scout scan runs in `docker-smoke` and blocks on CRITICAL CVEs
- [ ] Confirm SBOM attestation appears after `docker-publish` via `cosign verify-attestation`