### PR TITLE
Document maintainers and responsibilities in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,15 @@ See [AGENTS.md](AGENTS.md) for the full design philosophy — especially the
 sections on rule grounding, severity assignment, and what's explicitly out of
 scope.
 
+## Maintainers
+
+- Todd Matens ([@tmatens](https://github.com/tmatens)) — repository admin,
+  releases, security response.
+
+Maintainers review and merge PRs, triage issues within 14 days, respond to
+security reports within 7 days per [SECURITY.md](SECURITY.md), and cut
+releases per [docs/RELEASING.md](docs/RELEASING.md).
+
 ## Development setup
 
 ```bash


### PR DESCRIPTION
## Summary
- Add a "Maintainers" section to CONTRIBUTING.md listing the single maintainer (@tmatens) with repository admin, release, and security-response responsibilities.
- Placed in CONTRIBUTING.md rather than a new GOVERNANCE.md because a single-maintainer project doesn't need a separate top-level doc, and the content fits naturally next to the contributor guidance.

## Why
Closes two OpenSSF Baseline gaps identified during the baseline-1 self-assessment:
- **OSPS-GV-01.01** — list of project members with access to sensitive resources.
- **OSPS-GV-01.02** — descriptions of roles and responsibilities.

## Test plan
- [ ] CI green
- [ ] Section renders correctly on the rendered Markdown preview