### PR TITLE
Build Docker images on native arm64 runners to avoid QEMU crashes

### DIFF
--- a/.github/workflows/publish-channel.yml
+++ b/.github/workflows/publish-channel.yml
@@ -54,8 +54,62 @@ jobs:
         with:
           attestations: true
 
+  # Build one image per arch on a native runner (no QEMU) and push by
+  # digest only. See the matching block in publish.yml for the full
+  # rationale — the emulated arm64 apt-get path is unreliable.
+  build-docker:
+    if: inputs.channel == 'docker'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Derive artifact slug from platform
+        id: slug
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: echo "slug=${PLATFORM//\//-}" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.tag }}
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=composelint/compose-lint,push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digests-${{ steps.slug.outputs.slug }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
   publish-docker:
     if: inputs.channel == 'docker'
+    needs: build-docker
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:
@@ -66,41 +120,68 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          ref: ${{ inputs.tag }}
-          persist-credentials: false
+          pattern: digests-*
+          merge-multiple: true
+          path: /tmp/digests
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
       - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Extract metadata (tags, labels)
+      # workflow_dispatch sets GITHUB_REF to the dispatched branch, so
+      # docker/metadata-action's semver patterns can't derive tags from the
+      # release tag on their own. Compute them explicitly from inputs.tag
+      # to mirror publish.yml's output shape (version, major.minor, and
+      # major for v1+).
+      - name: Compute tags
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
-        with:
-          images: composelint/compose-lint
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}},enable=${{ !startsWith(inputs.tag, 'refs/tags/v0.') }}
-      - name: Build and push (multi-arch)
-        id: push
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-      - name: Sign image with cosign
         env:
