### PR TITLE
Detect cross-spec root forms in CL-0018

### DIFF
--- a/src/compose_lint/rules/CL0018_explicit_root.py
+++ b/src/compose_lint/rules/CL0018_explicit_root.py
@@ -17,7 +17,19 @@ OWASP_REF = (
 
 CIS_REF = "CIS Docker Benchmark 5.x — Do not run containers as root"
 
-_ROOT_VALUES = {"root", "0", "root:root", "0:0"}
+_ROOT_USER_PARTS = {"root", "0"}
+
+
+def _is_root_user(user_str: str) -> bool:
+    """Return True if user_str names UID 0 / root, regardless of group.
+
+    A non-root group does not change the effective user — running as root with
+    GID 1000 is still root. Cross-spec forms (root:0, 0:root) and the bare
+    forms (root, 0, root:root, 0:0) all collapse to "is the user portion
+    root?".
+    """
+    user_part = user_str.split(":", 1)[0]
+    return user_part in _ROOT_USER_PARTS
 
 
 @register_rule
@@ -50,7 +62,7 @@ class ExplicitRootRule(BaseRule):
             return
 
         user_str = str(user).strip().lower()
-        if user_str in _ROOT_VALUES:
+        if _is_root_user(user_str):
             yield Finding(
                 rule_id="CL-0018",
                 severity=Severity.MEDIUM,

--- a/tests/compose_files/insecure_root_user.yml
+++ b/tests/compose_files/insecure_root_user.yml
@@ -11,9 +11,24 @@ services:
   root_uid_gid:
     image: nginx:1.27-alpine
     user: "0:0"
+  root_colon_zero:
+    image: nginx:1.27-alpine
+    user: "root:0"
+  zero_colon_root:
+    image: nginx:1.27-alpine
+    user: "0:root"
+  root_nonroot_group:
+    image: nginx:1.27-alpine
+    user: "root:1000"
+  zero_nonroot_group:
+    image: nginx:1.27-alpine
+    user: "0:1000"
   non_root:
     image: nginx:1.27-alpine
     user: "1000:1000"
+  nonroot_uid_root_group:
+    image: nginx:1.27-alpine
+    user: "1000:0"
   named_user:
     image: nginx:1.27-alpine
     user: appuser

--- a/tests/test_CL0018.py
+++ b/tests/test_CL0018.py
@@ -40,6 +40,26 @@ class TestExplicitRootRule:
         findings = self._check("root_uid_gid")
         assert len(findings) == 1
 
+    def test_detects_root_colon_zero(self) -> None:
+        findings = self._check("root_colon_zero")
+        assert len(findings) == 1
+
+    def test_detects_zero_colon_root(self) -> None:
+        findings = self._check("zero_colon_root")
+        assert len(findings) == 1
+
+    def test_detects_root_with_nonroot_group(self) -> None:
+        findings = self._check("root_nonroot_group")
+        assert len(findings) == 1
+
+    def test_detects_zero_with_nonroot_group(self) -> None:
+        findings = self._check("zero_nonroot_group")
+        assert len(findings) == 1
+
+    def test_nonroot_uid_with_root_group_no_findings(self) -> None:
+        findings = self._check("nonroot_uid_root_group")
+        assert len(findings) == 0
+
     def test_non_root_no_findings(self) -> None:
         findings = self._check("non_root")
         assert len(findings) == 0


### PR DESCRIPTION
## Summary

Replaces the `_ROOT_VALUES = {"root", "0", "root:root", "0:0"}` allowlist with a parsed-form check: split on the first `:` and test whether the user portion is `root` or `0`. Catches the cross-spec forms `root:0` and `0:root` that Docker accepts, plus any other `user:group` value where the user is root.

**Behavior change worth calling out**: `user: root:1000` and `user: 0:1000` now fire. These were previously silent gaps in the rule. The container still runs as UID 0 — a non-root primary group does not change the effective user. The inverse `user: 1000:0` (non-root UID, root group) correctly does **not** fire.

Severity stays at MEDIUM.

Closes #137.

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy src/` clean (32 files)
- [x] `pytest` 290/290 pass, including 5 new tests:
  - `test_detects_root_colon_zero` — `user: "root:0"` fires
  - `test_detects_zero_colon_root` — `user: "0:root"` fires
  - `test_detects_root_with_nonroot_group` — `user: "root:1000"` fires (behavior change)
  - `test_detects_zero_with_nonroot_group` — `user: "0:1000"` fires (behavior change)
  - `test_nonroot_uid_with_root_group_no_findings` — `user: "1000:0"` does not fire (regression guard for the inverse)