### PR TITLE
Replace peter-evans/dockerhub-description with first-party action

### DIFF
--- a/.github/actions/update-dockerhub-description/action.yml
+++ b/.github/actions/update-dockerhub-description/action.yml
@@ -1,0 +1,45 @@
+name: 'Update Docker Hub description'
+description: >
+  Sync a Docker Hub repository's overview (long description) and short
+  description from a local README.md file. First-party replacement for
+  peter-evans/dockerhub-description — no third-party Node bundle holds the
+  delete-capable Docker Hub PAT. Implementation is a single bash script
+  invoking the Docker Hub v2 API; review diff before bumping.
+
+inputs:
+  username:
+    description: >
+      Docker Hub username of the account that owns the PAT. Not the
+      organization name, even if the repository lives under an org.
+    required: true
+  token:
+    description: >
+      Docker Hub Personal Access Token with "Read, Write, Delete" scope.
+      The description PATCH endpoint rejects narrower scopes with HTTP 403.
+    required: true
+  repository:
+    description: Docker Hub repository in `<namespace>/<name>` form.
+    required: true
+  readme-filepath:
+    description: Path to the README whose contents become the overview.
+    required: false
+    default: './README.md'
+  short-description:
+    description: One-line short description shown under the repo title.
+    required: false
+    default: 'Security-focused linter for Docker Compose files'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Sync Docker Hub description
+      shell: bash
+      env:
+        DOCKERHUB_USERNAME: ${{ inputs.username }}
+        DOCKERHUB_TOKEN: ${{ inputs.token }}
+        DOCKERHUB_REPO: ${{ inputs.repository }}
+        README_PATH: ${{ inputs.readme-filepath }}
+        SHORT_DESCRIPTION: ${{ inputs.short-description }}
+      run: |
+        "${GITHUB_WORKSPACE}/scripts/update-dockerhub-description.sh" \
+          "${DOCKERHUB_REPO}" "${README_PATH}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -545,6 +545,11 @@ jobs:
   # tags page) from this tag's README.md after a successful image push.
   # README.md uses absolute https://github.com/... links so it renders
   # correctly off-platform — Hub does not resolve relative paths.
+  #
+  # Uses a first-party composite action so no third-party Node bundle
+  # ever holds the delete-capable Docker Hub PAT. Implementation lives in
+  # `scripts/update-dockerhub-description.sh`; the action.yml just forwards
+  # inputs.
   dockerhub-description:
     needs: docker-publish
     runs-on: ubuntu-24.04
@@ -556,12 +561,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5.0.1
         with:
           persist-credentials: false
-      - uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
+      - uses: ./.github/actions/update-dockerhub-description
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          token: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: composelint/compose-lint
-          short-description: Security-focused linter for Docker Compose files
           readme-filepath: ./README.md
 
   # Create the GitHub Release only after both production channels

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -243,6 +243,15 @@ After approval, `publish` and `docker-publish` run in parallel.
       `uses: tmatens/compose-lint@<sha> # vX.Y.Z` lines. Review and
       squash-merge, then trigger **Actions → Marketplace smoke test →
       Run workflow** to verify the published Action end-to-end.
+- [ ] **Docker Hub overview (README) sync** — runs automatically in
+      `publish.yml`'s `dockerhub-description` job after `docker-publish`,
+      via the first-party composite action at
+      `.github/actions/update-dockerhub-description` (which just forwards
+      to `scripts/update-dockerhub-description.sh`). Requires
+      `DOCKERHUB_TOKEN` to have **Read, Write, Delete** scope — Read &
+      Write is not enough for the description PATCH endpoint. Verify
+      `https://hub.docker.com/r/composelint/compose-lint` reflects the
+      current README.
 - [ ] **Fresh `[Unreleased]` section** — already inserted by
       `release-prep.yml` as part of the release bump PR. No follow-up
       PR needed.

