### PR TITLE
Add ADRs for shellcheck integration and Linux packages

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,10 +22,11 @@ Reduce friction from "have Python" to "run one command."
 - Automated smoke tests in CI: version check, clean/insecure fixtures, SARIF output validation
 - Primary audience: teams that distrust pip in CI, or non-Python shops
 
-**Linux packages**
+**Linux packages** _(pending decision — [ADR-008](adr/008-linux-packages.md))_
 - `.deb` and `.rpm` via `nfpm` — self-contained, no Python required
-- Published to GitHub Releases as build artifacts on every tag
-- Secondary: AUR `compose-lint` PKGBUILD for Arch users
+- Published to GitHub Releases as build artifacts on every tag; signed via GitHub Artifact Attestation
+- Secondary: AUR `compose-lint` PKGBUILD for Arch users (manual push at release time)
+- CI shape: `linux-packages-build` → `linux-packages-smoke` → `release-gate` → `linux-packages-publish`, following the existing staging pattern
 
 **Homebrew tap**
 - `brew install tmatens/tap/compose-lint`
@@ -36,6 +37,12 @@ Reduce friction from "have Python" to "run one command."
 ## Milestone 3 — Better Remediation (v0.5)
 
 Finding a problem is half the value. Remediation guidance is the differentiator versus KICS, which identifies issues but rarely provides exact Compose-specific fix steps.
+
+**Shellcheck integration** _(pending decision — [ADR-007](adr/007-shellcheck-integration.md))_
+- Lint shell commands inside `command` and `entrypoint` (string form) and `healthcheck.test` with `CMD-SHELL`
+- shellcheck invoked via subprocess with `--format=json`; findings reported under their original `SC` codes alongside native `CL-XXXX` rules
+- Optional: rule skips silently if shellcheck is not present in `PATH`
+- Open question: deliver shellcheck as a Linux system package dependency or via `shellcheck-py`
 
 **`--fix` mode** — auto-fix for safe, unambiguous rules:
 - CL-0003: inject `no-new-privileges:true` into `security_opt:`

--- a/docs/adr/007-shellcheck-integration.md
+++ b/docs/adr/007-shellcheck-integration.md
@@ -1,0 +1,23 @@
+# ADR-007: Shellcheck Integration
+
+**Status:** Pending decision
+
+**Context:** Docker Compose files can contain shell commands in `command` and `entrypoint` (string form) and in `healthcheck.test` entries using `CMD-SHELL`. These fields are passed through a shell at runtime, making them subject to the same class of bugs that shellcheck detects in Dockerfiles: unquoted variables (SC2086), legacy backtick substitution (SC2006), silent `cd` failures (SC2164), and others. No existing tool checks these fields.
+
+**Proposed decision:** Integrate shellcheck as an optional external dependency, invoked via subprocess with `--format=json`. If shellcheck is not present in `PATH`, the rule skips silently. Shellcheck findings are remapped to compose file line numbers and reported under their original `SC` codes alongside native `CL-XXXX` rules. How shellcheck is delivered to the user's environment is the open question (see Alternatives).
+
+**Alternatives:**
+
+- **Linux system package (leading option):** shellcheck installed via `apk`/`apt`/etc., detected at runtime via `shutil.which("shellcheck")`. Zero new Python deps, no lockfile changes, works natively on Alpine. Users installing via `pip` must install shellcheck separately.
+- **shellcheck-py:** Python package that bundles the shellcheck binary as a `pip install compose-lint[shellcheck]` optional extra. Simpler install for Python users, but the bundled binary is glibc-linked and does not run on Alpine without additional configuration. Conflicts with the PyYAML-only runtime dep policy (see CLAUDE.md) and requires lockfile regeneration.
+- **Hybrid:** Detect shellcheck in `PATH` first, fall back to `shellcheck-py` if installed as an optional extra. Most flexible but adds two code paths to maintain and test.
+- **Implement shell checks in pure Python:** Would require maintaining a shell parser and duplicating shellcheck's rule set. Not justified when shellcheck already exists.
+- **Always-required shellcheck dep:** Makes the tool fail to run in environments without shellcheck, which is contrary to the optional nature of this feature.
+
+**Rationale:**
+
+- `command` and `entrypoint` in string form, and `healthcheck.test` with `CMD-SHELL`, are the only compose fields where the shell is actually invoked. Array form bypasses the shell; shellcheck findings there would be false positives.
+- Compose performs `$VAR` interpolation before the shell sees the string. Variables resolved by compose must be masked before passing to shellcheck to suppress false SC2086 positives.
+- The existing `LineLoader` (ADR-003) provides line numbers via the `lines` dict returned by `load_compose()`. Shellcheck findings are offset by the compose file line of the extracted shell string.
+- `--format=json` produces structured output that maps cleanly to `Finding` dataclasses without fragile text parsing.
+- Optional integration via `shutil.which` keeps the zero-dep install path intact and avoids breaking environments where shellcheck is unavailable.

