### PR TITLE
Dockerfile housekeeping: hadolint, USER nonroot, README hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,8 @@ jobs:
         # runner-bundled pip itself (those are out of scope for this
         # project's supply chain). The pip upgrade is deliberately
         # unpinned per the "always-latest for the bootstrap" exception
-        # in AGENTS.md sub-case 4. bandit and pip-audit come from the
-        # hash-pinned dev lockfile.
+        # in AGENTS.md "Dependency pinning". bandit and pip-audit come
+        # from the hash-pinned dev lockfile.
         run: |
           python -m pip install --upgrade pip
           pip install --require-hashes -r requirements-dev.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,11 @@
 
 # --- build stage: produce wheel, install into a venv ---
 FROM debian:trixie-slim@sha256:5fb70129351edec3723d13f427400ecae3f13b83750e23ad47c46721effcf2db AS build
+# apt versions intentionally unpinned: the base image digest above is
+# immutable, apt verifies package signatures, and Renovate has no
+# datasource for Debian apt. Pinning would bitrot when Debian purges
+# old versions from the index. See docs/adr/009-runtime-base-image.md.
+# hadolint ignore=DL3008
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         python3 python3-pip python3-venv \
@@ -32,4 +37,7 @@ LABEL org.opencontainers.image.title="compose-lint" \
       org.opencontainers.image.licenses="MIT"
 COPY --from=build /venv /venv
 WORKDIR /src
+# Distroless :nonroot already sets USER 65532; restated here so the
+# intent survives a future base-image swap that might not default nonroot.
+USER 65532:65532
 ENTRYPOINT ["/venv/bin/compose-lint"]

--- a/README.md
+++ b/README.md
@@ -21,8 +21,20 @@ pip install compose-lint
 **Docker** — [composelint/compose-lint](https://hub.docker.com/r/composelint/compose-lint)
 
 ```bash
-docker run --rm -v "$(pwd):/src" composelint/compose-lint
+docker run --rm \
+  --read-only \
+  --cap-drop ALL \
+  --security-opt no-new-privileges \
+  --network none \
+  -v "$(pwd):/src:ro" \
+  composelint/compose-lint
 ```
+
+compose-lint only reads local YAML, so it runs with no capabilities, no
+network, no privilege escalation, a read-only root filesystem, and a
+read-only mount. These flags aren't required — `docker run --rm -v
+"$(pwd):/src" composelint/compose-lint` works — but they model the
+least-privilege posture the linter itself recommends.
 
 ## Quick Start
 
@@ -41,7 +53,10 @@ compose-lint docker-compose.yml docker-compose.prod.yml
 Docker equivalent:
 
 ```bash
-docker run --rm -v "$(pwd):/src" composelint/compose-lint docker-compose.prod.yml
+docker run --rm \
+  --read-only --cap-drop ALL --security-opt no-new-privileges --network none \
+  -v "$(pwd):/src:ro" \
+  composelint/compose-lint docker-compose.prod.yml
 ```
 
 ## Example Output


### PR DESCRIPTION
## Summary

Three small, independent housekeeping changes on the runtime image and its docs, bundled because each is <10 lines:

- **`.github/workflows/ci.yml`** — fix stale `AGENTS.md sub-case 4` reference in the pip-bootstrap comment. AGENTS.md documents the exception as a single bullet, not a numbered list. Now points at the *Dependency pinning* section.
- **`Dockerfile`** — suppress hadolint `DL3008` (pin apt versions) with rationale citing ADR-009, and set `USER 65532:65532` explicitly. Distroless `:nonroot` already runs as UID 65532; restating it in the Dockerfile survives a future base-image swap that might not default nonroot.
- **`README.md`** — both `docker run` examples now show `--read-only --cap-drop ALL --security-opt no-new-privileges --network none` with a read-only mount, modelling the least-privilege posture the linter itself recommends. A follow-on paragraph notes the flags aren't required for the simple `docker run -v ... compose-lint` form.

## Why not pin apt versions?

Same class of problem ADR-009 rejected for apk: Renovate has no built-in datasource for Debian apt packages, and pinned apt versions bitrot when Debian purges them from the index. The base image digest (`debian:trixie-slim@sha256:...`) is already pinned and apt verifies package signatures, so the marginal supply-chain benefit doesn't justify the maintenance cost for a build-stage-only install.

## Test plan

- [x] `hadolint Dockerfile` exits 0
- [x] Local `docker build .` succeeds
- [x] Image runs with all five hardening flags: `docker run --rm --read-only --cap-drop ALL --security-opt no-new-privileges --network none composelint/compose-lint:local-test --version` → `compose-lint 0.3.4`
- [ ] CI green on this PR (type-check, tests 3.10–3.13, lint, security scan, CodeQL)