### PR TITLE
Populate [Unreleased] for 0.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Container image no longer ships `pip` or its `dist-info`. `pip` was
+  only used at build time against `--require-hashes` lockfiles and was
+  unreachable at runtime (distroless, no shell, nonroot entrypoint),
+  but its presence in the runtime layer surfaced ongoing Docker Scout
+  alerts (CVE-2025-8869, CVE-2026-1703 against pip 25.1.1) and would
+  have generated more on every future pip CVE. The runtime venv now
+  contains only PyYAML, compose_lint, and the Python interpreter
+  symlinks; image drops ~17 MB. (#116)
+
+### Fixed
+
+- `parser.load_compose` now wraps `RecursionError` as `ComposeError`.
+  PyYAML's composer is recursive; deeply-nested flow input like
+  `[[[[...]]]]` exhausted the interpreter stack from inside `yaml.load`
+  and raised `RecursionError` — a `RuntimeError`, not a `YAMLError` —
+  bypassing the existing wrapper and crashing the CLI with an unhandled
+  exception instead of returning exit code 2. Surfaced by ClusterFuzzLite
+  (#114). (#115)
+
+### Added
+
+- SLSA build provenance attestations on PyPI sdist + wheel and the
+  Docker image, providing verifiable supply-chain proof that release
+  artifacts were built from this repository's tagged source. (#107)
+
 ## [0.4.0] - 2026-04-19
 
 ### Added


### PR DESCRIPTION
## Summary
Captures the three user-facing changes since v0.4.0 so release-prep can lift them into the `[0.4.1]` section and the GitHub Release notes:

- **Security** — pip stripped from the runtime container image (#116)
- **Fixed** — parser `RecursionError` now wrapped as `ComposeError` (#115, surfaced by #114)
- **Added** — SLSA build provenance attestations on release artifacts (#107)

Docs/process commits (DCO requirement, OpenSSF badges, AI-attribution backfill, ADR drafts, roadmap resync, Renovate digest bumps) are intentionally omitted from the user-facing changelog.

## Test plan
- [x] `[Unreleased]` populated; `[0.4.0]` block untouched
- [x] DCO trailer present
- [ ] CI green