### PR TITLE
Prepare 0.3.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.7] - 2026-04-18
+
 ### Changed
 
 - CL-0003 fix guidance now warns that `no-new-privileges` breaks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "compose-lint"
-version = "0.3.6"
+version = "0.3.7"
 description = "A security-focused linter for Docker Compose files"
 readme = "README.md"
 license = "MIT"

--- a/src/compose_lint/__init__.py
+++ b/src/compose_lint/__init__.py
@@ -1,3 +1,3 @@
 """A security-focused linter for Docker Compose files."""
 
-__version__ = "0.3.6"
+__version__ = "0.3.7"


### PR DESCRIPTION
Automated release prep for    
  0.3.7. Bumps pyproject.toml + __init__.py and moves the CHANGELOG [Unreleased] section to [0.3.7].