### PR TITLE
Pin manifest-list digests and matrix docker-smoke across native runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,19 @@ jobs:
         # deps are still scanned.
         run: pip-audit --skip-editable
 
+  # Fails the PR if any FROM in the Dockerfile pins a per-arch manifest
+  # instead of a multi-arch OCI index. Multi-arch regressions otherwise
+  # don't surface until docker-publish at release time.
+  dockerfile-digests:
+    name: Verify Dockerfile digests are manifest lists
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - run: scripts/verify-dockerfile-digests.sh Dockerfile
+
   action-smoke:
     name: Smoke test action.yml
     runs-on: ubuntu-latest

--- a/.github/workflows/marketplace-smoke.yml
+++ b/.github/workflows/marketplace-smoke.yml
@@ -65,7 +65,7 @@ jobs:
           YAML
 
       - name: Clean fixture should pass
-        uses: tmatens/compose-lint@f8df184088dcce073c7bb17bc536012ad0ea8857 # v0.3.4
+        uses: tmatens/compose-lint@c49fc24773ea5bfb99358b4c695d1dfc0b66510a # v0.3.5
         with:
           files: smoke/clean.yml
           fail-on: high
@@ -73,7 +73,7 @@ jobs:
       - name: Insecure fixture should fail
         id: insecure
         continue-on-error: true
-        uses: tmatens/compose-lint@f8df184088dcce073c7bb17bc536012ad0ea8857 # v0.3.4
+        uses: tmatens/compose-lint@c49fc24773ea5bfb99358b4c695d1dfc0b66510a # v0.3.5
         with:
           files: smoke/insecure.yml
           fail-on: high

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -113,9 +113,26 @@ jobs:
             exit 1
           fi
 
+  # Build the image natively on each target arch and run the fixture battery.
+  # Emulated arm64 via QEMU crashes on Debian apt-get, and a single-arch smoke
+  # can't catch per-arch digest pins or native-wheel mismatches before the
+  # release-gate — so both legs are exercised here, on their own runners, no
+  # QEMU. Scout CVE scanning stays single-arch (amd64): CVE findings come from
+  # base-image layers that are identical across arch in practice, and running
+  # Scout twice would double-upload SARIF under the same category.
   docker-smoke:
     needs: build
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            scout: true
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            scout: false
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 15
     permissions:
       contents: read
@@ -129,6 +146,7 @@ jobs:
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
+          platforms: ${{ matrix.platform }}
           load: true
           tags: composelint/compose-lint:test
       - name: Test — version output matches tag
@@ -179,10 +197,12 @@ jobs:
           YAML
           docker run --rm -v /tmp/test.yml:/src/docker-compose.yml composelint/compose-lint:test --format sarif --fail-on critical | python3 -c "import sys,json; json.load(sys.stdin); print('Valid SARIF JSON')"
       - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        if: matrix.scout
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Scan for vulnerabilities (Docker Scout)
+        if: matrix.scout
         uses: docker/scout-action@bacf462e8d090c09660de30a6ccc718035f961e3 # v1.20.4
         with:
           command: cves
@@ -191,8 +211,8 @@ jobs:
           exit-code: true
           sarif-file: scout-results.sarif
       - name: Upload Scout results to GitHub Security
+        if: matrix.scout && always()
         uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
-        if: always()
         with:
           sarif_file: scout-results.sarif
           category: docker-scout

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # stages without shebang rewriting. Both digests are bumped by Renovate.
 
 # --- build stage: produce wheel, install into a venv ---
-FROM debian:trixie-slim@sha256:5fb70129351edec3723d13f427400ecae3f13b83750e23ad47c46721effcf2db AS build
+FROM debian:trixie-slim@sha256:4ffb3a1511099754cddc70eb1b12e50ffdb67619aa0ab6c13fcd800a78ef7c7a AS build
 # apt versions intentionally unpinned: the base image digest above is
 # immutable, apt verifies package signatures, and Renovate has no
 # datasource for Debian apt. Pinning would bitrot when Debian purges
