### PR TITLE
Automerge low-risk Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,6 +28,14 @@
       "matchManagers": ["dockerfile"],
       "matchDatasources": ["docker"],
       "pinDigests": true
+    },
+    {
+      "description": "Automerge low-risk routine updates once CI is green. Patch-level Python dep bumps, pinned-digest refreshes for GitHub Actions, and lockFileMaintenance go in without human review. Docker base images stay manual because the OCI manifest-list vs per-arch digest check (see MEMORY.md) is not mechanically verified in CI.",
+      "matchManagers": ["pep621", "pip_requirements", "github-actions"],
+      "matchUpdateTypes": ["patch", "pin", "digest", "lockFileMaintenance"],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Turn on GitHub-native auto-merge for routine Renovate PRs that CI already validates end-to-end:
- **Python deps** (\`pep621\`, \`pip_requirements\`) — \`patch\` only. Hash-pinned locks fail CI before the merge button could fire on a bad resolve.
- **GitHub Actions** — \`pin\` / \`digest\`. The \`actionlint\` PR-gate plus actual workflow runs validate the SHA bump before merge.
- **\`lockFileMaintenance\`** — weekly lock regen.

Docker base-image digest bumps stay **manual**. The manifest-list vs per-arch digest distinction (known-painful, captured in internal notes) isn't mechanically verified in CI; \`dockerfile-digests\` guards the multi-arch invariant but the "is this actually a patch-level bump" judgment still wants a human eye.

Minor / major bumps stay manual because this repo ships as a library — a minor dep change can affect downstream resolvers.

## Operator prerequisite

Enable **Settings → General → Allow auto-merge** on the repo. Without that, \`platformAutomerge: true\` silently falls back to Renovate-side merge (which would need a branch-protection bypass). Branch protection can continue to require green CI — that's the whole point.

## Test plan

- [ ] JSON validates (done locally)
- [ ] Next Renovate run should show \`automerge: true\` in the PR body for a patch/digest bump
- [ ] Verify a patch PR actually auto-merges after required checks pass (first real one is the smoke test)