### PR TITLE
Fast-track Renovate bumps for production base images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,6 +30,13 @@
       "pinDigests": true
     },
     {
+      "description": "Production runtime + build-stage base images bypass the weekly schedule. Debian and distroless rebuilds carry CVE patches we cannot apply ourselves (no shell, no apt at runtime), so opening the bump PR same-day shrinks the window between upstream patch and our published image. Still manual-merge — the manifest-list-vs-per-arch digest gotcha (memory/feedback_dockerfile_manifest_list_digest.md) needs human verification.",
+      "matchManagers": ["dockerfile"],
+      "matchFileNames": ["Dockerfile"],
+      "matchPackageNames": ["debian", "gcr.io/distroless/python3-debian13"],
+      "schedule": ["at any time"]
+    },
+    {
       "description": "Automerge low-risk routine updates once CI is green. Patch-level Python dep bumps, pinned-digest refreshes for GitHub Actions, and lockFileMaintenance go in without human review. Docker base images stay manual because the OCI manifest-list vs per-arch digest check (see MEMORY.md) is not mechanically verified in CI.",
       "matchManagers": ["pep621", "pip_requirements", "github-actions"],
       "matchUpdateTypes": ["patch", "pin", "digest", "lockFileMaintenance"],


### PR DESCRIPTION
## Summary
Trivy scan of the just-published v0.4.1 image surfaced 57 unique CVEs (152 package-instances) in the distroless base layer, zero with available fixes — Debian hasn't published patches yet for any of them. The only mechanism that actually closes these CVEs is the **upstream base rebuild**, since distroless has no shell or `apt` we can use to patch in place.

Today's `renovate.json` batches all updates to `"before 4am on monday"`. That same window applies to base-image digests, so a Debian or distroless rebuild that lands on Tuesday waits six days before opening a PR here.

This change adds one `packageRule` that exempts the two production base images from the weekly schedule:

- `debian` (the `debian:trixie-slim` build stage)
- `gcr.io/distroless/python3-debian13` (the runtime stage)

Both will now open digest-bump PRs `"at any time"`. The ClusterFuzzLite build image is intentionally **not** included — it's CI-only, and weekly cadence is fine for it.

## What this does NOT change
- **Manual merge stays in place.** Per `feedback_dockerfile_manifest_list_digest.md`, base-image bumps need human verification that the digest is the OCI manifest-list (not a per-arch manifest), or `docker-publish` will break on arm64 mid-release. The existing `verify-dockerfile-digests` CI check catches this at PR time but is still part of the review loop.
- **Other update categories** (Python deps, Actions, lockfile maintenance) keep their Monday batch — no extra noise for application-level churn.
- **No effect on the published image until next time the upstream base rebuilds.** This shortens the queue, not the patch latency at the source.

## Test plan
- [x] `python3 -m json.tool renovate.json` parses clean
- [ ] CI green (the only checks that touch this path are the JSON parse jobs)
- [ ] Next time `gcr.io/distroless/python3-debian13:nonroot` digest changes upstream, Renovate opens a PR within hours rather than waiting for Monday