### PR TITLE
Ignore pip CVE-2026-3219 in pip-audit until pip 26.0.2 ships

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,16 @@ jobs:
         # --skip-editable skips compose-lint itself (it isn't on PyPI
         # for the local install path); PyYAML and any future runtime
         # deps are still scanned.
-        run: pip-audit --skip-editable
+        #
+        # --ignore-vuln CVE-2026-3219: pip-audit transitively requires
+        # pip via pip-api, so it ends up auditing pip itself (pinned at
+        # 26.0.1 in requirements-dev.lock). pip CVEs are out of scope
+        # for this project's supply chain — pip is not in the runtime
+        # lockfile and is explicitly stripped from the runtime Docker
+        # image (Dockerfile lines 42-43). No fixed pip version is yet
+        # published; remove this flag once pip 26.0.2+ ships and the
+        # dev lockfile is regenerated.
+        run: pip-audit --skip-editable --ignore-vuln CVE-2026-3219
 
   # Fails the PR if `pyproject.toml` and `src/compose_lint/__init__.py`
   # disagree about the project version. The two strings drifted silently


### PR DESCRIPTION
## Summary

`pip-audit` transitively requires `pip` via `pip-api`, so the `security` job audits pip itself (pinned at `26.0.1` in `requirements-dev.lock`). pip 26.0.1 carries `CVE-2026-3219` with no fixed version yet on PyPI, blocking every PR even though pip is not in this project's runtime supply chain.

This PR adds `--ignore-vuln CVE-2026-3219` to the `pip-audit` invocation in `.github/workflows/ci.yml` with a comment explaining the dev-only scope and a removal trigger (once `pip 26.0.2+` ships and the dev lockfile is regenerated).

## Why this is the right scope for this project

pip is dev-tool-only here:

- **Not in `requirements.lock`** — the runtime lockfile pulls only `PyYAML`. Users `pip install`ing compose-lint never see this pip pin.
- **Stripped from the runtime Docker image** — `Dockerfile:42-43` explicitly removes `/venv/lib/python3.13/site-packages/pip` and the pip CLI binaries; only `.dist-info` is kept for SCA attribution.
- **Existing OpenVEX precedent** — `.vex/compose-lint.openvex.json` already declares prior pip CVEs (`CVE-2025-8869`, `CVE-2026-1703`) `not_affected` / `vulnerable_code_not_present` against the shipped image, on exactly the grounds above.

## Verified locally

```
$ pip-audit --skip-editable --ignore-vuln CVE-2026-3219
No known vulnerabilities found, 1 ignored
Name         Skip Reason
------------ -------------------------------
compose-lint distribution marked as editable
```

## Removal plan

When `pip 26.0.2+` (or any post-26.0.1 release with the fix) lands on PyPI:

1. Regenerate `requirements-dev.lock` per the recipe in `CLAUDE.md`.
2. Drop `--ignore-vuln CVE-2026-3219` and the surrounding comment from `ci.yml`.

## Test plan

- [ ] CI `security` job goes green on this PR (the previously failing pip-audit step).
- [ ] After merge, rebase the three open rule-fix PRs (#140, #141, #142) onto main and confirm their security jobs go green too.