### PR TITLE
Strip pip from runtime image to clear Docker Scout CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,20 @@ RUN python3 -m venv /build-venv \
     && /build-venv/bin/python -m build --wheel --outdir /dist \
     && python3 -m venv /venv \
     && /venv/bin/pip install --no-cache-dir --require-hashes -r requirements.lock \
-    && /venv/bin/pip install --no-cache-dir --no-deps /dist/*.whl
+    && /venv/bin/pip install --no-cache-dir --no-deps /dist/*.whl \
+    && rm -rf /venv/lib/python3.13/site-packages/pip \
+        /venv/lib/python3.13/site-packages/pip-*.dist-info \
+    && rm -f /venv/bin/pip /venv/bin/pip3 /venv/bin/pip3.13 \
+        /venv/bin/activate /venv/bin/activate.csh /venv/bin/activate.fish \
+        /venv/bin/Activate.ps1
+# Post-install cleanup: pip is only needed during build (the install steps
+# above), and the activate* scripts target shells the distroless runtime
+# doesn't have. Stripping pip eliminates Docker Scout CVEs in pip itself
+# (CVE-2025-8869, CVE-2026-1703 as of pip 25.1.1) — neither is reachable
+# at runtime since the entrypoint is /venv/bin/compose-lint and there's no
+# shell, but removing the bits also removes their attack surface and
+# future-CVE noise. PyYAML, compose_lint, and the Python interpreter
+# symlinks remain.
 
 # --- runtime stage: distroless Python, nonroot by default ---
 FROM gcr.io/distroless/python3-debian13:nonroot@sha256:51b1acc177d535f20fa30a175a657079ee7dce6e326541cfd83a474d9928e123


### PR DESCRIPTION
## Summary
- Docker Scout flags two CVEs ([alert #83](https://github.com/tmatens/compose-lint/security/code-scanning/83), [alert #82](https://github.com/tmatens/compose-lint/security/code-scanning/82)) against pip 25.1.1 in the runtime image (`/venv/lib/python3.13/site-packages/pip-25.1.1.dist-info/METADATA`):
  - **CVE-2025-8869** (Medium, CVSS 5.9) — symlink-following on tarball extraction during `pip install`
  - **CVE-2026-1703** (Low, CVSS 2.0) — path traversal on attacker-controlled wheel/sdist
- Neither is exploitable in our usage — pip only runs at build time against `--require-hashes` lockfiles; runtime entrypoint is `compose-lint`, distroless has no shell, and the process is nonroot UID 65532 — but the dist-info still generates alerts and will keep generating them with every new pip CVE.
- Strip `pip/`, `pip-*.dist-info/`, the `pip*` entry-point scripts, and the `activate*` shell scripts (distroless can't source them anyway) from the runtime venv after install. PyYAML, compose_lint, and the Python interpreter symlinks remain.
- Image drops ~17 MB (~112 MB → ~95 MB).

## Why strip instead of upgrade
Renovate has no datasource for Debian apt versions of `python3-pip`. Upgrading pip in place would require either hash-pinning pip itself (a dep we don't otherwise track) or an unpinned `pip install --upgrade pip` in the Dockerfile, which violates the project's hash-pinning rule. Stripping pip after build sidesteps both and makes the image immune to future pip CVEs.

## Test plan
- [x] `docker build` succeeds
- [x] `docker run --rm compose-lint:strip-test --version` → `compose-lint 0.4.0`
- [x] `docker run -v tests/compose_files:/src:ro compose-lint:strip-test valid_basic.yml` lints cleanly
- [x] `python3 -c "import pip"` inside the image → `ModuleNotFoundError: No module named 'pip'`
- [ ] `scout-scan` workflow on this PR shows zero findings against pip
- [ ] `marketplace-smoke` and `docker-smoke` jobs pass on both arches