### PR TITLE
Per-service overrides: engine suppression + CLI wiring

### DIFF
--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -113,9 +113,7 @@ def main(argv: list[str] | None = None) -> NoReturn:
     config_path = _effective_config_path(args.config)
 
     try:
-        disabled_rules, severity_overrides, _excluded_services = load_config(
-            args.config
-        )
+        disabled_rules, severity_overrides, excluded_services = load_config(args.config)
     except ConfigError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(2)
@@ -146,6 +144,7 @@ def main(argv: list[str] | None = None) -> NoReturn:
     all_sarif: list[dict[str, object]] = []
     all_file_findings: list[tuple[list[Finding], str]] = []
     has_errors = False
+    seen_services: set[str] = set()
 
     for filepath in args.files:
         try:
@@ -157,11 +156,14 @@ def main(argv: list[str] | None = None) -> NoReturn:
             print(f"Error: {e}", file=sys.stderr)
             sys.exit(2)
 
+        seen_services.update(data.get("services", {}).keys())
+
         findings = run_rules(
             data,
             lines,
             disabled_rules=disabled_rules,
             severity_overrides=severity_overrides,
+            excluded_services=excluded_services,
         )
 
         if args.skip_suppressed:
@@ -181,6 +183,15 @@ def main(argv: list[str] | None = None) -> NoReturn:
         failing = filter_findings(findings, args.fail_on)
         if failing:
             has_errors = True
+
+    for rule_id, services_map in excluded_services.items():
+        for service_name in services_map:
+            if service_name not in seen_services:
+                print(
+                    f"Warning: exclude_services for {rule_id} references "
+                    f"unknown service '{service_name}'",
+                    file=sys.stderr,
+                )
 
     if args.output_format == "text":
         if len(args.files) > 1:

--- a/src/compose_lint/engine.py
+++ b/src/compose_lint/engine.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any
 
 from compose_lint.models import Finding, Severity
@@ -13,15 +14,18 @@ def run_rules(
     lines: dict[str, int],
     disabled_rules: dict[str, str | None] | None = None,
     severity_overrides: dict[str, Severity] | None = None,
+    excluded_services: dict[str, dict[str, str | None]] | None = None,
 ) -> list[Finding]:
     """Run all registered rules against the parsed Compose data.
 
-    Disabled rules are still executed but their findings are marked as
-    suppressed. Returns a list of findings sorted by line number
-    (None-line findings last).
+    Disabled rules and per-service exclusions still produce findings, but
+    those findings are marked suppressed with an appropriate reason. A
+    global disable takes precedence over per-service exclusions (see
+    ADR-010). Returns findings sorted by line number (None-line last).
     """
     disabled = disabled_rules or {}
     overrides = severity_overrides or {}
+    excluded = excluded_services or {}
     findings: list[Finding] = []
 
     rule_classes = get_registered_rules()
