### PR TITLE
Auto-run marketplace-smoke on pin-bump merge

### DIFF
--- a/.github/workflows/marketplace-smoke.yml
+++ b/.github/workflows/marketplace-smoke.yml
@@ -8,9 +8,12 @@ name: Marketplace smoke test
 # the Marketplace boundary: a missing tag, a broken published
 # action.yml, a PyPI outage, etc.
 #
-# Trigger it from the Actions tab → "Marketplace smoke test" →
-# "Run workflow". No automatic triggers — this reaches out to PyPI
-# on every run and there's no reason to spend that on every push.
+# Auto-triggers on push-to-main that touches this file — i.e., when
+# the `bump-marketplace-smoke-pin` PR from publish.yml merges, the
+# smoke runs against the newly-pinned SHA without a manual click.
+# `release: published` would fire before the pin bump lands, smoking
+# the *previous* release; gating on the pin-bump merge avoids that.
+# Also triggerable manually from Actions tab for ad-hoc re-verification.
 #
 # When cutting a new release, bump the commit SHA on the two
 # `uses:` lines below (and the trailing `# vX.Y.Z` comment so a
@@ -29,6 +32,10 @@ name: Marketplace smoke test
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/marketplace-smoke.yml
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Add `push: branches:[main] paths:[marketplace-smoke.yml]` trigger so the Marketplace smoke runs automatically when the `bump-marketplace-smoke-pin` PR merges.
- Keep `workflow_dispatch` for ad-hoc re-verification.
- Update the workflow header comment to explain the new trigger and why `release: published` wasn't the right choice.

## Rationale

`release: published` fires *before* `bump-marketplace-smoke-pin` opens its PR in \`publish.yml\`, so it would smoke the **previous** release's pinned SHA. Gating on the pin-bump merge (push-to-main touching this file) fires at exactly the right moment — against the freshly-bumped pin — and replaces the manual click step that CI.md already documents ("Run it after every release bump PR merges").

## Test plan

- [ ] actionlint passes locally and in the ci.yml actionlint job
- [ ] Visual diff of the workflow header comment reads cleanly
- [ ] Confirm on the next release cycle that this runs automatically after the `chore/marketplace-smoke-<version>` PR merges