### PR TITLE
Pass OpenVEX to scheduled Docker Scout scan

### DIFF
--- a/.github/workflows/scout-scan.yml
+++ b/.github/workflows/scout-scan.yml
@@ -13,10 +13,19 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
+      contents: read
       security-events: write
       actions: read
       issues: write
     steps:
+      # Check out the repo so the OpenVEX document is on disk for the
+      # scout-action steps below. Scout doesn't auto-discover the
+      # cosign-attached VEX attestation on the registry manifest at
+      # v1.20.4, so we point it at the file instead.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -33,6 +42,10 @@ jobs:
           image: composelint/compose-lint:latest
           only-severities: critical
           exit-code: true
+          # Apply the same OpenVEX document the release asset and image
+          # attestation carry, so any critical-rated CVE already marked
+          # not_affected doesn't spuriously fail the schedule.
+          vex-location: .vex/compose-lint.openvex.json
 
       # Full-severity sweep for SARIF upload. Runs even when the
       # critical scan fails, so the Security tab always reflects the
@@ -45,6 +58,11 @@ jobs:
           image: composelint/compose-lint:latest
           exit-code: false
           sarif-file: scout-results.sarif
+          # Suppresses pip CVE-2025-8869 / CVE-2026-1703 alerts in the
+          # Security tab — both are not_affected /
+          # vulnerable_code_not_present against the published image.
+          # See .vex/compose-lint.openvex.json.
+          vex-location: .vex/compose-lint.openvex.json
 
       - name: Upload Scout results to GitHub Security
         uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2


### PR DESCRIPTION
## Summary

- Add `vex-location: .vex/compose-lint.openvex.json` to both scout-action steps in `scout-scan.yml` (the critical-only gate and the all-severities SARIF sweep).
- Add an `actions/checkout` step so the VEX file is on disk, plus `contents: read` to the job permissions.

## Why

PR #131 taught `docker-smoke` (publish.yml) to honor VEX, but #131 alone doesn't clear the currently-open pip CVE alerts in the Security tab:

- Open alerts #83 (CVE-2025-8869) and #82 (CVE-2026-1703) are tagged `category: docker-scout-scheduled` — that's this workflow's SARIF upload, not publish.yml's `docker-scout` category.
- They're severity `medium` / `low`, which `docker-smoke`'s `only-severities: critical` filter couldn't emit even in principle.
- `:latest` on Docker Hub currently points at `sha256:fdf35fc6…` — the 0.5.1 manifest that has the OpenVEX cosign attestation attached. Scout just isn't consuming it at v1.20.4, so file-based VEX is the working path.

Also applied `vex-location` to the critical-only gate step: pip CVEs aren't critical today, but if Scout ever re-rates them the schedule would spuriously fail.

## Test plan

- [ ] Dispatch `scout-scan.yml` manually and confirm step logs show VEX being applied.
- [ ] Uploaded SARIF no longer contains CVE-2025-8869 / CVE-2026-1703 entries against pip.
- [ ] Open alerts #82 and #83 close (or stop re-updating) on the next run.
- [ ] Gate scan still exits non-zero if a genuine CRITICAL CVE appears that isn't covered by VEX.