### PR TITLE
Prepare 0.3.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5] - 2026-04-17
+
+### Changed
+
+- Runtime Docker image switched from `python:3.13-alpine` to
+  `gcr.io/distroless/python3-debian13:nonroot`. The image no longer
+  ships `/bin/sh`, `apk`, or busybox — only the Python interpreter,
+  stdlib, libc, and the project venv. Attack surface in the event of
+  a container escape is significantly reduced. See
+  [ADR-009](docs/adr/009-runtime-base-image.md) for the rationale.
+- `docker run` examples in the README now show `--read-only --cap-drop
+  ALL --security-opt no-new-privileges --network none` with a
+  read-only mount, modelling the least-privilege posture the linter
+  itself recommends. The simpler form still works.
+
+### Security
+
+- Dockerfile sets `USER 65532:65532` explicitly at the runtime stage.
+  Distroless `:nonroot` already enforces this; the redundancy survives
+  a future base-image swap that might not default to nonroot.
+
+No CLI, config, or finding-shape changes. Exit codes (0/1/2) are
+preserved. A Compose file that passed on 0.3.4 passes identically on
+0.3.5.
+
 ## [0.3.4] - 2026-04-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,8 @@ First public release.
   inputs through `env:` rather than direct `${{ }}` interpolation to prevent
   shell injection.
 
+[0.3.5]: https://github.com/tmatens/compose-lint/compare/v0.3.4...v0.3.5
+[0.3.4]: https://github.com/tmatens/compose-lint/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/tmatens/compose-lint/compare/v0.3.0...v0.3.3
 [0.3.0]: https://github.com/tmatens/compose-lint/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/tmatens/compose-lint/releases/tag/v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "compose-lint"
-version = "0.3.4"
+version = "0.3.5"
 description = "A security-focused linter for Docker Compose files"
 readme = "README.md"
 license = "MIT"

--- a/src/compose_lint/__init__.py
+++ b/src/compose_lint/__init__.py
@@ -1,3 +1,3 @@
 """A security-focused linter for Docker Compose files."""
 
-__version__ = "0.3.4"
+__version__ = "0.3.5"


### PR DESCRIPTION
## Summary

Patch release bump. The only user-visible change in 0.3.5 is the runtime Docker image: `python:3.13-alpine` → `gcr.io/distroless/python3-debian13:nonroot` (see ADR-009). No CLI, config, or finding-shape changes — a Compose file that passed on 0.3.4 passes identically on 0.3.5.

Per `docs/RELEASING.md`, pre-1.0 PATCH is the right bump: infrastructure/packaging change, no rule behavior change, no exit-code change.

## Pre-release checks

- [x] `git status` clean, on `main` up to date
- [x] `ruff check src/ tests/` — All checks passed
- [x] `ruff format --check src/ tests/` — 58 files already formatted
- [x] `mypy src/` — no issues in 31 source files
- [x] `pytest` — 261 passed
- [x] No open Renovate PRs pending merge (both #58 and #59 landed)
- [x] Version bumped in both `pyproject.toml` and `src/compose_lint/__init__.py`
- [x] CHANGELOG updated

## Test plan

- [ ] CI green on this PR (lint, type-check, tests 3.10–3.13, security scan, CodeQL, smoke test)
- [ ] Squash-merge to main, then tag `v0.3.5` (signed) and push — triggers `publish.yml`
- [ ] TestPyPI smoke + Docker smoke pass
- [ ] Approve `release-gate`, verify PyPI + Docker Hub publish
- [ ] Follow-up PR bumping `marketplace-smoke.yml` SHA pin (post-release step per RELEASING.md)