### PR TITLE
Add --explain CL-XXXX for in-terminal rule docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `--explain CL-XXXX` prints the per-rule prose documentation
+  (`docs/rules/CL-XXXX.md`) to stdout so reviewers can read the full
+  rationale, references, and fix guidance without context-switching to
+  the browser. Accepts any case, exits 2 on unknown or malformed rule
+  ids, and refuses to run alongside FILE arguments. The rule-doc
+  markdown ships inside the wheel under `compose_lint/rule_docs/`.
+
 ## [0.4.1] - 2026-04-23
 
 ### Security

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,10 @@ WORKDIR /build
 COPY pyproject.toml README.md LICENSE ./
 COPY requirements.lock requirements-build.lock ./
 COPY src/ src/
+# Rule-doc markdown is force-included into the wheel at
+# compose_lint/rule_docs/ so `--explain CL-XXXX` can read it at runtime.
+# See pyproject.toml [tool.hatch.build.targets.wheel.force-include].
+COPY docs/rules/ docs/rules/
 # Two-venv layout so every package entering the final image is hash-pinned:
 #   /build-venv — ephemeral, runs `python -m build` (build + transitives)
 #   /venv       — the runtime venv that gets copied into the final stage

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ compose-lint [OPTIONS] [FILE ...]
   --fail-on SEVERITY          Minimum severity to trigger exit 1 (default: high)
   --skip-suppressed           Hide suppressed findings from output
   --config PATH               Path to config file (default: .compose-lint.yml)
