### PR TITLE
Automate release prep, version guards, marketplace-smoke bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,72 @@ jobs:
         # deps are still scanned.
         run: pip-audit --skip-editable
 
+  # Fails the PR if `pyproject.toml` and `src/compose_lint/__init__.py`
+  # disagree about the project version. The two strings drifted silently
+  # before 0.2.0 and are the single most-called-out release hazard in
+  # docs/RELEASING.md. This guard catches the drift at review time rather
+  # than at tag-push time (where the tag would already be minted against a
+  # wrong source of truth).
+  version-consistency:
+    name: Version strings in sync
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Compare pyproject.toml and __init__.py
+        run: |
+          pyproject=$(grep -E '^version = ' pyproject.toml | head -1 | cut -d'"' -f2)
+          init=$(grep '__version__' src/compose_lint/__init__.py | head -1 | cut -d'"' -f2)
+          echo "pyproject.toml: ${pyproject}"
+          echo "__init__.py:    ${init}"
+          if [ -z "${pyproject}" ] || [ -z "${init}" ]; then
+            echo "::error::Could not extract version from one or both files"
+            exit 1
+          fi
+          if [ "${pyproject}" != "${init}" ]; then
+            echo "::error::Version drift: pyproject.toml (${pyproject}) vs src/compose_lint/__init__.py (${init})"
+            exit 1
+          fi
+
+  # If a PR bumps the `version` in pyproject.toml, CHANGELOG.md must already
+  # contain a matching `## [X.Y.Z]` section. Without this, a release PR can
+  # merge with no release notes and the Publish workflow's `create-release`
+  # job fails *after* the tag has been minted — burning a PyPI version
+  # number on a broken release.
+  changelog-gate:
+    name: CHANGELOG entry for version bumps
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Require matching CHANGELOG section if version changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if ! git diff --name-only "${BASE_SHA}" "${HEAD_SHA}" | grep -q '^pyproject.toml$'; then
+            echo "pyproject.toml not touched; no version bump to gate."
+            exit 0
+          fi
+          base_version=$(git show "${BASE_SHA}:pyproject.toml" | grep -E '^version = ' | head -1 | cut -d'"' -f2)
+          head_version=$(git show "${HEAD_SHA}:pyproject.toml" | grep -E '^version = ' | head -1 | cut -d'"' -f2)
+          if [ "${base_version}" = "${head_version}" ]; then
+            echo "pyproject.toml changed but version line did not; not a release bump."
+            exit 0
+          fi
+          echo "Version bump detected: ${base_version} -> ${head_version}"
+          if ! grep -qE "^## \[${head_version}\]" CHANGELOG.md; then
+            echo "::error::pyproject.toml bumped to ${head_version} but CHANGELOG.md has no '## [${head_version}]' section"
+            exit 1
+          fi
+          echo "Found matching CHANGELOG section for ${head_version}."
+
   # Fails the PR if any FROM in the Dockerfile pins a per-arch manifest
   # instead of a multi-arch OCI index. Multi-arch regressions otherwise
   # don't surface until docker-publish at release time.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -514,3 +514,95 @@ jobs:
             --notes-file notes.md \
             --verify-tag \
             dist/*.whl dist/*.tar.gz signatures/*
+
+  # Post-tag, post-publish automation. At this point:
+  #   - The signed tag ${{ github.ref_name }} exists (it triggered this
+  #     workflow), so `git rev-parse <tag>^{commit}` resolves.
+  #   - `publish` and `docker-publish` have both succeeded (gated via
+  #     `needs: create-release`), so PyPI + Docker Hub show the new
+  #     version and the GitHub Release page is live.
+  # Only in that state does updating the Marketplace smoke test pin make
+  # sense: the pinned SHA must point at an artifact that actually shipped.
+  # This job opens a PR; a human still reviews and merges it, and then
+  # triggers the Marketplace smoke workflow to verify end-to-end.
+  bump-marketplace-smoke-pin:
+    name: Bump marketplace-smoke pin (post-tag, post-publish)
+    needs: create-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: true
+      - name: Resolve release SHA from tag
+        id: sha
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          sha=$(git rev-parse "${TAG}^{commit}")
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Post-tag marketplace-smoke pin bump"
+            echo ""
+            echo "Tag: \`${TAG}\`"
+            echo "Commit: \`${sha}\`"
+            echo ""
+            echo "This runs **after** publish + docker-publish + create-release all"
+            echo "succeeded, so the pinned SHA points at a release that actually"
+            echo "shipped to PyPI, Docker Hub, and GitHub Releases."
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Update .github/workflows/marketplace-smoke.yml
+        env:
+          TAG: ${{ github.ref_name }}
+          SHA: ${{ steps.sha.outputs.sha }}
+        run: |
+          version="${TAG#v}"
+          sed -i -E \
+            "s|uses: tmatens/compose-lint@[0-9a-f]+ # v[0-9.]+|uses: tmatens/compose-lint@${SHA} # v${version}|g" \
+            .github/workflows/marketplace-smoke.yml
+          if git diff --quiet .github/workflows/marketplace-smoke.yml; then
+            echo "no_changes=1" >> "$GITHUB_ENV"
+            echo "::notice::marketplace-smoke.yml already points at ${SHA}; nothing to do."
+          else
+            echo "marketplace-smoke.yml updated to ${SHA} (${TAG})."
+          fi
+      - name: Commit, push, open PR
+        if: env.no_changes != '1'
+        env:
+          TAG: ${{ github.ref_name }}
+          SHA: ${{ steps.sha.outputs.sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="${TAG#v}"
+          branch="chore/marketplace-smoke-${version}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${branch}"
+          git add .github/workflows/marketplace-smoke.yml
+          git commit -m "Bump marketplace-smoke pin to ${TAG}"
+          git push -u origin "${branch}"
+          cat > /tmp/pr-body.md <<EOF
+          **Post-tag follow-up.** This PR was opened automatically by \`publish.yml\` *after*:
+
+          - Tag \`${TAG}\` was pushed and triggered the Publish workflow
+          - TestPyPI + Docker smoke tests passed
+          - The \`release-gate\` environment was approved
+          - \`publish\` (PyPI) and \`docker-publish\` (Docker Hub) both succeeded
+          - \`create-release\` created the GitHub Release \`${TAG}\`
+
+          So the pinned SHA \`${SHA}\` is guaranteed to correspond to a release that actually shipped through every channel.
+
+          **After merging this PR**, trigger **Actions → Marketplace smoke test → Run workflow** to verify the published Action end-to-end against the new tag.
+          EOF
+          # Strip the 10-space indentation that the YAML block scalar requires.
+          sed -i -E 's/^          //' /tmp/pr-body.md
+          gh pr create \
+            --base main \
+            --head "${branch}" \
+            --title "Bump marketplace-smoke pin to ${TAG}" \
+            --body-file /tmp/pr-body.md

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -1,0 +1,139 @@
+name: Release prep
+
+# Maintainer-triggered. Opens the "Prepare X.Y.Z release" PR for you:
+# bumps pyproject.toml + src/compose_lint/__init__.py, renames the
+# CHANGELOG [Unreleased] section to [X.Y.Z] - <today>, inserts a fresh
+# empty [Unreleased] above it, commits on a release/X.Y.Z branch, and
+# opens a PR against main.
+#
+# The signed annotated tag is NOT created here. After the PR merges,
+# run `git tag -s vX.Y.Z -m "compose-lint X.Y.Z" && git push origin vX.Y.Z`
+# from your workstation. That signature is the root of the Sigstore
+# provenance chain; the publish workflow also refuses to trigger on tags
+# created via GITHUB_TOKEN, so automating tag creation here would break
+# the pipeline even if we wanted to.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g. 0.3.7) — no 'v' prefix"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  prep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Validate version input
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Version '${VERSION}' is not in X.Y.Z format"
+            exit 1
+          fi
+          if git rev-parse "v${VERSION}" >/dev/null 2>&1; then
+            echo "::error::Tag v${VERSION} already exists"
+            exit 1
+          fi
+          if git ls-remote --exit-code --heads origin "release/${VERSION}" >/dev/null 2>&1; then
+            echo "::error::Branch release/${VERSION} already exists on origin"
+            exit 1
+          fi
+
+      - name: Bump pyproject.toml
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          sed -i -E "s/^version = \"[^\"]+\"/version = \"${VERSION}\"/" pyproject.toml
+          grep -E '^version = ' pyproject.toml
+
+      - name: Bump src/compose_lint/__init__.py
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          sed -i -E "s/^__version__ = \"[^\"]+\"/__version__ = \"${VERSION}\"/" src/compose_lint/__init__.py
+          grep '__version__' src/compose_lint/__init__.py
+
+      - name: Rename CHANGELOG [Unreleased] and insert fresh header
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          today=$(date -u +%Y-%m-%d)
+          awk -v v="${VERSION}" -v d="${today}" '
+            !done && /^## \[Unreleased\]/ {
+              print "## [Unreleased]"
+              print ""
+              print "## [" v "] - " d
+              done=1
+              next
+            }
+            { print }
+          ' CHANGELOG.md > CHANGELOG.md.new
+          if ! grep -qE "^## \[${VERSION}\] - " CHANGELOG.md.new; then
+            echo "::error::Failed to rewrite CHANGELOG.md — no [Unreleased] header found?"
+            rm -f CHANGELOG.md.new
+            exit 1
+          fi
+          mv CHANGELOG.md.new CHANGELOG.md
+
+      - name: Verify versions match
+        run: |
+          pyproject=$(grep -E '^version = ' pyproject.toml | head -1 | cut -d'"' -f2)
+          init=$(grep '__version__' src/compose_lint/__init__.py | head -1 | cut -d'"' -f2)
+          if [ "${pyproject}" != "${init}" ] || [ "${pyproject}" != "${{ inputs.version }}" ]; then
+            echo "::error::Post-bump version mismatch: pyproject=${pyproject}, init=${init}, input=${{ inputs.version }}"
+            exit 1
+          fi
+
+      - name: Commit, push, open PR
+        env:
+          VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          branch="release/${VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${branch}"
+          git add pyproject.toml src/compose_lint/__init__.py CHANGELOG.md
+          git commit -m "Prepare ${VERSION} release"
+          git push -u origin "${branch}"
+          cat > /tmp/pr-body.md <<EOF
+          Automated release prep for \`${VERSION}\`. Review the CHANGELOG entry and version bumps, then squash-merge.
+
+          **After this PR merges**, create and push a signed annotated tag from your workstation:
+
+          \`\`\`
+          git checkout main && git pull --ff-only
+          git tag -s v${VERSION} -m "compose-lint ${VERSION}"
+          git push origin v${VERSION}
+          \`\`\`
+
+          The tag push triggers \`publish.yml\`, which runs TestPyPI/Docker smoke tests, waits for your approval on the \`release\` environment, then publishes PyPI + Docker Hub, creates the GitHub Release, and opens a follow-up PR to bump the \`marketplace-smoke\` pin.
+          EOF
+          sed -i -E 's/^          //' /tmp/pr-body.md
+          gh pr create \
+            --base main \
+            --head "${branch}" \
+            --title "Prepare ${VERSION} release" \
+            --body-file /tmp/pr-body.md
+
+          {
+            echo "### Release prep PR opened"
+            echo "Branch: \`${branch}\`"
+            echo "Next step: review and merge, then sign-push \`v${VERSION}\`."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -11,6 +11,36 @@ waits for a single manual approval on the `release` environment before
 publishing to all production channels in parallel. Sigstore build
 attestations are generated automatically.
 
+## What's automated vs. manual
+
+Most of this checklist is now wired into CI. At a glance:
+
+| Step                                   | Where it runs                                      |
+| -------------------------------------- | -------------------------------------------------- |
+| Pre-release checks (ruff/mypy/pytest)  | `ci.yml` on every PR                               |
+| Version strings in sync                | `ci.yml` → `version-consistency` job               |
+| CHANGELOG section exists for bump      | `ci.yml` → `changelog-gate` job                    |
+| Open the "Prepare X.Y.Z release" PR    | `release-prep.yml` (`workflow_dispatch`)           |
+| Create signed tag and push             | **Manual** (your workstation)                      |
+| Build, sign, TestPyPI, smoke tests     | `publish.yml`                                      |
+| Release-gate approval                  | **Manual** (GitHub Environment `release`)          |
+| PyPI + Docker Hub publish              | `publish.yml`                                      |
+| GitHub Release created from CHANGELOG  | `publish.yml` → `create-release` job               |
+| Marketplace-smoke pin bump PR          | `publish.yml` → `bump-marketplace-smoke-pin` job   |
+| Merge pin bump PR, re-run smoke        | **Manual**                                         |
+
+Tag creation stays manual on purpose. Tags created by `GITHUB_TOKEN`
+don't trigger downstream workflows (see "If something goes wrong"), and
+the SSH-signed tag is the root of the Sigstore provenance chain for the
+built artifact. Release-gate approval stays manual because it's the
+human-in-the-loop safety between TestPyPI smoke passing and real PyPI /
+Docker Hub publishing.
+
+Everything below is the manual checklist for the steps that are not
+automated. If you invoke `Release prep` from the Actions tab, it does
+the "Bump the version", "Update the changelog", and "Commit the bump"
+sections for you — your job is to review the resulting PR.
+
 ## Choosing the version number
 
 compose-lint follows [Semantic Versioning](https://semver.org/), with one
@@ -202,25 +232,21 @@ After approval, `publish` and `docker-publish` run in parallel.
 
 ## Post-release
 
-- [ ] Create a GitHub Release from the tag
-      (`gh release create vX.Y.Z --notes-from-tag` or use the web UI).
-      Copy the relevant CHANGELOG section as the release notes.
-- [ ] **Bump the Marketplace smoke test pin.** The commit SHA only
-      exists once the tag is pushed, so this can't live in the
-      release bump PR. Grab the SHA and update both
-      `uses: tmatens/compose-lint@<sha> # vX.Y.Z` lines in
-      `.github/workflows/marketplace-smoke.yml`:
-
-      ```bash
-      git rev-parse vX.Y.Z^{commit}
-      ```
-
-      Open a follow-up PR with the bump. Once it's merged, trigger
-      **Actions → Marketplace smoke test → Run workflow** to verify
-      the published action end-to-end against the new tag.
+- [ ] **GitHub Release** — created automatically by `publish.yml`'s
+      `create-release` job (runs after both `publish` and
+      `docker-publish` succeed). Notes come from the matching
+      `## [X.Y.Z]` section in `CHANGELOG.md`. Wheels, sdist, and
+      Sigstore bundles are attached as release assets.
+- [ ] **Marketplace smoke test pin bump** — `publish.yml`'s
+      `bump-marketplace-smoke-pin` job (runs after `create-release`)
+      opens a follow-up PR with the new SHA in both
+      `uses: tmatens/compose-lint@<sha> # vX.Y.Z` lines. Review and
+      squash-merge, then trigger **Actions → Marketplace smoke test →
+      Run workflow** to verify the published Action end-to-end.
+- [ ] **Fresh `[Unreleased]` section** — already inserted by
+      `release-prep.yml` as part of the release bump PR. No follow-up
+      PR needed.
 - [ ] Announce in Discussions if the release has user-visible changes.
-- [ ] Open a follow-up PR adding an empty `[Unreleased]` section at the
-      top of `CHANGELOG.md` so the next change has somewhere to land.
 
 ## If something goes wrong
 


### PR DESCRIPTION
## Summary

Four pieces of release automation. Cuts manual steps out of the tag-to-publish flow and catches the historically painful mistakes at PR review time instead of post-tag.

- **`ci.yml` → `version-consistency`** — fails any PR where `pyproject.toml` and `src/compose_lint/__init__.py` disagree. Catches the single most-called-out hazard in `docs/RELEASING.md` ("we almost shipped 0.2.0 with a mismatch") before merge.
- **`ci.yml` → `changelog-gate`** — on PRs, if `pyproject.toml`'s `version` line changed, `CHANGELOG.md` must already contain a matching `## [X.Y.Z]` section. Today, a missing section is only discovered by `publish.yml`'s `create-release` step, **after** the tag has been minted — burning the PyPI version if `publish` ran first.
- **New `release-prep.yml`** (`workflow_dispatch`) — opens the "Prepare X.Y.Z release" PR: bumps both version strings, renames `[Unreleased]` → `[X.Y.Z] - <today>`, inserts a fresh empty `[Unreleased]`, and links to the manual tag-signing step in the PR body. One click instead of three hand-edits.
- **`publish.yml` → `bump-marketplace-smoke-pin`** — runs after `create-release`. Opens a follow-up PR updating both `uses: tmatens/compose-lint@<sha> # vX.Y.Z` lines in `marketplace-smoke.yml`. The job name and PR body spell out that this is *post-tag, post-publish*, so the pinned SHA is guaranteed to correspond to a release that already shipped through every channel.

## What stays manual (on purpose)

- **Signed tag push** — `GITHUB_TOKEN`-created tags don't trigger downstream workflows, and the SSH-signed annotated tag is the root of the Sigstore provenance chain. Automating it breaks both.
- **`release-gate` approval** — human-in-the-loop safety between TestPyPI smoke passing and real PyPI + Docker Hub publishing.

## Docs

`docs/RELEASING.md` now opens with an "automated vs manual" table and the post-release section reflects that the GitHub Release, marketplace-smoke pin bump, and empty `[Unreleased]` insertion are all automated.

## Test plan

- [x] YAML parses (`yaml.safe_load` on all three workflows)
- [x] Local dry-run of `release-prep.yml`'s bump logic (sed + awk) against current repo state — produces correct version strings and CHANGELOG shape
- [x] Local dry-run of the `bump-marketplace-smoke-pin` sed against `marketplace-smoke.yml` — both pin lines rewrite correctly
- [x] `ruff check`, `ruff format --check`, `mypy src/`, `pytest` (264 tests)
- [ ] Actions-tab validation: trigger `Release prep` with a throwaway version against a throwaway branch to confirm the PR-open path works end-to-end (reviewer)
- [ ] First real use will be 0.3.7 — watch the flow and tune if anything surprises