### PR TITLE
Ship multi-identifier VEX products and loosen Scout author check

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -362,8 +362,10 @@ jobs:
           vex-location: .vex/compose-lint.openvex.json
           # Override Scout's default vex-author allowlist
           # (`<.*@docker.com>`) so our maintainer-authored statements
-          # are not silently dropped. See ADR-012.
-          vex-author: <.*@gmail\.com>
+          # are not silently dropped. `.*` accepts any author and is
+          # safe because the document is also cosign-attested to the
+          # image manifest. See ADR-012.
+          vex-author: .*
       - name: Upload Scout results to GitHub Security
         if: matrix.scout && always()
         uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2

--- a/.github/workflows/scout-scan.yml
+++ b/.github/workflows/scout-scan.yml
@@ -47,9 +47,13 @@ jobs:
           # not_affected doesn't spuriously fail the schedule.
           vex-location: .vex/compose-lint.openvex.json
           # Scout's default vex-author allowlist is `<.*@docker.com>`,
-          # so without this override our maintainer-authored statements
-          # are silently dropped. See ADR-012.
-          vex-author: <.*@gmail\.com>
+          # which silently drops our maintainer-authored statements.
+          # The first override attempt (`<.*@gmail\.com>`) was also
+          # silently dropped — Scout appears to require a full-string
+          # regex match on the author field, not substring. `.*`
+          # accepts any author and is safe because the document is
+          # also cosign-attested to the image manifest. See ADR-012.
+          vex-author: .*
 
       # Full-severity sweep for SARIF upload. Runs even when the
       # critical scan fails, so the Security tab always reflects the
@@ -69,7 +73,7 @@ jobs:
           vex-location: .vex/compose-lint.openvex.json
           # See note on the gate step above re: the default vex-author
           # allowlist. Same override required here.
-          vex-author: <.*@gmail\.com>
+          vex-author: .*
 
       - name: Upload Scout results to GitHub Security
         uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2

--- a/.vex/compose-lint.openvex.json
+++ b/.vex/compose-lint.openvex.json
@@ -3,8 +3,8 @@
   "@id": "https://github.com/tmatens/compose-lint/.vex/compose-lint.openvex.json",
   "author": "Todd Matens <tmatens@gmail.com>",
   "role": "Project Maintainer",
