### PR TITLE
Parse registry-with-port image refs correctly in CL-0004 and CL-0019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CL-0004** and **CL-0019** now parse OCI image references via a
+  shared `split_image_ref` helper that recognizes `registry:port/name`
+  prefixes. The previous naive `image.rsplit(":", 1)` mistook the
+  registry port for a tag separator, causing two related bugs:
+  (a) `localhost:5000/foo` was treated as tag-pinned by CL-0004, so
+  the "no tag, defaults to :latest" finding never fired; and
+  (b) CL-0019 fired on the same input with a misleading message
+  ("pinned to a tag but not a digest") for an image that had no tag at
+  all. Verified for `localhost:5000/foo`, `localhost:5000/foo:latest`,
+  `localhost:5000/foo:v1`, and digest variants of each.
 - **CL-0005** now detects IPv6 wildcard binds in short syntax
   (`"[::]:8080:80"`) — the previous regex's IP capture group rejected
   any colon-containing prefix, causing the rule to silently skip the

--- a/src/compose_lint/rules/CL0004_image_not_pinned.py
+++ b/src/compose_lint/rules/CL0004_image_not_pinned.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from compose_lint.models import Finding, RuleMetadata, Severity
 from compose_lint.rules import BaseRule, register_rule
+from compose_lint.rules._image import split_image_ref
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -61,10 +62,8 @@ class ImageNotPinnedRule(BaseRule):
         if "@sha256:" in image:
             return
 
-        # Split image into name and tag
-        # Handle registry prefixes like ghcr.io/org/image:tag
-        parts = image.rsplit(":", 1)
-        if len(parts) == 1:
+        name, tag = split_image_ref(image)
+        if tag is None:
             # No tag specified — defaults to :latest
             yield Finding(
                 rule_id="CL-0004",
@@ -75,12 +74,11 @@ class ImageNotPinnedRule(BaseRule):
                     "Pin to a specific version for reproducible builds."
                 ),
                 line=lines.get(f"services.{service_name}.image"),
-                fix=f"Pin to a specific version, e.g.: image: {image}:<version>",
+                fix=f"Pin to a specific version, e.g.: image: {name}:<version>",
                 references=[OWASP_REF, CIS_REF],
             )
             return
 
-        tag = parts[1]
         if tag.lower() in MUTABLE_TAGS:
             yield Finding(
                 rule_id="CL-0004",
@@ -91,6 +89,6 @@ class ImageNotPinnedRule(BaseRule):
                     "Pin to a specific version for reproducible builds."
                 ),
                 line=lines.get(f"services.{service_name}.image"),
-                fix=f"Pin to a specific version, e.g.: image: {parts[0]}:<version>",
+                fix=f"Pin to a specific version, e.g.: image: {name}:<version>",
                 references=[OWASP_REF, CIS_REF],
             )

--- a/src/compose_lint/rules/CL0019_image_no_digest.py
+++ b/src/compose_lint/rules/CL0019_image_no_digest.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from compose_lint.models import Finding, RuleMetadata, Severity
 from compose_lint.rules import BaseRule, register_rule
+from compose_lint.rules._image import split_image_ref
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -56,13 +57,11 @@ class ImageNoDigestRule(BaseRule):
         if "@sha256:" in image:
             return
 
-        # Split into name and tag
-        parts = image.rsplit(":", 1)
-        if len(parts) != 2:
+        _, tag = split_image_ref(image)
+        if tag is None:
             # No tag at all — CL-0004 handles this
             return
 
-        tag = parts[1]
         if tag.lower() in _MUTABLE_TAGS:
             # Mutable tags are CL-0004's domain
             return

--- a/src/compose_lint/rules/_image.py
+++ b/src/compose_lint/rules/_image.py
@@ -1,0 +1,33 @@
+"""Shared parsing helpers for OCI image references."""
+
+from __future__ import annotations
+
+
+def split_image_ref(image: str) -> tuple[str, str | None]:
+    """Split an OCI image reference into ``(name, tag)``.
+
+    Returns ``tag = None`` when no tag is present. A registry-with-port
+    prefix (``localhost:5000/foo``) is not mistaken for a tag — the
+    rightmost colon is part of the registry, not a tag separator, when
+    the candidate tag contains a slash.
+
+    Any trailing ``@digest`` is stripped before splitting, so the
+    returned name does not include the digest.
+
+    Examples:
+        nginx                          -> ("nginx", None)
+        nginx:1.25                     -> ("nginx", "1.25")
+        nginx@sha256:...               -> ("nginx", None)
+        nginx:1.25@sha256:...          -> ("nginx", "1.25")
+        localhost:5000/foo             -> ("localhost:5000/foo", None)
+        localhost:5000/foo:v1          -> ("localhost:5000/foo", "v1")
+        localhost:5000/foo@sha256:...  -> ("localhost:5000/foo", None)
+    """
+    if "@" in image:
+        image = image.split("@", 1)[0]
+    if ":" not in image:
+        return image, None
+    name, _, candidate = image.rpartition(":")
+    if "/" in candidate:
+        return image, None
+    return name, candidate

--- a/tests/compose_files/insecure_image_no_digest.yml
+++ b/tests/compose_files/insecure_image_no_digest.yml
@@ -15,3 +15,9 @@ services:
     image: nginx:stable
   build_only:
     build: .
+  port_registry_pinned:
+    image: localhost:5000/foo:v1.2.3
+  port_registry_no_tag:
+    image: localhost:5000/foo
+  port_registry_digest:
+    image: localhost:5000/foo:v1.2.3@sha256:abcdef