@@ -29,7 +29,7 @@ RUN python3 -m venv /venv \
     && /venv/bin/pip install --no-cache-dir /dist/*.whl
 
 # --- runtime stage: distroless Python, nonroot by default ---
-FROM gcr.io/distroless/python3-debian13:nonroot@sha256:9b1e35ec38db9ee528a2107c84b7d839b4dd412c5e003186aed8bd5e62900bfc
+FROM gcr.io/distroless/python3-debian13:nonroot@sha256:51b1acc177d535f20fa30a175a657079ee7dce6e326541cfd83a474d9928e123
 LABEL org.opencontainers.image.title="compose-lint" \
       org.opencontainers.image.description="Security-focused linter for Docker Compose files" \
       org.opencontainers.image.url="https://github.com/tmatens/compose-lint" \

--- a/scripts/verify-dockerfile-digests.sh
+++ b/scripts/verify-dockerfile-digests.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Fail if any FROM ...@sha256:<digest> in the Dockerfile pins a per-arch
+# manifest instead of a multi-arch OCI index (manifest list). Per-arch pins
+# work on the build host but fail at runtime on the other arch with an
+# "exec format error" — a class of bug that only surfaces during multi-arch
+# release builds unless caught here.
+#
+# Usage: scripts/verify-dockerfile-digests.sh [Dockerfile]
+#
+# No image pulls; HEAD the registry manifest endpoint and read Content-Type.
+set -euo pipefail
+
+dockerfile="${1:-Dockerfile}"
+
+if [ ! -f "${dockerfile}" ]; then
+    echo "Error: ${dockerfile} not found" >&2
+    exit 1
+fi
+
+# Extract "image@sha256:<digest>" refs from FROM lines only. The BuildKit
+# "# syntax=" directive is out of scope — scoping to FROM matches the plan
+# and avoids false positives from comment directives.
+refs=$(grep -iE '^[[:space:]]*FROM[[:space:]]' "${dockerfile}" \
+    | grep -oE '[a-zA-Z0-9./:_-]+@sha256:[a-f0-9]{64}' \
+    | sort -u || true)
+
+if [ -z "${refs}" ]; then
+    echo "No digest-pinned FROM lines found in ${dockerfile}"
+    exit 0
+fi
+
+status=0
+for ref in ${refs}; do
+    digest="${ref##*@}"
+    image="${ref%@*}"
+    repo="${image%%:*}"
+
+    # Split registry from repo. A leading segment with a dot, colon, or
+    # "localhost" is a registry host; otherwise it's Docker Hub and an
+    # unqualified name is under "library/".
+    first="${repo%%/*}"
+    case "${first}" in
+        *.*|*:*|localhost)
+            registry="${first}"
+            path="${repo#*/}"
+            ;;
+        *)
+            registry="registry-1.docker.io"
+            case "${repo}" in
+                */*) path="${repo}" ;;
+                *)   path="library/${repo}" ;;
+            esac
+            ;;
+    esac
+
+    url="https://${registry}/v2/${path}/manifests/${digest}"
+    accept='application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json'
+
+    resp=$(curl -sI -H "Accept: ${accept}" "${url}")
+
+    if printf '%s' "${resp}" | grep -qi '^HTTP/[0-9.]* 401'; then
+        hdr=$(printf '%s' "${resp}" | tr -d '\r' | grep -i '^www-authenticate:' || true)
+        realm=$(printf '%s' "${hdr}" | grep -oE 'realm="[^"]+"' | head -1 | cut -d'"' -f2)
+        service=$(printf '%s' "${hdr}" | grep -oE 'service="[^"]+"' | head -1 | cut -d'"' -f2)
+        scope=$(printf '%s' "${hdr}" | grep -oE 'scope="[^"]+"' | head -1 | cut -d'"' -f2)
+        if [ -z "${scope}" ]; then
+            scope="repository:${path}:pull"
+        fi
+        token=$(curl -s "${realm}?service=${service}&scope=${scope}" \
+            | python3 -c 'import sys,json;d=json.load(sys.stdin);print(d.get("token") or d.get("access_token",""))')
+        resp=$(curl -sI -H "Accept: ${accept}" -H "Authorization: Bearer ${token}" "${url}")
+    fi
+
+    ct=$(printf '%s' "${resp}" | tr -d '\r' | awk 'tolower($1) == "content-type:" { sub(/^[^:]+: */, ""); print; exit }')
+
+    case "${ct}" in
+        *image.index*|*manifest.list*)
+            echo "OK: ${ref} -> ${ct}"
+            ;;
+        *)
+            echo "::error::${ref} is NOT a manifest list (Content-Type: ${ct:-<none>})."
+            echo "       Pin the OCI index digest so both amd64 and arm64 resolve."
+            status=1
+            ;;
+    esac
+done
+
+exit "${status}"


### PR DESCRIPTION
## Summary

- Swap Dockerfile FROM digests from per-arch manifests to OCI image index (manifest list) digests so `docker-publish` stops failing the arm64 leg.
- Rewrite `docker-smoke` as a native-runner matrix (amd64 on `ubuntu-latest`, arm64 on `ubuntu-24.04-arm`) so every multi-arch bug — per-arch digest pins, native-wheel mismatches, future base-image surprises — hits a red build before the release-gate, not during production push.
- Add `scripts/verify-dockerfile-digests.sh` + a lightweight `ci.yml` job so the per-arch-pin mistake fails at PR review via a ~1s registry HEAD request.
- Bump `marketplace-smoke.yml` pin from v0.3.4 → v0.3.5 (pre-existing 0.3.5 follow-up; unrelated to multi-arch but cheap to include).

## Why now

v0.3.5 publish ran clean on PyPI but `docker-publish` failed: per-arch amd64 digest pins in the Dockerfile couldn't resolve on the arm64 build. The QEMU apt crash from the previous release and today's wrong-arch digest both surfaced post-approval. Matrix smoke on native runners + the verify script catch the whole class earlier.

## Test plan

- [ ] `ci.yml` dockerfile-digests job passes against the new manifest-list pins.
- [ ] Both matrix legs of `docker-smoke` pass on the next tag push (tested end-to-end by 0.3.6).
- [ ] Negative test locally: pinning back to a per-arch digest makes the verify script fail with `::error::... NOT a manifest list`.