### PR TITLE
Centralize smoke fixtures in tests/smoke/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,35 +231,10 @@ jobs:
         with:
           persist-credentials: false
 
-      # Fixtures are written inline so the smoke test is self-contained
-      # and doesn't couple to tests/compose_files/ (which may evolve as
-      # rules change). The action installs compose-lint from PyPI, so
-      # behavior here is pinned to the released version below, not the
-      # current source tree.
-      - name: Create smoke fixtures
-        run: |
-          mkdir -p smoke
-          cat > smoke/clean.yml <<'YAML'
-          services:
-            web:
-              image: nginx:1.27-alpine
-              ports:
-                - "127.0.0.1:8080:80"
-              security_opt:
-                - no-new-privileges:true
-              cap_drop:
-                - ALL
-              read_only: true
-              tmpfs:
-                - /tmp
-                - /run
-          YAML
-          cat > smoke/insecure.yml <<'YAML'
-          services:
-            app:
-              image: myapp:1.0
-              privileged: true
-          YAML
+      # Smoke fixtures live in tests/smoke/ and are shared with every
+      # other workflow that runs compose-lint end-to-end (publish.yml
+      # testpypi-smoke, publish.yml docker-smoke, marketplace-smoke.yml).
+      # One source of truth prevents per-workflow drift.
 
       # No `version:` pin — the action defaults to installing the latest
       # release from PyPI. What this job tests is the action.yml contract
@@ -269,7 +244,7 @@ jobs:
       - name: Clean fixture should pass
         uses: ./
         with:
-          files: smoke/clean.yml
+          files: tests/smoke/clean.yml
           fail-on: high
 
       - name: Insecure fixture should fail
@@ -277,7 +252,7 @@ jobs:
         continue-on-error: true
         uses: ./
         with:
-          files: smoke/insecure.yml
+          files: tests/smoke/insecure.yml
           fail-on: high
 
       - name: Assert insecure run failed

--- a/.github/workflows/marketplace-smoke.yml
+++ b/.github/workflows/marketplace-smoke.yml
@@ -39,35 +39,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Create smoke fixtures
-        run: |
-          mkdir -p smoke
-          cat > smoke/clean.yml <<'YAML'
-          services:
-            web:
-              image: nginx:1.27-alpine
-              ports:
-                - "127.0.0.1:8080:80"
-              security_opt:
-                - no-new-privileges:true
-              cap_drop:
-                - ALL
-              read_only: true
-              tmpfs:
-                - /tmp
-                - /run
-          YAML
-          cat > smoke/insecure.yml <<'YAML'
-          services:
-            app:
-              image: myapp:1.0
-              privileged: true
-          YAML
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Clean fixture should pass
         uses: tmatens/compose-lint@5d5a43a6134b7a0820b391a1f7876fe7b10df323 # v0.3.7
         with:
-          files: smoke/clean.yml
+          files: tests/smoke/clean.yml
           fail-on: high
 
       - name: Insecure fixture should fail
@@ -75,7 +54,7 @@ jobs:
         continue-on-error: true
         uses: tmatens/compose-lint@5d5a43a6134b7a0820b391a1f7876fe7b10df323 # v0.3.7
         with:
-          files: smoke/insecure.yml
+          files: tests/smoke/insecure.yml
           fail-on: high
 
       - name: Assert insecure run failed

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -119,6 +119,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
@@ -153,30 +156,11 @@ jobs:
             exit 1
           fi
       - name: Smoke test — lint a clean fixture
-        run: |
-          cat > /tmp/clean.yml <<'YAML'
-          services:
-            web:
-              image: nginx:1.27-alpine
-              ports:
-                - "127.0.0.1:8080:80"
-              security_opt:
-                - no-new-privileges:true
-              cap_drop:
-                - ALL
-              read_only: true
-          YAML
-          compose-lint /tmp/clean.yml
+        run: compose-lint tests/smoke/clean.yml
       - name: Smoke test — insecure fixture exits 1
         run: |
-          cat > /tmp/insecure.yml <<'YAML'
-          services:
-            app:
-              image: myapp:1.0
-              privileged: true
-          YAML
           exit_code=0
-          compose-lint /tmp/insecure.yml || exit_code=$?
+          compose-lint tests/smoke/insecure.yml || exit_code=$?
           if [ "${exit_code}" -ne 1 ]; then
             echo "::error::Expected exit code 1, got ${exit_code}"
             exit 1
@@ -230,41 +214,25 @@ jobs:
           fi
       - name: Test — clean fixture exits 0
         run: |