-  "timestamp": "2026-04-24T00:00:00Z",
-  "version": 2,
+  "timestamp": "2026-04-25T00:00:00Z",
+  "version": 3,
   "tooling": "hand-authored",
   "statements": [
     {
@@ -15,6 +15,12 @@
       "products": [
         {
           "@id": "pkg:oci/compose-lint?repository_url=index.docker.io/composelint/compose-lint",
+          "subcomponents": [
+            { "@id": "pkg:pypi/pip@25.1.1" }
+          ]
+        },
+        {
+          "@id": "pkg:docker/composelint/compose-lint",
           "subcomponents": [
             { "@id": "pkg:pypi/pip@25.1.1" }
           ]
@@ -35,6 +41,12 @@
           "subcomponents": [
             { "@id": "pkg:pypi/pip@25.1.1" }
           ]
+        },
+        {
+          "@id": "pkg:docker/composelint/compose-lint",
+          "subcomponents": [
+            { "@id": "pkg:pypi/pip@25.1.1" }
+          ]
         }
       ],
       "status": "not_affected",
@@ -49,6 +61,12 @@
       "products": [
         {
           "@id": "pkg:oci/compose-lint?repository_url=index.docker.io/composelint/compose-lint",
+          "subcomponents": [
+            { "@id": "pkg:pypi/pip@25.1.1" }
+          ]
+        },
+        {
+          "@id": "pkg:docker/composelint/compose-lint",
           "subcomponents": [
             { "@id": "pkg:pypi/pip@25.1.1" }
           ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,13 +59,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   images: Trivy, Grype (per anchore/grype#2818), and Scout all canonicalise
   Docker Hub to `index.docker.io` for VEX product matching. Confirmed
   locally with Trivy 0.70.0 against the published image.
-- Every `docker/scout-action` step that passes `vex-location` also now
-  passes `vex-author: <.*@gmail\.com>`. Scout's default `--vex-author`
-  allowlist is `<.*@docker.com>` and silently drops statements signed
-  outside that pattern, which is why 0.5.1's `Loaded 1 VEX document`
-  log line was followed by both pip CVEs still flagged. Applied to
-  both `scout-scan.yml` steps and the `docker-smoke` Scout step in
-  `publish.yml`.
+- Every VEX statement now ships two `products[]` entries —
+  `pkg:oci/compose-lint?repository_url=index.docker.io/composelint/compose-lint`
+  for Trivy and Grype, plus a bare `pkg:docker/composelint/compose-lint`
+  for Docker Scout, whose own "Create exceptions" docs example uses the
+  `pkg:docker/` form. Trivy honoured the single-PURL form from PR #143
+  but Scout did not — verified empirically on commit `5abd036`'s
+  `scout-scan.yml` dispatch where `Loaded 1 VEX document` was followed
+  by all three pip CVEs still flagged. OpenVEX explicitly invites
+  multi-identifier products for exactly this scanner-disagreement case.
+- Every `docker/scout-action` step that passes `vex-location` now passes
+  `vex-author: .*`. Scout's default `--vex-author` allowlist is
+  `<.*@docker.com>` and silently drops statements signed outside that
+  pattern. PR #143's first override (`<.*@gmail\.com>`) was also
+  silently dropped — Scout appears to use full-string regex match on
+  the author field rather than substring, so the bracket-anchored shape
+  did not match the full author string `Todd Matens <tmatens@gmail.com>`.
+  `.*` accepts any author and is safe because the document is also
+  cosign-attested to the image manifest. Applied to both `scout-scan.yml`
+  steps and the `docker-smoke` Scout step in `publish.yml`.
 
 ### Added
 
@@ -77,9 +89,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- VEX document `version` bumped to 2 and `timestamp` refreshed. See
+- VEX document `version` bumped to 3 and `timestamp` refreshed. See
   ADR-012 (`docs/adr/012-vex-product-identifier.md`) for the full
-  rationale on the product-identifier and author-allowlist decisions.
+  rationale on the product-identifier and author-allowlist decisions,
+  including the empirical evidence from PR #143's first attempt.
 
 ## [0.5.1] - 2026-04-24
 

--- a/docs/adr/012-vex-product-identifier.md
+++ b/docs/adr/012-vex-product-identifier.md
@@ -1,34 +1,40 @@
 # ADR-012: VEX Product Identifier and Author Allowlist
 
-**Status:** Accepted
+**Status:** Accepted (revised after PR #143's first attempt did not suppress on Scout)
 
-**Context:** compose-lint 0.5.1 shipped `.vex/compose-lint.openvex.json` declaring CVE-2025-8869 and CVE-2026-1703 as `not_affected` / `vulnerable_code_not_present` against the published container image, and wired `docker/scout-action`'s `vex-location` input on every step that scans the image (`scout-scan.yml`, `publish.yml`'s `docker-smoke`). After 0.5.1 shipped, Scout still flagged both CVEs and the post-merge code-scanning analysis kept alerts #82 and #83 open. Two independent failures were responsible.
+**Context:** compose-lint 0.5.1 shipped `.vex/compose-lint.openvex.json` declaring CVE-2025-8869 and CVE-2026-1703 as `not_affected` / `vulnerable_code_not_present` against the published container image, and wired `docker/scout-action`'s `vex-location` input on every step that scans the image (`scout-scan.yml`, `publish.yml`'s `docker-smoke`). After 0.5.1 shipped, Scout still flagged both CVEs and the post-merge code-scanning analysis kept alerts #82 and #83 open. PR #143 made two changes (registry alias + author override). Trivy honoured the result locally; the post-merge `scout-scan.yml` dispatch on commit `5abd036` showed Scout still flagging all three pip CVEs despite logging `Loaded 1 VEX document`. This ADR captures the revised decision after that empirical failure.
 
-**Decision:** Two changes.
+**Decision:** Three changes.
 
-1. **Product identifier registry alias.** The OpenVEX `products[].@id` uses `pkg:oci/compose-lint?repository_url=index.docker.io/composelint/compose-lint`, not `docker.io/...`. The Trivy / Scout / Grype canonical hostname for Docker Hub is `index.docker.io`; `docker.io` is widely accepted as a user-facing alias but is not what scanners normalise to internally for VEX product matching.
-2. **`vex-author` override on every Scout step.** `docker scout cves` defaults `--vex-author` to `<.*@docker.com>` and silently drops statements signed by anyone outside that allowlist. Every `docker/scout-action` step that passes `vex-location` also passes `vex-author: <.*@gmail\.com>` so our maintainer-authored statements are honoured.
+1. **Registry alias.** OpenVEX `products[].@id` uses `repository_url=index.docker.io/composelint/compose-lint`, not `docker.io/...`. Trivy, Grype (anchore/grype#2818), and Scout all canonicalise Docker Hub to `index.docker.io` for VEX product matching. *(Unchanged from PR #143.)*
+2. **Multiple product identifiers per statement.** Every statement carries two `products[]` entries: the `pkg:oci/...?repository_url=...` form (which Trivy and Grype accept) and a bare `pkg:docker/composelint/compose-lint` form (which Docker Scout's own "Create exceptions" docs example uses). OpenVEX explicitly invites this — "list as many software identifiers as possible to help VEX processors when matching the product." *(Added in this revision.)*
+3. **Permissive `vex-author`.** Every `docker/scout-action` step that passes `vex-location` also passes `vex-author: .*`. The first attempt used `<.*@gmail\.com>` (mirroring Scout's default-allowlist shape `<.*@docker.com>`) and was silently dropped, suggesting Scout uses full-string regex match rather than substring. `.*` accepts any author and is safe because the document is also cosign-attested to the image manifest at publish time. *(Loosened in this revision.)*
 
-The product `@id` is digest-free so re-releases do not require editing the VEX file or running a substitution step in the publish pipeline. If a future scanner is observed to require digest qualification specifically (none in our tested set do), that decision can be revisited; the substitution would slot in between manifest-list creation and the `cosign attest` / release-asset upload steps in `publish.yml`.
+The product `@id`s remain digest-free so re-releases do not require editing the VEX file or running a substitution step in the publish pipeline. If even the multi-identifier static form is observed to fail against Scout, the next escalation is digest qualification (`pkg:oci/compose-lint@sha256:<index-digest>?repository_url=...`); the substitution step would slot in between manifest-list creation and the `cosign attest` / release-asset upload steps in `publish.yml`. We prefer to avoid that complexity unless required.
 
 ---
 
-## Why `index.docker.io` instead of `docker.io`
+## Why two PURL types instead of one
+
+There is no single product-identifier convention for "an image on Docker Hub" that all attestation-aware scanners accept. The PURL spec defines two registered types for the same artifact and scanners disagree on which one (and which registry hostname) they normalise to:
+
+- **`pkg:oci/<name>?repository_url=<registry>/<namespace>/<name>`** — registry-agnostic, modern PURL form. Trivy's "VEX Attestation" docs use this form (`pkg:oci/trivy?repository_url=ghcr.io/aquasecurity/trivy`); Trivy and Grype accept it. Tested locally.
+- **`pkg:docker/<namespace>/<name>`** — Docker-specific legacy PURL form, no registry component (Docker Hub is implicit). Docker Scout's "Create exceptions" docs page uses this form (`pkg:docker/example/app@v1`). Pre-revision, Scout did not match against the `pkg:oci/` form alone in production.
+
+Both are *registered* PURL types in the spec; both are valid. Shipping one identifier means picking a winner in a disagreement that has no winner. Shipping both costs ~12 lines of JSON and lets each scanner match against whatever form it normalises the scanned image to.
+
+The `pkg:docker/` form intentionally omits a tag and a digest. A tag-qualified form (`pkg:docker/composelint/compose-lint:latest`) would suppress only against the `latest` tag, which is wrong — a digest-pinned consumer pulling the same image should still see the suppression. A digest-qualified form (`pkg:docker/composelint/compose-lint@sha256:<digest>`) would force release-time substitution. The bare form covers all tags and all digests of the named image.
+
+## Why `index.docker.io` not `docker.io`
 
 Local probing against `composelint/compose-lint:latest` (0.5.1, manifest digest `sha256:fdf35fc6…`):
 
-- Trivy 0.70.0 with `--vex .vex/compose-lint.openvex.json` and `repository_url=docker.io/composelint/compose-lint` — both pip CVEs still listed.
-- Trivy 0.70.0 with `repository_url=index.docker.io/composelint/compose-lint` — both pip CVEs suppressed, only the new CVE-2026-3219 (added in this same change) remains, and is also suppressed once its statement lands.
+- Trivy 0.70.0 with `repository_url=docker.io/composelint/compose-lint` — both pip CVEs still listed.
+- Trivy 0.70.0 with `repository_url=index.docker.io/composelint/compose-lint` — pip CVEs suppressed.
 
-This matches anchore/grype#2818, which documents the same `docker.io` → `index.docker.io` alias gap as a Grype bug with a working workaround. Scout was not retested locally because the scout-cli container requires a Docker Hub login the development machine does not have; verification deferred to the next `scout-scan.yml` dispatch on `main`.
+This matches anchore/grype#2818, which documents the same `docker.io` → `index.docker.io` alias gap as a Grype bug with a working workaround. Scout exhibits the same behaviour empirically — `docker.io` form did not suppress before PR #143; `index.docker.io` form did not suppress *alone* but is retained because Trivy and Grype need it.
 
-The `pkg:oci/<name>?repository_url=<registry>/<namespace>/<name>` form (with the image name appearing twice) follows the convention shown in the Trivy "VEX Attestation" docs (`pkg:oci/trivy?repository_url=ghcr.io/aquasecurity/trivy`). Other forms considered and rejected for v1:
-
-- `pkg:docker/composelint/compose-lint?repository_url=index.docker.io` (per docker/scout-cli#199's example) — Trivy did not match this form against the image; would need a parallel `pkg:oci` entry to keep Trivy working, doubling the surface for no observed benefit.
-- Multi-identifier products (multiple `products[]` entries on one statement, each with a different `@id`) — viable but unnecessary while one form is accepted by all tested scanners. Revisit if a scanner is observed to need a form the current entry does not cover.
-- Digest-qualified PURLs — would require a release-time substitution step. Not adopted because the digest-free form works against Trivy and is what Scout's official docs example uses.
-
-## Why the `vex-author` override
+## Why the `vex-author` override is permissive
 
 `docker scout cves --help` lists:
 
@@ -36,22 +42,28 @@ The `pkg:oci/<name>?repository_url=<registry>/<namespace>/<name>` form (with the
 --vex-author strings   List of VEX statement authors to accept (default [<.*@docker.com>])
 ```
 
-Our document is authored by `Todd Matens <tmatens@gmail.com>`. Without an override, Scout loads the document (the action logs `Loaded 1 VEX document`) and then drops every statement during the author check. The CLI default is undocumented in `docker/scout-action`'s `action.yaml` input schema — `vex-author` is exposed as an input but its default-allowlist behaviour is inherited silently from the underlying CLI.
+Our document is authored by `Todd Matens <tmatens@gmail.com>`. The first override (`<.*@gmail\.com>`, mirroring the bracket-anchored shape of Scout's default) was silently dropped — the post-merge dispatch of `scout-scan.yml` showed `Loaded 1 VEX document` followed by all three CVEs still flagged. The simplest hypothesis is that Scout's matcher is full-string rather than substring, so `<.*@gmail\.com>` only matches the bracketed-email portion of the author string, not the entire `Todd Matens <tmatens@gmail.com>`.
 
-The override is set on every scout-action step (`scout-scan.yml` gate, `scout-scan.yml` SARIF sweep, `publish.yml` docker-smoke). The pattern `<.*@gmail\.com>` mirrors the bracket-anchored shape of Scout's default and is intentionally a regex rather than a literal email so a future maintainer email under the same domain doesn't silently re-break suppression.
+Rather than chase the exact regex shape (which Scout's behaviour is undocumented on), `vex-author: .*` accepts any author. This is acceptable because:
+
+- The document on disk in CI comes from `actions/checkout` of the project repo, not from an arbitrary URL — there is no opportunity for an attacker-authored VEX file to reach the scout-action step.
+- The same document is cosign-attested to the image manifest with predicate type `openvex` at release time, so external consumers verifying via attestation discovery have signature-level provenance.
+- The default allowlist exists to filter VEX documents *Docker* did not author from being trusted by enterprise customers using Scout's hosted Hub workflow. That threat model does not apply to a project's own VEX document running against its own repo's CI.
 
 ## Open Scout caveats
 
 Two upstream Scout issues affect statement-level behaviour but do not change this ADR:
 
-- **docker/scout-cli#199** — Scout 1.18.2+ does not always honour newer VEX statements that include subcomponents. Our document uses subcomponents on every statement (so the scanner pins the suppression to the specific pip version, not "any pip"). This is acceptable risk: when we change a statement we bump `version` and `timestamp` and accept that Scout may continue to apply the prior statement until its index refreshes. The post-fix `scout-scan.yml` run is the canary for this.
-- **docker/scout-cli#207** — `docker scout cves --vex-location` historically had product-matching gaps for VEX statements scoped to the image rather than to nested components. Our statements scope to the image *with subcomponents*, which matches what felipecruz91/node-ip-vex (Docker's reference example) does and is the form Scout's "Create exceptions" docs page targets.
+- **docker/scout-cli#199** — Scout 1.18.2+ does not always honour newer VEX statements that include subcomponents. Our document uses subcomponents on every statement (so the scanner pins the suppression to the specific pip version, not "any pip"). When we change a statement we bump `version` and `timestamp` and accept that Scout may continue to apply the prior statement until its index refreshes. The post-fix `scout-scan.yml` run is the canary for this.
+- **docker/scout-cli#207** — `docker scout cves --vex-location` historically had product-matching gaps for VEX statements scoped to the image rather than to nested components. Our statements scope to the image *with subcomponents*; the multi-identifier change is an explicit response to this issue.
 
 ## References
 
 - [OpenVEX Specification v0.2.0](https://github.com/openvex/spec/blob/main/OPENVEX-SPEC.md) — "list as many software identifiers as possible to help VEX processors when matching the product."
-- [Trivy — VEX Attestation (OCI)](https://trivy.dev/latest/docs/supply-chain/vex/oci/) — canonical `pkg:oci/<name>?repository_url=<registry>/<namespace>/<name>` example.
-- [Docker Scout — Create an exception using VEX](https://docs.docker.com/scout/how-tos/create-exceptions-vex/)
+- [Trivy — VEX Attestation (OCI)](https://trivy.dev/latest/docs/supply-chain/vex/oci/) — `pkg:oci/<name>?repository_url=<registry>/<namespace>/<name>` example.
+- [Docker Scout — Create an exception using VEX](https://docs.docker.com/scout/how-tos/create-exceptions-vex/) — `pkg:docker/example/app@v1` example.
+- [PURL spec — `pkg:oci` and `pkg:docker` types](https://github.com/package-url/purl-spec) — two registered types for the same artifact class.
 - [anchore/grype#2818](https://github.com/anchore/grype/issues/2818) — `docker.io` registry alias does not match; `index.docker.io` does.
 - [docker/scout-cli#199](https://github.com/docker/scout-cli/issues/199) — VEX statements with subcomponents not honoured across updates.
 - [docker/scout-cli#207](https://github.com/docker/scout-cli/issues/207) — `docker scout cves --vex-location` product-matching gaps.
+- PR #143 — first attempt (registry alias + bracket-anchored author regex). Verified Scout still flagged all three CVEs on the post-merge dispatch (run `24921123739`).


### PR DESCRIPTION
## Summary

PR #143 fixed the registry alias and added a `vex-author` override for Docker Scout, but Scout **still flagged all three pip CVEs** on the post-merge `scout-scan.yml` dispatch ([run 24921123739](https://github.com/tmatens/compose-lint/actions/runs/24921123739/job/72982651768) on commit `5abd036`). Scout logged `Loaded 1 VEX document` — the document loaded but no statement matched. This PR addresses the two suspect axes simultaneously so the next dispatch is conclusive.

## Changes

- **Multi-identifier products.** Every VEX statement now ships two `products[]` entries: the existing `pkg:oci/compose-lint?repository_url=index.docker.io/composelint/compose-lint` form (Trivy and Grype accept this) plus a bare `pkg:docker/composelint/compose-lint` form, which is the shape [Docker Scout's own "Create exceptions" docs page](https://docs.docker.com/scout/how-tos/create-exceptions-vex/) uses.
- **Permissive `vex-author: .*`** on every `docker/scout-action` step (`scout-scan.yml` × 2, `publish.yml` × 1). PR #143's first override (`<.*@gmail\.com>`, mirroring Scout's bracket-anchored default `<.*@docker.com>`) was silently dropped — Scout appears to use full-string regex match rather than substring, so the bracket-anchored shape did not match the full author string `Todd Matens <tmatens@gmail.com>`. `.*` accepts any author; safe because the document in CI comes from `actions/checkout` and is also cosign-attested to the image manifest at release time.
- VEX `version` bumped 2 → 3, `timestamp` refreshed.
- ADR-012 revised to record the empirical evidence from #143 and the multi-identifier rationale. Status changed to "Accepted (revised after PR #143's first attempt did not suppress on Scout)".
- CHANGELOG updated under `[Unreleased]`.

## Why two PURL types

The PURL spec registers both `pkg:oci/` and `pkg:docker/` types for the same artifact class, and scanners disagree on which they normalise to. Trivy/Grype docs use the `pkg:oci/` form; Scout's exception docs use the `pkg:docker/` form. OpenVEX's spec explicitly invites multi-identifier products for exactly this case: "list as many software identifiers as possible to help VEX processors when matching the product." Twelve extra lines of JSON buys us both scanners matching without picking a winner in a disagreement that has no winner.

## Verification

- **Trivy 0.70.0** with the new multi-identifier doc against `composelint/compose-lint:latest`: zero pip CVEs (`pip-25.1.1.dist-info/METADATA: 0`). Unchanged from PR #143.
- **Scout** verification deferred to the post-merge `scout-scan.yml` dispatch on `main`. The outcome we're watching for is `Loaded 1 VEX document` → CVE-2025-8869, CVE-2026-1703, CVE-2026-3219 all absent from the per-severity output, and alerts #82/#83/#84 transitioning to closed.
- `ruff check`, `ruff format --check`, `mypy src/`, `pytest` — all pass locally (310 tests).

## Test plan

- [ ] CI green on this PR.
- [ ] After merge, dispatch `Docker Scout (scheduled)` from the Actions tab. Target signal: per-severity output lists 0 vulnerabilities from pip.
- [ ] `docker-scout-scheduled` SARIF upload reports `results_count: 0` for the resulting commit.
- [ ] Alerts #82/#83/#84 auto-close (if not, dismiss as "won't fix - VEX'd" linking ADR-012).
- [ ] If Scout **still** flags the CVEs: the next escalation is digest qualification (add a third `products[]` entry `pkg:oci/compose-lint@sha256:<index-digest>?repository_url=...`), with a substitution step in `publish.yml`. Not doing it in this PR because it adds release-pipeline complexity only justified if the static multi-identifier form is proven insufficient.

Reopens the work tracked by #139 (closed by #143) since the suppression is still not effective on Scout.