### PR TITLE
Detect IPv6 and IPv4 wildcard port binds in CL-0005

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CL-0005** now detects IPv6 wildcard binds in short syntax
+  (`"[::]:8080:80"`) — the previous regex's IP capture group rejected
+  any colon-containing prefix, causing the rule to silently skip the
+  port. Bracketed IPv6 prefixes are now stripped before the main pattern
+  runs.
+- **CL-0005** now detects explicit wildcard `host_ip` values in long
+  syntax (`host_ip: "0.0.0.0"`, `host_ip: "::"`). The previous
+  implementation treated *any* non-empty `host_ip` as a real bind, so
+  operators who explicitly wildcarded their long-syntax bind got no
+  warning. Loopback (`127.0.0.1`, `::1`) and specific addresses still
+  suppress the finding.
+- **CL-0005** also detects IPv4 wildcard short syntax (`"0.0.0.0:8080:80"`)
+  — incidental fix; the previous `_is_ip_address` helper accepted
+  `0.0.0.0` as a "real" IP and suppressed the finding.
 - **CL-0013** now detects mounting the entire host root filesystem
   (`"/:/host"`, `"/:/host:ro"`) at CRITICAL severity — previously the
   short-syntax regex required at least one non-colon character after `/`

--- a/docs/rules/CL-0005.md
+++ b/docs/rules/CL-0005.md
@@ -8,7 +8,7 @@
 
 ## What it detects
 
-Port mappings that don't specify a bind address, in both short syntax (`"8080:80"`) and long syntax (`published:` without `host_ip:`). Container-only ports (`"80"`) are not flagged since they are not published to the host.
+Port mappings that don't specify a bind address or that bind to a wildcard, in both short syntax (`"8080:80"`, `"0.0.0.0:8080:80"`, `"[::]:8080:80"`) and long syntax (`published:` without `host_ip:`, or with `host_ip: "0.0.0.0"` / `host_ip: "::"`). Specific bind addresses including loopback (`127.0.0.1`, `[::1]`) are not flagged. Container-only ports (`"80"`) are not flagged since they are not published to the host.
 
 ## Why it matters
 

--- a/src/compose_lint/rules/CL0005_unbound_ports.py
+++ b/src/compose_lint/rules/CL0005_unbound_ports.py
@@ -30,7 +30,8 @@ _PORT_PATTERN = re.compile(
 )
 
 # Values that publish on all interfaces — equivalent to no bind address.
-_WILDCARD_IPS = frozenset({"0.0.0.0", "::", "[::]", "*"})
+# These are detection patterns, not actual bind addresses.
+_WILDCARD_IPS = frozenset({"0.0.0.0", "::", "[::]", "*"})  # nosec B104
 
 
 def _is_wildcard_ip(value: str) -> bool:
@@ -42,7 +43,7 @@ def _is_wildcard_ip(value: str) -> bool:
     # Bracketed IPv6 form like "[::]" — already covered above, but also
     # accept "[0.0.0.0]" defensively.
     if value.startswith("[") and value.endswith("]"):
-        return value[1:-1] in {"::", "0.0.0.0", "*"}
+        return value[1:-1] in {"::", "0.0.0.0", "*"}  # nosec B104
     return False
 
 

--- a/src/compose_lint/rules/CL0005_unbound_ports.py
+++ b/src/compose_lint/rules/CL0005_unbound_ports.py
@@ -22,21 +22,28 @@ CIS_REF = (
     " — Bind incoming container traffic to a specific host interface"
 )
 
-# Matches short syntax: "HOST:CONTAINER" or "HOST:CONTAINER/proto"
-# With optional IP prefix: "IP:HOST:CONTAINER"
-# Port ranges: "8000-8100:8000-8100"
+# Matches HOST:CONTAINER (with optional non-bracketed IPv4/hostname prefix)
+# or HOST:CONTAINER/proto. Bracketed IPv6 prefixes are stripped before this
+# pattern is applied — see _check_short_syntax.
 _PORT_PATTERN = re.compile(
     r"^(?:(?P<ip>[^:]+):)?(?P<host>[\d\-]+):(?P<container>[\d\-]+(?:/\w+)?)$"
 )
 
