### PR TITLE
Add ci-ok rollup job for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,3 +386,41 @@ jobs:
         run: |
           echo "::error::Expected action to fail on insecure fixture, got '${{ steps.insecure.outcome }}'"
           exit 1
+
+  # Single rollup job for branch protection. Required-status-checks should
+  # point at this job name instead of the individual ci.yml job names, so
+  # adding/renaming/removing jobs doesn't require a protection-rule edit.
+  #
+  # `if: always()` ensures the rollup runs when any dependency fails or is
+  # skipped — otherwise the overall check stays pending and nothing fails
+  # the PR. The script then pass-or-fails explicitly by inspecting each
+  # dependency's `result`. `skipped` counts as pass so push-to-main (where
+  # pull_request-gated jobs skip) doesn't wedge the required check.
+  ci-ok:
+    name: ci-ok
+    needs:
+      - lint
+      - type-check
+      - test
+      - security
+      - version-consistency
+      - changelog-gate
+      - dependency-review
+      - actionlint
+      - dockerfile-digests
+      - docker-smoke
+      - action-smoke
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 1
+    permissions: {}
+    steps:
+      - name: All required CI jobs must succeed
+        env:
+          RESULTS: ${{ toJSON(needs) }}
+        run: |
+          echo "$RESULTS"
+          if ! echo "$RESULTS" | jq -e 'to_entries | all(.value.result == "success" or .value.result == "skipped")' >/dev/null; then
+            echo "::error::One or more required CI jobs failed or were cancelled."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

One aggregating job in `ci.yml` that `needs:` every other job and checks their results. Required-status-checks should point at `ci-ok` instead of individual job names, so adding/renaming/removing a CI job no longer requires a branch-protection edit.

- `if: always()` so the rollup runs even when a dependency fails or skips (otherwise the check stays pending forever).
- Treats `success` and `skipped` as pass, everything else as fail — necessary because `changelog-gate` and `dependency-review` are `if: github.event_name == 'pull_request'` and skip on push-to-main.
- Does **not** include CodeQL, Scorecard, or other workflows — cross-workflow `needs:` isn't supported. Those stay as separate required checks if they're currently required.

## Follow-up (after merge)

1. Wait for this PR to run once so GitHub registers `ci-ok` as a known check name.
2. In **Settings → Rules → Rulesets → \<main ruleset\> → Require status checks to pass**: add `ci-ok`, then delete every individual `ci.yml` entry (lint, type-check, test (3.10)–(3.14), Security scan (bandit + pip-audit), version-consistency, changelog-gate, dependency-review, actionlint, dockerfile-digests, docker-smoke, action-smoke). Keep any non-ci.yml checks as-is.

## Test plan

- [x] `actionlint` clean
- [ ] This PR's `ci-ok` run is green (all dependencies succeed or skip)
- [ ] On push-to-main after merge, `ci-ok` is green even though `changelog-gate` and `dependency-review` are skipped
- [ ] A deliberately-failing follow-up (e.g. `ruff check` violation) fails `ci-ok`