### PR TITLE
Fix VEX product identifier and Scout author allowlist

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -355,10 +355,15 @@ jobs:
           # Honor the OpenVEX document for this release. Smoke scans the
           # locally-built image, which has no registry manifest for Scout
           # to discover cosign attestations on, so point at the file
-          # directly. CVE-2025-8869 and CVE-2026-1703 against pip 25.1.1
-          # are marked not_affected / vulnerable_code_not_present — see
-          # .vex/compose-lint.openvex.json and CHANGELOG 0.5.1.
+          # directly. The pip CVEs (CVE-2025-8869, CVE-2026-1703,
+          # CVE-2026-3219) against pip 25.1.1 are marked not_affected /
+          # vulnerable_code_not_present — see
+          # .vex/compose-lint.openvex.json and ADR-012.
           vex-location: .vex/compose-lint.openvex.json
+          # Override Scout's default vex-author allowlist
+          # (`<.*@docker.com>`) so our maintainer-authored statements
+          # are not silently dropped. See ADR-012.
+          vex-author: <.*@gmail\.com>
       - name: Upload Scout results to GitHub Security
         if: matrix.scout && always()
         uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2

--- a/.github/workflows/scout-scan.yml
+++ b/.github/workflows/scout-scan.yml
@@ -46,6 +46,10 @@ jobs:
           # attestation carry, so any critical-rated CVE already marked
           # not_affected doesn't spuriously fail the schedule.
           vex-location: .vex/compose-lint.openvex.json
+          # Scout's default vex-author allowlist is `<.*@docker.com>`,
+          # so without this override our maintainer-authored statements
+          # are silently dropped. See ADR-012.
+          vex-author: <.*@gmail\.com>
 
       # Full-severity sweep for SARIF upload. Runs even when the
       # critical scan fails, so the Security tab always reflects the
@@ -58,11 +62,14 @@ jobs:
           image: composelint/compose-lint:latest
           exit-code: false
           sarif-file: scout-results.sarif
-          # Suppresses pip CVE-2025-8869 / CVE-2026-1703 alerts in the
-          # Security tab — both are not_affected /
+          # Suppresses the pip CVE alerts (CVE-2025-8869, CVE-2026-1703,
+          # CVE-2026-3219) in the Security tab — all are not_affected /
           # vulnerable_code_not_present against the published image.
           # See .vex/compose-lint.openvex.json.
           vex-location: .vex/compose-lint.openvex.json
+          # See note on the gate step above re: the default vex-author
+          # allowlist. Same override required here.
+          vex-author: <.*@gmail\.com>
 
       - name: Upload Scout results to GitHub Security
         uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2

--- a/.vex/compose-lint.openvex.json
+++ b/.vex/compose-lint.openvex.json
@@ -3,8 +3,8 @@
   "@id": "https://github.com/tmatens/compose-lint/.vex/compose-lint.openvex.json",
   "author": "Todd Matens <tmatens@gmail.com>",
   "role": "Project Maintainer",