--- a/docs/adr/008-linux-packages.md
+++ b/docs/adr/008-linux-packages.md
@@ -1,0 +1,27 @@
+# ADR-008: Linux Package Distribution
+
+**Status:** Pending decision
+
+**Context:** compose-lint is currently distributed via PyPI, Docker Hub, and a GitHub Action. Users who install via system package managers (apt, dnf, pacman) cannot install from PyPI without pip, which is not always present in minimal or managed Linux environments. Adding native `.deb`, `.rpm`, and AUR packages lowers the installation barrier for those users and makes compose-lint installable alongside other system security tools.
+
+**Decision:** Distribute `.deb` and `.rpm` packages via GitHub Releases, built with nfpm. Maintain an AUR package for Arch Linux. No hosted APT or DNF repository.
+
+**Proposed approach:**
+
+- **Build tool:** nfpm, SHA-pinned in CI, produces `.deb` and `.rpm` from a wheel + PyYAML bundled into `/usr/lib/compose-lint/`. An `entrypoint.sh` wrapper at `/usr/bin/compose-lint` invokes the bundled install via `python3`.
+- **Distribution:** Packages are attached to GitHub Releases via `gh release create`. GitHub Artifact Attestation (`gh attestation verify`) satisfies the signing requirement from DISTRIBUTION.md.
+- **AUR:** A `PKGBUILD` is maintained in `packaging/aur/` and pushed to AUR manually at release time. AUR uses `python-yaml` as a declared dep (Arch convention) rather than bundling.
+- **CI shape:** Three new jobs in `publish.yml` — `linux-packages-build`, `linux-packages-smoke`, `linux-packages-publish` — following the staging → smoke → gate → prod pattern from DISTRIBUTION.md. `linux-packages-smoke` feeds the existing `release-gate`.
+
+**Alternatives rejected:**
+
+- **Hosted APT/DNF repository:** Requires custom repo infrastructure and GPG package signing. Not justified for current scale; GitHub Releases only.
+- **arm64 packages:** amd64 first. nfpm supports a matrix build with minimal changes if demand warrants it.
+- **AUR automation via CI:** Would require an AUR SSH key repo secret. Not worth the supply-chain surface area; AUR pushes remain a manual post-release step.
+
+**Rationale:**
+
+- nfpm produces standards-compliant `.deb` and `.rpm` from a single config with no distro-specific tooling on the build host.
+- Bundling PyYAML into the package (`pip install --target`) avoids declaring a system `python3-yaml` dep on Debian/RPM targets, where the package name and availability vary. AUR is the exception — Arch convention prefers declared deps over bundling.
+- GitHub Releases with Artifact Attestation matches the signing posture already established for the Docker image. GPG signing for hosted repos is deferred until there is a reason to run repo infrastructure.
+- GitHub Release creation currently happens manually as a post-release checklist step. `linux-packages-publish` takes this over atomically, removing a manual step.


### PR DESCRIPTION
## Summary

- **ADR-007**: Documents proposed shellcheck integration — optional subprocess invocation, findings reported as `SC` codes, compose variable masking, line number remapping. Delivery mechanism (system package vs `shellcheck-py`) left as a pending decision.
- **ADR-008**: Converts `docs/linux-packages-plan.md` into a formal ADR (pending decision). Plan file removed.
- **Roadmap**: Linux packages and shellcheck integration entries updated with ADR links and pending-decision callouts.

## Test plan

- [ ] ADR-007 renders correctly at `docs/adr/007-shellcheck-integration.md`
- [ ] ADR-008 renders correctly at `docs/adr/008-linux-packages.md`
- [ ] `docs/linux-packages-plan.md` is gone
- [ ] Roadmap links to both ADRs resolve correctly
- [ ] No conflicts with open PRs