### PR TITLE
v0.4 repoint + per-service overrides: config schema (ADR-010)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,73 +1,77 @@
 # Roadmap
 
-compose-lint v0.3.0 shipped 19 rules, PyPI distribution, SARIF/JSON/text output, pre-commit support, and a GitHub Action. The gap is distribution reach and developer experience.
+compose-lint v0.3.0 shipped 19 rules, PyPI distribution, SARIF/JSON/text output, pre-commit support, and a GitHub Action. The product has a solid foundation; the next investments should make the tool more useful to the users already running it, not chase speculative distribution channels.
+
+## Strategic framing
+
+compose-lint's differentiation is depth in Compose-specific security, not distribution breadth. Competitors (KICS, Checkov, Trivy) cover Compose as one format among many; they are wide and shallow per-format. Compose-lint wins by being the one tool that tells you exactly what's wrong with a Compose file and exactly how to fix it. Roadmap priorities are ordered around that thesis.
+
+Open issues #4 (CL-0006 capability profiles) and #5 (per-service rule overrides) are both signal from real-world usage. Distribution items beyond the already-shipped Docker image have no demand signal and are deprioritized accordingly.
 
 ---
 
 ## Milestone 1 — Rule Coverage (v0.3) [complete]
 
-**Shipped in v0.3.0.** Added 9 rules (CL-0011 – CL-0019) plus CL-0010 `uts: host` enhancement, bringing the total to 19 rules. See CHANGELOG.md for details.
+Shipped in v0.3.0. Added 9 rules (CL-0011 – CL-0019) plus CL-0010 `uts: host` enhancement, bringing the total to 19 rules. See CHANGELOG.md.
 
 ---
 
-## Milestone 2 — Distribution (v0.4)
+## Milestone 2 — Configuration Depth + Install Polish (v0.4)
 
-Reduce friction from "have Python" to "run one command."
+Make the tool more useful for users already running it, and close the one distribution gap with a real UX win.
 
