### PR TITLE
Add OpenSSF Best Practices badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![License](https://img.shields.io/github/license/tmatens/compose-lint)](LICENSE)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/tmatens/compose-lint/badge)](https://scorecard.dev/viewer/?uri=github.com/tmatens/compose-lint)
 [![OpenSSF Baseline](https://www.bestpractices.dev/projects/12472/baseline)](https://www.bestpractices.dev/projects/12472)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12472/badge)](https://www.bestpractices.dev/projects/12472)
 
 A security-focused linter for Docker Compose files. Catches dangerous misconfigurations before they reach production.
 


### PR DESCRIPTION
## Summary
- Adds the OpenSSF Best Practices tier badge (`/projects/12472/badge`) alongside the existing OpenSSF Baseline badge.
- Same project ID (12472), different program: Baseline = minimum criteria, Best Practices = passing/silver/gold tier.

## Test plan
- [ ] Confirm badge renders on the rendered README
- [ ] Click-through resolves to https://www.bestpractices.dev/projects/12472