### PR TITLE
Switch runtime image to Google distroless Python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,44 +2,34 @@
 # Build: docker build -t composelint/compose-lint .
 # Run:   docker run --rm -v "$(pwd):/src" composelint/compose-lint
 #
-# Base: Chainguard Wolfi (free, daily CVE rebuilds, glibc).
-# Base digest refresh: docker buildx imagetools inspect cgr.dev/chainguard/wolfi-base:latest
-# apk versions are bumped by Renovate (see renovate.json customManagers).
-
-# renovate: datasource=apk depName=python-3.13 registryUrl=https://packages.wolfi.dev/os
-ARG PYTHON_APK_VERSION=3.13.13-r0
-# renovate: datasource=apk depName=py3.13-pip registryUrl=https://packages.wolfi.dev/os
-ARG PIP_APK_VERSION=26.0.1-r2
+# Runtime: Google distroless Python on Debian 13 (Python 3.13, no shell,
+# no package manager, runs as nonroot UID 65532). See docs/adr/009-runtime-base-image.md.
+# Build stage uses debian:trixie-slim so the build-time Python path
+# (/usr/bin/python3) matches the runtime — the venv transfers across
+# stages without shebang rewriting. Both digests are bumped by Renovate.
 
 # --- build stage: produce wheel, install into a venv ---
-FROM cgr.dev/chainguard/wolfi-base:latest@sha256:1af610c4a70668dad46159ee178b20378c79a49b554f76405670fc442d30183a AS build
-ARG PYTHON_APK_VERSION
-ARG PIP_APK_VERSION
-RUN apk add --no-cache \
-        "python-3.13=${PYTHON_APK_VERSION}" \
-        "py3.13-pip=${PIP_APK_VERSION}"
+FROM debian:trixie-slim@sha256:5fb70129351edec3723d13f427400ecae3f13b83750e23ad47c46721effcf2db AS build
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python3 python3-pip python3-venv \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /build
 COPY pyproject.toml README.md LICENSE ./
 COPY src/ src/
