### PR TITLE
Split scorecard auto-issue into its own job

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -10,6 +10,9 @@ on:
 permissions: {}
 
 jobs:
+  # Scorecard's webapp verification rejects a SARIF publish if the analysis
+  # job contains any non-`uses:` steps (see ossf/scorecard-action workflow
+  # restrictions). The auto-issue step lives in a downstream job instead.
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-24.04
@@ -18,7 +21,6 @@ jobs:
       contents: read
       security-events: write
       id-token: write
-      issues: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -37,8 +39,15 @@ jobs:
         with:
           sarif_file: results.sarif
 
-      - name: Report scheduled failure as issue
-        if: failure() && github.event_name == 'schedule'
+  report-failure:
+    needs: analysis
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 3
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update scheduled-failure issue
         env:
           GH_TOKEN: ${{ github.token }}
           WORKFLOW: ${{ github.workflow }}


### PR DESCRIPTION
## Summary

- `ossf/scorecard-action` with `publish_results: true` rejects any analysis job that has non-`uses:` steps (webapp returns 400 on SARIF verification).
- PR #85 added a `run:` step to the analysis job to auto-open an issue on scheduled failures. Every push-to-main Scorecard run has failed since.
- Move the issue-opening step to a separate `report-failure` job gated on `needs: analysis` + `failure() && schedule`. `issues: write` moves with it; `analysis` keeps only the scopes Scorecard itself needs.

Evidence: [run 24615178279](https://github.com/tmatens/compose-lint/actions/runs/24615178279) failed with `workflow verification failed: scorecard job must only have steps with uses`.

## Test plan

- [x] `actionlint` clean
- [ ] Next push-to-main triggers Scorecard with no 400 on publish
- [ ] Simulated schedule failure still opens/updates the issue (covered by the existing auto-issue pattern used in cflite-batch / scout-scan)