### PR TITLE
Detect root filesystem mount and implicit binds in CL-0013

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CL-0013** now detects mounting the entire host root filesystem
+  (`"/:/host"`, `"/:/host:ro"`) at CRITICAL severity — previously the
+  short-syntax regex required at least one non-colon character after `/`
+  and silently skipped the most dangerous bind possible.
+- **CL-0013** now detects long-syntax binds where `source:` is an absolute
+  path even when `type: bind` is omitted. Compose infers bind mounts from
+  absolute-path sources, but the rule previously gated on `type` and missed
+  this realistic configuration.
+- **CL-0013** sensitive-paths list extended with `/var/lib/docker`,
+  `/var/run`, and `/home`. The existing `/root` entry already covered
+  `/root/.ssh` and `/root/.aws` via subpath matching.
 - OpenVEX product identifier in `.vex/compose-lint.openvex.json` now uses
   `repository_url=index.docker.io/composelint/compose-lint`. The previous
   `docker.io/...` form loaded successfully but matched zero scanned

--- a/docs/rules/CL-0013.md
+++ b/docs/rules/CL-0013.md
@@ -1,6 +1,6 @@
 # CL-0013: Sensitive Host Path Mounted
 
-**Severity:** HIGH
+**Severity:** HIGH (CRITICAL when the entire host root filesystem is mounted)
 
 **References:**
 - [OWASP Docker Security Rule #8](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-8---set-filesystem-and-volumes-to-read-only)
@@ -9,22 +9,29 @@
 ## What it detects
 
 Services that bind-mount sensitive host directories into a container:
+- `/` — the entire host root filesystem (CRITICAL — one-line container escape)
 - `/etc` — host system configuration
 - `/proc` — kernel and process information
 - `/sys` — kernel device and driver interfaces
 - `/boot` — bootloader and kernel images
-- `/root` — root user's home directory
+- `/root` — root user's home directory (SSH keys, shell history)
+- `/var/lib/docker` — Docker daemon state, including images and other containers
+- `/var/run` — runtime sockets (parent of `/var/run/docker.sock`)
+- `/home` — user home directories with credentials and source code
 
-Subpaths (e.g., `/etc/passwd`) are also flagged. Both short syntax (`/etc:/host-etc`) and long syntax (`type: bind, source: /etc`) are checked. Named volumes are not flagged.
+Subpaths (e.g., `/etc/passwd`, `/root/.ssh`) are also flagged. Both short syntax (`/etc:/host-etc`) and long syntax (`source: /etc, target: /host-etc`) are checked. The long syntax is recognized whether `type: bind` is set explicitly or omitted — Compose treats absolute-path sources as bind mounts either way. Named volumes are not flagged.
 
 ## Why it matters
 
 Mounting these paths gives the container read (and potentially write) access to critical host infrastructure:
+- `/` is a complete container escape — the workload has full access to the host filesystem
 - `/etc` contains `shadow`, `sudoers`, `ssh` configs — a writable mount enables full host takeover
 - `/proc` exposes kernel parameters, process environments (secrets), and sysrq triggers
 - `/sys` provides direct interfaces to hardware, cgroups, and kernel modules
 - `/boot` contains the kernel and initramfs — modification enables persistent rootkits
-- `/root` may contain SSH keys, shell history, and credentials
+- `/root` and `/home` typically contain SSH keys, cloud credentials, and shell history
+- `/var/lib/docker` exposes other containers' filesystems and image layers
+- `/var/run` is the parent of the Docker socket and other privileged sockets
 
 ## Fix
 

--- a/src/compose_lint/rules/CL0013_sensitive_mount.py
+++ b/src/compose_lint/rules/CL0013_sensitive_mount.py
@@ -18,10 +18,20 @@ OWASP_REF = (
 
 CIS_REF = "CIS Docker Benchmark 5.5 — Do not mount sensitive host system directories"
 
-_SENSITIVE_PATHS = ("/etc", "/proc", "/sys", "/boot", "/root")
+_SENSITIVE_PATHS = (
+    "/etc",
+    "/proc",
+    "/sys",
+    "/boot",
+    "/root",
+    "/var/lib/docker",
+    "/var/run",
+    "/home",
+)
 
-# Matches host:container or host:container:mode in short syntax
-_SHORT_VOLUME_RE = re.compile(r"^(?P<host>/[^:]+):(?P<container>[^:]+)")
+# Matches host:container or host:container:mode in short syntax.
+# Host group allows a bare "/" (root mount) by using `*` instead of `+`.
+_SHORT_VOLUME_RE = re.compile(r"^(?P<host>/[^:]*):(?P<container>[^:]+)")
 
 
 def _extract_host_path(volume: Any) -> str | None:
@@ -35,9 +45,15 @@ def _extract_host_path(volume: Any) -> str | None:
 
 
 def _is_sensitive(host_path: str) -> str | None:
-    """Return the sensitive prefix if host_path starts with one, else None."""
-    # Normalize trailing slashes for comparison
+    """Return the sensitive prefix if host_path starts with one, else None.
+
+    Returns "/" for a literal root mount — the most sensitive path possible.
+    """
+    if host_path == "/":
+        return "/"
     normalized = host_path.rstrip("/")
+    if normalized == "":
+        return "/"
     for sensitive in _SENSITIVE_PATHS:
         if normalized == sensitive or normalized.startswith(sensitive + "/"):
             return sensitive
@@ -55,8 +71,10 @@ class SensitiveMountRule(BaseRule):
             name="Sensitive host path mounted",
             description=(
                 "Mounting sensitive host directories like /etc, /proc, /sys, "
-                "/boot, or /root into a container exposes host configuration "
-                "and kernel interfaces."
+                "/boot, /root, /var/lib/docker, /var/run, or /home into a "
+                "container exposes host configuration, kernel interfaces, and "
+                "credentials. Mounting the entire host root filesystem is a "
+                "one-line container escape."
             ),
             severity=Severity.HIGH,
             references=[OWASP_REF, CIS_REF],
@@ -76,35 +94,49 @@ class SensitiveMountRule(BaseRule):
         for volume in volumes:
             # Short syntax: /host/path:/container/path[:mode]
             host_path = _extract_host_path(volume)
-            if (
-                host_path is None
-                and isinstance(volume, dict)
-                and volume.get("type") == "bind"
-            ):
-                # Long syntax: dict with 'source' key
+            if host_path is None and isinstance(volume, dict):
+                # Long syntax: dict with 'source' key.
+                # Treat as a bind when type == "bind" OR when source is an
+                # absolute path (Compose infers bind from absolute paths even
+                # when type is omitted).
                 source = volume.get("source")
-                if isinstance(source, str):
+                vtype = volume.get("type")
+                if isinstance(source, str) and (
+                    vtype == "bind" or source.startswith("/")
+                ):
                     host_path = source
 
             if host_path is None:
                 continue
 
             sensitive = _is_sensitive(host_path)
-            if sensitive:
-                yield Finding(
-                    rule_id="CL-0013",
-                    severity=Severity.HIGH,
-                    service=service_name,
-                    message=(
-                        f"Service mounts sensitive host path '{host_path}' "
-                        f"(under {sensitive}). This exposes host system files "
-                        "to the container."
-                    ),
-                    line=lines.get(f"services.{service_name}.volumes"),
-                    fix=(
-                        f"Remove the bind mount for {host_path}. If the container "
-                        "needs specific files, copy them into the image at build time "
-                        "or use a named volume with only the required data."
-                    ),
-                    references=[OWASP_REF, CIS_REF],
+            if sensitive is None:
+                continue
+
+            is_root_mount = sensitive == "/"
+            severity = Severity.CRITICAL if is_root_mount else Severity.HIGH
+            if is_root_mount:
+                message = (
+                    f"Service mounts the entire host root filesystem "
+                    f"('{host_path}'). This is a one-line container escape — "
+                    "the container has full read/write access to the host."
                 )
+            else:
+                message = (
+                    f"Service mounts sensitive host path '{host_path}' "
+                    f"(under {sensitive}). This exposes host system files "
+                    "to the container."
+                )
+            yield Finding(
+                rule_id="CL-0013",
+                severity=severity,
+                service=service_name,
+                message=message,
+                line=lines.get(f"services.{service_name}.volumes"),
+                fix=(
+                    f"Remove the bind mount for {host_path}. If the container "
+                    "needs specific files, copy them into the image at build time "
+                    "or use a named volume with only the required data."
+                ),
+                references=[OWASP_REF, CIS_REF],
+            )

--- a/tests/compose_files/insecure_sensitive_mount.yml
+++ b/tests/compose_files/insecure_sensitive_mount.yml
@@ -28,6 +28,30 @@ services:
     volumes:
       - /etc:/host-etc
       - /proc:/host-proc
+  mounts_root_filesystem:
+    image: nginx:1.27-alpine
+    volumes:
+      - "/:/host"
+  mounts_root_filesystem_ro:
+    image: nginx:1.27-alpine
+    volumes:
+      - "/:/host:ro"
+  mounts_var_lib_docker:
+    image: nginx:1.27-alpine
+    volumes:
+      - /var/lib/docker:/host-docker
+  mounts_var_run:
+    image: nginx:1.27-alpine
+    volumes:
+      - /var/run:/host-var-run
+  mounts_home:
+    image: nginx:1.27-alpine
+    volumes:
+      - /home:/host-home
+  mounts_root_ssh:
+    image: nginx:1.27-alpine
+    volumes:
+      - /root/.ssh:/keys:ro
   safe_volume:
     image: nginx:1.27-alpine
     volumes:
@@ -41,6 +65,16 @@ services:
       - type: bind
         source: /etc
         target: /host-etc
+  long_syntax_bind_no_type:
+    image: nginx:1.27-alpine
+    volumes:
+      - source: /etc
+        target: /host-etc
+  long_syntax_root_no_type:
+    image: nginx:1.27-alpine
+    volumes:
+      - source: /
+        target: /host
   long_syntax_named:
     image: nginx:1.27-alpine
     volumes:

--- a/tests/test_CL0013.py
+++ b/tests/test_CL0013.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from compose_lint.models import Severity
 from compose_lint.parser import load_compose
 from compose_lint.rules.CL0013_sensitive_mount import SensitiveMountRule
 
@@ -27,6 +28,7 @@ class TestSensitiveMountRule:
         assert len(findings) == 1
         assert findings[0].rule_id == "CL-0013"
         assert "/etc" in findings[0].message
+        assert findings[0].severity == Severity.HIGH
 
     def test_detects_proc(self) -> None:
         findings = self._check("mounts_proc")
@@ -57,6 +59,37 @@ class TestSensitiveMountRule:
         findings = self._check("mounts_multiple")
         assert len(findings) == 2
 
+    def test_detects_root_filesystem(self) -> None:
+        findings = self._check("mounts_root_filesystem")
+        assert len(findings) == 1
+        assert findings[0].severity == Severity.CRITICAL
+        assert "root filesystem" in findings[0].message
+
+    def test_detects_root_filesystem_ro(self) -> None:
+        findings = self._check("mounts_root_filesystem_ro")
+        assert len(findings) == 1
+        assert findings[0].severity == Severity.CRITICAL
+
+    def test_detects_var_lib_docker(self) -> None:
+        findings = self._check("mounts_var_lib_docker")
+        assert len(findings) == 1
+        assert "/var/lib/docker" in findings[0].message
+
+    def test_detects_var_run(self) -> None:
+        findings = self._check("mounts_var_run")
+        assert len(findings) == 1
+        assert "/var/run" in findings[0].message
+
+    def test_detects_home(self) -> None:
+        findings = self._check("mounts_home")
+        assert len(findings) == 1
+        assert "/home" in findings[0].message
+
+    def test_detects_root_ssh(self) -> None:
+        findings = self._check("mounts_root_ssh")
+        assert len(findings) == 1
+        assert "/root/.ssh" in findings[0].message
+
     def test_safe_volume_no_findings(self) -> None:
         findings = self._check("safe_volume")
         assert len(findings) == 0
@@ -69,6 +102,17 @@ class TestSensitiveMountRule:
         findings = self._check("long_syntax_bind")
         assert len(findings) == 1
         assert "/etc" in findings[0].message
+
+    def test_long_syntax_bind_no_type(self) -> None:
+        findings = self._check("long_syntax_bind_no_type")
+        assert len(findings) == 1
+        assert "/etc" in findings[0].message
+        assert findings[0].severity == Severity.HIGH
+
+    def test_long_syntax_root_no_type(self) -> None:
+        findings = self._check("long_syntax_root_no_type")
+        assert len(findings) == 1
+        assert findings[0].severity == Severity.CRITICAL
 
     def test_long_syntax_named_no_findings(self) -> None:
         findings = self._check("long_syntax_named")


### PR DESCRIPTION
Closes #134.

## Summary

- Short-syntax regex now matches `/:/host` (root group changed from `/[^:]+:` to `/[^:]*:` plus an empty-string check in `_is_sensitive`)
- Long-syntax binds detected when `source:` is an absolute path even without explicit `type: bind` — Compose infers bind from absolute paths
- `_SENSITIVE_PATHS` extended with `/var/lib/docker`, `/var/run`, `/home`
- Root-filesystem mount escalates to CRITICAL via the dynamic-severity precedent from #140; other sensitive paths stay HIGH

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy src/` clean
- [x] `pytest` — 304 passed (22 in `test_CL0013.py`, including new cases for `/:/host`, `/:/host:ro`, `/var/lib/docker`, `/var/run`, `/home`, `/root/.ssh`, long-syntax bind without `type:`, long-syntax root mount without `type:`)