-          cat > /tmp/clean.yml <<'YAML'
-          services:
-            web:
-              image: nginx:1.27-alpine
-              ports:
-                - "127.0.0.1:8080:80"
-              security_opt:
-                - no-new-privileges:true
-              cap_drop:
-                - ALL
-              read_only: true
-          YAML
-          docker run --rm -v /tmp/clean.yml:/src/docker-compose.yml composelint/compose-lint:test
+          docker run --rm \
+            -v "${PWD}/tests/smoke/clean.yml":/src/docker-compose.yml \
+            composelint/compose-lint:test
       - name: Test — insecure fixture exits 1
         run: |
-          cat > /tmp/insecure.yml <<'YAML'
-          services:
-            app:
-              image: myapp:1.0
-              privileged: true
-          YAML
           exit_code=0
-          docker run --rm -v /tmp/insecure.yml:/src/docker-compose.yml composelint/compose-lint:test || exit_code=$?
+          docker run --rm \
+            -v "${PWD}/tests/smoke/insecure.yml":/src/docker-compose.yml \
+            composelint/compose-lint:test || exit_code=$?
           if [ "${exit_code}" -ne 1 ]; then
             echo "::error::Expected exit code 1, got ${exit_code}"
             exit 1
           fi
       - name: Test — SARIF output is valid JSON
         run: |
-          cat > /tmp/test.yml <<'YAML'
-          services:
-            db:
-              image: postgres:16
-          YAML
-          docker run --rm -v /tmp/test.yml:/src/docker-compose.yml composelint/compose-lint:test --format sarif --fail-on critical | python3 -c "import sys,json; json.load(sys.stdin); print('Valid SARIF JSON')"
+          docker run --rm \
+            -v "${PWD}/tests/smoke/sarif-shape.yml":/src/docker-compose.yml \
+            composelint/compose-lint:test --format sarif --fail-on critical \
+            | python3 -c "import sys, json; json.load(sys.stdin); print('Valid SARIF JSON')"
       - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         if: matrix.scout
         with:

--- a/tests/smoke/clean.yml
+++ b/tests/smoke/clean.yml
@@ -1,0 +1,17 @@
+# Canonical "clean" smoke fixture shared by every workflow that runs
+# compose-lint end-to-end (ci.yml, publish.yml, marketplace-smoke.yml).
+# Keeping one copy prevents the drift we had through 0.3.x where the
+# fixture existed in five heredocs and only some included `tmpfs:`.
+services:
+  web:
+    image: nginx:1.27-alpine
+    ports:
+      - "127.0.0.1:8080:80"
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp
+      - /run

--- a/tests/smoke/insecure.yml
+++ b/tests/smoke/insecure.yml
@@ -1,0 +1,8 @@
+# Canonical "insecure" smoke fixture shared by every workflow that runs
+# compose-lint end-to-end. A minimal privileged container — every
+# current version of compose-lint flags this HIGH or above, so smoke
+# tests can reliably assert `exit 1`.
+services:
+  app:
+    image: myapp:1.0
+    privileged: true

--- a/tests/smoke/sarif-shape.yml
+++ b/tests/smoke/sarif-shape.yml
@@ -1,0 +1,7 @@
+# Minimal fixture used only to exercise `--format sarif` output shape.
+# Not asserted for specific findings — the smoke test just verifies
+# that the produced SARIF parses as JSON. Any real Compose file would
+# do; a single unpinned image keeps it short.
+services:
+  db:
+    image: postgres:16


### PR DESCRIPTION
## Summary
- The \"clean\" and \"insecure\" smoke fixtures have lived in five separate heredocs (ci.yml action-smoke, publish.yml testpypi-smoke, publish.yml docker-smoke, marketplace-smoke.yml) since 0.2.x. They drifted — action-smoke was the only one that included `tmpfs: [/tmp, /run]`.
- Move them to `tests/smoke/{clean,insecure,sarif-shape}.yml`. Every workflow now checks out the repo and references these files directly.
- pytest only discovers `test_*.py`, and the wheel already excludes `tests/`, so the files don't leak into the suite or the published package.

## Follow-ups
- PR #77 adds a new `docker-smoke` job in ci.yml with its own heredoc fixtures — once #77 merges, a trivial follow-up will point it at `tests/smoke/` too.
- PR #78 removes the `version: "0.2.0"` pin from the same action-smoke block this PR edits. Whichever lands first, the other rebases cleanly.

## Test plan
- [ ] `action-smoke` in this PR passes against the relocated fixtures
- [ ] Inspect the diff — no fixture content has changed semantically; only location
- [ ] `pytest` still collects the same set of tests (no YAML files discovered)