### PR TITLE
Reflect baseline 2 level in OpenSSF badge alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Python](https://img.shields.io/pypi/pyversions/compose-lint)](https://pypi.org/project/compose-lint/)
 [![License](https://img.shields.io/github/license/tmatens/compose-lint)](LICENSE)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/tmatens/compose-lint/badge)](https://scorecard.dev/viewer/?uri=github.com/tmatens/compose-lint)
-[![OpenSSF Baseline](https://www.bestpractices.dev/projects/12472/baseline)](https://www.bestpractices.dev/projects/12472)
+[![OpenSSF Baseline 2](https://www.bestpractices.dev/projects/12472/baseline)](https://www.bestpractices.dev/projects/12472)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12472/badge)](https://www.bestpractices.dev/projects/12472)
 
 A security-focused linter for Docker Compose files. Catches dangerous misconfigurations before they reach production.


### PR DESCRIPTION
## Summary
- The project earned the OpenSSF Best Practices **baseline-2** level on 2026-04-18. The badge image at `/projects/12472/baseline` already updates dynamically — only the markdown alt text needed refreshing to match.

## Test plan
- [ ] Badge renders "Baseline 2" variant on the rendered README (visual check on GitHub).
- [ ] Link still resolves to https://www.bestpractices.dev/projects/12472.