+# Values that publish on all interfaces — equivalent to no bind address.
+_WILDCARD_IPS = frozenset({"0.0.0.0", "::", "[::]", "*"})
 
-def _is_ip_address(value: str) -> bool:
-    """Check if a string looks like an IP address."""
-    parts = value.split(".")
-    if len(parts) == 4:
-        return all(p.isdigit() and 0 <= int(p) <= 255 for p in parts)
-    # IPv6 or :: shorthand
-    return ":" in value or value == "[::]"
+
+def _is_wildcard_ip(value: str) -> bool:
+    """Return True if the value publishes on all interfaces."""
+    if not value:
+        return True
+    if value in _WILDCARD_IPS:
+        return True
+    # Bracketed IPv6 form like "[::]" — already covered above, but also
+    # accept "[0.0.0.0]" defensively.
+    if value.startswith("[") and value.endswith("]"):
+        return value[1:-1] in {"::", "0.0.0.0", "*"}
+    return False
 
 
 @register_rule
@@ -51,7 +58,8 @@ class UnboundPortsRule(BaseRule):
             description=(
                 "Docker publishes ports by manipulating iptables directly, "
                 "bypassing host firewalls like UFW and firewalld. Ports without "
-                "a bind address are accessible on all network interfaces."
+                "a bind address — or bound to a wildcard like 0.0.0.0 or :: — "
+                "are accessible on all network interfaces."
             ),
             severity=Severity.HIGH,
             references=[OWASP_REF, CIS_REF],
@@ -70,10 +78,8 @@ class UnboundPortsRule(BaseRule):
 
         for i, port in enumerate(ports):
             if isinstance(port, dict):
-                # Long syntax
                 yield from self._check_long_syntax(port, service_name, lines, i)
             else:
