### PR TITLE
Hold Python major bumps for the runtime image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,11 +22,17 @@ updates:
 
   # Runtime image — digest-pinned per AGENTS.md policy. Keeps the
   # python:3.13-alpine base current so Alpine security fixes (musl,
-  # openssl, etc.) flow in as upstream rebuilds.
+  # openssl, etc.) flow in as upstream rebuilds. Python major bumps
+  # are held back because the CI matrix in pyproject.toml is
+  # 3.10–3.13; jumping the shipped image to 3.14 would run users on
+  # an untested interpreter. Re-evaluate when the matrix adds 3.14.
   - package-ecosystem: docker
     directory: "/"
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: "python"
+        update-types: ["version-update:semver-major"]
 
   # ClusterFuzzLite build image — digest-pinned per AGENTS.md policy.
   - package-ecosystem: docker


### PR DESCRIPTION
## Summary
- Add an `ignore` rule under the root docker ecosystem in `.github/dependabot.yml` to skip semver-major bumps of the `python` base image.
- Context: Dependabot just opened #45 proposing `python:3.13-alpine` → `3.14-alpine`. The CI test matrix in `pyproject.toml` covers 3.10–3.13, so jumping the shipped Docker image to 3.14 would run users on an interpreter we don't test against.
- Digest refreshes and minor/patch bumps still flow through — this only holds back the major-version jump. Re-evaluate when the CI matrix adds 3.14.

## Test plan
- [ ] After merge, confirm Dependabot doesn't reopen a 3.14 PR on its next weekly run.
- [ ] Confirm a future digest refresh of `python:3.13-alpine` still produces a PR.