### PR TITLE
Brand the text output: header, severity alignment, PASS/FAIL verdict

### DIFF
--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -14,9 +14,14 @@ from compose_lint.engine import filter_findings, run_rules
 from compose_lint.formatters.json import format_findings as format_json
 from compose_lint.formatters.sarif import build_sarif_log
 from compose_lint.formatters.sarif import format_findings as format_sarif
+from compose_lint.formatters.text import (
+    format_aggregate_summary,
+    format_header,
+    format_summary,
+    format_verdict,
+)
 from compose_lint.formatters.text import format_findings as format_text
-from compose_lint.formatters.text import format_summary
-from compose_lint.models import Severity
+from compose_lint.models import Finding, Severity
 from compose_lint.parser import ComposeError, load_compose
 
 
@@ -42,6 +47,14 @@ _COMPOSE_FILENAMES = [
 def _discover_compose_files() -> list[str]:
     """Find Compose files in the current directory."""
     return [name for name in _COMPOSE_FILENAMES if Path(name).is_file()]
+
+
+def _effective_config_path(explicit: str | None) -> Path | None:
+    """Return the config file path that will be used, or None if no config."""
+    if explicit:
+        return Path(explicit)
+    p = Path(".compose-lint.yml")
+    return p if p.exists() else None
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -97,6 +110,8 @@ def main(argv: list[str] | None = None) -> NoReturn:
     parser = _build_parser()
     args = parser.parse_args(argv)
 
+    config_path = _effective_config_path(args.config)
+
     try:
         disabled_rules, severity_overrides = load_config(args.config)
     except ConfigError as e:
@@ -114,8 +129,20 @@ def main(argv: list[str] | None = None) -> NoReturn:
             )
             sys.exit(2)
 
+    # Print branded header in text mode before scanning begins.
+    if args.output_format == "text":
+        print(
+            format_header(
+                args.files,
+                str(config_path) if config_path else None,
+                args.fail_on,
+                __version__,
+            )
+        )
+
     all_json: list[dict[str, object]] = []
     all_sarif: list[dict[str, object]] = []
+    all_file_findings: list[tuple[list[Finding], str]] = []
     has_errors = False
 
     for filepath in args.files:
@@ -143,6 +170,7 @@ def main(argv: list[str] | None = None) -> NoReturn:
             if output:
                 print(output)
             print(format_summary(findings, filepath))
+            all_file_findings.append((findings, filepath))
         elif args.output_format == "sarif":
             all_sarif.extend(format_sarif(findings, filepath))
         else:
@@ -152,7 +180,12 @@ def main(argv: list[str] | None = None) -> NoReturn:
         if failing:
             has_errors = True
 
-    if args.output_format == "json":
+    if args.output_format == "text":
+        if len(args.files) > 1:
+            print()
+            print(format_aggregate_summary(all_file_findings))
+        print(format_verdict(all_file_findings, args.fail_on))
+    elif args.output_format == "json":
         print(json.dumps(all_json, indent=2))
     elif args.output_format == "sarif":
         print(json.dumps(build_sarif_log(all_sarif), indent=2))

--- a/src/compose_lint/formatters/text.py
+++ b/src/compose_lint/formatters/text.py
@@ -13,9 +13,13 @@ _COLORS = {
     Severity.LOW: "\033[36m",  # Cyan
 }
 _SUPPRESSED_COLOR = "\033[90m"  # Gray
+_GREEN = "\033[32m"  # Green for pass / no issues
 _RESET = "\033[0m"
 _BOLD = "\033[1m"
 _DIM = "\033[2m"
+
+# All active severity labels are padded to this width so finding columns align.
+_SEV_WIDTH = max(len(s.value) for s in Severity)  # len("critical") == 8
 
 
 def _colorize(text: str, code: str) -> str:
@@ -23,6 +27,23 @@ def _colorize(text: str, code: str) -> str:
     if not sys.stdout.isatty():
         return text
     return f"{code}{text}{_RESET}"