--- a/scripts/update-dockerhub-description.sh
+++ b/scripts/update-dockerhub-description.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Sync a Docker Hub repository's long-description (overview) and short
+# description from README.md. First-party replacement for
+# peter-evans/dockerhub-description; invoked from CI via
+# `.github/actions/update-dockerhub-description` and also runnable locally
+# for ad-hoc description refreshes.
+#
+# Usage:
+#   DOCKERHUB_USERNAME=<user> DOCKERHUB_TOKEN=<pat> \
+#     [SHORT_DESCRIPTION="..."] \
+#     scripts/update-dockerhub-description.sh [repo] [readme-path]
+#
+# Defaults: repo=composelint/compose-lint, readme-path=./README.md,
+# short-description="Security-focused linter for Docker Compose files".
+#
+# Requires: curl, jq
+# Requires DOCKERHUB_TOKEN to be a Docker Hub PAT with "Read, Write, Delete"
+# scope — "Read & Write" is enough for `docker push` but NOT for the
+# description PATCH endpoint.
+set -euo pipefail
+
+repo="${1:-composelint/compose-lint}"
+readme="${2:-./README.md}"
+short_description="${SHORT_DESCRIPTION:-Security-focused linter for Docker Compose files}"
+
+: "${DOCKERHUB_USERNAME:?DOCKERHUB_USERNAME must be set}"
+: "${DOCKERHUB_TOKEN:?DOCKERHUB_TOKEN must be set}"
+
+if [ ! -f "${readme}" ]; then
+    echo "Error: ${readme} not found" >&2
+    exit 1
+fi
+
+for cmd in curl jq; do
+    command -v "${cmd}" >/dev/null 2>&1 || {
+        echo "Error: ${cmd} not found on PATH" >&2
+        exit 1
+    }
+done
+
+tmp=$(mktemp -d)
+trap 'rm -rf "${tmp}"' EXIT
+
+echo "Authenticating to Docker Hub as ${DOCKERHUB_USERNAME}..."
+jq -n --arg u "${DOCKERHUB_USERNAME}" --arg p "${DOCKERHUB_TOKEN}" \
+    '{username:$u, password:$p}' >"${tmp}/login.json"
+jwt=$(curl -fsSL -H 'Content-Type: application/json' \
+    --data-binary "@${tmp}/login.json" \
+    https://hub.docker.com/v2/users/login/ | jq -r .token)
+if [ -z "${jwt}" ] || [ "${jwt}" = "null" ]; then
+    echo "Error: failed to acquire JWT — check DOCKERHUB_USERNAME and that" \
+         "DOCKERHUB_TOKEN is a valid Docker Hub PAT" >&2
+    exit 1
+fi
+
+echo "Patching description for ${repo}..."
+jq -n --rawfile full "${readme}" --arg short "${short_description}" \
+    '{full_description:$full, description:$short}' >"${tmp}/patch.json"
+http_code=$(curl -sSL -o "${tmp}/resp" -w '%{http_code}' \
+    -X PATCH \
+    -H "Authorization: JWT ${jwt}" \
+    -H 'Content-Type: application/json' \
+    --data-binary "@${tmp}/patch.json" \
+    "https://hub.docker.com/v2/repositories/${repo}/")
+
+if [ "${http_code}" != "200" ]; then
+    echo "Error: PATCH returned HTTP ${http_code}" >&2
+    echo "Response body:" >&2
+    cat "${tmp}/resp" >&2
+    echo >&2
+    if [ "${http_code}" = "403" ]; then
+        echo "HTTP 403 Forbidden typically means the PAT lacks" \
+             "'Read, Write, Delete' scope." >&2
+    fi
+    exit 1
+fi
+
+echo "Docker Hub overview synced: https://hub.docker.com/r/${repo}"


### PR DESCRIPTION
## Summary

- Replaces the third-party `peter-evans/dockerhub-description` GitHub Action with a first-party composite action at `.github/actions/update-dockerhub-description/`, which forwards inputs to a new `scripts/update-dockerhub-description.sh` (~60 lines of bash + curl + jq hitting Docker Hub's v2 API directly).
- Functionally identical: the `dockerhub-description` job in `publish.yml` still runs after `docker-publish` and syncs the Docker Hub overview from `README.md`.
- Eliminates the last place where a Docker Hub credential was consumed by third-party code each release. The local `uses: ./` form is the sanctioned exception to SHA-pinning per CLAUDE.md.
- Script is also runnable locally for ad-hoc description refreshes without cutting a release.

## Test plan

- [ ] CI: lint + YAML workflow checks pass
- [ ] After merge, next release exercises `dockerhub-description` end-to-end
- [ ] Verify Docker Hub overview updates after the next release