### PR TITLE
Document parser RecursionError fix in 0.3.5 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   read-only mount, modelling the least-privilege posture the linter
   itself recommends. The simpler form still works.
 
+### Fixed
+
+- Parser post-YAML traversals (`_collect_lines`, `_strip_lines`) no
+  longer recurse one Python frame per nesting level, so pathologically-
+  deep input raises `ComposeError` (or lints cleanly) instead of
+  crashing with an uncaught `RecursionError`. Found by ClusterFuzzLite.
+
 ### Security
 
 - Dockerfile sets `USER 65532:65532` explicitly at the runtime stage.


### PR DESCRIPTION
## Summary

- PR #61 (parser recursion fix, commit \`87ebd82\`) landed in main after the 0.3.5 release PR was drafted, so the fuzzer-driven fix is in the tree but wasn't called out in the 0.3.5 release notes.
- Adds a \`### Fixed\` subsection under \`[0.3.5]\` citing the fix and its ClusterFuzzLite origin.
- No code changes. Done before tagging so the GitHub release notes and PyPI changelog tell the full story.