### PR TITLE
Add OpenSSF trust badges and tidy SECURITY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![Docker](https://img.shields.io/badge/docker-composelint%2Fcompose--lint-2496ED?logo=docker&logoColor=white)](https://hub.docker.com/r/composelint/compose-lint)
 [![Python](https://img.shields.io/pypi/pyversions/compose-lint)](https://pypi.org/project/compose-lint/)
 [![License](https://img.shields.io/github/license/tmatens/compose-lint)](LICENSE)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/tmatens/compose-lint/badge)](https://scorecard.dev/viewer/?uri=github.com/tmatens/compose-lint)
+[![OpenSSF Baseline](https://www.bestpractices.dev/projects/12472/baseline)](https://www.bestpractices.dev/projects/12472)
 
 A security-focused linter for Docker Compose files. Catches dangerous misconfigurations before they reach production.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,8 @@
 
 ## Supported Versions
 
-compose-lint follows semantic versioning. Only the latest minor release receives
-security fixes.
-
-| Version | Supported |
-| ------- | --------- |
-| 0.3.x   | Yes       |
+compose-lint follows semantic versioning. Only the latest minor release
+receives security fixes.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Summary
- Add OpenSSF Scorecard badge (already running weekly; current score 7.6).
- Add OpenSSF Baseline badge (self-attested at bestpractices.dev, project 12472, passing baseline-1).
- Drop the supported-versions table from SECURITY.md — the policy sentence above it already states "only the latest minor release receives security fixes" and the table drifted on every minor bump.

## Test plan
- [ ] CI green
- [ ] Scorecard badge renders on the PR's README preview
- [ ] Baseline badge renders on the PR's README preview