-          DIGEST: ${{ steps.push.outputs.digest }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          version="${TAG#v}"
+          major_minor="${version%.*}"
+          major="${major_minor%.*}"
+          tags="composelint/compose-lint:${version}"
+          tags="${tags},composelint/compose-lint:${major_minor}"
+          if [[ ! "${version}" =~ ^0\. ]]; then
+            tags="${tags},composelint/compose-lint:${major}"
+          fi
+          {
+            echo "tags=${tags}"
+            echo "version=${version}"
+          } >> "$GITHUB_OUTPUT"
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          IFS=',' read -ra TAG_ARGS <<< "${TAGS}"
+          tag_flags=()
+          for t in "${TAG_ARGS[@]}"; do
+            tag_flags+=(-t "$t")
+          done
+          docker buildx imagetools create \
+            "${tag_flags[@]}" \
+            $(printf 'composelint/compose-lint@sha256:%s ' *)
+      - name: Inspect manifest digest
+        id: inspect
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          digest="$(docker buildx imagetools inspect \
+            "composelint/compose-lint:${VERSION}" \
+            --format '{{json .Manifest}}' | jq -r '.digest')"
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+      - name: Sign manifest with cosign
+        env:
+          DIGEST: ${{ steps.inspect.outputs.digest }}
         run: cosign sign --yes "composelint/compose-lint@${DIGEST}"
       - name: Verify — cosign signature
         env:
-          DIGEST: ${{ steps.push.outputs.digest }}
+          DIGEST: ${{ steps.inspect.outputs.digest }}
         run: |
           for attempt in 1 2 3; do
             if cosign verify \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -227,8 +227,62 @@ jobs:
         with:
           attestations: true
 
-  docker-publish:
+  # Build one image per architecture on a native runner and push it to the
+  # registry by digest only (no tags). Emulated arm64 via QEMU crashes on
+  # Debian apt-get (exit 255 from the QEMU emulator itself), so each arch
+  # builds on its own native runner. A subsequent job stitches the
+  # per-arch digests into a multi-arch manifest list.
+  docker-build:
     needs: release-gate
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Derive artifact slug from platform
+        id: slug
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: echo "slug=${PLATFORM//\//-}" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=composelint/compose-lint,push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digests-${{ steps.slug.outputs.slug }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  docker-publish:
+    needs: docker-build
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -239,9 +293,11 @@ jobs:
       name: dockerhub
       url: https://hub.docker.com/r/composelint/compose-lint
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          persist-credentials: false
+          pattern: digests-*
+          merge-multiple: true
+          path: /tmp/digests
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
       - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -257,28 +313,28 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-      - name: Build and push (multi-arch)
-        id: push
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-      - name: Sign image with cosign
-        env:
-          DIGEST: ${{ steps.push.outputs.digest }}
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
         run: |
-          cosign sign --yes "composelint/compose-lint@${DIGEST}"
-      - name: Verify — pull published image
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf 'composelint/compose-lint@sha256:%s ' *)
+      - name: Inspect manifest digest
+        id: inspect
         env:
-          DIGEST: ${{ steps.push.outputs.digest }}
+          VERSION: ${{ steps.meta.outputs.version }}
         run: |
-          docker pull "composelint/compose-lint@${DIGEST}"
+          digest="$(docker buildx imagetools inspect \
+            "composelint/compose-lint:${VERSION}" \
+            --format '{{json .Manifest}}' | jq -r '.digest')"
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+      - name: Sign manifest with cosign
+        env:
+          DIGEST: ${{ steps.inspect.outputs.digest }}
+        run: cosign sign --yes "composelint/compose-lint@${DIGEST}"
       - name: Verify — cosign signature
         env:
-          DIGEST: ${{ steps.push.outputs.digest }}
+          DIGEST: ${{ steps.inspect.outputs.digest }}
         run: |
           for attempt in 1 2 3; do
             if cosign verify \
@@ -294,7 +350,7 @@ jobs:
           exit 1
       - name: Verify — published image version matches tag
         env:
-          DIGEST: ${{ steps.push.outputs.digest }}
+          DIGEST: ${{ steps.inspect.outputs.digest }}
         run: |
           expected="compose-lint ${GITHUB_REF_NAME#v}"
           actual="$(docker run --rm "composelint/compose-lint@${DIGEST}" --version)"
@@ -307,12 +363,12 @@ jobs:
       - name: Generate SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          image: composelint/compose-lint@${{ steps.push.outputs.digest }}
+          image: composelint/compose-lint@${{ steps.inspect.outputs.digest }}
           format: spdx-json
           output-file: sbom.spdx.json
       - name: Attest SBOM to image
         env:
-          DIGEST: ${{ steps.push.outputs.digest }}
+          DIGEST: ${{ steps.inspect.outputs.digest }}
         run: |
           cosign attest --yes --type spdxjson --predicate sbom.spdx.json \
             "composelint/compose-lint@${DIGEST}"


### PR DESCRIPTION
## Summary

- \`docker-publish\` in \`publish.yml\` (and \`publish-docker\` in \`publish-channel.yml\`) built \`linux/amd64,linux/arm64\` with QEMU emulating arm64. The Debian-based build stage introduced in 0.3.5 runs \`apt-get\` in the arm64 leg, and that crashes under emulation with exit 255 from the QEMU emulator itself — a known rseq/glibc interaction that Alpine sidestepped.
- v0.3.5 shipped to PyPI successfully but the Docker arm64 leg failed, leaving the Docker side of that release un-published. Once this lands, re-drive the Docker side of v0.3.5 by running **Actions → Publish channel (manual)** with \`tag=v0.3.5\`, \`channel=docker\`.
- Both workflows now use the distribute-across-runners pattern: one matrix job per arch on a native runner (\`ubuntu-latest\` + \`ubuntu-24.04-arm\`) pushes to Docker Hub by digest only, then a merge job calls \`docker buildx imagetools create\` to stitch the per-arch digests into a manifest list. Cosign signs, verifies, and SBOM-attests the manifest digest. No QEMU anywhere.
- Fixed a latent bug in \`publish-channel.yml\`: \`docker/metadata-action\` reads \`GITHUB_REF\` for its semver patterns, but \`workflow_dispatch\` sets that to the dispatched branch, not \`inputs.tag\`. The escape hatch would have produced no version tags when dispatched. Tags are now computed explicitly from \`inputs.tag\` to match \`publish.yml\`'s output shape.

## Test plan

- [x] Both workflow files parse as YAML
- [x] Job dependency graph: \`docker-build\` (matrix) → \`docker-publish\` → \`create-release\`. \`release-gate\` still blocks both channels.
- [ ] Post-merge: dispatch \`Publish channel (manual)\` with \`tag=v0.3.5 channel=docker\` and confirm the manifest list, cosign signature, and SBOM attestation all land on Docker Hub.
- [ ] Next real release exercises the tag-triggered path in \`publish.yml\`.