### PR TITLE
Prepare 0.3.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4] - 2026-04-13
+
+### Changed
+
+- Text output now opens with a branded one-line header showing the tool
+  version and active parameters (`files`, `config`, `fail-on`) so runs are
+  self-describing in CI logs.
+- Severity labels in findings are padded to 8 chars so rule IDs line up
+  across `MEDIUM`, `HIGH`, `CRITICAL`, and `LOW` rows.
+- "No issues found" message is now green instead of dim gray.
+- Multi-file text runs end with an aggregate `N files scanned · N issues
+  (...)` line.
+- Every text run ends with an explicit verdict relative to `--fail-on`:
+  `✓ PASS · threshold: high` or `✗ FAIL · N findings at or above high`.
+- Suppressed counts are separated from the severity breakdown and labeled
+  `(not counted)` so the severity totals reconcile at a glance.
+
+JSON and SARIF output shapes are unchanged. Exit codes (0/1/2) are
+preserved.
+
 ## [0.3.3] - 2026-04-12
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "compose-lint"
-version = "0.3.3"
+version = "0.3.4"
 description = "A security-focused linter for Docker Compose files"
 readme = "README.md"
 license = "MIT"

--- a/src/compose_lint/__init__.py
+++ b/src/compose_lint/__init__.py
@@ -1,3 +1,3 @@
 """A security-focused linter for Docker Compose files."""
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"


### PR DESCRIPTION
## Summary

Patch release bumping `0.3.3 → 0.3.4`.

Picks up #37 — text-mode output polish (branded header, severity alignment, PASS/FAIL verdict, suppressed counts separated from severity breakdown). JSON/SARIF schemas unchanged, exit codes preserved.

## Version bumps

- `pyproject.toml` → `0.3.4`
- `src/compose_lint/__init__.py` → `0.3.4`
- `CHANGELOG.md` — new `[0.3.4] - 2026-04-13` section under `Changed`
- `.github/workflows/marketplace-smoke.yml` — follow-up PR post-tag, per `docs/RELEASING.md`

## Test plan

- [x] `pytest` — 261 passed
- [x] `ruff check src tests` — clean
- [x] `ruff format --check src tests` — clean
- [x] `mypy src` — clean
- [x] Version strings match in `pyproject.toml` and `__init__.py`