### PR TITLE
Document CL-0003 and CL-0007 compatibility caveats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- CL-0003 fix guidance now warns that `no-new-privileges` breaks
+  images whose entrypoint switches users via `gosu`/`su-exec` (e.g.
+  official `postgres`, `redis`, `minecraft-server`). The finding's
+  `fix` field gains a one-line caveat; full compatibility notes and
+  a testing workflow live in `docs/rules/CL-0003.md`. Closes #2.
+- CL-0007 fix guidance now describes the writable-path discovery
+  workflow (`docker diff`) and the chown-on-startup pitfall seen on
+  `netdata` and `valkey`. The finding's `fix` field gains a one-line
+  caveat; details live in `docs/rules/CL-0007.md`. Closes #3.
+
+No rule logic, severity, or finding-shape changes. A compose file
+that passed on 0.3.6 passes identically on this revision; only the
+`fix` field text and rule docs changed.
+
 ## [0.3.6] - 2026-04-18
 
 ### Fixed

--- a/docs/rules/CL-0003.md
+++ b/docs/rules/CL-0003.md
@@ -21,4 +21,32 @@ security_opt:
   - no-new-privileges:true
 ```
 
-This setting rarely breaks applications. Most containers do not rely on setuid/setgid binaries, so this can be applied broadly without per-service testing.
+## Compatibility
+
+`no-new-privileges` blocks any privilege gain through `execve`, including the user-switching that many official images perform at startup. Applying it to those services will crash-loop the container.
+
+Known-incompatible patterns:
+
+- Entrypoints that drop from `root` to an unprivileged user via `gosu` or `su-exec` — e.g. the official `postgres`, `redis`, and `mysql` images, `itzg/minecraft-server`, `itzg/mc-backup`.
+- Plugins or agents that rely on capability inheritance across `execve` — e.g. `netdata/netdata`.
+
+Services that already start as a non-root user (`USER` in the Dockerfile, or `user:` in compose) and do not fork privileged helpers are safe.
+
+### How to test
+
+Add the setting, then run:
+
+```
+docker compose up
+```
+
+If the container exits immediately with a message like `operation not permitted` around `setuid`, `setgid`, or `execve`, the image is incompatible. Either remove the setting for that service or rebuild the image to start directly as the target user.
+
+### Per-service handling
+
+Until per-service config overrides land ([#5](https://github.com/tmatens/compose-lint/issues/5)), the workaround is to disable CL-0003 globally via `.compose-lint.yml` and leave a comment in the compose file on the services where it was intentionally omitted.
+
+## Further reading
+
+- [Docker capabilities and no-new-privs (raesene)](https://raesene.github.io/blog/2019/06/01/docker-capabilities-and-no-new-privs/)
+- [Docker engine security — Linux kernel capabilities](https://docs.docker.com/engine/security/#linux-kernel-capabilities)

--- a/docs/rules/CL-0007.md
+++ b/docs/rules/CL-0007.md
@@ -41,3 +41,32 @@ Common writable paths applications may need:
 - `/run` — PID files and sockets
 - `/var/log` — application logs (prefer stdout/stderr instead)
 - Application-specific cache directories
+
+## Compatibility
+
+`read_only: true` is an advanced hardening step. Most images write to paths beyond `/tmp` and `/run` at startup, and the minimal `tmpfs` list above is rarely sufficient on its own.
+
+Observed failure modes:
+
+- Images that write state or registry files under image-specific paths (e.g. `netdata` writes to `/etc/netdata/.container-hostname` and `/var/lib/netdata/registry`).
+- Entrypoints that `chown` their data directory on first boot (e.g. `valkey`, `redis`). On a read-only rootfs `chown` fails unless the `CHOWN` capability is retained and the target path is on a writable mount.
+- Applications that rewrite their own config at startup (some exporters, some TLS-fetching sidecars).
+
+### Writable-path discovery
+
+1. Run the service **without** `read_only` and let it reach a steady state.
+2. Inspect what was written:
+
+   ```
+   docker diff <container>
+   ```
+
+3. Add each writable path as a `tmpfs` entry (for ephemeral data) or a named volume (for persistent data). Named volumes remain writable regardless of `read_only`.
+4. Enable `read_only: true` and restart.
+
+If the entrypoint runs `chown`, either pre-own the mount as the target UID:GID in the image build, or drop that specific service from the rule scope.
+
+## Further reading
+
+- [Docker best practices: read-only containers (ploetzli)](https://blog.ploetzli.ch/2025/docker-best-practices-read-only-containers/)
+- [netdata read-only filesystem discussion](https://github.com/netdata/netdata/issues/14103)

--- a/src/compose_lint/rules/CL0003_no_new_privileges.py
+++ b/src/compose_lint/rules/CL0003_no_new_privileges.py
@@ -68,7 +68,9 @@ class NoNewPrivilegesRule(BaseRule):
                 fix=(
                     "Add to your service:\n"
                     "  security_opt:\n"
-                    "    - no-new-privileges:true"
+                    "    - no-new-privileges:true\n"
+                    "Note: breaks images that switch users via "
+                    "gosu/su-exec — test first."
                 ),
                 references=[OWASP_REF, CIS_REF],
             )

--- a/src/compose_lint/rules/CL0007_read_only.py
+++ b/src/compose_lint/rules/CL0007_read_only.py
@@ -53,12 +53,14 @@ class ReadOnlyFilesystemRule(BaseRule):
                 ),
                 line=lines.get(f"services.{service_name}"),
                 fix=(
-                    "Set the root filesystem to read-only and use tmpfs for "
+                    "Set the root filesystem to read-only and declare "
                     "writable paths:\n"
                     "  read_only: true\n"
                     "  tmpfs:\n"
                     "    - /tmp\n"
-                    "    - /run"
+                    "    - /run\n"
+                    "Note: run once without read_only and check "
+                    "`docker diff` first."
                 ),
                 references=[OWASP_REF, CIS_REF],
             )


### PR DESCRIPTION
## Summary

- CL-0003 and CL-0007 `fix` strings each gain one caveat line flagging the most common breakage mode (gosu/su-exec entrypoints; image-specific writable paths).
- Full compatibility notes, testing workflow, and image examples live in `docs/rules/CL-0003.md` and `docs/rules/CL-0007.md` — keeping the terminal output compact while giving users a landing page to read.
- No rule logic, severity, or finding-shape changes. Closes #2 and closes #3.

## Test plan

- [x] \`ruff check\`
- [x] \`ruff format --check\`
- [x] \`mypy src/\` (strict)
- [x] \`pytest\` — 264 passed
- [ ] Manual text-output sanity check on a multi-service compose file (reviewer)