+
+
+def format_header(
+    files: list[str],
+    config_path: str | None,
+    fail_on: Severity,
+    version: str,
+) -> str:
+    """Format a branded run header showing the tool version and active parameters."""
+    sep = _colorize("·", _DIM)
+    config_str = config_path if config_path else "none"
+    params = (
+        f"files: {', '.join(files)}"
+        f"  {sep}  config: {config_str}"
+        f"  {sep}  fail-on: {fail_on.value}"
+    )
+    return f"{_colorize(f'compose-lint {version}', _BOLD)}\n{params}\n"
 
 
 def format_findings(findings: list[Finding], filepath: str) -> str:
@@ -47,35 +68,28 @@ def format_findings(findings: list[Finding], filepath: str) -> str:
             lines.append("")
             continue
 
-        severity_label = f.severity.value.upper()
+        severity_label = f.severity.value.upper().ljust(_SEV_WIDTH)
         color = _COLORS.get(f.severity, "")
-
-        # Location
         loc = f"{filepath}:{f.line}" if f.line else filepath
 
-        # Main finding line
         lines.append(
             f"{_colorize(loc, _BOLD)}  "
             f"{_colorize(severity_label, color)}  "
             f"{_colorize(f.rule_id, _DIM)}  "
             f"{f.message}"
         )
-
-        # Service name
         lines.append(f"  {_colorize('service:', _DIM)} {f.service}")
 
-        # Fix guidance
         if f.fix:
             fix_lines = f.fix.split("\n")
             lines.append(f"  {_colorize('fix:', _DIM)} {fix_lines[0]}")
             for fix_line in fix_lines[1:]:
                 lines.append(f"       {fix_line}")
 
-        # References
         if f.references:
             lines.append(f"  {_colorize('ref:', _DIM)} {f.references[0]}")
 
-        lines.append("")  # Blank line between findings
+        lines.append("")
 
     return "\n".join(lines).rstrip()
 
@@ -84,9 +98,9 @@ def format_summary(
     findings: list[Finding],
     filepath: str,
 ) -> str:
-    """Format a one-line summary of findings."""
+    """Format a one-line summary of findings for a single file."""
     if not findings:
-        return _colorize(f"{filepath}: no issues found", _DIM)
+        return _colorize(f"{filepath}: no issues found", _GREEN)
 
     by_severity: dict[str, int] = {}
     suppressed_count = 0
