### PR TITLE
Smoke Dockerfile on PRs; cut PR fuzz budget to 120s

### DIFF
--- a/.github/workflows/cflite-pr.yml
+++ b/.github/workflows/cflite-pr.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           language: python
           sanitizer: address
-          fuzz-seconds: 300
+          fuzz-seconds: 120
           mode: code-change
           output-sarif: true
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,91 @@ jobs:
           persist-credentials: false
       - run: scripts/verify-dockerfile-digests.sh Dockerfile
 
+  # Builds the Dockerfile on PRs that touch build inputs and runs the
+  # image against fixtures. Without this, a broken Dockerfile or runtime
+  # dependency change silently rides to tag time where the release
+  # `docker-smoke` job is the first thing to notice. amd64-only to keep
+  # the gate cheap; the release pipeline covers multi-arch.
+  docker-smoke:
+    name: Smoke test Dockerfile (amd64)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Determine if Docker-relevant files changed
+        id: changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --name-only "${BASE_SHA}" "${HEAD_SHA}" \
+              | grep -qE '^(Dockerfile|\.dockerignore|requirements\.lock|requirements-build\.lock|pyproject\.toml|src/)'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "No Docker-relevant files changed — skipping build."
+          fi
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        if: steps.changes.outputs.run == 'true'
+      - name: Build image
+        if: steps.changes.outputs.run == 'true'
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          platforms: linux/amd64
+          load: true
+          tags: composelint/compose-lint:pr-smoke
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Clean fixture exits 0
+        if: steps.changes.outputs.run == 'true'
+        run: |
+          cat > /tmp/clean.yml <<'YAML'
+          services:
+            web:
+              image: nginx:1.27-alpine
+              ports:
+                - "127.0.0.1:8080:80"
+              security_opt:
+                - no-new-privileges:true
+              cap_drop:
+                - ALL
+              read_only: true
+          YAML
+          docker run --rm -v /tmp/clean.yml:/src/docker-compose.yml composelint/compose-lint:pr-smoke
+      - name: Insecure fixture exits 1
+        if: steps.changes.outputs.run == 'true'
+        run: |
+          cat > /tmp/insecure.yml <<'YAML'
+          services:
+            app:
+              image: myapp:1.0
+              privileged: true
+          YAML
+          exit_code=0
+          docker run --rm -v /tmp/insecure.yml:/src/docker-compose.yml composelint/compose-lint:pr-smoke || exit_code=$?
+          if [ "${exit_code}" -ne 1 ]; then
+            echo "::error::Expected exit code 1, got ${exit_code}"
+            exit 1
+          fi
+      - name: SARIF output is valid JSON
+        if: steps.changes.outputs.run == 'true'
+        run: |
+          cat > /tmp/test.yml <<'YAML'
+          services:
+            db:
+              image: postgres:16
+          YAML
+          docker run --rm -v /tmp/test.yml:/src/docker-compose.yml composelint/compose-lint:pr-smoke --format sarif --fail-on critical \
+            | python3 -c "import sys, json; json.load(sys.stdin); print('Valid SARIF JSON')"
+
   action-smoke:
     name: Smoke test action.yml
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `docker-smoke` job to `ci.yml` — builds `linux/amd64` from the current `Dockerfile` and runs the image against clean/insecure/SARIF fixtures. Path-filtered to `Dockerfile`, `.dockerignore`, `requirements.lock`, `requirements-build.lock`, `pyproject.toml`, and `src/` so docs-only PRs skip the build. GHA buildx cache keeps repeat runs cheap.
- Closes the gap where a broken Dockerfile or bad `requirements-build.lock` bump only surfaced in `publish.yml`'s `docker-smoke` after the tag was minted.
- Reduce `cflite-pr.yml` `fuzz-seconds` from 300 → 120. PR fuzzing is code-change mode on a cold corpus — its job is to catch regressions introduced by the diff, not to reach deep state. Batch (nightly) fuzzing stays at 600s across both sanitizers.

## Test plan
- [ ] Docs-only PR: `docker-smoke` job runs the guard step, reports `run=false`, remaining steps skip
- [ ] Dockerfile-touching PR: guard reports `run=true`, image builds, all three fixture steps pass
- [ ] Break the Dockerfile deliberately in a draft PR to confirm the job fails (then revert)
- [ ] Confirm `cflite-pr` run now finishes in ~2 min instead of ~5