### PR TITLE
Wire PAT into bump-marketplace-smoke-pin

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -564,11 +564,28 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      # Fail fast with a clear message if the PAT isn't configured.
+      # GITHUB_TOKEN cannot push commits that modify .github/workflows/*
+      # (that scope is deliberately withheld to prevent an action from
+      # self-modifying its own triggers), so this job needs a PAT with
+      # the `workflow` scope. Without the secret, the checkout below
+      # would still succeed but `git push` would fail halfway through
+      # the job — catch it here instead.
+      - name: Preflight — MARKETPLACE_SMOKE_PAT must be configured
+        env:
+          PAT: ${{ secrets.MARKETPLACE_SMOKE_PAT }}
+        run: |
+          if [ -z "${PAT}" ]; then
+            echo "::error::MARKETPLACE_SMOKE_PAT secret is not configured. See docs/CI.md > bump-marketplace-smoke-pin for PAT scopes."
+            exit 1
+          fi
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: main
           fetch-depth: 0
           persist-credentials: true
+          # Use a PAT so `git push` can include workflow-file changes.
+          token: ${{ secrets.MARKETPLACE_SMOKE_PAT }}
       - name: Resolve release SHA from tag
         id: sha
         env:

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -161,10 +161,26 @@ the GitHub Release alongside the distributions and Sigstore bundles.
 and `cosign attest`s it to the manifest digest.
 
 The `bump-marketplace-smoke-pin` job opens a post-release PR updating
-`marketplace-smoke.yml` to the SHA the tag pointed at. Today that job is
-blocked from pushing directly because `GITHUB_TOKEN` lacks `workflows`
-scope — the PR is opened by hand until a PAT with `workflow` scope is
-wired in.
+`marketplace-smoke.yml` to the SHA the tag pointed at. `GITHUB_TOKEN`
+can't push commits that modify `.github/workflows/*`, so this job
+uses a repo-scoped PAT stored in the `MARKETPLACE_SMOKE_PAT` secret.
+The job preflights that secret and fails early if it's unset.
+
+### Provisioning `MARKETPLACE_SMOKE_PAT`
+
+Create a **fine-grained personal access token**:
+
+- Scope: this repository only
+- Permissions:
+  - **Contents:** Read and write
+  - **Workflows:** Read and write
+  - **Pull requests:** Read and write
+- Expiration: whatever your rotation policy allows; Renovate won't
+  prompt you, so a calendar reminder helps
+
+Store as the `MARKETPLACE_SMOKE_PAT` repo secret. Classic PATs with
+the `repo` + `workflow` scopes also work, but fine-grained is easier
+to revoke and audit.
 
 ---
 


### PR DESCRIPTION
## Summary

Unblocks the \`bump-marketplace-smoke-pin\` job at the end of \`publish.yml\` by switching from the default \`GITHUB_TOKEN\` to a repo-scoped PAT (\`MARKETPLACE_SMOKE_PAT\`). GITHUB_TOKEN deliberately can't push commits touching \`.github/workflows/*\`, so that job has been silently failing post-release; its output PR gets reconstructed by hand each release.

### Changes

- **\`publish.yml\`** — \`bump-marketplace-smoke-pin\` gets a preflight step that asserts \`MARKETPLACE_SMOKE_PAT\` is set (fails fast with a pointer to \`docs/CI.md\` rather than dying on \`git push\` halfway through). The \`actions/checkout\` step now takes \`token: \${{ secrets.MARKETPLACE_SMOKE_PAT }}\` so subsequent \`git push\` can include workflow-file changes. \`gh pr create\` stays on \`GITHUB_TOKEN\` — the restriction is on the push, not on PR creation.
- **\`docs/CI.md\`** — updated the paragraph about this job to describe the new flow plus a "Provisioning \`MARKETPLACE_SMOKE_PAT\`" subsection listing the recommended fine-grained PAT permissions.

### Operator prerequisite (before merge)

Create the PAT and store it as \`MARKETPLACE_SMOKE_PAT\`:

- Fine-grained PAT, this repo only
- Permissions: **Contents: read/write**, **Workflows: read/write**, **Pull requests: read/write**

If the secret isn't set when the next release tag is pushed, the job will fail on the preflight step with a clear message — safer than the previous silent-breakage mode.

## Test plan

- [ ] actionlint passes (done locally)
- [ ] Before merging, create the PAT and add the secret
- [ ] On the next release, confirm \`bump-marketplace-smoke-pin\` completes and opens a PR under the bot identity