@@ -32,33 +36,28 @@ def run_rules(
     for rule in rules:
         rule_id = rule.metadata.id
         is_suppressed = rule_id in disabled
+        rule_excluded = excluded.get(rule_id, {})
 
         for service_name, service_config in services.items():
             for finding in rule.check(service_name, service_config, data, lines):
                 if rule_id in overrides and not is_suppressed:
-                    finding = Finding(
-                        rule_id=finding.rule_id,
-                        severity=overrides[rule_id],
-                        service=finding.service,
-                        message=finding.message,
-                        line=finding.line,
-                        fix=finding.fix,
-                        references=finding.references,
-                    )
+                    finding = replace(finding, severity=overrides[rule_id])
                 if is_suppressed:
                     reason = disabled[rule_id]
-                    finding = Finding(
-                        rule_id=finding.rule_id,
-                        severity=finding.severity,
-                        service=finding.service,
-                        message=finding.message,
-                        line=finding.line,
-                        fix=finding.fix,
-                        references=finding.references,
+                    finding = replace(
+                        finding,
                         suppressed=True,
-                        suppression_reason=reason
-                        if reason
-                        else "disabled in .compose-lint.yml",
+                        suppression_reason=reason or "disabled in .compose-lint.yml",
+                    )
+                elif service_name in rule_excluded:
+                    reason = rule_excluded[service_name]
+                    default = (
+                        f"excluded for service '{service_name}' in .compose-lint.yml"
+                    )
+                    finding = replace(
+                        finding,
+                        suppressed=True,
+                        suppression_reason=reason or default,
                     )
                 findings.append(finding)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,3 +65,42 @@ class TestCLI:
             str(FIXTURES / "valid_v2.yml"),
         )
         assert result.returncode == 0
+
+    def test_exclude_services_suppresses_named_service(self, tmp_path: Path) -> None:
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text(
+            "rules:\n"
+            "  CL-0003:\n"
+            "    exclude_services:\n"
+            '      missing: "entrypoint switches users"\n'
+        )
+        result = run_cli(
+            "--config",
+            str(config),
+            "--format",
+            "json",
+            str(FIXTURES / "insecure_no_new_priv.yml"),
+        )
+        assert result.returncode in (0, 1)
+        data = json.loads(result.stdout)
+        by_service = {f["service"]: f for f in data if f["rule_id"] == "CL-0003"}
+        assert by_service["missing"]["suppressed"] is True
+        assert (
+            by_service["missing"]["suppression_reason"] == "entrypoint switches users"
+        )
+        assert by_service["empty_security_opt"]["suppressed"] is False
+
+    def test_exclude_services_unknown_service_warns(self, tmp_path: Path) -> None:
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text(
+            "rules:\n  CL-0003:\n    exclude_services:\n      - does-not-exist\n"
+        )
+        result = run_cli(
+            "--config",
+            str(config),
+            "--format",
+            "json",
+            str(FIXTURES / "insecure_no_new_priv.yml"),
+        )
+        assert "unknown service 'does-not-exist'" in result.stderr
+        assert "CL-0003" in result.stderr

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -126,6 +126,89 @@ class TestRunRules:
         findings = run_rules(data, {})
         assert len(findings) == 0
 
+    def test_excluded_service_produces_suppressed_finding(self) -> None:
+        data = {
+            "services": {
+                "web": {"test_flag": True},
+                "worker": {"test_flag": True},
+            }
+        }
+        findings = run_rules(
+            data,
+            {},
+            excluded_services={"CL-TEST": {"worker": "entrypoint switches users"}},
+        )
+        assert len(findings) == 2
+        by_service = {f.service: f for f in findings}
+        assert by_service["web"].suppressed is False
+        assert by_service["worker"].suppressed is True
+        assert by_service["worker"].suppression_reason == "entrypoint switches users"
+
+    def test_excluded_service_without_reason(self) -> None:
+        data = {"services": {"worker": {"test_flag": True}}}
+        findings = run_rules(
+            data,
+            {},
+            excluded_services={"CL-TEST": {"worker": None}},
+        )
+        assert len(findings) == 1
+        assert findings[0].suppressed is True
+        assert "worker" in (findings[0].suppression_reason or "")
+
+    def test_excluded_service_only_affects_named_service(self) -> None:
+        data = {
+            "services": {
+                "web": {"test_flag": True},
+                "worker": {"test_flag": True},
+            }
+        }
+        findings = run_rules(
+            data,
+            {},
+            excluded_services={"CL-TEST": {"worker": None}},
+        )
+        assert len(findings) == 2
+        suppressed = {f.service: f.suppressed for f in findings}
+        assert suppressed == {"web": False, "worker": True}
+
+    def test_global_disable_takes_precedence_over_per_service(self) -> None:
+        """Per ADR-010: global disable wins over per-service exclusion."""
+        data = {"services": {"worker": {"test_flag": True}}}
+        findings = run_rules(
+            data,
+            {},
+            disabled_rules={"CL-TEST": None},
+            excluded_services={"CL-TEST": {"worker": "per-service reason"}},
+        )
+        assert len(findings) == 1
+        assert findings[0].suppressed is True
+        assert findings[0].suppression_reason == "disabled in .compose-lint.yml"
+
+    def test_excluded_service_with_severity_override(self) -> None:
+        """Severity overrides apply before suppression tagging."""
+        data = {"services": {"worker": {"test_flag": True}}}
+        findings = run_rules(
+            data,
+            {},
+            severity_overrides={"CL-TEST": Severity.CRITICAL},
+            excluded_services={"CL-TEST": {"worker": None}},
+        )
+        assert len(findings) == 1
+        assert findings[0].severity == Severity.CRITICAL
+        assert findings[0].suppressed is True
+
+    def test_excluded_unknown_service_is_noop(self) -> None:
+        """Stale service names in config do not affect findings for real services."""
+        data = {"services": {"web": {"test_flag": True}}}
+        findings = run_rules(
+            data,
+            {},
+            excluded_services={"CL-TEST": {"does-not-exist": "stale"}},
+        )
+        assert len(findings) == 1
+        assert findings[0].service == "web"
+        assert findings[0].suppressed is False
+
 
 class TestFilterFindings:
     """Tests for filter_findings function."""


### PR DESCRIPTION
## Summary

Part 2 of 3 for per-service rule overrides (issue #5, ADR-010). Builds on #94. Makes `exclude_services` actually do something; user-facing docs follow in PR3.

### Commits in this PR

1. **Apply per-service exclusions in the rule engine** — `run_rules` accepts `excluded_services` and marks matching findings suppressed with the per-service reason (or a default message if null). Global disable takes precedence. Finding reconstruction refactored to `dataclasses.replace` so the new branch doesn't duplicate every field.
2. **Thread `excluded_services` through CLI and warn on unknown names** — CLI passes the parsed map into `run_rules` per file and, after processing all files, emits one stderr warning per `(rule, service)` pair named in config but absent from every scanned Compose file.

## Behavior

- Suppressed findings appear in JSON with `suppressed: true` and `suppression_reason: <string>`, in SARIF with a `justification`, and in text with a `SUPPRESSED` trailer — reusing existing suppression plumbing.
- Stale/unknown service names warn on stderr, don't error. Rationale in ADR-010: Compose files are edited independently of config, and a stale entry shouldn't break the linter.
- Global `rules.CL-XXXX.enabled: false` wins over per-service — single precedence rule, covered by test.

## Test plan

- [x] `ruff check` / `ruff format --check` — pass
- [x] `mypy src/` (strict) — pass
- [x] `pytest` — 279 passed (6 new engine tests, 2 new CLI tests)
- [x] Engine tests cover: suppressed-with-reason, suppressed-without-reason, only-named-service-affected, global-disable-precedence, severity-override-interaction, unknown-service-is-noop
- [x] CLI test covers: JSON output shows suppressed finding with reason; unknown service name produces stderr warning
- [ ] Reviewer: default reason message when null is acceptable (`excluded for service 'X' in .compose-lint.yml`)
- [ ] Reviewer: warning text is useful but not noisy

Target: `main`. PR3 (docs + CHANGELOG) will branch off this PR.