### PR TITLE
Fix cosign SBOM attest type for SPDX-JSON predicate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -314,5 +314,5 @@ jobs:
         env:
           DIGEST: ${{ steps.push.outputs.digest }}
         run: |
-          cosign attest --yes --type spdx --predicate sbom.spdx.json \
+          cosign attest --yes --type spdxjson --predicate sbom.spdx.json \
             "composelint/compose-lint@${DIGEST}"


### PR DESCRIPTION
## Summary

The SBOM-attest step in \`docker-publish\` was failing with:

\`\`\`
invalid attestation: decoding json
\`\`\`

Root cause: mismatch between the predicate format and cosign's \`--type\`:
- \`anchore/sbom-action\` runs with \`format: spdx-json\` → produces \`sbom.spdx.json\` (SPDX in JSON)
- \`cosign attest --type spdx\` expects SPDX **tag-value** (plain text), not JSON
- Envelope signs, then fails post-sign validation when cosign re-parses the predicate

Fix: swap \`--type spdx\` for \`--type spdxjson\`, which matches the predicate content type.

Seen on [v0.3.4 run 24375295946](https://github.com/tmatens/compose-lint/actions/runs/24375295946/job/71187691242).

## Release blast radius

This step was non-blocking for 0.3.4 — the image is pushed, signed with cosign (keyless), and version-verified. Only the SBOM attestation is missing. Retro-attach is possible:

\`\`\`bash
# Regenerate SBOM and attach to the published digest
syft composelint/compose-lint:0.3.4 -o spdx-json > sbom.spdx.json
cosign attest --yes --type spdxjson --predicate sbom.spdx.json \\
  "composelint/compose-lint@sha256:6fbdfb69716b5f22a718e36b592f39217098c5f5b244ccc5b1fd3b5b98595953"
\`\`\`

## Test plan

- [ ] Land this PR
- [ ] On next release, confirm \`docker-publish\` job completes including SBOM attest
- [ ] Verify attestation: \`cosign verify-attestation --type spdxjson --certificate-identity-regexp=".*" --certificate-oidc-issuer-regexp=".*" composelint/compose-lint:<version>\`