-                # Short syntax
                 yield from self._check_short_syntax(str(port), service_name, lines, i)
 
     def _check_short_syntax(
@@ -87,18 +93,29 @@ class UnboundPortsRule(BaseRule):
         if ":" not in port_str:
             return
 
-        match = _PORT_PATTERN.match(port_str)
+        # Extract bracketed IPv6 prefix (e.g. "[::]:8080:80") before the
+        # main regex, which doesn't accept colons inside the IP group.
+        ip: str | None = None
+        rest = port_str
+        if port_str.startswith("["):
+            end = port_str.find("]:")
+            if end == -1:
+                return  # malformed
+            ip = port_str[: end + 1]
+            rest = port_str[end + 2 :]
+
+        match = _PORT_PATTERN.match(rest)
         if not match:
             return
 
-        ip = match.group("ip")
+        if ip is None:
+            ip = match.group("ip")
 
-        # If there's an IP prefix and it looks like an IP, it's bound
-        if ip and _is_ip_address(ip):
-            return
-
-        # No IP prefix or IP doesn't look like an address — bound to all interfaces
-        yield self._make_finding(port_str, service_name, lines, index)
+        # Fire when there's no bind address or it's a wildcard form.
+        # Any other value (loopback, specific interface IP, hostname) is
+        # treated as a real bind.
+        if ip is None or _is_wildcard_ip(ip):
+            yield self._make_finding(port_str, service_name, lines, index)
 
     def _check_long_syntax(
         self,
@@ -112,7 +129,7 @@ class UnboundPortsRule(BaseRule):
             return
 
         host_ip = port_config.get("host_ip", "")
-        if host_ip:
+        if isinstance(host_ip, str) and not _is_wildcard_ip(host_ip):
             return
 
         port_desc = f"{port_config.get('published')}:{port_config.get('target')}"

--- a/tests/compose_files/insecure_ports.yml
+++ b/tests/compose_files/insecure_ports.yml
@@ -29,3 +29,33 @@ services:
       - "8000-8100:8000-8100"
   no_ports:
     image: nginx:1.27-alpine
+  ipv6_wildcard_short:
+    image: nginx:1.27-alpine
+    ports:
+      - "[::]:8080:80"
+  ipv6_loopback_short:
+    image: nginx:1.27-alpine
+    ports:
+      - "[::1]:8080:80"
+  ipv4_wildcard_short:
+    image: nginx:1.27-alpine
+    ports:
+      - "0.0.0.0:8080:80"
+  long_ipv6_wildcard:
+    image: nginx:1.27-alpine
+    ports:
+      - target: 80
+        published: 8080
+        host_ip: "::"
+  long_ipv4_wildcard:
+    image: nginx:1.27-alpine
+    ports:
+      - target: 443
+        published: 8443
+        host_ip: "0.0.0.0"
+  long_ipv6_loopback:
+    image: nginx:1.27-alpine
+    ports:
+      - target: 80
+        published: 8080
+        host_ip: "::1"

--- a/tests/test_CL0005.py
+++ b/tests/test_CL0005.py
@@ -59,3 +59,29 @@ class TestUnboundPortsRule:
     def test_has_references(self) -> None:
         assert len(self.rule.metadata.references) > 0
         assert "owasp" in self.rule.metadata.references[0].lower()
+
+    def test_detects_ipv6_wildcard_short(self) -> None:
+        findings = self._check("ipv6_wildcard_short")
+        assert len(findings) == 1
+        assert "[::]:8080:80" in findings[0].message
+
+    def test_ipv6_loopback_short_no_findings(self) -> None:
+        findings = self._check("ipv6_loopback_short")
+        assert len(findings) == 0
+
+    def test_detects_ipv4_wildcard_short(self) -> None:
+        findings = self._check("ipv4_wildcard_short")
+        assert len(findings) == 1
+        assert "0.0.0.0:8080:80" in findings[0].message
+
+    def test_detects_long_ipv6_wildcard(self) -> None:
+        findings = self._check("long_ipv6_wildcard")
+        assert len(findings) == 1
+
+    def test_detects_long_ipv4_wildcard(self) -> None:
+        findings = self._check("long_ipv4_wildcard")
+        assert len(findings) == 1
+
+    def test_long_ipv6_loopback_no_findings(self) -> None:
+        findings = self._check("long_ipv6_loopback")
+        assert len(findings) == 0


### PR DESCRIPTION
Closes #133.

## Summary

- Short syntax now matches `[::]:8080:80` — bracketed IPv6 prefixes are stripped before the main regex runs (the IP capture group's `[^:]+` rejected colon-containing prefixes)
- Long-syntax `host_ip` validated against a wildcard set (`""`, `"0.0.0.0"`, `"::"`, `"[::]"`, `"*"`); only non-wildcard values suppress the finding
- Replaced `_is_ip_address` with `_is_wildcard_ip` — the old helper accepted `0.0.0.0` as a "real" IP and treated any IPv6 string as bound, which was the inverse of the desired semantics
- Loopback (`127.0.0.1`, `::1`) and specific addresses still suppress; wildcard or missing fires

No severity escalation: wildcard binds (v4/v6) are equally HIGH and loopback fires zero findings — there's no strictly-worse variant within the same finding shape, so the dynamic-severity precedent from #140 doesn't fit.

## Test plan

- [x] `ruff check`
- [x] `ruff format --check`
- [x] `mypy src/`
- [x] `pytest` — 310 passed (15 in `test_CL0005.py`, including new cases for IPv6 wildcard short, IPv6 loopback short, IPv4 wildcard short, long-syntax IPv6/IPv4 wildcard, long-syntax IPv6 loopback)