### PR TITLE
Add Python 3.14 to the CI matrix and document version-support cadence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Disables still produce suppressed findings. `reason` flows to `suppression_reaso
 
 ## Quality checks
 
-`ruff check`, `ruff format --check`, `mypy src/` (strict), `pytest`. All four must pass. CI test matrix: Python 3.10–3.13 on ubuntu-latest.
+`ruff check`, `ruff format --check`, `mypy src/` (strict), `pytest`. All four must pass. CI test matrix: Python 3.10–3.14 on ubuntu-latest.
 
 ## Adding a rule
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -93,6 +93,22 @@ Pursue based on user demand after v1.0.
 
 ---
 
+## Python version support
+
+Track current CPython: add new minor versions to the CI matrix within ~3 months of each October release, drop versions at upstream end-of-life. Adding a version is additive (PATCH per `docs/RELEASING.md`); dropping a version is a MINOR pre-1.0 and a MAJOR post-1.0.
+
+| Version | Released  | EOL       | In matrix as of |
+|---------|-----------|-----------|-----------------|
+| 3.10    | 2021-10   | 2026-10   | 0.2.0           |
+| 3.11    | 2022-10   | 2027-10   | 0.2.0           |
+| 3.12    | 2023-10   | 2028-10   | 0.2.0           |
+| 3.13    | 2024-10   | 2029-10   | 0.2.0           |
+| 3.14    | 2025-10   | 2030-10   | 0.3.8           |
+
+Python 3.10 is scheduled to age out of the matrix when it reaches upstream EOL in October 2026 (release bump to 0.4.x or later).
+
+---
+
 ## Summary
 
 | Milestone | Version |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Security",
     "Topic :: Software Development :: Quality Assurance",
 ]


### PR DESCRIPTION
## Summary

- **Matrix bump** — Python 3.14 (released 2025-10) added to `ci.yml` and to the `pyproject.toml` classifiers. `AGENTS.md` / `CLAUDE.md` (symlinked) updated from `3.10–3.13` to `3.10–3.14`.
- **Lockfiles** — unchanged. `requires-python` lower bound is still `>=3.10` and the locks were compiled with `--universal`, so they already satisfy 3.14 without regeneration. CI proves it.
- **Roadmap** — new "Python version support" section with a release/EOL table and an explicit cadence: add new minors within ~3 months of each October release, drop at upstream EOL. Python 3.10 is next up for removal (EOL 2026-10).

Additive change, pre-existing users unaffected → PATCH per `docs/RELEASING.md`. Will ship as part of 0.3.8.

## Test plan

- [x] `ruff check`, `ruff format --check`, `mypy src/`, `pytest` — all green locally on 3.12
- [ ] CI matrix: all five Python legs (3.10, 3.11, 3.12, 3.13, 3.14) pass
- [ ] `version-consistency` + `changelog-gate` jobs pass (no version change here, so changelog-gate should no-op)