### PR TITLE
Retry testpypi-smoke install until /simple/ index propagates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,18 +63,31 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Wait for TestPyPI index to update
-        run: sleep 30
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
       - name: Install from TestPyPI and verify version
+        # TestPyPI's JSON API sees a new release within seconds of the
+        # publish step, but the /simple/ index pip uses can lag by
+        # minutes. A fixed sleep has flaked mid-release before (0.3.6),
+        # so retry the install with backoff until the index catches up
+        # or we hit ~2 minutes of attempts.
         run: |
           version="${GITHUB_REF_NAME#v}"
-          pip install \
-            -i https://test.pypi.org/simple/ \
-            --extra-index-url https://pypi.org/simple/ \
-            "compose-lint==${version}"
+          for attempt in 1 2 3 4 5 6; do
+            if pip install \
+                -i https://test.pypi.org/simple/ \
+                --extra-index-url https://pypi.org/simple/ \
+                "compose-lint==${version}"; then
+              break
+            fi
+            if [ "${attempt}" = 6 ]; then
+              echo "::error::TestPyPI install failed after 6 attempts; index may still be propagating"
+              exit 1
+            fi
+            echo "Attempt ${attempt} failed; sleeping 20s for /simple/ index propagation..."
+            sleep 20
+          done
           expected="compose-lint ${version}"
           actual="$(compose-lint --version)"
           echo "Expected: ${expected}"


### PR DESCRIPTION
## Summary

Replace the blind 30s sleep in `testpypi-smoke` with a retry loop around the `pip install` (6 attempts × 20s backoff). The old sleep flaked twice during the 0.3.6 release — TestPyPI's JSON API saw the new version immediately but the `/simple/` index pip uses took longer to propagate.

## Why this shape

- Succeeds the instant the index catches up (no wasted wall-clock time on fast propagation).
- Fails fast at ~2 minutes with a clear error on a truly stuck propagation.
- Keeps the cause-of-failure signal separate from a real install bug: if retries exhaust, the error message names propagation as the likely cause.

## Test plan

- [ ] CI green on this PR.
- [ ] Next release's `testpypi-smoke` goes green on the first attempt without needing a manual `gh run rerun`.