### PR TITLE
Memoize _collect_lines to prevent alias-fanout OOM

### DIFF
--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -111,13 +111,24 @@ def _collect_lines(data: Any, prefix: str = "") -> dict[str, int]:
     """Collect line numbers into a flat dot-notation map.
 
     Iterative traversal with an explicit work stack so pathologically-
-    nested YAML can't exhaust the interpreter's recursion limit.
+    nested YAML can't exhaust the interpreter's recursion limit. The
+    visited set keyed by id() collapses YAML anchor-shared subtrees so
+    chained aliases can't fan out into O(branching^depth) work — each
+    unique container is walked once under the first prefix that reaches
+    it. Recorded line numbers come from the container's own __lines__
+    map, which is identical no matter which alias path arrived first, so
+    rule lookups against any reachable path still resolve correctly for
+    keys directly on that container.
     """
     lines: dict[str, int] = {}
+    visited: set[int] = set()
     stack: list[tuple[Any, str]] = [(data, prefix)]
     while stack:
         current, current_prefix = stack.pop()
         if isinstance(current, dict):
+            if id(current) in visited:
+                continue
+            visited.add(id(current))
             line_map = current.get("__lines__", {})
             for key, value in current.items():
                 if key == "__lines__":
@@ -127,6 +138,9 @@ def _collect_lines(data: Any, prefix: str = "") -> dict[str, int]:
                     lines[full_key] = line_map[key]
                 stack.append((value, full_key))
         elif isinstance(current, list):
+            if id(current) in visited:
+                continue
+            visited.add(id(current))
             for i, item in enumerate(current):
                 stack.append((item, f"{current_prefix}[{i}]"))
     return lines

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -165,3 +165,37 @@ class TestDeepNestingTraversal:
         # Same stripped dict returned for both aliases.
         assert stripped["services"]["web"] is stripped["services"]["api"]
         assert "__lines__" not in stripped["services"]["web"]
+
+    def test_collect_lines_bounds_chained_alias_blowup(self) -> None:
+        # Regression for issue #154: ClusterFuzzLite found a sub-1KB Compose
+        # file where chained YAML aliases fanned out _collect_lines into
+        # O(branching^depth) traversal, growing memory past 3GB and OOMing
+        # the linter. Without the id() memoization the parsed graph below
+        # expands to >11M path entries (~1.4GB); with it, work stays linear
+        # in the number of unique nodes.
+        import time
+
+        import yaml
+
+        from compose_lint.parser import LineLoader
+
+        content = """services:
+  s: {image: foo}
+a: &a {x: 1}
+b: &b {p: *a, q: *a, r: *a, s: *a, t: *a, u: *a, v: *a, w: *a, x: *a}
+c: &c {p: *b, q: *b, r: *b, s: *b, t: *b, u: *b, v: *b, w: *b, x: *b}
+d: &d {p: *c, q: *c, r: *c, s: *c, t: *c, u: *c, v: *c, w: *c, x: *c}
+e: &e {p: *d, q: *d, r: *d, s: *d, t: *d, u: *d, v: *d, w: *d, x: *d}
+f: &f {p: *e, q: *e, r: *e, s: *e, t: *e, u: *e, v: *e, w: *e, x: *e}
+g: &g {p: *f, q: *f, r: *f, s: *f, t: *f, u: *f, v: *f, w: *f, x: *f}
+h: {p: *g, q: *g, r: *g, s: *g, t: *g, u: *g, v: *g, w: *g, x: *g}
+"""
+        raw = yaml.load(content, Loader=LineLoader)  # noqa: S506
+        start = time.perf_counter()
+        result = _collect_lines(raw)
+        elapsed = time.perf_counter() - start
+        # Pre-fix: ~35s and >11M entries on a typical CI runner.
+        assert elapsed < 1.0
+        assert len(result) < 1000
+        # The legitimate `services.s.image` lookup still resolves.
+        assert "services.s" in result


### PR DESCRIPTION
## Summary
- Closes #154 — ClusterFuzzLite batch fuzz found a sub-4KB Compose input that drove the linter's RSS past 3GB and tripped libFuzzer's OOM limit
- Root cause: `parser._collect_lines` walked the parsed YAML graph without node memoization. `_strip_lines` already memoized; `_collect_lines` did not. Chained aliases (`b: {p: *a, q: *a, ...}`, `c: {p: *b, ...}`, …) produce a DAG that fans out into O(branching^depth) path expansion, generating millions of dot-notation entries
- Fix: add an `id()`-keyed `visited` set to `_collect_lines`, mirroring `_strip_lines`. Each unique container is walked once under the first prefix that reaches it. Recorded line numbers come from the container's own `__lines__` map (identical regardless of alias path), so rule lookups against any reachable path still resolve for keys directly on that container
- Local repro: 528-byte file → before: 35s / 1.4GB; after: <1ms / 13MB

## Test plan
- [x] `ruff check src/ tests/`
- [x] `ruff format --check src/ tests/`
- [x] `mypy src/` (strict)
- [x] `pytest` (336 passed, includes new `test_collect_lines_bounds_chained_alias_blowup` regression)
- [ ] Next scheduled ClusterFuzzLite batch run does not reproduce the OOM