### PR TITLE
Auto-open issue when a scheduled run fails

### DIFF
--- a/.github/workflows/cflite-batch.yml
+++ b/.github/workflows/cflite-batch.yml
@@ -14,6 +14,7 @@ jobs:
       contents: read
       actions: write
       security-events: write
+      issues: write
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -38,3 +39,21 @@ jobs:
           mode: batch
           output-sarif: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Report scheduled failure as issue
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW: ${{ github.workflow }}
+          SANITIZER: ${{ matrix.sanitizer }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          title="Scheduled run failed: ${WORKFLOW} (${SANITIZER})"
+          body=$(printf -- '- Workflow: **%s**\n- Matrix leg: **%s**\n- Run: %s\n- Commit: %s\n\nReopen or close when triaged.' \
+            "${WORKFLOW}" "${SANITIZER}" "${RUN_URL}" "${GITHUB_SHA}")
+          existing=$(gh issue list --state open --search "\"${title}\" in:title" --json number --jq '.[0].number // empty')
+          if [ -n "${existing}" ]; then
+            gh issue comment "${existing}" --body "${body}"
+          else
+            gh issue create --title "${title}" --body "${body}"
+          fi

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       security-events: write
       id-token: write
+      issues: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -34,3 +35,20 @@ jobs:
       - uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           sarif_file: results.sarif
+
+      - name: Report scheduled failure as issue
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW: ${{ github.workflow }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          title="Scheduled run failed: ${WORKFLOW}"
+          body=$(printf -- '- Workflow: **%s**\n- Run: %s\n- Commit: %s\n\nReopen or close when triaged.' \
+            "${WORKFLOW}" "${RUN_URL}" "${GITHUB_SHA}")
+          existing=$(gh issue list --state open --search "\"${title}\" in:title" --json number --jq '.[0].number // empty')
+          if [ -n "${existing}" ]; then
+            gh issue comment "${existing}" --body "${body}"
+          else
+            gh issue create --title "${title}" --body "${body}"
+          fi

--- a/.github/workflows/scout-scan.yml
+++ b/.github/workflows/scout-scan.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       security-events: write
       actions: read
+      issues: write
     steps:
       - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
@@ -37,3 +38,20 @@ jobs:
         with:
           sarif_file: scout-results.sarif
           category: docker-scout-scheduled
+
+      - name: Report scheduled failure as issue
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW: ${{ github.workflow }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          title="Scheduled run failed: ${WORKFLOW}"
+          body=$(printf -- '- Workflow: **%s**\n- Run: %s\n- Commit: %s\n\nReopen or close when triaged.' \
+            "${WORKFLOW}" "${RUN_URL}" "${GITHUB_SHA}")
+          existing=$(gh issue list --state open --search "\"${title}\" in:title" --json number --jq '.[0].number // empty')
+          if [ -n "${existing}" ]; then
+            gh issue comment "${existing}" --body "${body}"
+          else
+            gh issue create --title "${title}" --body "${body}"
+          fi


### PR DESCRIPTION
## Summary

Turn scheduled-workflow failures into durable issues instead of easy-to-miss emails to the workflow author. Touches three workflows: \`cflite-batch\`, \`scout-scan\`, \`scorecard\`.

### Behavior

- **Only on scheduled runs** — \`if: failure() && github.event_name == 'schedule'\`. PR/manual/workflow_dispatch failures still show as red Xs and are visible to the triggerer; the scheduled path is the one that goes unseen.
- **De-duplicated** — search by a stable title (\`Scheduled run failed: <workflow>\`). If an open issue exists, comment on it; otherwise create. Prevents a broken Scout run from filing a new issue every day of the week it stays broken.
- **One-click triage** — each issue/comment links the run URL, commit SHA, and (for cflite-batch) the sanitizer matrix leg.

### Permissions

Each affected job gains \`issues: write\`. No other permission scopes changed.

### Why inline, not a shared composite action

Three workflows, ~15 lines each, 95% identical. A composite action in \`.github/actions/\` would add a file + a \`uses:\` indirection for a marginal DRY win. Inline keeps the review unit obvious per workflow.

## Test plan

- [ ] actionlint passes (verified locally)
- [ ] On next scheduled run, confirm green runs don't create issues
- [ ] First real scheduled failure should open issue #N; second failure within the same week should comment rather than file a second