### PR TITLE
Detect SELinux label:disable in CL-0009

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CL-0009** now detects SELinux disabled via `security_opt:
+  [label:disable]`. The rule's description and references promised
+  SELinux coverage but the implementation only checked seccomp and
+  AppArmor — `label:disable` turns off SELinux type enforcement for
+  the container and was silently ignored. Description updated to
+  reflect actual coverage; messages now read "SELinux" rather than
+  "label profile". `label:user:...`, `label:type:...`, `label:role:...`
+  and `label:level:...` overrides remain unflagged since they
+  reconfigure rather than disable confinement.
 - **CL-0004** and **CL-0019** now parse OCI image references via a
   shared `split_image_ref` helper that recognizes `registry:port/name`
   prefixes. The previous naive `image.rsplit(":", 1)` mistook the

--- a/docs/rules/CL-0009.md
+++ b/docs/rules/CL-0009.md
@@ -9,18 +9,19 @@
 
 ## What it detects
 
-Any service with `seccomp:unconfined` or `apparmor:unconfined` in `security_opt`.
+Any service with `seccomp:unconfined`, `apparmor:unconfined`, or `label:disable` in `security_opt`.
 
-This rule only flags *explicitly disabled* profiles. Services that omit `security_opt` entirely are not flagged — Docker applies default profiles automatically. Custom profiles (e.g., `seccomp:custom.json`) are also not flagged.
+This rule only flags *explicitly disabled* profiles. Services that omit `security_opt` entirely are not flagged — the host applies default profiles automatically. Custom profiles (e.g., `seccomp:custom.json`) and SELinux label overrides that don't disable confinement (e.g., `label:user:system_u`) are also not flagged.
 
 ## Why it matters
 
-Docker applies security profiles by default:
+Linux distributions apply security profiles by default:
 
 - **seccomp**: Blocks ~44 dangerous syscalls including `mount`, `reboot`, `kexec_load`, and `bpf`. Disabling it gives the container unrestricted syscall access.
 - **AppArmor**: Restricts file access, network operations, and capability usage beyond what capabilities alone enforce. Disabling it removes mandatory access controls.
+- **SELinux**: On RHEL-family hosts, applies type enforcement via labels that confine what files and processes a container can access. `label:disable` turns off SELinux confinement for the container.
 
-Explicitly setting these to `unconfined` is an intentional weakening of container isolation that should only be done with strong justification.
+Explicitly disabling any of these is an intentional weakening of container isolation that should only be done with strong justification.
 
 ## Fix
 