+  --explain CL-XXXX           Print the full documentation for a single rule
   --version                   Show version and exit
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ pip install compose-lint
 docker run --rm -v "$(pwd):/src" composelint/compose-lint
 ```
 
+The image runs on [Google's distroless Python](https://github.com/GoogleContainerTools/distroless) (Debian 13, Python 3.13): no shell, no package manager, no `apt`, no `pip` at runtime. The entrypoint runs as nonroot (UID 65532). Only the Python interpreter, PyYAML, and `compose_lint` itself live in the final image — pip and the `dist-info` metadata are stripped from the venv after the build stage so Python-ecosystem CVEs don't surface on an unreachable binary. Multi-arch (linux/amd64 + linux/arm64), SHA-pinned base images bumped by Renovate, SLSA build provenance and Sigstore attestations published with every release. See [ADR-009](https://github.com/tmatens/compose-lint/blob/main/docs/adr/009-runtime-base-image.md).
+
 ## Quick Start
 
 Run without arguments to auto-detect `compose.yml`, `compose.yaml`, `docker-compose.yml`, or `docker-compose.yaml` in the current directory:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -49,7 +49,7 @@ _Deferred:_ `.deb`/`.rpm` Linux packages (see [ADR-008](adr/008-linux-packages.m
 
 Turn findings into fixes. This is where the product's differentiation grows the most against KICS/Checkov.
 
-**`--explain CL-XXXX`** — print the full prose from `docs/rules/CL-XXXX.md` in the terminal, reducing context-switching to the browser during triage. Small, no new deps, foundation for `--fix` UX.
+**`--explain CL-XXXX`** _(shipped in v0.4.x)_ — prints the full prose from `docs/rules/CL-XXXX.md` in the terminal, reducing context-switching to the browser during triage. Rule-doc markdown is force-included into the wheel at build time. No new deps; pulled forward out of Milestone 3 because it's strictly additive and unblocks the `--fix` UX work.
 
 **`--fix` mode** — auto-fix for safe, unambiguous rules:
 - CL-0003: inject `no-new-privileges:true` into `security_opt:`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,3 +123,9 @@ exclude = [
     "Dockerfile",
     ".dockerignore",
 ]
+
+# Ship the per-rule markdown docs inside the wheel so `--explain CL-XXXX`
+# can read them at runtime. Single source of truth remains `docs/rules/`;
+# the force-include maps that directory into the installed package.
+[tool.hatch.build.targets.wheel.force-include]
+"docs/rules" = "compose_lint/rule_docs"

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -11,6 +11,7 @@ from typing import NoReturn
 from compose_lint import __version__
 from compose_lint.config import ConfigError, load_config
 from compose_lint.engine import filter_findings, run_rules
+from compose_lint.explain import UnknownRuleError, load_rule_doc
 from compose_lint.formatters.json import format_findings as format_json
 from compose_lint.formatters.sarif import build_sarif_log
 from compose_lint.formatters.sarif import format_findings as format_sarif
@@ -98,6 +99,14 @@ def _build_parser() -> argparse.ArgumentParser:
         help="hide suppressed findings from output",
     )
     parser.add_argument(
+        "--explain",
+        metavar="CL-XXXX",
+        help=(
+            "print the prose documentation for a single rule and exit. "
+            "Cannot be combined with FILE arguments."
+        ),
+    )
+    parser.add_argument(
         "--version",
         action="version",
         version=f"%(prog)s {__version__}",
@@ -109,6 +118,23 @@ def main(argv: list[str] | None = None) -> NoReturn:
     """Main entry point for the CLI."""
     parser = _build_parser()
     args = parser.parse_args(argv)
+
+    if args.explain is not None:
+        if args.files:
+            print(
+                "Error: --explain cannot be combined with FILE arguments",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        try:
+            print(load_rule_doc(args.explain))
+        except UnknownRuleError:
+            print(
+                f"Error: unknown rule id '{args.explain}' (expected format: CL-XXXX)",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        sys.exit(0)
 
     config_path = _effective_config_path(args.config)
 

--- a/src/compose_lint/explain.py
+++ b/src/compose_lint/explain.py
@@ -1,0 +1,52 @@
+"""Load the prose documentation for a single rule.
+
+The per-rule markdown lives in `docs/rules/CL-XXXX.md` in the repo and is
+force-included into the wheel at `compose_lint/rule_docs/CL-XXXX.md` (see
+`pyproject.toml`). Editable installs and direct source checkouts miss the
+packaged copy, so this module probes the source layout as a fallback.
+"""
+
+from __future__ import annotations
+
+import re
+from importlib import resources
+from pathlib import Path
+
+_RULE_ID_RE = re.compile(r"^CL-\d{4}$")
+
+
+class UnknownRuleError(ValueError):
+    """Raised when a rule id has no corresponding documentation file."""
+
+
+def normalize_rule_id(raw: str) -> str:
+    """Normalize a user-supplied rule id to the canonical `CL-NNNN` form.
+
+    Accepts any case and surrounding whitespace. Rejects anything that
+    does not match the zero-padded four-digit scheme from ADR-005.
+    """
+    candidate = raw.strip().upper()
+    if not _RULE_ID_RE.match(candidate):
+        raise UnknownRuleError(raw)
+    return candidate
+
+
+def load_rule_doc(rule_id: str) -> str:
+    """Return the markdown body of `docs/rules/<rule_id>.md`.
+
+    Looks first in the installed package (wheel path), then falls back to
+    the repo's `docs/rules/` directory so `pip install -e .` and source
+    checkouts keep working.
+    """
+    canonical = normalize_rule_id(rule_id)
+    filename = f"{canonical}.md"
+
+    packaged = resources.files("compose_lint").joinpath("rule_docs", filename)
+    if packaged.is_file():
+        return packaged.read_text(encoding="utf-8")
+
+    repo_copy = Path(__file__).resolve().parents[2] / "docs" / "rules" / filename
+    if repo_copy.is_file():
+        return repo_copy.read_text(encoding="utf-8")
+
+    raise UnknownRuleError(canonical)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -90,6 +90,34 @@ class TestCLI:
         )
         assert by_service["empty_security_opt"]["suppressed"] is False
 
+    def test_explain_prints_rule_doc(self) -> None:
+        result = run_cli("--explain", "CL-0003")
+        assert result.returncode == 0
+        assert "CL-0003: Privilege Escalation Not Blocked" in result.stdout
+        assert "no-new-privileges:true" in result.stdout
+
+    def test_explain_is_case_insensitive(self) -> None:
+        result = run_cli("--explain", "cl-0003")
+        assert result.returncode == 0
+        assert "CL-0003" in result.stdout
+
+    def test_explain_unknown_rule_exits_2(self) -> None:
+        result = run_cli("--explain", "CL-9999")
+        assert result.returncode == 2
+        assert "unknown rule id" in result.stderr.lower()
+        assert "CL-9999" in result.stderr
+
+    def test_explain_rejects_malformed_id(self) -> None:
+        result = run_cli("--explain", "not-a-rule")
+        assert result.returncode == 2
+        assert result.stderr
+
+    def test_explain_rejects_file_argument(self) -> None:
+        result = run_cli("--explain", "CL-0003", str(FIXTURES / "valid_basic.yml"))
+        assert result.returncode == 2
+        assert "--explain" in result.stderr
+        assert "FILE" in result.stderr
+
     def test_exclude_services_unknown_service_warns(self, tmp_path: Path) -> None:
         config = tmp_path / ".compose-lint.yml"
         config.write_text(


### PR DESCRIPTION
## Summary

- Adds `--explain CL-XXXX` — prints the full prose from `docs/rules/CL-XXXX.md` to stdout so reviewers can read rationale, references, and fix guidance without leaving the terminal. Case-insensitive, exits 2 on unknown or malformed ids, refuses to run alongside `FILE` arguments.
- Rule-doc markdown is force-included into the wheel at `compose_lint/rule_docs/` via hatch; a repo-relative fallback keeps `pip install -e .` and source checkouts working.
- Pulls `--explain` forward out of Milestone 3 (see updated `docs/ROADMAP.md`) because it's strictly additive, needs no new deps, and unblocks the eventual `--fix` UX.
- Documents the container image's distroless posture in the README under the Docker install block — no shell, no apt, no pip at runtime, nonroot, pip stripped, multi-arch, SHA-pinned, SLSA + Sigstore attestations.

## Test plan

- [x] `ruff check`, `ruff format --check`, `mypy src/` (strict), `pytest` — all pass (285 cases).
- [x] Built the wheel and confirmed all 19 `CL-XXXX.md` files land at `compose_lint/rule_docs/` and no forbidden files (AGENTS.md, CLAUDE.md, memory/) were included.
- [x] Smoke-tested known rule, unknown rule (exit 2), case-insensitive input (`cl-0003`), and `--explain` combined with a file arg (exit 2).