### PR TITLE
Pass OpenVEX to Docker Scout in smoke scan

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -352,6 +352,13 @@ jobs:
           only-severities: critical
           exit-code: true
           sarif-file: scout-results.sarif
+          # Honor the OpenVEX document for this release. Smoke scans the
+          # locally-built image, which has no registry manifest for Scout
+          # to discover cosign attestations on, so point at the file
+          # directly. CVE-2025-8869 and CVE-2026-1703 against pip 25.1.1
+          # are marked not_affected / vulnerable_code_not_present — see
+          # .vex/compose-lint.openvex.json and CHANGELOG 0.5.1.
+          vex-location: .vex/compose-lint.openvex.json
       - name: Upload Scout results to GitHub Security
         if: matrix.scout && always()
         uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2


### PR DESCRIPTION
## Summary

- Add `vex-location: .vex/compose-lint.openvex.json` to the `docker/scout-action` step in `docker-smoke` so Scout honors the OpenVEX document when scanning the locally-built test image.
- Fixes the post-0.5.1 regression where `CVE-2025-8869` and `CVE-2026-1703` reopened in GitHub Security: 0.5.1 restored pip's `.dist-info` for honest SCA reporting, Scout re-detects pip 25.1.1, and the SARIF upload reopens the (correctly VEX-suppressed) alerts.

## Why the attestation alone wasn't enough

The OpenVEX attestation is attached to the image manifest by `docker-publish` (publish.yml:550-563), which runs **after** `docker-smoke`. Smoke also scans `local://composelint/compose-lint:test`, which has no registry manifest for Scout's attestation discovery to key off. File-based VEX is the simplest fix here — the local test image and the published image carry identical pip content, so the same VEX applies.

## Test plan

- [ ] Next publish run's docker-smoke scan shows Scout consuming the VEX (check step logs for VEX lines).
- [ ] Uploaded SARIF no longer contains CVE-2025-8869 / CVE-2026-1703 against pip.
- [ ] GitHub Security code-scanning alerts for those CVEs stop reopening after next release.
- [ ] Release-gate still exits non-zero on any genuine CRITICAL finding not covered by VEX.