### PR TITLE
Detect cap_add: ALL in CL-0011 at CRITICAL severity

### DIFF
--- a/src/compose_lint/rules/CL0011_dangerous_cap_add.py
+++ b/src/compose_lint/rules/CL0011_dangerous_cap_add.py
@@ -19,6 +19,10 @@ OWASP_REF = (
 CIS_REF = "CIS Docker Benchmark 5.5 — Do not mount sensitive host system directories"
 
 DANGEROUS_CAPS: dict[str, str] = {
+    "ALL": (
+        "grants every Linux capability — functionally equivalent to disabling "
+        "capability-based isolation"
+    ),
     "SYS_ADMIN": "near-root access: mount filesystems, configure namespaces, BPF",
     "SYS_PTRACE": "trace/inspect any process, read secrets from memory",
     "NET_ADMIN": "modify routing tables, firewall rules, sniff traffic",
@@ -27,6 +31,8 @@ DANGEROUS_CAPS: dict[str, str] = {
     "SYS_TIME": "change system clock, affecting all containers and the host",
     "DAC_READ_SEARCH": "bypass file read permission checks on the host",
 }
+
+CRITICAL_CAPS: frozenset[str] = frozenset({"ALL"})
 
 
 @register_rule
@@ -61,9 +67,12 @@ class DangerousCapAddRule(BaseRule):
         for cap in cap_add:
             cap_upper = str(cap).upper()
             if cap_upper in DANGEROUS_CAPS:
+                severity = (
+                    Severity.CRITICAL if cap_upper in CRITICAL_CAPS else Severity.HIGH
+                )
                 yield Finding(
                     rule_id="CL-0011",
-                    severity=Severity.HIGH,
+                    severity=severity,
                     service=service_name,
                     message=(
                         f"Service adds dangerous capability {cap_upper}: "

--- a/tests/compose_files/insecure_cap_add.yml
+++ b/tests/compose_files/insecure_cap_add.yml
@@ -38,3 +38,11 @@ services:
       - SYS_RAWIO
       - SYS_TIME
       - DAC_READ_SEARCH
+  cap_all:
+    image: nginx:1.27-alpine
+    cap_add:
+      - ALL
+  cap_all_lowercase:
+    image: nginx:1.27-alpine
+    cap_add:
+      - all

--- a/tests/test_CL0011.py
+++ b/tests/test_CL0011.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from compose_lint.models import Severity
 from compose_lint.parser import load_compose
 from compose_lint.rules.CL0011_dangerous_cap_add import DangerousCapAddRule
 
@@ -58,6 +59,22 @@ class TestDangerousCapAddRule:
     def test_all_seven_dangerous(self) -> None:
         findings = self._check("all_dangerous")
         assert len(findings) == 7
+
+    def test_detects_cap_all_critical(self) -> None:
+        findings = self._check("cap_all")
+        assert len(findings) == 1
+        assert findings[0].severity == Severity.CRITICAL
+        assert "ALL" in findings[0].message
+
+    def test_detects_cap_all_lowercase(self) -> None:
+        findings = self._check("cap_all_lowercase")
+        assert len(findings) == 1
+        assert findings[0].severity == Severity.CRITICAL
+        assert "ALL" in findings[0].message
+
+    def test_named_cap_still_high(self) -> None:
+        findings = self._check("sys_admin")
+        assert findings[0].severity == Severity.HIGH
 
     def test_has_fix_guidance(self) -> None:
         findings = self._check("sys_admin")


### PR DESCRIPTION
## Summary

- Adds `ALL` to `DANGEROUS_CAPS` in `CL0011_dangerous_cap_add.py` so `cap_add: [ALL]` no longer passes silently.
- Emits the `ALL` finding at **CRITICAL** (functionally equivalent to `--privileged` for capability isolation); the seven named caps stay at HIGH via a small `CRITICAL_CAPS` set.
- Rule metadata severity stays HIGH so existing `--fail-on` thresholds keep their current behavior for the named caps.

This is the first rule to emit per-finding severity dynamically. The pattern is intentionally narrow (one named exception) so future strictly-worse variants in other rules (e.g. IPv6 wildcard vs loopback in CL-0005, root mount vs `/etc` in CL-0013) can follow the same shape.

Closes #130.

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy src/` clean (32 files)
- [x] `pytest` 288/288 pass, including 3 new tests:
  - `test_detects_cap_all_critical` — `cap_add: [ALL]` fires at CRITICAL
  - `test_detects_cap_all_lowercase` — `cap_add: [all]` normalizes and fires at CRITICAL
  - `test_named_cap_still_high` — `SYS_ADMIN` still fires at HIGH (no regression)