### PR TITLE
Stop pinning action-smoke to compose-lint 0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,12 +261,16 @@ jobs:
               privileged: true
           YAML
 
+      # No `version:` pin — the action defaults to installing the latest
+      # release from PyPI. What this job tests is the action.yml contract
+      # (inputs, file discovery, SARIF wiring) against whatever compose-lint
+      # is currently published. Pinning to a stale version hid breakages
+      # between the source action and the published package through 0.3.x.
       - name: Clean fixture should pass
         uses: ./
         with:
           files: smoke/clean.yml
           fail-on: high
-          version: "0.2.0"
 
       - name: Insecure fixture should fail
         id: insecure
@@ -275,7 +279,6 @@ jobs:
         with:
           files: smoke/insecure.yml
           fail-on: high
-          version: "0.2.0"
 
       - name: Assert insecure run failed
         if: steps.insecure.outcome != 'failure'


### PR DESCRIPTION
## Summary
- `ci.yml`'s `action-smoke` job has pinned the installed compose-lint to `0.2.0` since that release. The action has since shipped 0.3.0–0.3.7 worth of changes; any drift between a current `action.yml` change and the actually-published package has gone untested.
- Drops the `version:` input so `action.yml` installs the latest release from PyPI. What the job tests (the `action.yml` contract: inputs, file discovery, SARIF wiring) now runs against the version users will actually get.

## Test plan
- [ ] `action-smoke` job still runs and passes on this PR
- [ ] Logs show `pip install compose-lint` (no `==0.2.0`) during the action's install step