-**Docker Hub image** (`composelint/compose-lint`) [complete]
-- Multi-stage build on `python:3.13-alpine` (digest-pinned), ~25 MB final image
-- Multi-arch: `linux/amd64`, `linux/arm64`
-- Enables `docker run --rm -v $(pwd):/src composelint/compose-lint`
-- Published via GitHub Actions on tag push; signed with cosign (Sigstore keyless)
-- Automated smoke tests in CI: version check, clean/insecure fixtures, SARIF output validation
-- Primary audience: teams that distrust pip in CI, or non-Python shops
+**Per-service rule overrides** _(issue #5)_
+- `.compose-lint.yml` gains a way to disable or tune rules on a per-service basis.
+- Motivation: in multi-service compose files, a rule like CL-0003 (`no-new-privileges`) is valid for some services and impossible for others (e.g. entrypoints that switch users). Global disable loses the valid findings; leaving it enabled produces unactionable noise.
+- Schema design TBD — two shapes proposed in the issue, needs an ADR before implementation.
 
-**Linux packages** _(pending decision — [ADR-008](adr/008-linux-packages.md))_
-- `.deb` and `.rpm` via `nfpm` — self-contained, no Python required
-- Published to GitHub Releases as build artifacts on every tag; signed via GitHub Artifact Attestation
-- Secondary: AUR `compose-lint` PKGBUILD for Arch users (manual push at release time)
-- CI shape: `linux-packages-build` → `linux-packages-smoke` → `release-gate` → `linux-packages-publish`, following the existing staging pattern
+**CL-0006 capability profiles** _(issue #4)_
+- Ship known capability profiles for popular base images (PostgreSQL, Redis, Caddy, Netdata, etc.) so the finding's `fix` field names the specific `cap_add` list instead of a generic `<SPECIFIC_CAP>` placeholder.
+- Data-driven: ships as a profile table in the rule, no engine changes.
+- Scope-limit: data + docs only in v0.4. A `--suggest-caps` CLI flag is out of scope here; revisit if the profiles land well.
 
 **Homebrew tap**
-- `brew install tmatens/tap/compose-lint`
-- Widens macOS developer reach beyond pip users
+- `brew install tmatens/tap/compose-lint` — works on macOS (Intel + Apple Silicon) and Linux via Homebrew-on-Linux.
+- Closes the "not everyone has pip" gap with working `brew upgrade` UX (which GitHub-Releases-hosted `.deb`/`.rpm` could not match).
+- Formula lives in a separate `homebrew-tap` repo; release workflow uses `brew bump-formula-pr` to keep versions in sync with low manual overhead.
+
+_Deferred:_ `.deb`/`.rpm` Linux packages (see [ADR-008](adr/008-linux-packages.md) — no user demand, no upgrade path without hosted repo infrastructure).
 
 ---
 
-## Milestone 3 — Better Remediation (v0.5)
+## Milestone 3 — Remediation (v0.5)
 
-Finding a problem is half the value. Remediation guidance is the differentiator versus KICS, which identifies issues but rarely provides exact Compose-specific fix steps.
+Turn findings into fixes. This is where the product's differentiation grows the most against KICS/Checkov.
 
-**Shellcheck integration** _(pending decision — [ADR-007](adr/007-shellcheck-integration.md))_
-- Lint shell commands inside `command` and `entrypoint` (string form) and `healthcheck.test` with `CMD-SHELL`
-- shellcheck invoked via subprocess with `--format=json`; findings reported under their original `SC` codes alongside native `CL-XXXX` rules
-- Optional: rule skips silently if shellcheck is not present in `PATH`
-- Open question: deliver shellcheck as a Linux system package dependency or via `shellcheck-py`
+**`--explain CL-XXXX`** — print the full prose from `docs/rules/CL-XXXX.md` in the terminal, reducing context-switching to the browser during triage. Small, no new deps, foundation for `--fix` UX.
 
 **`--fix` mode** — auto-fix for safe, unambiguous rules:
 - CL-0003: inject `no-new-privileges:true` into `security_opt:`
 - CL-0005: prepend `127.0.0.1:` to unbound port mappings
 - CL-0007: add `read_only: true`
-- Dry run by default; `--fix --apply` writes in-place
-- Out of scope for auto-fix: CL-0001 (socket proxy replacement is non-trivial), CL-0016 (correct secret management is context-dependent)
+- Dry run by default; `--fix --apply` writes in-place.
+- Out of scope for auto-fix: CL-0001 (socket proxy replacement is non-trivial), CL-0016 (correct secret management is context-dependent).
 
 **Remediation snippets in SARIF** — populate `fix.changes[]` objects so GitHub Code Scanning can display a suggested-change diff inline on pull requests.
 
-**`--explain CL-XXXX`** — print the full prose from `docs/rules/CL-XXXX.md` in the terminal, reducing context-switching to the browser during triage.
+**Shellcheck integration** _(pending decision — [ADR-007](adr/007-shellcheck-integration.md))_
+- Lint shell commands inside `command` and `entrypoint` (string form) and `healthcheck.test` with `CMD-SHELL`.
+- Unique coverage vs. KICS/Checkov — reinforces the "depth" thesis.
+- Optional dependency; rule skips silently if shellcheck is not in `PATH`.
 
 ---
 
 ## Milestone 4 — VS Code Extension + GA (v1.0)
 
-**Why VS Code before LSP**: the extension market is where Docker Compose authors spend most of their editing time. LSP can follow after v1.0.
+The biggest reach multiplier. Compose authors spend most editing time in editors, not CI. Sequenced after `--fix` because the extension's value pops only once fixes are one-click.
 
-**Architecture**: the extension shells out to `compose-lint --format json` on save. No embedded Python runtime in the extension — this keeps it thin and ensures the user's installed version is always what runs.
+**Architecture:** the extension shells out to `compose-lint --format json` on save. No embedded Python runtime in the extension — this keeps it thin and ensures the user's installed version is always what runs.
 
 - Underlines findings inline with diagnostic severity mapping
 - Hover tooltip shows the `fix:` and `ref:` fields
 - Command palette: `Compose Lint: Fix All Auto-fixable` (requires Milestone 3)
 
-**GA declaration**: v1.0 moves the PyPI classifier from `3 - Alpha` to `5 - Production/Stable`. Prerequisites: 19+ rules, `--fix` mode, VS Code extension, and a documented upgrade/deprecation policy.
+**GA declaration:** v1.0 moves the PyPI classifier from `3 - Alpha` to `5 - Production/Stable`. Prerequisites: 19+ rules, `--fix` mode, VS Code extension, and a documented upgrade/deprecation policy.
 
 ---
 
@@ -82,6 +86,7 @@ Pursue based on user demand after v1.0.
 | JetBrains plugin | Same shell-out pattern as VS Code |
 | Custom rule plugins | `entry_points` hook (`compose_lint.rules` group) for third-party rules |
 | LSP server | Language Server Protocol support — follows VS Code extension post-v1.0 |
+| Linux packages (`.deb`/`.rpm`) | Revisit [ADR-008](adr/008-linux-packages.md) on first concrete user request |
 
 ---
 
@@ -111,10 +116,10 @@ Python 3.10 is scheduled to age out of the matrix when it reaches upstream EOL i
 
 ## Summary
 
-| Milestone | Version |
-|-----------|---------|
-| Rule Coverage (19 rules) | v0.3 [complete] |
-| Distribution (Docker Hub, packages, Homebrew) | v0.4 [Docker Hub complete] |
-| Remediation (`--fix`, SARIF fixes, `--explain`) | v0.5 |
-| VS Code extension + GA | v1.0 |
-| Ecosystem integrations, custom rules | v1.x |
+| Milestone | Version | Status |
+|-----------|---------|--------|
+| Rule Coverage (19 rules) | v0.3 | complete |
+| Config depth + Homebrew tap | v0.4 | in progress (Docker Hub shipped in v0.3.x) |
+| Remediation (`--explain`, `--fix`, SARIF fixes, shellcheck) | v0.5 | |
+| VS Code extension + GA | v1.0 | |
+| Ecosystem integrations, custom rules | v1.x | |

--- a/docs/adr/008-linux-packages.md
+++ b/docs/adr/008-linux-packages.md
@@ -1,12 +1,20 @@
 # ADR-008: Linux Package Distribution
 
-**Status:** Pending decision
+**Status:** Deferred — revisit when a user requests `.deb`/`.rpm` install.
 
 **Context:** compose-lint is currently distributed via PyPI, Docker Hub, and a GitHub Action. Users who install via system package managers (apt, dnf, pacman) cannot install from PyPI without pip, which is not always present in minimal or managed Linux environments. Adding native `.deb`, `.rpm`, and AUR packages lowers the installation barrier for those users and makes compose-lint installable alongside other system security tools.
 
-**Decision:** Distribute `.deb` and `.rpm` packages via GitHub Releases, built with nfpm. Maintain an AUR package for Arch Linux. No hosted APT or DNF repository.
+**Deferral rationale:**
 
-**Proposed approach:**
+- Zero demand signal today. No issues or discussions have asked for `.deb`/`.rpm`.
+- Packages on GitHub Releases require manual `curl + dpkg -i` install and manual re-download on every upgrade — strictly worse UX than `pip install --upgrade` or the already-shipped multi-arch Docker image, which covers the same "no Python toolchain" persona.
+- A hosted APT/DNF repo (where `apt upgrade` works) is the only shape that materially improves on existing channels, and its infra cost is out of proportion with the product's current scale.
+- AUR maintenance is a manual push per release forever; CI automation was already rejected due to supply-chain surface area.
+- Build + smoke + publish jobs would be maintained indefinitely against speculative demand. The homebrew tap (tracked in the roadmap) covers the "not everyone has pip" gap with lower maintenance cost and working upgrade UX.
+
+Revisit this ADR when a user files a concrete request. If that happens, the proposed approach below is the starting point; if the request is for `apt install`-style flow specifically, hosted-repo tradeoffs need re-evaluation at that time.
+
+**Proposed approach (retained for future revisit):**
 
 - **Build tool:** nfpm, SHA-pinned in CI, produces `.deb` and `.rpm` from a wheel + PyYAML bundled into `/usr/lib/compose-lint/`. An `entrypoint.sh` wrapper at `/usr/bin/compose-lint` invokes the bundled install via `python3`.
 - **Distribution:** Packages are attached to GitHub Releases via `gh release create`. GitHub Artifact Attestation (`gh attestation verify`) satisfies the signing requirement from DISTRIBUTION.md.

--- a/docs/adr/010-per-service-rule-overrides.md
+++ b/docs/adr/010-per-service-rule-overrides.md
@@ -1,0 +1,58 @@
+# ADR-010: Per-Service Rule Overrides
+
+**Status:** Accepted
+
+**Context:** `.compose-lint.yml` currently configures rules globally (enable/disable, severity override, reason). In multi-service compose files different services have different security profiles — a rule may be valid for one service and architecturally impossible for another. The example in issue #5 is CL-0003 (`no-new-privileges`): valid for a web service, but incompatible with a service whose entrypoint switches users via `su-exec`/`gosu`. Today the user chooses between losing the valid finding (global disable) or tolerating unactionable noise (leave enabled). Neither is the right answer.
+
+**Decision:** Extend the existing rule-centric config shape with a per-rule `exclude_services` field. No new top-level section. Excluded services still produce findings, but the findings are marked suppressed with the per-service reason — matching the existing suppression semantics in CLAUDE.md.
+
+**Schema:**
+
+```yaml
+rules:
+  CL-0003:
+    exclude_services:
+      minecraft: "entrypoint switches users via su-exec"
+      backup: "forks as different user"
+  CL-0007:
+    exclude_services:
+      - legacy-worker   # list form when no reason is needed
+```
+
+- Mapping form (service → reason string): reason flows to `suppression_reason` (JSON), `justification` (SARIF), and the text formatter's `SUPPRESSED` trailer, consistent with global suppression.
+- List form (service names only): shorthand when the user doesn't want to record a reason. Findings still suppressed, no justification emitted.
+- Both forms accepted under the same key; type of the value decides the parse path.
+- Service names are matched exactly. Glob patterns are deferred until someone asks for them — keeps the v0.4 surface area small and reversible.
+
+**Interaction with existing config:**
+
+- Global `enabled: false` wins. If a rule is globally disabled, per-service overrides are ignored (all findings are already suppressed).
+- Global `severity:` override applies uniformly; per-service severity overrides are out of scope for v0.4 (YAGNI — issue #5 only asks for exclusion).
+- Unknown service names in `exclude_services` produce a warning on stderr, not an error. Compose files are edited independently of config; a stale entry shouldn't break the linter.
+
+**Alternatives rejected:**
+
+- **Service-centric schema** (`services.<name>.rules.CL-XXXX.enabled: false`): reads naturally but duplicates the rule-config vocabulary and creates a parallel config surface. Two places to look for "why is this rule not firing" is worse than one.
+- **Both shapes (hybrid):** two parsers, two sets of inheritance semantics to document, users pick the wrong one. The existing `rules:` top-level is already the source of truth — extend it, don't fork it.
+- **Inline suppression comments** in the Compose file itself (`# compose-lint: ignore CL-0003`): explicitly forbidden by CLAUDE.md ("No inline suppression syntax unless explicitly planned"). Keeping suppression in `.compose-lint.yml` preserves the single-source-of-truth model.
+- **Glob patterns on day one:** solves a hypothetical problem. Adding them later is additive and non-breaking.
+
+**Rationale:**
+
+- Rule-centric shape extends `config.py`'s existing `_parse_rules` with one branch; no new top-level keys, no new config file conventions for users to learn.
+- Per-service reasons reuse the suppression plumbing that already flows to SARIF `justification` and JSON `suppression_reason`. No new output-format work.
+- Producing suppressed-but-visible findings (rather than silently dropping them) preserves auditability — users can see that compose-lint saw the issue and was explicitly told to ignore it, which matters for security review and for catching stale suppressions.
+- Exact-match service names cover the motivating case in issue #5 without committing to glob semantics that later turn out to be wrong.
+
+**Known limitation — granularity is rule+service, not per-finding:**
+
+Several rules can fire multiple times within a single service (CL-0004, CL-0005, CL-0011, CL-0013, CL-0016, CL-0017 iterate over ports, mounts, capabilities, or devices). This ADR suppresses all findings for a given rule+service pair; it cannot suppress one port on a service while keeping another visible on the same service.
+
+This is accepted for v0.4. Issue #5's motivating cases are architectural ("this rule does not apply to this service at all"), which rule+service granularity handles cleanly. Finer granularity would require either per-rule discriminator vocabulary in config (`exclude_ports:`, `exclude_mounts:`, …) — which balloons the config surface — or inline suppression comments, which CLAUDE.md currently forbids. Both are larger policy changes and are parked until a user requests finer control.
+
+**Implementation notes (non-binding):**
+
+- `config.py`: extend `load_config` return type to include a third map, `excluded: dict[str, dict[str, str | None]]` (rule_id → service → reason).
+- `engine.py`: after a rule produces a finding, if `finding.service in excluded[rule_id]`, mark the finding suppressed and attach the reason. Follows the same code path as global suppression.
+- Rules receive plain Python types (per ADR-004) and remain unaware of the config layer — all suppression happens in the engine.
+- Test matrix must cover: mapping form, list form, mixed global-disable + per-service (global wins), unknown service warning, and the three output formatters.

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -113,7 +113,9 @@ def main(argv: list[str] | None = None) -> NoReturn:
     config_path = _effective_config_path(args.config)
 
     try:
-        disabled_rules, severity_overrides = load_config(args.config)
+        disabled_rules, severity_overrides, _excluded_services = load_config(
+            args.config
+        )
     except ConfigError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(2)

--- a/src/compose_lint/config.py
+++ b/src/compose_lint/config.py
@@ -25,16 +25,26 @@ def _parse_severity(value: str) -> Severity:
         ) from None
 
 
+ExcludedServices = dict[str, dict[str, str | None]]
+
+
 def load_config(
     path: str | Path | None = None,
-) -> tuple[dict[str, str | None], dict[str, Severity]]:
+) -> tuple[dict[str, str | None], dict[str, Severity], ExcludedServices]:
     """Load a .compose-lint.yml config file.
 
-    Returns a tuple of (disabled_rules, severity_overrides).
+    Returns a tuple of (disabled_rules, severity_overrides, excluded_services).
     disabled_rules maps rule ID to an optional reason string.
+    excluded_services maps rule ID to a mapping of service name to optional
+    per-service reason (see ADR-010).
     If path is None, looks for .compose-lint.yml in the current directory.
     If no config file is found, returns empty defaults.
     """
+    empty: tuple[dict[str, str | None], dict[str, Severity], ExcludedServices] = (
+        {},
+        {},
+        {},
+    )
     if path is not None:
         config_path = Path(path)
         if not config_path.exists():
@@ -42,7 +52,7 @@ def load_config(
     else:
         config_path = Path(".compose-lint.yml")
         if not config_path.exists():
-            return {}, {}
+            return empty
 
     try:
         content = config_path.read_text(encoding="utf-8")
@@ -55,7 +65,7 @@ def load_config(
         raise ConfigError(f"Invalid YAML in config file: {e}") from e
 
     if data is None:
-        return {}, {}
+        return empty
 
     if not isinstance(data, dict):
         raise ConfigError("Config file must be a YAML mapping")
@@ -65,13 +75,14 @@ def load_config(
 
 def _parse_rules(
     rules: Any,
-) -> tuple[dict[str, str | None], dict[str, Severity]]:
+) -> tuple[dict[str, str | None], dict[str, Severity], ExcludedServices]:
     """Parse the rules section of a config file."""
     if not isinstance(rules, dict):
         raise ConfigError("'rules' must be a mapping")
 
     disabled: dict[str, str | None] = {}
     overrides: dict[str, Severity] = {}
+    excluded: ExcludedServices = {}
 
     for rule_id, rule_config in rules.items():
         rule_id = str(rule_id)
@@ -86,4 +97,43 @@ def _parse_rules(
         if "severity" in rule_config:
             overrides[rule_id] = _parse_severity(str(rule_config["severity"]))
 
-    return disabled, overrides
+        if "exclude_services" in rule_config:
+            excluded[rule_id] = _parse_exclude_services(
+                rule_id, rule_config["exclude_services"]
+            )
+
+    return disabled, overrides, excluded
+
+
+def _parse_exclude_services(rule_id: str, value: Any) -> dict[str, str | None]:
+    """Parse an exclude_services entry into a service-name → reason mapping.
+
+    Accepts either a list of service names (no reasons) or a mapping of
+    service name to reason string.
+    """
+    if isinstance(value, list):
+        result: dict[str, str | None] = {}
+        for item in value:
+            if not isinstance(item, str):
+                raise ConfigError(
+                    f"exclude_services for '{rule_id}' list entries must be "
+                    "service name strings"
+                )
+            result[item] = None
+        return result
+
+    if isinstance(value, dict):
+        result = {}
+        for service_name, reason in value.items():
+            if not isinstance(service_name, str):
+                raise ConfigError(
+                    f"exclude_services for '{rule_id}' keys must be "
+                    "service name strings"
+                )
+            if reason is None:
+                result[service_name] = None
+            else:
+                result[service_name] = str(reason)
+        return result
+
+    raise ConfigError(f"exclude_services for '{rule_id}' must be a list or mapping")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,7 +22,7 @@ class TestLoadConfig:
         old_cwd = os.getcwd()
         os.chdir(tmp_path)
         try:
-            disabled, overrides = load_config()
+            disabled, overrides, _excluded = load_config()
             assert disabled == {}
             assert overrides == {}
         finally:
@@ -31,13 +31,13 @@ class TestLoadConfig:
     def test_disable_rule(self, tmp_path: Path) -> None:
         config = tmp_path / ".compose-lint.yml"
         config.write_text("rules:\n  CL-0001:\n    enabled: false\n")
-        disabled, overrides = load_config(config)
+        disabled, overrides, _excluded = load_config(config)
         assert "CL-0001" in disabled
 
     def test_severity_override(self, tmp_path: Path) -> None:
         config = tmp_path / ".compose-lint.yml"
         config.write_text("rules:\n  CL-0005:\n    severity: high\n")
-        disabled, overrides = load_config(config)
+        disabled, overrides, _excluded = load_config(config)
         assert overrides["CL-0005"] == Severity.HIGH
 
     def test_multiple_rules(self, tmp_path: Path) -> None:
@@ -51,7 +51,7 @@ class TestLoadConfig:
             "  CL-0005:\n"
             "    enabled: false\n"
         )
-        disabled, overrides = load_config(config)
+        disabled, overrides, _excluded = load_config(config)
         assert set(disabled) == {"CL-0001", "CL-0005"}
         assert overrides["CL-0003"] == Severity.HIGH
 
@@ -63,14 +63,14 @@ class TestLoadConfig:
             "    enabled: false\n"
             '    reason: "SEC-1234 approved by J. Smith"\n'
         )
-        disabled, overrides = load_config(config)
+        disabled, overrides, _excluded = load_config(config)
         assert "CL-0001" in disabled
         assert disabled["CL-0001"] == "SEC-1234 approved by J. Smith"
 
     def test_disable_rule_without_reason(self, tmp_path: Path) -> None:
         config = tmp_path / ".compose-lint.yml"
         config.write_text("rules:\n  CL-0001:\n    enabled: false\n")
-        disabled, overrides = load_config(config)
+        disabled, overrides, _excluded = load_config(config)
         assert "CL-0001" in disabled
         assert disabled["CL-0001"] is None
 
@@ -93,7 +93,7 @@ class TestLoadConfig:
     def test_empty_config(self, tmp_path: Path) -> None:
         config = tmp_path / ".compose-lint.yml"
         config.write_text("")
-        disabled, overrides = load_config(config)
+        disabled, overrides, _excluded = load_config(config)
         assert disabled == {}
         assert overrides == {}
 
@@ -107,4 +107,76 @@ class TestLoadConfig:
         config = tmp_path / ".compose-lint.yml"
         config.write_text("rules:\n  - CL-0001\n")
         with pytest.raises(ConfigError, match="'rules' must be a mapping"):
+            load_config(config)
+
+
+class TestExcludeServices:
+    """Tests for per-service rule exclusions (ADR-010)."""
+
+    def test_list_form(self, tmp_path: Path) -> None:
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text(
+            "rules:\n"
+            "  CL-0003:\n"
+            "    exclude_services:\n"
+            "      - minecraft\n"
+            "      - backup\n"
+        )
+        _disabled, _overrides, excluded = load_config(config)
+        assert excluded == {"CL-0003": {"minecraft": None, "backup": None}}
+
+    def test_mapping_form_with_reasons(self, tmp_path: Path) -> None:
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text(
+            "rules:\n"
+            "  CL-0003:\n"
+            "    exclude_services:\n"
+            '      minecraft: "entrypoint switches users"\n'
+            '      backup: "forks as different user"\n'
+        )
+        _disabled, _overrides, excluded = load_config(config)
+        assert excluded == {
+            "CL-0003": {
+                "minecraft": "entrypoint switches users",
+                "backup": "forks as different user",
+            }
+        }
+
+    def test_mapping_form_null_reason(self, tmp_path: Path) -> None:
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text(
+            "rules:\n  CL-0003:\n    exclude_services:\n      minecraft:\n"
+        )
+        _disabled, _overrides, excluded = load_config(config)
+        assert excluded == {"CL-0003": {"minecraft": None}}
+
+    def test_coexists_with_severity_override(self, tmp_path: Path) -> None:
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text(
+            "rules:\n"
+            "  CL-0005:\n"
+            "    severity: high\n"
+            "    exclude_services:\n"
+            "      - internal-admin\n"
+        )
+        _disabled, overrides, excluded = load_config(config)
+        assert overrides["CL-0005"] == Severity.HIGH
+        assert excluded["CL-0005"] == {"internal-admin": None}
+
+    def test_absent_when_not_configured(self, tmp_path: Path) -> None:
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text("rules:\n  CL-0003:\n    enabled: false\n")
+        _disabled, _overrides, excluded = load_config(config)
+        assert excluded == {}
+
+    def test_invalid_scalar_value(self, tmp_path: Path) -> None:
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text("rules:\n  CL-0003:\n    exclude_services: minecraft\n")
+        with pytest.raises(ConfigError, match="must be a list or mapping"):
+            load_config(config)
+
+    def test_invalid_list_entry(self, tmp_path: Path) -> None:
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text("rules:\n  CL-0003:\n    exclude_services:\n      - 42\n")
+        with pytest.raises(ConfigError, match="service name strings"):
             load_config(config)


### PR DESCRIPTION
## Summary

Part 1 of 3 for per-service rule overrides (issue #5). This PR covers the strategic reframe and the config-layer schema work; engine suppression and user-facing docs follow in PR2 and PR3.

### Commits in this PR

1. **Reframe v0.4 roadmap toward config depth** — `docs/ROADMAP.md` rewritten around the depth thesis; `ADR-008` (Linux packages) moved to **Deferred** (no demand signal, strictly worse upgrade UX than pip/Docker without hosted-repo infra). v0.4 becomes per-service overrides (#5) + CL-0006 capability profiles (#4) + Homebrew tap.
2. **Accept ADR-010 per-service rule overrides** — status flipped to Accepted. Rule-centric schema (extends existing `rules.CL-XXXX` block), rule+service granularity with finding-level suppression explicitly parked.
3. **Parse `exclude_services` in `.compose-lint.yml`** — `load_config` now returns a 3-tuple, accepting both mapping (`service: reason`) and list (bare service names) forms.

### What's NOT in this PR

- Engine does not yet apply the exclusions. `cli.py` unpacks the new return value into `_excluded_services`. Behavior is unchanged for existing configs.
- No user-facing doc updates. PR3 covers README + CHANGELOG.

## Test plan

- [x] `ruff check` / `ruff format --check` — pass
- [x] `mypy src/` (strict) — pass
- [x] `pytest` — 271 passed (existing tests updated for 3-tuple unpack; 7 new tests in `TestExcludeServices`)
- [ ] Reviewer: schema matches ADR-010 (mapping + list forms, reason flows through)
- [ ] Reviewer: error messages include the rule id for invalid shapes

Stacked: PR2 (engine) will target this branch, PR3 (docs) will target PR2.