### PR TITLE
Require DCO sign-off on every PR commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,49 @@ jobs:
           fi
           echo "Found matching CHANGELOG section for ${head_version}."
 
+  dco:
+    name: Developer Certificate of Origin
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Require matching Signed-off-by on every PR commit
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Bot commits (Dependabot, Renovate, github-actions) can't add a
+          # Signed-off-by trailer from the Probot runtime. They're allow-listed.
+          bot_pattern='(dependabot|renovate|github-actions|mend)\[bot\]'
+          bad=""
+          while IFS=$'\t' read -r sha author_name author_email; do
+            if echo "${author_name}${author_email}" | grep -iqE "${bot_pattern}"; then
+              continue
+            fi
+            expected="Signed-off-by: ${author_name} <${author_email}>"
+            if ! git log -1 --format='%B' "${sha}" | grep -qiF "${expected}"; then
+              bad="${bad}${sha}	${author_name} <${author_email}>
+          "
+            fi
+          done < <(git log --format='%H%x09%an%x09%ae' "${BASE_SHA}..${HEAD_SHA}")
+          if [ -n "${bad}" ]; then
+            echo "::error::Commits missing matching Signed-off-by (DCO) trailer:"
+            printf '%s' "${bad}" | while IFS=$'\t' read -r sha author; do
+              [ -n "${sha}" ] && echo "::error::  ${sha}  ${author}"
+            done
+            echo "::error::Add 'Signed-off-by: Name <email>' matching your author identity."
+            echo "::error::Fix with 'git commit --amend --signoff' or 'git rebase --signoff ${BASE_SHA}'."
+            exit 1
+          fi
+          echo "All PR commits carry a matching Signed-off-by trailer."
+
   no-ai-attribution:
     name: No AI authorship attribution
     runs-on: ubuntu-24.04
@@ -441,6 +484,7 @@ jobs:
       - security
       - version-consistency
       - changelog-gate
+      - dco
       - no-ai-attribution
       - dependency-review
       - actionlint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,10 @@ pytest                          # Tests
 - **Explain the *why* in the body, not just the *what*.** The diff already
   shows what changed; the commit message exists to explain the reason.
 - **Sign your commits.** See [commit signing](#commit-signing) below.
+- **Sign off your commits.** Use `git commit -s` to add the
+  `Signed-off-by:` trailer required by the
+  [DCO](#developer-certificate-of-origin) — this is separate from
+  cryptographic signing.
 - **No AI attribution.** Do not include `Co-Authored-By` trailers or any other
   references to AI/coding assistants in commit messages, code, or
   documentation.
@@ -117,6 +121,30 @@ from authentication keys) at <https://github.com/settings/ssh/new>.
 Verify locally with `git log --show-signature`. If it prints
 `Good "git" signature`, you're set. On GitHub, your commits will show a green
 **Verified** badge.
+
+### Developer Certificate of Origin
+
+All commits must carry a `Signed-off-by:` trailer certifying that you wrote
+the change (or have the right to submit it under this project's MIT license).
+This is the [Developer Certificate of Origin](https://developercertificate.org).
+It is independent of [commit signing](#commit-signing) above: cryptographic
+signing proves *who committed*, DCO asserts *right to contribute*.
+
+Add the trailer automatically with `-s`:
+
+```bash
+git commit -s -m "Your change"
+```
+
+Or enable it once per-clone so every commit gets signed off:
+
+```bash
+git config format.signOff true
+```
+
+The `Signed-off-by` name and email must match your commit author identity. CI
+will block the PR if any commit is missing a matching trailer. Fix existing
+commits with `git commit --amend --signoff` or `git rebase --signoff main`.
 
 ## Pull requests
 


### PR DESCRIPTION
## Summary
- Adds a DCO gate to `ci.yml` that fails any PR where a non-bot commit between base and head lacks a `Signed-off-by` trailer matching the commit author identity.
- Allow-lists Dependabot, Renovate, github-actions, and Mend bot commits, since their runtimes can't append the trailer.
- Documents the requirement in `CONTRIBUTING.md` (new DCO subsection alongside commit signing, plus a `git commit -s` pointer in commit conventions).

Closes the OpenSSF Baseline OSPS-LE-01.01 gap: per-commit legal authorization assertion.

## Test plan
- [ ] CI passes on this PR (the DCO check runs against itself; the single commit is signed off).
- [ ] Open a throwaway test PR with an unsigned commit and confirm the DCO job fails with a clear error.
- [ ] Confirm a Renovate/Dependabot PR still passes (allow-list path).