--- a/src/compose_lint/rules/CL0009_security_profile.py
+++ b/src/compose_lint/rules/CL0009_security_profile.py
@@ -24,6 +24,19 @@ CIS_APPARMOR_REF = (
 _DISABLED_PROFILES = {
     "seccomp:unconfined",
     "apparmor:unconfined",
+    "label:disable",
+}
+
+_PROFILE_DISPLAY_NAME = {
+    "seccomp": "seccomp",
+    "apparmor": "AppArmor",
+    "label": "SELinux",
+}
+
+_PROFILE_REMOVAL = {
+    "seccomp": "syscall filtering",
+    "apparmor": "mandatory access controls",
+    "label": "SELinux labeling and confinement",
 }
 
 
@@ -37,9 +50,9 @@ class SecurityProfileRule(BaseRule):
             id="CL-0009",
             name="Security profile disabled",
             description=(
-                "Explicitly disabling seccomp or AppArmor removes syscall "
-                "filtering and mandatory access controls that limit what a "
-                "compromised container can do."
+                "Explicitly disabling seccomp, AppArmor, or SELinux removes "
+                "syscall filtering, mandatory access controls, and labeling "
+                "that limit what a compromised container can do."
             ),
             severity=Severity.HIGH,
             references=[OWASP_REF, CIS_SECCOMP_REF, CIS_APPARMOR_REF],
@@ -58,26 +71,24 @@ class SecurityProfileRule(BaseRule):
 
         for opt in security_opt:
             opt_str = str(opt).strip().lower()
-            if opt_str in _DISABLED_PROFILES:
-                profile_type = opt_str.split(":")[0]
-                removal = (
-                    "syscall filtering"
-                    if profile_type == "seccomp"
-                    else "mandatory access controls"
-                )
-                yield Finding(
-                    rule_id="CL-0009",
-                    severity=Severity.HIGH,
-                    service=service_name,
-                    message=(
-                        f"Service disables {profile_type} profile "
-                        f"('{opt_str}'). This removes {removal} "
-                        "that limit what a compromised container can do."
-                    ),
-                    line=lines.get(f"services.{service_name}.security_opt"),
-                    fix=(
-                        f"Remove '{opt_str}' from security_opt. Docker applies "
-                        f"a default {profile_type} profile automatically."
-                    ),
-                    references=[OWASP_REF, CIS_SECCOMP_REF, CIS_APPARMOR_REF],
-                )
+            if opt_str not in _DISABLED_PROFILES:
+                continue
+            profile_key = opt_str.split(":", 1)[0]
+            profile_name = _PROFILE_DISPLAY_NAME[profile_key]
+            removal = _PROFILE_REMOVAL[profile_key]
+            yield Finding(
+                rule_id="CL-0009",
+                severity=Severity.HIGH,
+                service=service_name,
+                message=(
+                    f"Service disables {profile_name} "
+                    f"('{opt_str}'). This removes {removal} "
+                    "that limit what a compromised container can do."
+                ),
+                line=lines.get(f"services.{service_name}.security_opt"),
+                fix=(
+                    f"Remove '{opt_str}' from security_opt. The host applies "
+                    f"a default {profile_name} policy automatically."
+                ),
+                references=[OWASP_REF, CIS_SECCOMP_REF, CIS_APPARMOR_REF],
+            )

--- a/tests/compose_files/insecure_security_profile.yml
+++ b/tests/compose_files/insecure_security_profile.yml
@@ -22,3 +22,17 @@ services:
       - no-new-privileges:true
   no_security_opt:
     image: nginx:1.27-alpine
+  selinux_disabled:
+    image: nginx:1.27-alpine
+    security_opt:
+      - label:disable
+  all_three_disabled:
+    image: nginx:1.27-alpine
+    security_opt:
+      - seccomp:unconfined
+      - apparmor:unconfined
+      - label:disable
+  selinux_label_user:
+    image: nginx:1.27-alpine
+    security_opt:
+      - label:user:system_u

--- a/tests/test_CL0009.py
+++ b/tests/test_CL0009.py
@@ -122,3 +122,43 @@ class TestSecurityProfileRule:
         assert meta.id == "CL-0009"
         assert meta.severity.value == "high"
         assert len(meta.references) > 0
+
+    def test_detects_selinux_label_disable(self) -> None:
+        data, lines = load_compose(FIXTURES / "insecure_security_profile.yml")
+        findings = list(
+            self.rule.check(
+                "selinux_disabled",
+                data["services"]["selinux_disabled"],
+                data,
+                lines,
+            )
+        )
+        assert len(findings) == 1
+        assert findings[0].rule_id == "CL-0009"
+        assert "SELinux" in findings[0].message
+        assert "label:disable" in findings[0].message
+
+    def test_detects_all_three_profiles(self) -> None:
+        data, lines = load_compose(FIXTURES / "insecure_security_profile.yml")
+        findings = list(
+            self.rule.check(
+                "all_three_disabled",
+                data["services"]["all_three_disabled"],
+                data,
+                lines,
+            )
+        )
+        assert len(findings) == 3
+
+    def test_selinux_label_user_no_finding(self) -> None:
+        """label:user:... is a label override, not a disable — don't fire."""
+        data, lines = load_compose(FIXTURES / "insecure_security_profile.yml")
+        findings = list(
+            self.rule.check(
+                "selinux_label_user",
+                data["services"]["selinux_label_user"],
+                data,
+                lines,
+            )
+        )
+        assert len(findings) == 0


### PR DESCRIPTION
Closes #138.

## Summary

- `_DISABLED_PROFILES` extended with `label:disable`
- Message and fix-guidance derivation refactored into two small lookup tables (`_PROFILE_DISPLAY_NAME`, `_PROFILE_REMOVAL`) so the output reads "Service disables SELinux" rather than the awkward "Service disables label profile"
- Description updated to mention SELinux — matches the existing CIS 5.2 reference
- Fix guidance generalized from "Docker applies" to "the host applies" (SELinux is host-side)
- Label overrides that reconfigure rather than disable confinement (`label:user:...`, `label:type:...`, `label:role:...`, `label:level:...`) intentionally not flagged

## Test plan

- [x] `ruff check`
- [x] `ruff format --check`
- [x] `mypy src/`
- [x] `pytest` — 335 passed (12 in `test_CL0009.py`, including SELinux-disable case, all-three-profiles fixture, and a `label:user:system_u` negative case)
- [x] `bandit -r src/ -ll` clean