### PR TITLE
Detect healthcheck disabled via test: ["NONE"] in CL-0015

### DIFF
--- a/src/compose_lint/rules/CL0015_healthcheck_disabled.py
+++ b/src/compose_lint/rules/CL0015_healthcheck_disabled.py
@@ -48,18 +48,23 @@ class HealthcheckDisabledRule(BaseRule):
             return
 
         disable = healthcheck.get("disable")
-        if disable is True:
+        test = healthcheck.get("test")
+        disabled_via_test = test == ["NONE"] or test == "NONE"
+
+        if disable is True or disabled_via_test:
+            offending = "disable: true" if disable is True else 'test: ["NONE"]'
             yield Finding(
                 rule_id="CL-0015",
                 severity=Severity.LOW,
                 service=service_name,
                 message=(
-                    "Healthcheck is explicitly disabled. The orchestrator cannot "
-                    "detect or automatically restart unhealthy containers."
+                    f"Healthcheck is explicitly disabled via {offending}. The "
+                    "orchestrator cannot detect or automatically restart "
+                    "unhealthy containers."
                 ),
                 line=lines.get(f"services.{service_name}.healthcheck"),
                 fix=(
-                    "Remove 'disable: true' and configure a healthcheck:\n"
+                    f"Remove '{offending}' and configure a healthcheck:\n"
                     "  healthcheck:\n"
                     '    test: ["CMD", "curl", "-f", "http://localhost/"]\n'
                     "    interval: 30s\n"

--- a/tests/compose_files/insecure_healthcheck.yml
+++ b/tests/compose_files/insecure_healthcheck.yml
@@ -17,3 +17,15 @@ services:
     healthcheck:
       disable: false
       test: ["CMD", "curl", "-f", "http://localhost/"]
+  disabled_via_test_list:
+    image: nginx:1.27-alpine
+    healthcheck:
+      test: ["NONE"]
+  disabled_via_test_string:
+    image: nginx:1.27-alpine
+    healthcheck:
+      test: NONE
+  disabled_via_test_lowercase:
+    image: nginx:1.27-alpine
+    healthcheck:
+      test: ["none"]

--- a/tests/test_CL0015.py
+++ b/tests/test_CL0015.py
@@ -40,6 +40,21 @@ class TestHealthcheckDisabledRule:
         findings = self._check("disable_false")
         assert len(findings) == 0
 
+    def test_detects_test_none_list(self) -> None:
+        findings = self._check("disabled_via_test_list")
+        assert len(findings) == 1
+        assert findings[0].rule_id == "CL-0015"
+        assert 'test: ["NONE"]' in findings[0].message
+
+    def test_detects_test_none_string(self) -> None:
+        findings = self._check("disabled_via_test_string")
+        assert len(findings) == 1
+        assert 'test: ["NONE"]' in findings[0].message
+
+    def test_test_none_lowercase_no_findings(self) -> None:
+        findings = self._check("disabled_via_test_lowercase")
+        assert len(findings) == 0
+
     def test_has_fix_guidance(self) -> None:
         findings = self._check("disabled")
         assert findings[0].fix is not None


### PR DESCRIPTION
## Summary

- Adds detection for `test: ["NONE"]` and the string form `test: NONE` in `CL0015_healthcheck_disabled.py` — the idiomatic way to disable a healthcheck inherited from a base image, used in Docker's own examples.
- Finding message and fix guidance adapt to name the offending form (`disable: true` vs `test: ["NONE"]`).
- Lowercase `test: ["none"]` deliberately does **not** fire — Docker's runtime treats only uppercase `NONE` as the disable sentinel; lowercase would be executed as a command and is a broken healthcheck (different problem).

Severity stays at LOW per the rule's existing metadata.

Closes #135.

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy src/` clean (32 files)
- [x] `pytest` 288/288 pass, including 3 new tests:
  - `test_detects_test_none_list` — `test: ["NONE"]` fires with the right message
  - `test_detects_test_none_string` — `test: NONE` fires
  - `test_test_none_lowercase_no_findings` — `test: ["none"]` does not fire (regression guard)