### PR TITLE
Wrap PyYAML RecursionError as ComposeError

### DIFF
--- a/fuzz/fuzz_compose.py
+++ b/fuzz/fuzz_compose.py
@@ -33,6 +33,11 @@ def _test_one_input(data: bytes) -> None:
         # PyYAML converts some malformed scalars (e.g. massive ints, bad
         # timestamps) into Python exceptions before our ComposeError wrapper.
         return
+    except RecursionError:
+        # PyYAML's composer is recursive; deeply-nested flow input exhausts
+        # the interpreter stack. load_compose wraps this as ComposeError, but
+        # the harness calls yaml.load directly, so swallow it here too.
+        return
 
     if raw is None:
         return

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -188,6 +188,14 @@ def load_compose(
         )
     except yaml.YAMLError as e:
         raise ComposeError(f"Invalid YAML: {e}") from e
+    except RecursionError as e:
+        # PyYAML's composer is recursive (compose_node -> compose_sequence_node
+        # -> compose_node) with no built-in depth limit, so deeply-nested input
+        # like `[[[[...]]]]` exhausts the interpreter stack from inside the
+        # parser. RecursionError is a RuntimeError, not a YAMLError, so it
+        # bypasses the wrapper above; surface it as ComposeError so the public
+        # contract holds for all malformed input.
+        raise ComposeError("Invalid YAML: input is too deeply nested") from e
 
     if raw is None:
         raise ComposeError("Not a valid Compose file: file is empty")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -99,6 +99,17 @@ class TestLoadCompose:
         with pytest.raises(ComposeError, match="unhashable key"):
             load_compose(FIXTURES / "invalid_complex_key.yml")
 
+    def test_deeply_nested_yaml_raises_compose_error(self, tmp_path: Path) -> None:
+        # Regression: ClusterFuzzLite found that deeply-nested flow sequences
+        # (`[[[[...]]]]`) exhaust PyYAML's recursive composer and raise
+        # RecursionError, which is a RuntimeError and bypassed the
+        # `except yaml.YAMLError` wrapper. load_compose now catches it.
+        depth = sys.getrecursionlimit() * 2
+        path = tmp_path / "deeply_nested.yml"
+        path.write_text("[" * depth + "]" * depth, encoding="utf-8")
+        with pytest.raises(ComposeError, match="too deeply nested"):
+            load_compose(path)
+
 
 class TestDeepNestingTraversal:
     """Regression for ClusterFuzzLite-found RecursionError in _collect_lines.


### PR DESCRIPTION
## Summary
- ClusterFuzzLite caught a reproducible crash ([run](https://github.com/tmatens/compose-lint/actions/runs/24651843653), [issue #114](https://github.com/tmatens/compose-lint/issues/114)): deeply-nested flow input like `[[[[...]]]]` exhausts PyYAML's recursive composer and raises `RecursionError` from inside `yaml.load`. `RecursionError` is a `RuntimeError`, not a `YAMLError`, so it bypassed `load_compose`'s wrapper and crashed the CLI with an unhandled exception instead of returning exit code 2.
- `parser.load_compose` now catches `RecursionError` and surfaces it as `ComposeError("Invalid YAML: input is too deeply nested")`, restoring the public-API contract that all malformed input becomes `ComposeError`.
- Mirror the exclusion in `fuzz/fuzz_compose.py` so future ClusterFuzzLite runs surface new crashes instead of rediscovering this one.

## Test plan
- [x] New regression test in `tests/test_parser.py` writes `"[" * (recursionlimit*2) + "]" * (...)` and asserts `ComposeError` matching "too deeply nested"
- [x] `ruff check`, `ruff format --check`, `mypy src/`, full `pytest` (280 passed)

Closes #114