### PR TITLE
Refresh README Example Output against current CLI rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,24 +46,51 @@ docker run --rm -v "$(pwd):/src" composelint/compose-lint docker-compose.prod.ym
 
 ## Example Output
 
+Given this `docker-compose.yml`:
+
+```yaml
+services:
+  traefik:
+    image: traefik:v3.0@sha256:aaaabbbbccccddddeeeeffff00001111222233334444555566667777888899990
+    read_only: true
+    cap_drop: [ALL]
+    security_opt:
+      - no-new-privileges:true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - "8080:80"
 ```
-docker-compose.yml:5  CRITICAL  CL-0001  Docker socket mounted via
-  '/var/run/docker.sock:/var/run/docker.sock'. This gives the container
-  full control over the Docker daemon.
+
+and this `.compose-lint.yml` (suppressing CL-0001 for `traefik` with a tracked reason):
+
+```yaml
+rules:
+  CL-0001:
+    exclude_services:
+      traefik: "SEC-1234 approved — socket proxy planned for 2026-Q3"
+```
+
+running `compose-lint docker-compose.yml` produces:
+
+```
+compose-lint 0.3.7
+files: docker-compose.yml  ·  config: .compose-lint.yml  ·  fail-on: high
+
+docker-compose.yml:8  SUPPRESSED  CL-0001  Docker socket mounted via '/var/run/docker.sock:/var/run/docker.sock'. This gives the container full control over the Docker daemon.
   service: traefik
-  fix: Use a Docker socket proxy (e.g., tecnativa/docker-socket-proxy)
-       to expose only the API endpoints your service needs.
-  ref: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1
+  reason: SEC-1234 approved — socket proxy planned for 2026-Q3
 
-docker-compose.yml:3  HIGH  CL-0005  Port '8080:80' is bound to all
-  interfaces. Docker bypasses host firewalls (UFW/firewalld), potentially
-  exposing this port to the public internet.
-  service: web
+docker-compose.yml:10  HIGH      CL-0005  Port '8080:80' is bound to all interfaces. Docker bypasses host firewalls (UFW/firewalld), potentially exposing this port to the public internet.
+  service: traefik
   fix: Bind to localhost: 127.0.0.1:8080:80
-  ref: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-5a
-
-docker-compose.yml: 1 critical, 1 high
+       If public access is needed, use a reverse proxy with TLS.
+  ref: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-5a---be-careful-when-mapping-container-ports-to-the-host-with-firewalls-like-ufw
+docker-compose.yml: 1 high  ·  1 suppressed (not counted)
+✗ FAIL  ·  1 finding at or above high
 ```
+
+Exit code is `1` (one finding at or above the default `--fail-on high` threshold). Suppressed findings are shown for auditability but do not count toward the threshold.
 
 ## Rules
 


### PR DESCRIPTION
## Summary

The README's **Example Output** block predated several CLI changes and no longer matched actual output:

- Missing the branded header (`compose-lint 0.3.7\nfiles: ... · config: ... · fail-on: ...`)
- Missing the final verdict line (`✗ FAIL · N findings at or above high`)
- Finding bodies were hand-wrapped; the tool emits them on a single line
- `fix:` text for CL-0001 was the old short form — current rules often have multi-line fixes with indented code and `Note:` caveats
- No example of a `SUPPRESSED` finding, despite the Configuration section describing the rendering
- Summary line didn't include lower severities or the suppression count

## What changed

Replaced the **Example Output** section with:

1. The `docker-compose.yml` fixture the example is generated from (so readers can reproduce).
2. A `.compose-lint.yml` showing per-service suppression in use (exercising the #95/#96 feature).
3. The actual captured output — header, one `SUPPRESSED` finding with reason, one real `HIGH` finding with multi-line fix, per-file summary (`1 high · 1 suppressed (not counted)`), verdict line.
4. A trailing sentence noting exit code 1 and that suppressed findings don't count toward the threshold.

Output was captured from a real run of `python -m compose_lint docker-compose.yml` against the shown fixture.

## Test plan

- [x] Output block is verbatim from the CLI (no hand edits, no wrapping)
- [x] Fixture is self-contained and reproducible
- [x] Suppression example uses per-service syntax now available on main
- [ ] Reviewer: example length feels right — informative without dominating the README
- [ ] Reviewer: fixture covers the interesting rendering paths (header, SUPPRESSED, multi-line fix, verdict) without being cluttered

Closes the follow-up noted during the per-service overrides review cycle.