### PR TITLE
Per-service overrides: README + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Per-service rule exclusions in `.compose-lint.yml`. A rule's
+  `exclude_services` key accepts either a mapping (service name →
+  reason) or a list of service names. Excluded services still produce
+  findings marked suppressed, with the per-service reason flowing to
+  `suppression_reason` (JSON), SARIF `justification`, and the text
+  formatter's `SUPPRESSED` trailer. Global `enabled: false` takes
+  precedence over per-service exclusions. Unknown service names in
+  `exclude_services` warn on stderr rather than erroring. Closes #5.
+  See [ADR-010](docs/adr/010-per-service-rule-overrides.md).
+
+### Changed
+
+- v0.4 roadmap repointed from Linux package distribution to
+  configuration depth and a Homebrew tap. ADR-008 deferred: no
+  demand signal, and GitHub-Releases-hosted `.deb`/`.rpm` have
+  strictly worse upgrade UX than pip/Docker without hosted-repo
+  infrastructure.
+
 ## [0.3.7] - 2026-04-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -120,6 +120,31 @@ To hide suppressed findings from output:
 compose-lint --skip-suppressed docker-compose.yml
 ```
 
+### Per-service rule exclusions
+
+When a rule is valid for some services but architecturally incompatible with
+others (e.g. CL-0003 `no-new-privileges` and an image whose entrypoint
+switches users), use `exclude_services` to suppress it for just the
+affected services while keeping it active elsewhere:
+
+```yaml
+rules:
+  CL-0003:
+    exclude_services:
+      minecraft: "entrypoint switches users via su-exec"
+      backup: "forks as different user"
+  CL-0007:
+    exclude_services:
+      - legacy-worker   # list form when no reason is needed
+```
+
+Excluded services still produce findings marked **SUPPRESSED** with the
+per-service reason flowing to `suppression_reason` / SARIF `justification`,
+same as a global disable. Service names are matched exactly; unknown names
+produce a stderr warning but do not error (Compose files are edited
+independently of config). Global `enabled: false` takes precedence over
+per-service exclusions.
+
 ## CLI Reference
 
 ```


### PR DESCRIPTION
## Summary

Part 3 of 3 for per-service rule overrides (issue #5, ADR-010). Stacked on #95. User-facing documentation only — no code changes.

### Contents

- **README.md** — new **Per-service rule exclusions** subsection under Configuration. Shows mapping form (with reasons) and list form, documents the suppression output flow (`SUPPRESSED` / `suppression_reason` / SARIF `justification`), the unknown-service stderr warning, and the global-disable precedence rule.
- **CHANGELOG.md** — Unreleased entry under Added (feature) and Changed (v0.4 roadmap repoint), referencing issue #5 and ADR-010.

## Test plan

- [x] README renders: syntax block valid YAML, prose matches ADR-010 behavior
- [x] CHANGELOG Unreleased section follows Keep-a-Changelog conventions already in use
- [ ] Reviewer: README example is representative without being misleading
- [ ] Reviewer: CHANGELOG framing is accurate for the feature shipping across #94, #95, and this PR

**Merge order:** #94 (merged) → #95 → this PR. Once #95 merges, this PR rebases to target `main`.