### PR TITLE
Rewrite parser traversals iteratively to prevent RecursionError

### DIFF
--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -60,29 +60,75 @@ LineLoader.add_constructor(
 
 
 def _strip_lines(data: Any) -> Any:
-    """Recursively remove __lines__ metadata from parsed data."""
-    if isinstance(data, dict):
-        return {k: _strip_lines(v) for k, v in data.items() if k != "__lines__"}
-    if isinstance(data, list):
-        return [_strip_lines(item) for item in data]
-    return data
+    """Remove __lines__ metadata from parsed data at every depth.
+
+    Iterative post-order traversal with an explicit work stack so
+    pathologically-nested YAML can't exhaust the interpreter's recursion
+    limit. The memo table keyed by object id() also collapses YAML
+    anchor-shared subtrees into O(n) work instead of O(2^n).
+    """
+    if not isinstance(data, (dict, list)):
+        return data
+
+    _BUILD = object()
+    memo: dict[int, Any] = {}
+    stack: list[tuple[Any, ...]] = [(data,)]
+
+    while stack:
+        top = stack[-1]
+        node = top[0]
+        if len(top) == 1:
+            if id(node) in memo:
+                stack.pop()
+                continue
+            stack[-1] = (node, _BUILD)
+            if isinstance(node, dict):
+                for v in node.values():
+                    if isinstance(v, (dict, list)) and id(v) not in memo:
+                        stack.append((v,))
+            elif isinstance(node, list):
+                for item in node:
+                    if isinstance(item, (dict, list)) and id(item) not in memo:
+                        stack.append((item,))
+        else:
+            stack.pop()
+            if isinstance(node, dict):
+                memo[id(node)] = {
+                    k: memo[id(v)] if isinstance(v, (dict, list)) else v
+                    for k, v in node.items()
+                    if k != "__lines__"
+                }
+            else:
+                memo[id(node)] = [
+                    memo[id(item)] if isinstance(item, (dict, list)) else item
+                    for item in node
+                ]
+
+    return memo[id(data)]
 
 
 def _collect_lines(data: Any, prefix: str = "") -> dict[str, int]:
-    """Recursively collect line numbers into a flat dot-notation map."""
+    """Collect line numbers into a flat dot-notation map.
+
+    Iterative traversal with an explicit work stack so pathologically-
+    nested YAML can't exhaust the interpreter's recursion limit.
+    """
     lines: dict[str, int] = {}
-    if isinstance(data, dict):
-        line_map = data.get("__lines__", {})
-        for key, value in data.items():
-            if key == "__lines__":
-                continue
-            full_key = f"{prefix}.{key}" if prefix else key
-            if key in line_map:
-                lines[full_key] = line_map[key]
-            lines.update(_collect_lines(value, full_key))
-    if isinstance(data, list):
-        for i, item in enumerate(data):
-            lines.update(_collect_lines(item, f"{prefix}[{i}]"))
+    stack: list[tuple[Any, str]] = [(data, prefix)]
+    while stack:
+        current, current_prefix = stack.pop()
+        if isinstance(current, dict):
+            line_map = current.get("__lines__", {})
+            for key, value in current.items():
+                if key == "__lines__":
+                    continue
+                full_key = f"{current_prefix}.{key}" if current_prefix else key
+                if key in line_map:
+                    lines[full_key] = line_map[key]
+                stack.append((value, full_key))
+        elif isinstance(current, list):
+            for i, item in enumerate(current):
+                stack.append((item, f"{current_prefix}[{i}]"))
     return lines
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 
-from compose_lint.parser import ComposeError, load_compose
+from compose_lint.parser import (
+    ComposeError,
+    _collect_lines,
+    _strip_lines,
+    load_compose,
+)
 
 FIXTURES = Path(__file__).parent / "compose_files"
 
@@ -91,3 +98,59 @@ class TestLoadCompose:
         # of a ComposeError. The parser now rejects unhashable keys up front.
         with pytest.raises(ComposeError, match="unhashable key"):
             load_compose(FIXTURES / "invalid_complex_key.yml")
+
+
+class TestDeepNestingTraversal:
+    """Regression for ClusterFuzzLite-found RecursionError in _collect_lines.
+
+    The parser's post-YAML traversals used to recurse one Python frame per
+    nesting level. An input deeper than sys.getrecursionlimit() crashed the
+    tool with an uncaught RecursionError instead of either linting or
+    rejecting the file. These tests construct dicts deeper than the default
+    recursion limit, bypassing YAML parsing (which has its own independent
+    limit) to exercise the traversal functions directly.
+    """
+
+    @staticmethod
+    def _build_deep_chain(depth: int) -> dict[str, Any]:
+        node: Any = "leaf"
+        for i in range(depth):
+            node = {"a": node, "__lines__": {"a": i + 1}}
+        return node
+
+    def test_collect_lines_handles_depth_above_recursion_limit(self) -> None:
+        depth = sys.getrecursionlimit() * 2
+        node = self._build_deep_chain(depth)
+        result = _collect_lines(node)
+        # One entry per level (all keyed "a"-chained via dot notation).
+        assert len(result) == depth
+
+    def test_strip_lines_handles_depth_above_recursion_limit(self) -> None:
+        depth = sys.getrecursionlimit() * 2
+        node = self._build_deep_chain(depth)
+        result = _strip_lines(node)
+        # Walk iteratively (not recursively) to verify every level was stripped.
+        walk: Any = result
+        for _ in range(depth):
+            assert isinstance(walk, dict)
+            assert "__lines__" not in walk
+            walk = walk["a"]
+        assert walk == "leaf"
+
+    def test_strip_lines_dedupes_shared_subtrees(self) -> None:
+        # YAML anchors produce the same Python dict reachable from multiple
+        # parents. The iterative impl memoizes by id() so shared subtrees
+        # are processed once, keeping work linear in the underlying graph.
+        shared = {"image": "nginx", "__lines__": {"image": 3}}
+        root = {
+            "services": {
+                "web": shared,
+                "api": shared,
+                "__lines__": {"web": 2, "api": 4},
+            },
+            "__lines__": {"services": 1},
+        }
+        stripped = _strip_lines(root)
+        # Same stripped dict returned for both aliases.
+        assert stripped["services"]["web"] is stripped["services"]["api"]
+        assert "__lines__" not in stripped["services"]["web"]


### PR DESCRIPTION
## Summary

- ClusterFuzzLite found that \`_collect_lines\` and \`_strip_lines\` recursed one Python frame per YAML nesting level, so input deeper than \`sys.getrecursionlimit()\` crashed the tool with an uncaught \`RecursionError\` instead of linting or rejecting the file cleanly.
- Both functions now walk with an explicit work stack. \`_strip_lines\` memoizes by \`id()\` so YAML anchor-shared subtrees are processed once (linear in the graph, not the expansion).
- Adds three regression tests in \`TestDeepNestingTraversal\` that build dicts deeper than the recursion limit directly, bypassing YAML parsing (which has its own independent composer limit in PyYAML) to exercise the traversal functions in isolation. The third test covers anchor-shared subtree memoization.

## Test plan

- [x] \`ruff check\` — clean
- [x] \`ruff format --check\` — clean
- [x] \`mypy src/\` (strict) — no issues
- [x] \`pytest\` — 264 passed (3 new regression tests)
- [x] Verified the old recursive implementation \`RecursionError\`s on the new tests at depth \`sys.getrecursionlimit() * 2\`, confirming they exercise the fix