### PR TITLE
Bump marketplace-smoke pin to v0.3.6

### DIFF
--- a/.github/workflows/marketplace-smoke.yml
+++ b/.github/workflows/marketplace-smoke.yml
@@ -65,7 +65,7 @@ jobs:
           YAML
 
       - name: Clean fixture should pass
-        uses: tmatens/compose-lint@c49fc24773ea5bfb99358b4c695d1dfc0b66510a # v0.3.5
+        uses: tmatens/compose-lint@4facca88bd8a9f5c7c5e1bc897bc5f2913020e72 # v0.3.6
         with:
           files: smoke/clean.yml
           fail-on: high
@@ -73,7 +73,7 @@ jobs:
       - name: Insecure fixture should fail
         id: insecure
         continue-on-error: true
-        uses: tmatens/compose-lint@c49fc24773ea5bfb99358b4c695d1dfc0b66510a # v0.3.5
+        uses: tmatens/compose-lint@4facca88bd8a9f5c7c5e1bc897bc5f2913020e72 # v0.3.6
         with:
           files: smoke/insecure.yml
           fail-on: high


### PR DESCRIPTION
## Summary

Post-release follow-up per `docs/RELEASING.md`. Updates both `uses: tmatens/compose-lint@<sha> # vX.Y.Z` lines in `marketplace-smoke.yml` from v0.3.5 to v0.3.6 (SHA `4facca88bd8a9f5c7c5e1bc897bc5f2913020e72`). The commit SHA only exists after the release tag is pushed, which is why this can't live in the release bump PR.

## Test plan

- [ ] CI green.
- [ ] After merge, manually trigger **Actions → Marketplace smoke test → Run workflow** and confirm the published v0.3.6 action exits 0 on the clean fixture and exits 1 on the insecure fixture.