-  "timestamp": "2026-04-23T00:00:00Z",
-  "version": 1,
+  "timestamp": "2026-04-24T00:00:00Z",
+  "version": 2,
   "tooling": "hand-authored",
   "statements": [
     {
@@ -14,7 +14,7 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/compose-lint?repository_url=docker.io/composelint/compose-lint",
+          "@id": "pkg:oci/compose-lint?repository_url=index.docker.io/composelint/compose-lint",
           "subcomponents": [
             { "@id": "pkg:pypi/pip@25.1.1" }
           ]
@@ -31,7 +31,7 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/compose-lint?repository_url=docker.io/composelint/compose-lint",
+          "@id": "pkg:oci/compose-lint?repository_url=index.docker.io/composelint/compose-lint",
           "subcomponents": [
             { "@id": "pkg:pypi/pip@25.1.1" }
           ]
@@ -40,6 +40,23 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_present",
       "impact_statement": "Same mitigation as CVE-2025-8869: pip package code and CLI binaries are removed from the runtime image during the container build stage; only the .dist-info metadata directory remains so SCA scanners can identify pip. `import pip` raises ModuleNotFoundError at runtime; no pip binary exists. The distroless runtime (no shell, nonroot entrypoint /venv/bin/compose-lint) makes the code both absent and unreachable."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-3219",
+        "description": "pip incorrect file installation due to improper archive handling"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/compose-lint?repository_url=index.docker.io/composelint/compose-lint",
+          "subcomponents": [
+            { "@id": "pkg:pypi/pip@25.1.1" }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Same mitigation as CVE-2025-8869 and CVE-2026-1703: the pip archive-handling code lives in /venv/lib/python3.13/site-packages/pip/ which is removed at container build time. Only the .dist-info metadata directory is retained for SCA scanner identification; the executable code paths exercised by this CVE are physically absent from the runtime image. The distroless runtime (no shell, nonroot entrypoint /venv/bin/compose-lint) makes pip both absent and unreachable."
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- OpenVEX product identifier in `.vex/compose-lint.openvex.json` now uses
+  `repository_url=index.docker.io/composelint/compose-lint`. The previous
+  `docker.io/...` form loaded successfully but matched zero scanned
+  images: Trivy, Grype (per anchore/grype#2818), and Scout all canonicalise
+  Docker Hub to `index.docker.io` for VEX product matching. Confirmed
+  locally with Trivy 0.70.0 against the published image.
+- Every `docker/scout-action` step that passes `vex-location` also now
+  passes `vex-author: <.*@gmail\.com>`. Scout's default `--vex-author`
+  allowlist is `<.*@docker.com>` and silently drops statements signed
+  outside that pattern, which is why 0.5.1's `Loaded 1 VEX document`
+  log line was followed by both pip CVEs still flagged. Applied to
+  both `scout-scan.yml` steps and the `docker-smoke` Scout step in
+  `publish.yml`.
+
+### Added
+
+- VEX statement covering CVE-2026-3219 (pip 25.1.1 — incorrect file
+  installation due to improper archive handling). Same
+  `vulnerable_code_not_present` mitigation as the existing pip CVEs:
+  pip's runtime code is removed from the container image during build,
+  only `.dist-info` metadata remains for SCA scanner identification.
+
+### Changed
+
+- VEX document `version` bumped to 2 and `timestamp` refreshed. See
+  ADR-012 (`docs/adr/012-vex-product-identifier.md`) for the full
+  rationale on the product-identifier and author-allowlist decisions.
+
 ## [0.5.1] - 2026-04-24
 
 ### Changed

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -143,6 +143,10 @@ version number.
       the runtime image. If the CVE **is** reachable, do not VEX it — fix
       it. Bump `version` and `timestamp` in the VEX doc when statements
       change.
+- [ ] Product identifiers in the VEX doc keep using
+      `repository_url=index.docker.io/composelint/compose-lint` (not
+      `docker.io/...`). The `docker.io` alias is silently ignored by
+      Scout, Trivy, and Grype for VEX matching. See ADR-012.
 
 ## Bump the version
 

--- a/docs/adr/012-vex-product-identifier.md
+++ b/docs/adr/012-vex-product-identifier.md
@@ -1,0 +1,57 @@
+# ADR-012: VEX Product Identifier and Author Allowlist
+
+**Status:** Accepted
+
+**Context:** compose-lint 0.5.1 shipped `.vex/compose-lint.openvex.json` declaring CVE-2025-8869 and CVE-2026-1703 as `not_affected` / `vulnerable_code_not_present` against the published container image, and wired `docker/scout-action`'s `vex-location` input on every step that scans the image (`scout-scan.yml`, `publish.yml`'s `docker-smoke`). After 0.5.1 shipped, Scout still flagged both CVEs and the post-merge code-scanning analysis kept alerts #82 and #83 open. Two independent failures were responsible.
+
+**Decision:** Two changes.
+
+1. **Product identifier registry alias.** The OpenVEX `products[].@id` uses `pkg:oci/compose-lint?repository_url=index.docker.io/composelint/compose-lint`, not `docker.io/...`. The Trivy / Scout / Grype canonical hostname for Docker Hub is `index.docker.io`; `docker.io` is widely accepted as a user-facing alias but is not what scanners normalise to internally for VEX product matching.
+2. **`vex-author` override on every Scout step.** `docker scout cves` defaults `--vex-author` to `<.*@docker.com>` and silently drops statements signed by anyone outside that allowlist. Every `docker/scout-action` step that passes `vex-location` also passes `vex-author: <.*@gmail\.com>` so our maintainer-authored statements are honoured.
+
+The product `@id` is digest-free so re-releases do not require editing the VEX file or running a substitution step in the publish pipeline. If a future scanner is observed to require digest qualification specifically (none in our tested set do), that decision can be revisited; the substitution would slot in between manifest-list creation and the `cosign attest` / release-asset upload steps in `publish.yml`.
+
+---
+
+## Why `index.docker.io` instead of `docker.io`
+
+Local probing against `composelint/compose-lint:latest` (0.5.1, manifest digest `sha256:fdf35fc6…`):
+
+- Trivy 0.70.0 with `--vex .vex/compose-lint.openvex.json` and `repository_url=docker.io/composelint/compose-lint` — both pip CVEs still listed.
+- Trivy 0.70.0 with `repository_url=index.docker.io/composelint/compose-lint` — both pip CVEs suppressed, only the new CVE-2026-3219 (added in this same change) remains, and is also suppressed once its statement lands.
+
+This matches anchore/grype#2818, which documents the same `docker.io` → `index.docker.io` alias gap as a Grype bug with a working workaround. Scout was not retested locally because the scout-cli container requires a Docker Hub login the development machine does not have; verification deferred to the next `scout-scan.yml` dispatch on `main`.
+
+The `pkg:oci/<name>?repository_url=<registry>/<namespace>/<name>` form (with the image name appearing twice) follows the convention shown in the Trivy "VEX Attestation" docs (`pkg:oci/trivy?repository_url=ghcr.io/aquasecurity/trivy`). Other forms considered and rejected for v1:
+
+- `pkg:docker/composelint/compose-lint?repository_url=index.docker.io` (per docker/scout-cli#199's example) — Trivy did not match this form against the image; would need a parallel `pkg:oci` entry to keep Trivy working, doubling the surface for no observed benefit.
+- Multi-identifier products (multiple `products[]` entries on one statement, each with a different `@id`) — viable but unnecessary while one form is accepted by all tested scanners. Revisit if a scanner is observed to need a form the current entry does not cover.
+- Digest-qualified PURLs — would require a release-time substitution step. Not adopted because the digest-free form works against Trivy and is what Scout's official docs example uses.
+
+## Why the `vex-author` override
+
+`docker scout cves --help` lists:
+
+```
+--vex-author strings   List of VEX statement authors to accept (default [<.*@docker.com>])
+```
+
+Our document is authored by `Todd Matens <tmatens@gmail.com>`. Without an override, Scout loads the document (the action logs `Loaded 1 VEX document`) and then drops every statement during the author check. The CLI default is undocumented in `docker/scout-action`'s `action.yaml` input schema — `vex-author` is exposed as an input but its default-allowlist behaviour is inherited silently from the underlying CLI.
+
+The override is set on every scout-action step (`scout-scan.yml` gate, `scout-scan.yml` SARIF sweep, `publish.yml` docker-smoke). The pattern `<.*@gmail\.com>` mirrors the bracket-anchored shape of Scout's default and is intentionally a regex rather than a literal email so a future maintainer email under the same domain doesn't silently re-break suppression.
+
+## Open Scout caveats
+
+Two upstream Scout issues affect statement-level behaviour but do not change this ADR:
+
+- **docker/scout-cli#199** — Scout 1.18.2+ does not always honour newer VEX statements that include subcomponents. Our document uses subcomponents on every statement (so the scanner pins the suppression to the specific pip version, not "any pip"). This is acceptable risk: when we change a statement we bump `version` and `timestamp` and accept that Scout may continue to apply the prior statement until its index refreshes. The post-fix `scout-scan.yml` run is the canary for this.
+- **docker/scout-cli#207** — `docker scout cves --vex-location` historically had product-matching gaps for VEX statements scoped to the image rather than to nested components. Our statements scope to the image *with subcomponents*, which matches what felipecruz91/node-ip-vex (Docker's reference example) does and is the form Scout's "Create exceptions" docs page targets.
+
+## References
+
+- [OpenVEX Specification v0.2.0](https://github.com/openvex/spec/blob/main/OPENVEX-SPEC.md) — "list as many software identifiers as possible to help VEX processors when matching the product."
+- [Trivy — VEX Attestation (OCI)](https://trivy.dev/latest/docs/supply-chain/vex/oci/) — canonical `pkg:oci/<name>?repository_url=<registry>/<namespace>/<name>` example.
+- [Docker Scout — Create an exception using VEX](https://docs.docker.com/scout/how-tos/create-exceptions-vex/)
+- [anchore/grype#2818](https://github.com/anchore/grype/issues/2818) — `docker.io` registry alias does not match; `index.docker.io` does.
+- [docker/scout-cli#199](https://github.com/docker/scout-cli/issues/199) — VEX statements with subcomponents not honoured across updates.
+- [docker/scout-cli#207](https://github.com/docker/scout-cli/issues/207) — `docker scout cves --vex-location` product-matching gaps.


### PR DESCRIPTION
## Summary

Two independent issues caused 0.5.1's OpenVEX document to load successfully but suppress nothing, leaving Security tab alerts #82 and #83 open. Both fixed here. Closes #139.

- **`repository_url=docker.io/...` does not match the scanned image.** Trivy, Grype ([anchore/grype#2818](https://github.com/anchore/grype/issues/2818)), and Scout all canonicalise Docker Hub to `index.docker.io` for VEX product matching. Swapped to `pkg:oci/compose-lint?repository_url=index.docker.io/composelint/compose-lint`.
- **Scout silently drops non-Docker-authored statements.** `docker scout cves` defaults `--vex-author` to `<.*@docker.com>`. Our author is `tmatens@gmail.com`. Every `docker/scout-action` step that passes `vex-location` now also passes `vex-author: <.*@gmail\.com>` (`scout-scan.yml` × 2, `publish.yml` × 1).
- **CVE-2026-3219** (pip 25.1.1, same `vulnerable_code_not_present` mitigation) was surfaced by scanners after 0.5.1 shipped. Added as a third statement.
- VEX `version` bumped 1 → 2, `timestamp` refreshed.
- New [ADR-012](../blob/fix/vex-product-identifier/docs/adr/012-vex-product-identifier.md) captures the decision, lab evidence, alternatives considered, and upstream issue references (docker/scout-cli#199, #207, anchore/grype#2818).
- `docs/RELEASING.md` gains a checklist line about the `index.docker.io` requirement.

## Verification

- **Trivy 0.70.0** with the new VEX file against `composelint/compose-lint:latest` (digest `sha256:fdf35fc6…`): zero pip CVEs reported (down from three). Same scan with the old `docker.io` form still flags all three — clean A/B.
- **Scout** verification deferred to the next `scout-scan.yml` dispatch on `main`: scout-cli requires a Docker Hub login the development environment does not have.
- `ruff check`, `ruff format --check`, `mypy src/`, `pytest` (290 tests) — all green locally.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge, dispatch `Docker Scout (scheduled)` from the Actions tab. The "Scan all severities for SARIF upload" step should still log `Loaded 1 VEX document` and the per-severity output should no longer list CVE-2025-8869, CVE-2026-1703, or CVE-2026-3219.
- [ ] `docker-scout-scheduled` SARIF upload reports `results_count: 0` for the resulting commit.
- [ ] Alerts #82 and #83 transition to closed automatically (if not, dismiss as "won't fix - VEX'd" linking ADR-012).
- [ ] Roll into the 0.5.2 cut.