### PR TITLE
Bump marketplace-smoke pin to v0.3.7

### DIFF
--- a/.github/workflows/marketplace-smoke.yml
+++ b/.github/workflows/marketplace-smoke.yml
@@ -65,7 +65,7 @@ jobs:
           YAML
 
       - name: Clean fixture should pass
-        uses: tmatens/compose-lint@4facca88bd8a9f5c7c5e1bc897bc5f2913020e72 # v0.3.6
+        uses: tmatens/compose-lint@5d5a43a6134b7a0820b391a1f7876fe7b10df323 # v0.3.7
         with:
           files: smoke/clean.yml
           fail-on: high
@@ -73,7 +73,7 @@ jobs:
       - name: Insecure fixture should fail
         id: insecure
         continue-on-error: true
-        uses: tmatens/compose-lint@4facca88bd8a9f5c7c5e1bc897bc5f2913020e72 # v0.3.6
+        uses: tmatens/compose-lint@5d5a43a6134b7a0820b391a1f7876fe7b10df323 # v0.3.7
         with:
           files: smoke/insecure.yml
           fail-on: high


### PR DESCRIPTION
Post-tag follow-up for v0.3.7. Pins SHA `5d5a43a6134b7a0820b391a1f7876fe7b10df323` across both `uses: tmatens/compose-lint@<sha>` lines in marketplace-smoke.yml.

SHA resolved from the signed tag (`git rev-parse v0.3.7^{commit}`) and matches the commit that was published to PyPI, Docker Hub, and GitHub Releases.

The automated `bump-marketplace-smoke-pin` job in publish.yml tried to do this but hit the GITHUB_TOKEN workflows-scope restriction — it can't modify files under .github/workflows/. A follow-up PR will wire that job to a PAT so next release's bump is automated.

After merging this PR, trigger **Actions → Marketplace smoke test → Run workflow** to verify the published Action end-to-end against v0.3.7.