### PR TITLE
Watch root Dockerfile with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,14 @@ updates:
       python:
         patterns: ["*"]
 
+  # Runtime image — digest-pinned per AGENTS.md policy. Keeps the
+  # python:3.13-alpine base current so Alpine security fixes (musl,
+  # openssl, etc.) flow in as upstream rebuilds.
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+
   # ClusterFuzzLite build image — digest-pinned per AGENTS.md policy.
   - package-ecosystem: docker
     directory: "/.clusterfuzzlite"


### PR DESCRIPTION
## Summary
- Add a `package-ecosystem: docker` entry for `directory: "/"` in `.github/dependabot.yml`.
- Previously only `/.clusterfuzzlite` was watched, so the runtime `python:3.13-alpine` digest pin in the root `Dockerfile` drifted stale — surfacing as 6 HIGH Alpine CVEs (musl, openssl) in the Security tab via the new Docker Scout scheduled scan (#42).
- This PR alone does **not** clear those CVEs; upstream `python:3.13-alpine` hasn't been rebuilt with patched Alpine packages yet. Once it is, Dependabot will open a digest bump PR automatically.

## Test plan
- [ ] After merge, confirm Dependabot picks up the new entry (Insights → Dependency graph → Dependabot).
- [ ] When upstream rebuilds `python:3.13-alpine`, verify Dependabot opens a PR bumping the `FROM` digests in `Dockerfile`.
- [ ] After that bump merges and republishes, verify the scheduled Scout scan clears the 6 open alerts.