### PR TITLE
Gate publish on annotated-tag check and attach SBOM to PyPI releases

### DIFF
--- a/.github/workflows/publish-channel.yml
+++ b/.github/workflows/publish-channel.yml
@@ -30,11 +30,29 @@ jobs:
     permissions:
       id-token: write
       attestations: write
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          # Full history so we can verify the tag is annotated and
+          # reachable from main before shipping.
+          fetch-depth: 0
           ref: ${{ inputs.tag }}
           persist-credentials: false
+      - name: Verify tag is annotated and reachable from main
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          obj_type=$(git cat-file -t "${TAG}")
+          if [ "${obj_type}" != "tag" ]; then
+            echo "::error::${TAG} is a ${obj_type}, expected an annotated tag"
+            exit 1
+          fi
+          tag_commit=$(git rev-parse "${TAG}^{commit}")
+          if ! git merge-base --is-ancestor "${tag_commit}" origin/main; then
+            echo "::error::${TAG} commit ${tag_commit} is not reachable from origin/main"
+            exit 1
+          fi
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
@@ -88,9 +106,25 @@ jobs:
             echo "::error::Expected exit 1 on insecure fixture, got ${exit_code}"
             exit 1
           fi
+      # SBOM parity with publish.yml's build job. Emergency pypi publishes
+      # should leave the same SPDX artifact on the Release as the normal
+      # path. Attach (or replace) it with --clobber so re-running this
+      # workflow against a tag whose Release already has an SBOM is idempotent.
+      - name: Generate SPDX SBOM for dists
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: dist/
+          format: spdx-json
+          output-file: sbom.spdx.json
+          upload-artifact: false
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           attestations: true
+      - name: Attach SBOM to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+        run: gh release upload "${TAG}" sbom.spdx.json --clobber
 
   # Pre-publish smoke for the docker channel. publish.yml runs docker-smoke
   # multi-arch before the release-gate; this emergency path has no shared
@@ -104,8 +138,23 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          fetch-depth: 0
           ref: ${{ inputs.tag }}
           persist-credentials: false
+      - name: Verify tag is annotated and reachable from main
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          obj_type=$(git cat-file -t "${TAG}")
+          if [ "${obj_type}" != "tag" ]; then
+            echo "::error::${TAG} is a ${obj_type}, expected an annotated tag"
+            exit 1
+          fi
+          tag_commit=$(git rev-parse "${TAG}^{commit}")
+          if ! git merge-base --is-ancestor "${tag_commit}" origin/main; then
+            echo "::error::${TAG} commit ${tag_commit} is not reachable from origin/main"
+            exit 1
+          fi
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Build image for testing
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,44 @@ permissions:
   contents: read
 
 jobs:
+  # Gate every publish path on two lightweight tag checks:
+  #   1. The ref is an annotated tag (not a lightweight tag). Release tags
+  #      are created with `git tag -s`, which is always annotated; a
+  #      lightweight tag here means something/someone pushed a malformed
+  #      release tag.
+  #   2. The tag commit is reachable from origin/main. Without this, a
+  #      rogue tag pointed at an arbitrary commit (outside main's merge
+  #      history) would still trigger publish.yml and ship whatever tree
+  #      that commit has.
+  #
+  # Full SSH-signature verification would require committing the
+  # maintainer's allowed-signers file; that's a follow-up.
+  verify-tag:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Assert annotated tag and reachable from main
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          obj_type=$(git cat-file -t "${TAG}")
+          if [ "${obj_type}" != "tag" ]; then
+            echo "::error::${TAG} is a ${obj_type}, expected an annotated tag (git tag -s/-a)"
+            exit 1
+          fi
+          tag_commit=$(git rev-parse "${TAG}^{commit}")
+          if ! git merge-base --is-ancestor "${tag_commit}" origin/main; then
+            echo "::error::${TAG} commit ${tag_commit} is not reachable from origin/main"
+            exit 1
+          fi
+          echo "Tag ${TAG} is annotated and reachable from origin/main (commit ${tag_commit})."
+
   build:
+    needs: verify-tag
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -85,6 +122,17 @@ jobs:
             fi
           done
           echo "All ${#dists[@]} distributions have matching signatures."
+      # Generate an SPDX SBOM covering everything in dist/ (wheel + sdist).
+      # docker-publish already attests an SBOM to the image; this closes
+      # the PyPI gap so every shipped channel has a machine-readable bill
+      # of materials. Attached as a Release asset by create-release.
+      - name: Generate SPDX SBOM for dists
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: dist/
+          format: spdx-json
+          output-file: sbom.spdx.json
+          upload-artifact: false
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
@@ -93,6 +141,10 @@ jobs:
         with:
           name: signatures
           path: signatures/
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sbom
+          path: sbom.spdx.json
 
   testpypi:
     needs: build
@@ -460,6 +512,10 @@ jobs:
         with:
           name: signatures
           path: signatures/
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: sbom
+          path: .
       - name: Extract changelog section for this tag
         env:
           TAG: ${{ github.ref_name }}
@@ -487,7 +543,7 @@ jobs:
             --title "${TAG}" \
             --notes-file notes.md \
             --verify-tag \
-            dist/*.whl dist/*.tar.gz signatures/*
+            dist/*.whl dist/*.tar.gz signatures/* sbom.spdx.json
 
   # Post-tag, post-publish automation. At this point:
   #   - The signed tag ${{ github.ref_name }} exists (it triggered this


### PR DESCRIPTION
## Summary

Two independent supply-chain gaps in the release pipeline, bundled because both touch \`publish.yml\` + \`publish-channel.yml\`.

### 1. Tag verification

Today \`publish.yml\` runs on *any* \`v*\` tag push — a lightweight tag, or a tag pointing at a commit outside main's merge history, would still ship whatever tree that commit has.

- **publish.yml** — new \`verify-tag\` job runs first with \`fetch-depth: 0\` and asserts:
  - \`git cat-file -t <tag>\` returns \`tag\` (annotated, not lightweight)
  - tag commit is an ancestor of \`origin/main\`
  \`build\` now depends on \`verify-tag\`, so every downstream job (testpypi, smoke, gate, publish, docker, release) inherits the check.
- **publish-channel.yml** — same check inline in \`publish-pypi\` and \`docker-smoke\` so the emergency path doesn't skip it.

Full SSH-signature verification (\`git tag -v\`) is a follow-up — it needs the maintainer's SSH public key committed as an allowed-signers file.

### 2. SPDX SBOM for the PyPI channel

\`docker-publish\` already generates + \`cosign attest\`s an SBOM to the image. The PyPI path shipped nothing.

- **publish.yml** — \`build\` runs \`anchore/sbom-action\` (path: \`dist/\`) to produce \`sbom.spdx.json\`, uploads it as the \`sbom\` artifact; \`create-release\` downloads and attaches it to the Release alongside wheels, sdist, and Sigstore bundles.
- **publish-channel.yml** — \`publish-pypi\` generates the same SBOM and uses \`gh release upload --clobber\` so re-running against a tag whose Release already has an SBOM is idempotent. \`contents: write\` permission added for the upload.

## Test plan

- [ ] actionlint passes (verified locally on both files)
- [ ] On the next release, confirm \`verify-tag\` runs and passes for a clean annotated tag; confirm \`sbom.spdx.json\` appears as a Release asset
- [ ] Dry-run scenario: push an unsigned/lightweight tag; confirm \`verify-tag\` fails with a clear message (not exercised in CI; behavior derived from the \`git cat-file\` semantics)