-RUN python3.13 -m venv /venv \
+RUN python3 -m venv /venv \
     && /venv/bin/pip install --no-cache-dir build~=1.0 \
     && /venv/bin/python -m build --wheel --outdir /dist \
     && /venv/bin/pip uninstall -y build \
     && /venv/bin/pip install --no-cache-dir /dist/*.whl
 
-# --- runtime stage: python interpreter + copied venv, no pip ---
-FROM cgr.dev/chainguard/wolfi-base:latest@sha256:1af610c4a70668dad46159ee178b20378c79a49b554f76405670fc442d30183a
-ARG PYTHON_APK_VERSION
+# --- runtime stage: distroless Python, nonroot by default ---
+FROM gcr.io/distroless/python3-debian13:nonroot@sha256:9b1e35ec38db9ee528a2107c84b7d839b4dd412c5e003186aed8bd5e62900bfc
 LABEL org.opencontainers.image.title="compose-lint" \
       org.opencontainers.image.description="Security-focused linter for Docker Compose files" \
       org.opencontainers.image.url="https://github.com/tmatens/compose-lint" \
       org.opencontainers.image.source="https://github.com/tmatens/compose-lint" \
       org.opencontainers.image.licenses="MIT"
-RUN apk add --no-cache "python-3.13=${PYTHON_APK_VERSION}" \
-    && mkdir -p /src \
-    && chown 65532:65532 /src
 COPY --from=build /venv /venv
-ENV PATH="/venv/bin:${PATH}"
-USER nonroot
 WORKDIR /src
-ENTRYPOINT ["compose-lint"]
+ENTRYPOINT ["/venv/bin/compose-lint"]

--- a/docs/adr/009-runtime-base-image.md
+++ b/docs/adr/009-runtime-base-image.md
@@ -1,0 +1,22 @@
+# ADR-009: Runtime Container Base Image
+
+**Status:** Accepted
+
+**Context:** compose-lint ships a Docker image alongside the PyPI wheel. The runtime image was originally `python:3.13-alpine`, then briefly `cgr.dev/chainguard/wolfi-base:latest` with `apk add python-3.13`. Both include a shell, package manager, and busybox-level utilities at runtime, which is larger attack surface than necessary for a local linter. The wolfi-base approach also required Renovate to track apk package versions, which has no built-in datasource in Renovate's free tier — the community workaround (`renovate-apk-indexer`) requires self-hosting an HTTP server and was ruled out.
+
+**Decision:** Runtime image `gcr.io/distroless/python3-debian13:nonroot`; build stage `debian:trixie-slim`. Both digest-pinned.
+
+**Alternatives rejected:**
+
+- **`cgr.dev/chainguard/wolfi-base:latest` + `apk add python-3.13`:** Ships a shell, `apk`, and busybox at runtime. Requires self-hosted Renovate datasource to track apk package versions. Pinned apk versions become unbuildable once Chainguard rotates the index and the old version is removed.
+- **`cgr.dev/chainguard/python:latest`:** Truly distroless and otherwise an excellent fit, but the free tier only publishes `:latest`/`:latest-dev`, which currently resolves to Python 3.14. That is outside the `3.10–3.13` CI matrix and would ship users an untested interpreter. Version-pinned tags (`:3.13`, `:3.13-dev`) require a Chainguard subscription.
+- **`python:3.13-alpine`:** Ships apk + ash shell. musl-based, occasional compatibility surprises with Python wheels vs. glibc.
+
+**Rationale:**
+
+- **Attack surface.** Distroless removes `/bin/sh`, coreutils, `apt`, and busybox. The runtime image contains only the Python interpreter, stdlib, libc, and the project venv. A container escape has nowhere useful to go.
+- **Python version stays inside the CI matrix.** Debian 13 (Trixie) ships Python 3.13; our CI tests 3.10–3.13. No matrix expansion, no policy amendment.
+- **Cross-stage venv transfer works unchanged.** `debian:trixie-slim` and `python3-debian13` both install Python at `/usr/bin/python3`, so the venv built in the build stage is shebang-compatible with the runtime. No `pip install --target` gymnastics.
+- **Simpler Renovate story.** Both `FROM` lines are tracked by Renovate's built-in `docker` datasource via `pinDigests: true`. The `customManagers` regex for apk ARG markers and the apk-specific `packageRules` entry are both removed.
+- **CVE posture is adequate for a local CLI.** Google distroless inherits Debian's security-release cadence — typically 2–7 days behind Chainguard's daily rebuilds. compose-lint has no network listener, no TLS, and no daemon mode; its only attacker-reachable input is a YAML file the operator deliberately handed it. For a networked service the cadence tradeoff would be reconsidered; for this tool the gap is acceptable. Reassess if compose-lint ever grows a long-running or networked mode.
+- **Debian-major upgrades stay human-driven.** Moving from `python3-debian13` to a future `python3-debian14` image changes the tag and likely the Python minor version. Renovate does not bump the image's Debian major automatically; this matches the existing "ship only tested Python" policy.

--- a/renovate.json
+++ b/renovate.json
@@ -28,23 +28,6 @@
       "matchManagers": ["dockerfile"],
       "matchDatasources": ["docker"],
       "pinDigests": true
-    },
-    {
-      "description": "Hold back python-3.13 apk to patch bumps only; a python-minor jump must be a deliberate package-name change.",
-      "matchDatasources": ["apk"],
-      "matchPackageNames": ["python-3.13"],
-      "matchUpdateTypes": ["major", "minor"],
-      "enabled": false
-    }
-  ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "description": "Pick up apk versions declared via 'ARG X=version' with a renovate marker comment.",
-      "fileMatch": ["(^|/)Dockerfile$", "(^|/)\\.clusterfuzzlite/Dockerfile$"],
-      "matchStrings": [
-        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)\\s+registryUrl=(?<registryUrl>\\S+)\\s*\\nARG\\s+[A-Z0-9_]+=(?<currentValue>\\S+)"
-      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Moves the runtime image from `cgr.dev/chainguard/wolfi-base` + `apk add python-3.13` to `gcr.io/distroless/python3-debian13:nonroot`, with `debian:trixie-slim` as the build stage. Both digest-pinned.

## Why

The wolfi-base runtime ships `/bin/sh`, `apk`, and busybox — more attack surface than a linter needs. It also required Renovate to track apk package versions via a `customManagers` regex, but `apk` is not a built-in Renovate datasource (only workaround is self-hosting `renovate-apk-indexer`), so the apk ARG pins triggered the "Missing datasource!" warning on the first Renovate run after silent mode flipped off. Pinned apk versions would also eventually fail the build once Chainguard rotated the index.

Google distroless on Debian 13 is truly distroless (no shell, no package manager), ships Python 3.13.5 which stays inside the existing 3.10–3.13 CI matrix, and is tracked by Renovate's built-in `docker` datasource with zero custom config.

Decision and alternatives recorded in `docs/adr/009-runtime-base-image.md`.

## Type of change

- [x] Build / CI / release tooling

## Checklist

- [x] Commits are signed (GitHub shows **Verified**)
- [x] One logical change per commit; no unrelated changes bundled in
- [x] `ruff check`, `ruff format --check`, `mypy src/`, and `pytest` all pass locally (261/261)
- [x] No AI attribution anywhere (commits, comments, docs)

## Smoke tests (local)

- `docker build .` succeeds
- Final image is 112 MB; `--version` prints `compose-lint 0.3.4`
- `/bin/sh` absent — confirmed distroless (exec of `/bin/sh` fails with `no such file or directory`)
- Runs as `nonroot` (UID 65532) by default — no explicit `USER` needed
- End-to-end lint on a sample compose file produces expected CRITICAL finding and exits non-zero

## Renovate follow-up

On merge, Renovate will stop warning about the missing `apk` datasource. The next weekly run should produce clean digest-bump PRs for both `debian:trixie-slim` and `gcr.io/distroless/python3-debian13:nonroot` when upstream publishes new digests.

## Breaking changes

None for end users. Container's user is still `nonroot` at UID 65532; image still runs `compose-lint` as its entrypoint.