@@ -104,10 +118,72 @@ def format_summary(
             color = _COLORS.get(sev, "")
             parts.append(_colorize(f"{count} {sev.value}", color))
 
+    if not parts and not suppressed_count:
+        return _colorize(f"{filepath}: no issues found", _GREEN)
+
+    sep = _colorize("·", _DIM)
+    body = ", ".join(parts) if parts else _colorize("0 issues", _DIM)
     if suppressed_count:
-        parts.append(_colorize(f"{suppressed_count} suppressed", _SUPPRESSED_COLOR))
+        supp_text = f"{suppressed_count} suppressed (not counted)"
+        body += f"  {sep}  {_colorize(supp_text, _SUPPRESSED_COLOR)}"
+    return f"{_colorize(filepath, _BOLD)}: {body}"
 
-    if not parts:
-        return _colorize(f"{filepath}: no issues found", _DIM)
 
-    return f"{_colorize(filepath, _BOLD)}: {', '.join(parts)}"
+def format_aggregate_summary(
+    file_findings: list[tuple[list[Finding], str]],
+) -> str:
+    """Format a combined summary line across all scanned files (multi-file runs)."""
+    total_files = len(file_findings)
+    by_severity: dict[str, int] = {}
+    suppressed_total = 0
+
+    for findings, _ in file_findings:
+        for f in findings:
+            if f.suppressed:
+                suppressed_total += 1
+            else:
+                by_severity[f.severity.value] = by_severity.get(f.severity.value, 0) + 1
+
+    total_issues = sum(by_severity.values())
+    files_label = _colorize(f"{total_files} files scanned", _BOLD)
+    sep = _colorize("·", _DIM)
+
+    if total_issues == 0 and suppressed_total == 0:
+        return f"{files_label}  {sep}  {_colorize('no issues found', _GREEN)}"
+
+    parts = []
+    for sev in (Severity.CRITICAL, Severity.HIGH, Severity.MEDIUM, Severity.LOW):
+        count = by_severity.get(sev.value, 0)
+        if count:
+            parts.append(_colorize(f"{count} {sev.value}", _COLORS[sev]))
+
+    issue_word = "issue" if total_issues == 1 else "issues"
+    breakdown = f" ({', '.join(parts)})" if parts else ""
+    result = f"{files_label}  {sep}  {total_issues} {issue_word}{breakdown}"
+    if suppressed_total:
+        supp_text = f"{suppressed_total} suppressed (not counted)"
+        result += f"  {sep}  {_colorize(supp_text, _SUPPRESSED_COLOR)}"
+    return result
+
+
+def format_verdict(
+    file_findings: list[tuple[list[Finding], str]],
+    fail_on: Severity,
+) -> str:
+    """Return a pass/fail verdict line relative to the --fail-on threshold."""
+    failing = sum(
+        1
+        for findings, _ in file_findings
+        for f in findings
+        if not f.suppressed and f.severity >= fail_on
+    )
+
+    sep = _colorize("·", _DIM)
+    if failing == 0:
+        return f"{_colorize('✓ PASS', _GREEN)}  {sep}  threshold: {fail_on.value}"
+
+    word = "finding" if failing == 1 else "findings"
+    return (
+        f"{_colorize('✗ FAIL', _COLORS[Severity.HIGH])}  {sep}  "
+        f"{failing} {word} at or above {fail_on.value}"
+    )


### PR DESCRIPTION
## Summary

Product-focused polish on the `--format text` console output. No changes to JSON/SARIF schemas. Exit codes (0/1/2) preserved.

- **Branded header** with tool version and active params (`files · config · fail-on`) so runs are self-describing in CI logs
- **Severity badges padded** to 8 chars (critical width) so rule IDs line up across `MEDIUM  `, `HIGH    `, `CRITICAL`, `LOW     `
- **Clean state is green** — `no issues found` promoted from dim gray
- **Multi-file aggregate** line: `3 files scanned · 18 issues (2 critical, 6 high, 10 medium) · 2 suppressed (not counted)`
- **PASS/FAIL verdict** relative to `--fail-on`: `✓ PASS · threshold: high` or `✗ FAIL · N findings at or above high`
- **Suppressed counts** pulled out of the breakdown and labeled `(not counted)` so the math reconciles at a glance

## Example

Before:
```
compose.yml:2  MEDIUM  CL-0003  ...
compose.yml:4  CRITICAL  CL-0002  ...
compose.yml: 1 critical, 8 medium
```

After:
```
compose-lint 0.3.3
files: compose.yml  ·  config: none  ·  fail-on: high

compose.yml:2  MEDIUM    CL-0003  ...
compose.yml:4  CRITICAL  CL-0002  ...
compose.yml: 1 critical, 8 medium
✗ FAIL  ·  1 finding at or above high
```

## Test plan

- [x] `pytest` — 261 passed
- [x] `ruff check src tests` — clean
- [x] `ruff format --check src tests` — clean
- [x] `mypy src` — clean
- [x] Exit codes verified: 0 (clean), 1 (findings at/above threshold), 2 (bad args / missing file)
- [x] JSON output unchanged (flat array preserved for downstream CI consumers)
- [x] SARIF output unchanged (spec-compliant 2.1.0)
- [x] Colors only emitted to TTY (piped output stays plain text)