### PR TITLE
Fail scheduled Scout scan on critical CVEs

### DIFF
--- a/.github/workflows/scout-scan.yml
+++ b/.github/workflows/scout-scan.yml
@@ -22,12 +22,27 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Scan published image (Docker Scout)
+      # Gate the run on criticals so a fresh critical CVE fails the job
+      # and the `Report scheduled failure as issue` step downstream fires
+      # on schedule. High-severity stays warning-only — still uploaded to
+      # the Security tab by the second scan, just doesn't page.
+      - name: Scan for critical CVEs (fails the run)
         uses: docker/scout-action@bacf462e8d090c09660de30a6ccc718035f961e3 # v1.20.4
         with:
           command: cves
           image: composelint/compose-lint:latest
-          only-severities: critical,high
+          only-severities: critical
+          exit-code: true
+
+      # Full-severity sweep for SARIF upload. Runs even when the
+      # critical scan fails, so the Security tab always reflects the
+      # complete picture rather than a partial snapshot.
+      - name: Scan all severities for SARIF upload
+        if: always()
+        uses: docker/scout-action@bacf462e8d090c09660de30a6ccc718035f961e3 # v1.20.4
+        with:
+          command: cves
+          image: composelint/compose-lint:latest
           exit-code: false
           sarif-file: scout-results.sarif
 


### PR DESCRIPTION
## Summary

- Scheduled Scout scan was `exit-code: false` and only scanned critical+high — a new critical CVE on the published image never failed the run, never fired the auto-issue, and only showed up when Scorecard noticed days later.
- Split into two `docker/scout-action` steps:
  1. **Gate**: `only-severities: critical`, `exit-code: true`. Fails the job (and triggers the schedule-failure auto-issue) when a critical lands.
  2. **Report**: no severity filter (scans every severity), `exit-code: false`, `if: always()`. Produces the SARIF uploaded to the Security tab even when the gate fails, so Security always reflects the complete picture.
- High still visible in the Security tab but no longer pages; medium and low now appear there too (they weren't scanned before).

## Test plan

- [x] `actionlint` clean
- [ ] Next scheduled run completes green if no critical CVEs, and the Security tab shows critical/high/medium/low
- [ ] (Future) when a critical does land, the run fails and an issue titled `Scheduled run failed: Docker Scout (scheduled)` opens