### PR TITLE
Bump README and marketplace-smoke pin to 0.3.4

### DIFF
--- a/.github/workflows/marketplace-smoke.yml
+++ b/.github/workflows/marketplace-smoke.yml
@@ -65,7 +65,7 @@ jobs:
           YAML
 
       - name: Clean fixture should pass
-        uses: tmatens/compose-lint@29d14a0e4178bec6d7b6b5309969c80d38f81bc7 # v0.3.3
+        uses: tmatens/compose-lint@f8df184088dcce073c7bb17bc536012ad0ea8857 # v0.3.4
         with:
           files: smoke/clean.yml
           fail-on: high
@@ -73,7 +73,7 @@ jobs:
       - name: Insecure fixture should fail
         id: insecure
         continue-on-error: true
-        uses: tmatens/compose-lint@29d14a0e4178bec6d7b6b5309969c80d38f81bc7 # v0.3.3
+        uses: tmatens/compose-lint@f8df184088dcce073c7bb17bc536012ad0ea8857 # v0.3.4
         with:
           files: smoke/insecure.yml
           fail-on: high

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: tmatens/compose-lint@v0.3.3
+      - uses: tmatens/compose-lint@v0.3.4
         with:
           sarif-file: results.sarif
 ```
@@ -190,7 +190,7 @@ compose-lint --format sarif docker-compose.yml > results.sarif
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/tmatens/compose-lint
-    rev: v0.3.3
+    rev: v0.3.4
     hooks:
       - id: compose-lint
 ```


### PR DESCRIPTION
## Summary

Post-release cleanup for 0.3.4. Two user-facing version references plus the Marketplace smoke test's SHA pin.

- \`README.md\` — GitHub Actions usage (\`uses: tmatens/compose-lint@v0.3.4\`) and pre-commit \`rev: v0.3.4\`
- \`.github/workflows/marketplace-smoke.yml\` — both \`uses:\` lines SHA-pinned to \`f8df184\` (v0.3.4 commit) with updated trailing version comment

Per \`docs/RELEASING.md\`, the marketplace-smoke bump has to land *after* the release tag is pushed, because the commit SHA only exists once the tag is in place.

## Out of scope (intentionally)

- \`CHANGELOG.md\` — historical entries, immutable per Keep a Changelog
- \`docs/ROADMAP.md\` — \"v0.3.0 shipped\" is a milestone record, not a current pointer
- \`docs/RELEASING.md\` — \`0.2.0\`/\`0.3.0\`/\`0.3.3\` references are SemVer pedagogy, not live version pins

## Test plan

- [ ] CI green
- [ ] After merge, trigger **Actions → Marketplace smoke test → Run workflow** to verify the new pin resolves the published \`tmatens/compose-lint@v0.3.4\` action end-to-end