### PR TITLE
Pin runner OS, cache pip wheels, empty workflow-level permissions

### DIFF
--- a/.github/workflows/cflite-batch.yml
+++ b/.github/workflows/cflite-batch.yml
@@ -5,8 +5,7 @@ on:
     - cron: "17 4 * * *"
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   batch-fuzzing:
@@ -15,7 +14,7 @@ jobs:
       actions: write
       security-events: write
       issues: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cflite-pr.yml
+++ b/.github/workflows/cflite-pr.yml
@@ -8,11 +8,13 @@ on:
       - ".clusterfuzzlite/**"
       - ".github/workflows/cflite-pr.yml"
 
-permissions: read-all
+permissions: {}
 
 jobs:
   pr-fuzzing:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     concurrency:
       group: cflite-pr-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,15 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# Default to read-only — individual jobs can request more if they need it.
-permissions:
-  contents: read
+# Deny-all at the workflow level; every job declares the scopes it needs.
+permissions: {}
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -26,6 +27,11 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
+          cache: pip
+          cache-dependency-path: |
+            requirements.lock
+            requirements-dev.lock
+            requirements-build.lock
       - name: Install pinned dev env
         run: |
           pip install --require-hashes -r requirements-dev.lock
@@ -34,8 +40,10 @@ jobs:
       - run: ruff format --check src/ tests/
 
   type-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -43,6 +51,11 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
+          cache: pip
+          cache-dependency-path: |
+            requirements.lock
+            requirements-dev.lock
+            requirements-build.lock
       - name: Install pinned dev env
         run: |
           pip install --require-hashes -r requirements-dev.lock
@@ -50,8 +63,10 @@ jobs:
       - run: mypy src/
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -63,6 +78,11 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            requirements.lock
+            requirements-dev.lock
+            requirements-build.lock
       - name: Install pinned dev env
         run: |
           pip install --require-hashes -r requirements-dev.lock
@@ -71,8 +91,10 @@ jobs:
 
   security:
     name: Security scan (bandit + pip-audit)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -80,6 +102,11 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
+          cache: pip
+          cache-dependency-path: |
+            requirements.lock
+            requirements-dev.lock
+            requirements-build.lock
       - name: Install scan tools
         # Upgrade pip first so pip-audit doesn't flag CVEs in the
         # runner-bundled pip itself (those are out of scope for this