--- a/tests/compose_files/insecure_image_tags.yml
+++ b/tests/compose_files/insecure_image_tags.yml
@@ -17,3 +17,13 @@ services:
     image: ghcr.io/org/myapp:latest
   registry_pinned:
     image: ghcr.io/org/myapp:1.2.3
+  port_registry_no_tag:
+    image: localhost:5000/foo
+  port_registry_latest:
+    image: localhost:5000/foo:latest
+  port_registry_pinned:
+    image: localhost:5000/foo:v1.2.3
+  port_registry_digest:
+    image: localhost:5000/foo@sha256:abc123
+  port_registry_pinned_digest:
+    image: localhost:5000/foo:v1.2.3@sha256:abc123

--- a/tests/test_CL0004.py
+++ b/tests/test_CL0004.py
@@ -69,3 +69,26 @@ class TestImageNotPinnedRule:
 
     def test_has_references(self) -> None:
         assert len(self.rule.metadata.references) > 0
+
+    def test_port_registry_no_tag_fires(self) -> None:
+        findings = self._check("port_registry_no_tag")
+        assert len(findings) == 1
+        assert "no tag" in findings[0].message.lower()
+        assert "localhost:5000/foo" in findings[0].message
+
+    def test_port_registry_latest_fires(self) -> None:
+        findings = self._check("port_registry_latest")
+        assert len(findings) == 1
+        assert "latest" in findings[0].message
+
+    def test_port_registry_pinned_no_findings(self) -> None:
+        findings = self._check("port_registry_pinned")
+        assert len(findings) == 0
+
+    def test_port_registry_digest_no_findings(self) -> None:
+        findings = self._check("port_registry_digest")
+        assert len(findings) == 0
+
+    def test_port_registry_pinned_digest_no_findings(self) -> None:
+        findings = self._check("port_registry_pinned_digest")
+        assert len(findings) == 0

--- a/tests/test_CL0019.py
+++ b/tests/test_CL0019.py
@@ -74,3 +74,17 @@ class TestImageNoDigestRule:
         meta = self.rule.metadata
         assert meta.id == "CL-0019"
         assert meta.severity.value == "medium"
+
+    def test_port_registry_pinned_fires(self) -> None:
+        findings = self._check("port_registry_pinned")
+        assert len(findings) == 1
+        assert "localhost:5000/foo:v1.2.3" in findings[0].message
+
+    def test_port_registry_no_tag_no_findings(self) -> None:
+        """No tag at all is CL-0004's domain, not CL-0019."""
+        findings = self._check("port_registry_no_tag")
+        assert len(findings) == 0
+
+    def test_port_registry_digest_no_findings(self) -> None:
+        findings = self._check("port_registry_digest")
+        assert len(findings) == 0

--- a/tests/test_image_ref.py
+++ b/tests/test_image_ref.py
@@ -1,0 +1,34 @@
+"""Unit tests for the shared image-reference parser."""
+
+from __future__ import annotations
+
+import pytest
+
+from compose_lint.rules._image import split_image_ref
+
+
+@pytest.mark.parametrize(
+    ("image", "expected"),
+    [
+        # Simple cases
+        ("nginx", ("nginx", None)),
+        ("nginx:1.25", ("nginx", "1.25")),
+        ("nginx:latest", ("nginx", "latest")),
+        # Digest pinning — name strips digest, tag preserved or None
+        ("nginx@sha256:abc", ("nginx", None)),
+        ("nginx:1.25@sha256:abc", ("nginx", "1.25")),
+        # Registry without explicit port — colon belongs to tag
+        ("ghcr.io/org/app", ("ghcr.io/org/app", None)),
+        ("ghcr.io/org/app:2.0.1", ("ghcr.io/org/app", "2.0.1")),
+        ("ghcr.io/org/app:2.0.1@sha256:abc", ("ghcr.io/org/app", "2.0.1")),
+        # Registry WITH explicit port — colon belongs to registry, not tag
+        ("localhost:5000/foo", ("localhost:5000/foo", None)),
+        ("localhost:5000/foo:v1", ("localhost:5000/foo", "v1")),
+        ("localhost:5000/foo:latest", ("localhost:5000/foo", "latest")),
+        ("localhost:5000/foo@sha256:abc", ("localhost:5000/foo", None)),
+        ("localhost:5000/foo:v1@sha256:abc", ("localhost:5000/foo", "v1")),
+        ("registry.internal:5000/foo:v1.2.3", ("registry.internal:5000/foo", "v1.2.3")),
+    ],
+)
+def test_split_image_ref(image: str, expected: tuple[str, str | None]) -> None:
+    assert split_image_ref(image) == expected


### PR DESCRIPTION
Closes #136.

## Summary

- New shared helper `split_image_ref` at `src/compose_lint/rules/_image.py`. Detects the `registry:port/name` case via the giveaway that a tag never contains `/` but `5000/foo` does. Strips trailing `@digest` first.
- CL-0004 and CL-0019 both call the helper. Fixes:
  - **CL-0004 false negative**: `localhost:5000/foo` now fires "no tag, defaults to :latest" (was silently skipped — the "5000/foo" pseudo-tag wasn't in `MUTABLE_TAGS`)
  - **CL-0019 false positive**: `localhost:5000/foo` no longer fires the misleading "pinned to a tag but not a digest" message for an image that has no tag at all
- New parametrized unit tests in `tests/test_image_ref.py` cover plain names, registries without ports, registries with ports, digest variants, and combined tag+digest refs

## Test plan

- [x] `ruff check`
- [x] `ruff format --check`
- [x] `mypy src/`
- [x] `pytest` — 332 passed
- [x] `bandit -r src/ -ll` clean