@@ -107,8 +134,10 @@ jobs:
   # wrong source of truth).
   version-consistency:
     name: Version strings in sync
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 2
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -135,9 +164,11 @@ jobs:
   # number on a broken release.
   changelog-gate:
     name: CHANGELOG entry for version bumps
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 2
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -171,9 +202,11 @@ jobs:
   # a base ref to diff against.
   dependency-review:
     name: Dependency review (PR deps)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -191,8 +224,10 @@ jobs:
   # Renovate's github-releases datasource handles version bumps.
   actionlint:
     name: Lint GitHub Actions workflows
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 3
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -214,8 +249,10 @@ jobs:
   # don't surface until docker-publish at release time.
   dockerfile-digests:
     name: Verify Dockerfile digests are manifest lists
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 2
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -229,8 +266,10 @@ jobs:
   # the gate cheap; the release pipeline covers multi-arch.
   docker-smoke:
     name: Smoke test Dockerfile (amd64)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -309,8 +348,10 @@ jobs:
 
   action-smoke:
     name: Smoke test action.yml
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,15 +9,15 @@ on:
     # Weekly run catches new advisories on unchanged code.
     - cron: "27 4 * * 1"
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   analyze:
     name: CodeQL (${{ matrix.language }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
+      contents: read
       # Required to upload SARIF results.
       security-events: write
       # Required for private repos; harmless on public.

--- a/.github/workflows/marketplace-smoke.yml
+++ b/.github/workflows/marketplace-smoke.yml
@@ -37,14 +37,15 @@ on:
     paths:
       - .github/workflows/marketplace-smoke.yml
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   marketplace-smoke:
     name: Smoke test published action
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/publish-channel.yml
+++ b/.github/workflows/publish-channel.yml
@@ -16,13 +16,12 @@ on:
           - pypi
           - docker
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   publish-pypi:
     if: inputs.channel == 'pypi'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     environment:
       name: pypi
@@ -56,6 +55,11 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
+          cache: pip
+          cache-dependency-path: |
+            requirements.lock
+            requirements-dev.lock
+            requirements-build.lock
       - name: Install pinned build env
         run: |
           pip install --require-hashes -r requirements-dev.lock
@@ -133,8 +137,10 @@ jobs:
   # multi-arch is still covered by the real build-docker matrix below.
   docker-smoke:
     if: inputs.channel == 'docker'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -219,7 +225,7 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
@@ -265,7 +271,7 @@ jobs:
   publish-docker:
     if: inputs.channel == 'docker'
     needs: build-docker
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     environment:
       name: dockerhub

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,9 +5,8 @@ on:
     tags:
       - "v*"
 
-# Default to read-only — individual jobs request what they need.
-permissions:
-  contents: read
+# Deny-all at the workflow level; every job declares the scopes it needs.
+permissions: {}
 
 jobs:
   # Gate every publish path on two lightweight tag checks:
@@ -23,8 +22,10 @@ jobs:
   # Full SSH-signature verification would require committing the
   # maintainer's allowed-signers file; that's a follow-up.
   verify-tag:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 3
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -48,7 +49,7 @@ jobs:
 
   build:
     needs: verify-tag
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read
@@ -60,6 +61,11 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
+          cache: pip
+          cache-dependency-path: |
+            requirements.lock
+            requirements-dev.lock
+            requirements-build.lock
       - name: Install pinned build env
         run: |
           pip install --require-hashes -r requirements-dev.lock
@@ -148,7 +154,7 @@ jobs:
 
   testpypi:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     environment:
       name: testpypi
@@ -168,8 +174,10 @@ jobs:
 
   testpypi-smoke:
     needs: testpypi
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -177,6 +185,11 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
+          cache: pip
+          cache-dependency-path: |
+            requirements.lock
+            requirements-dev.lock
+            requirements-build.lock
       - name: Install from TestPyPI and verify version
         # TestPyPI's JSON API sees a new release within seconds of the
         # publish step, but the /simple/ index pip uses can lag by
@@ -232,7 +245,7 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
             scout: true
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
@@ -310,7 +323,7 @@ jobs:
   # Configure the 'release' GitHub Environment with required reviewers.
   release-gate:
     needs: [testpypi-smoke, docker-smoke]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     environment:
       name: release
@@ -319,7 +332,7 @@ jobs:
 
   publish:
     needs: release-gate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     environment:
       name: pypi
@@ -348,7 +361,7 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
@@ -392,7 +405,7 @@ jobs:
 
   docker-publish:
     needs: docker-build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
       contents: read
@@ -496,7 +509,7 @@ jobs:
   # Release also updates the Marketplace listing for the action.
   create-release:
     needs: [publish, docker-publish]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       contents: write
@@ -558,7 +571,7 @@ jobs:
   bump-marketplace-smoke-pin:
     name: Bump marketplace-smoke pin (post-tag, post-publish)
     needs: create-release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       contents: write

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -21,12 +21,11 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   prep:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       contents: write

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,14 +7,15 @@ on:
   push:
     branches: [main]
 
-permissions: read-all
+permissions: {}
 
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
+      contents: read
       security-events: write
       id-token: write
       issues: write

--- a/.github/workflows/scout-scan.yml
+++ b/.github/workflows/scout-scan.yml
@@ -6,12 +6,11 @@ on:
     # Daily; catches new advisories against the published image.
     - cron: "0 6 * * *"
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   scout:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
       security-events: write


### PR DESCRIPTION
## Summary

Three hygiene changes bundled because they all touch every workflow:

- **Pin runner OS**: `ubuntu-latest` → `ubuntu-24.04` across all `runs-on` and matrix `runner` entries. Prevents silent behavior change when GitHub flips `latest` to the next Ubuntu LTS mid-release.
- **pip cache on setup-python**: `cache: pip` keyed on `requirements.lock`, `requirements-dev.lock`, `requirements-build.lock`. Added in `ci.yml`, `publish.yml`, `publish-channel.yml`. Speeds up installs and reduces PyPI-flake exposure.
- **Empty workflow-level permissions**: every workflow now starts from `permissions: {}` and declares scopes per-job. Defense in depth — unspecified scopes are explicitly denied rather than implicitly inherited. Jobs that previously relied on workflow-level `contents: read` now declare it themselves.

Preserved behavior deliberately:
- `dependency-review` keeps `contents: read` only — no new `pull-requests: write`, matches what was effectively granted before.
- `cflite-pr.yml` switched from `read-all` to `{}` + per-job `contents: read`; ClusterFuzzLite PR mode doesn't need broader read.

## Test plan

- [x] `actionlint` passes locally
- [ ] CI green on this PR (lint, type-check, test matrix 3.10–3.14, security, actionlint, dockerfile-digests, docker-smoke, action-smoke, dependency-review)
- [ ] Spot-check that pip cache hit surfaces on a second run