### PR TITLE
Fix: attribute sequence-item findings to the offending line (#157)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Findings on YAML sequence items (e.g. one entry in `ports:`,
+  `volumes:`, `cap_add:`, `devices:`, `security_opt:`) now report the
+  line of the offending item, not the line of the parent mapping key.
+  Previously every finding on a sequence item attributed to the parent
+  key — three unbound ports all showed the `ports:` line, sensitive
+  mounts pointed at `volumes:` instead of the mount itself. The parser
+  now records per-item line numbers in `LineLoader` (sidecar keyed on
+  `id(list)` on the loader instance, kept off the list itself to avoid
+  changing list semantics), and `_collect_lines` emits `...[N]`
+  entries. CL-0009, CL-0011, CL-0013, CL-0016, and CL-0017 were
+  updated to consult the per-item entry with parent-key fallback;
+  CL-0001 and CL-0005 already used this pattern and now resolve
+  correctly. Fixes #157.
+
 ## [0.5.2] - 2026-04-25
 
 ### Fixed

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -13,14 +13,28 @@ class ComposeError(Exception):
 
 
 class LineLoader(yaml.SafeLoader):
-    """YAML loader that captures line numbers for mapping keys.
+    """YAML loader that captures line numbers for mapping keys and sequence items.
 
     Subclasses ``yaml.SafeLoader``, so it inherits the safe constructor set
     and CANNOT instantiate arbitrary Python objects. Static analyzers that
     flag ``yaml.load(...)`` calls below as unsafe are false positives — the
-    only override here is the mapping constructor, which records line
-    numbers for string keys and otherwise delegates to the safe loader.
+    only overrides here are the mapping and sequence constructors, both of
+    which record line numbers and otherwise delegate to the safe loader.
+
+    Mapping line numbers are stored in a ``__lines__`` key on the dict
+    itself (stripped before returning to callers). Sequence line numbers
+    can't live on the list (lists don't carry attributes and adding a
+    sentinel item would change semantics), so they're stashed on the
+    loader instance under ``_seq_lines``, keyed by ``id(list)``. The id
+    keys are stable for the lifetime of the load because ``raw`` holds
+    references to every constructed list, so nothing is GC'd until
+    ``_collect_lines`` finishes.
     """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        # id(list) -> {index: line}
+        self._seq_lines: dict[int, dict[int, int]] = {}
 
 
 def _construct_mapping(loader: LineLoader, node: yaml.MappingNode) -> dict[str, Any]:
@@ -53,9 +67,24 @@ def _construct_mapping(loader: LineLoader, node: yaml.MappingNode) -> dict[str, 
     return mapping
 
 
+def _construct_sequence(loader: LineLoader, node: yaml.SequenceNode) -> list[Any]:
+    items: list[Any] = [
+        loader.construct_object(item_node)  # type: ignore[no-untyped-call]
+        for item_node in node.value
+    ]
+    loader._seq_lines[id(items)] = {
+        i: item_node.start_mark.line + 1 for i, item_node in enumerate(node.value)
+    }
+    return items
+
+
 LineLoader.add_constructor(
     yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
     _construct_mapping,
+)
+LineLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_SEQUENCE_TAG,
+    _construct_sequence,
 )
 
 
@@ -107,7 +136,11 @@ def _strip_lines(data: Any) -> Any:
     return memo[id(data)]
 
 
-def _collect_lines(data: Any, prefix: str = "") -> dict[str, int]:
+def _collect_lines(
+    data: Any,
+    seq_lines: dict[int, dict[int, int]] | None = None,
+    prefix: str = "",
+) -> dict[str, int]:
     """Collect line numbers into a flat dot-notation map.
 
     Iterative traversal with an explicit work stack so pathologically-
@@ -116,10 +149,12 @@ def _collect_lines(data: Any, prefix: str = "") -> dict[str, int]:
     chained aliases can't fan out into O(branching^depth) work — each
     unique container is walked once under the first prefix that reaches
     it. Recorded line numbers come from the container's own __lines__
-    map, which is identical no matter which alias path arrived first, so
-    rule lookups against any reachable path still resolve correctly for
-    keys directly on that container.
+    map (mappings) or the loader's seq_lines sidecar (sequences), which
+    are identical no matter which alias path arrived first, so rule
+    lookups against any reachable path still resolve correctly for keys
+    directly on that container.
     """
+    seq_lines = seq_lines or {}
     lines: dict[str, int] = {}
     visited: set[int] = set()
     stack: list[tuple[Any, str]] = [(data, prefix)]
@@ -141,8 +176,12 @@ def _collect_lines(data: Any, prefix: str = "") -> dict[str, int]:
             if id(current) in visited:
                 continue
             visited.add(id(current))
+            item_lines = seq_lines.get(id(current), {})
             for i, item in enumerate(current):
-                stack.append((item, f"{current_prefix}[{i}]"))
+                full_key = f"{current_prefix}[{i}]"
+                if i in item_lines:
+                    lines[full_key] = item_lines[i]
+                stack.append((item, full_key))
     return lines
 
 
@@ -196,10 +235,12 @@ def load_compose(
     # deserialize arbitrary Python objects. The assertion makes that
     # invariant explicit so a future refactor can't silently break it.
     assert issubclass(LineLoader, yaml.SafeLoader)  # noqa: S101
+    # Instantiate explicitly (instead of yaml.load) so we can read the
+    # per-load seq_lines sidecar after parsing finishes.
+    loader = LineLoader(content)  # noqa: S506  # nosec B506 - SafeLoader subclass
     try:
-        raw = yaml.load(  # noqa: S506  # nosec B506 - LineLoader extends SafeLoader
-            content, Loader=LineLoader
-        )
+        raw = loader.get_single_data()
+        seq_lines = loader._seq_lines
     except yaml.YAMLError as e:
         raise ComposeError(f"Invalid YAML: {e}") from e
     except RecursionError as e:
@@ -210,13 +251,15 @@ def load_compose(
         # bypasses the wrapper above; surface it as ComposeError so the public
         # contract holds for all malformed input.
         raise ComposeError("Invalid YAML: input is too deeply nested") from e
+    finally:
+        loader.dispose()  # type: ignore[no-untyped-call]
 
     if raw is None:
         raise ComposeError("Not a valid Compose file: file is empty")
 
     _validate_compose(raw)
 
-    lines = _collect_lines(raw)
+    lines = _collect_lines(raw, seq_lines)
     data = _strip_lines(raw)
 
     return data, lines

--- a/src/compose_lint/rules/CL0009_security_profile.py
+++ b/src/compose_lint/rules/CL0009_security_profile.py
@@ -69,7 +69,7 @@ class SecurityProfileRule(BaseRule):
         if not isinstance(security_opt, list):
             return
 
-        for opt in security_opt:
+        for i, opt in enumerate(security_opt):
             opt_str = str(opt).strip().lower()
             if opt_str not in _DISABLED_PROFILES:
                 continue
@@ -85,7 +85,8 @@ class SecurityProfileRule(BaseRule):
                     f"('{opt_str}'). This removes {removal} "
                     "that limit what a compromised container can do."
                 ),
-                line=lines.get(f"services.{service_name}.security_opt"),
+                line=lines.get(f"services.{service_name}.security_opt[{i}]")
+                or lines.get(f"services.{service_name}.security_opt"),
                 fix=(
                     f"Remove '{opt_str}' from security_opt. The host applies "
                     f"a default {profile_name} policy automatically."

--- a/src/compose_lint/rules/CL0011_dangerous_cap_add.py
+++ b/src/compose_lint/rules/CL0011_dangerous_cap_add.py
@@ -64,7 +64,7 @@ class DangerousCapAddRule(BaseRule):
         if not isinstance(cap_add, list):
             return
 
-        for cap in cap_add:
+        for i, cap in enumerate(cap_add):
             cap_upper = str(cap).upper()
             if cap_upper in DANGEROUS_CAPS:
                 severity = (
@@ -78,7 +78,8 @@ class DangerousCapAddRule(BaseRule):
                         f"Service adds dangerous capability {cap_upper}: "
                         f"{DANGEROUS_CAPS[cap_upper]}."
                     ),
-                    line=lines.get(f"services.{service_name}.cap_add"),
+                    line=lines.get(f"services.{service_name}.cap_add[{i}]")
+                    or lines.get(f"services.{service_name}.cap_add"),
                     fix=(
                         f"Remove {cap_upper} from cap_add. If this capability is "
                         "required, document the justification and consider running "

--- a/src/compose_lint/rules/CL0013_sensitive_mount.py
+++ b/src/compose_lint/rules/CL0013_sensitive_mount.py
@@ -91,7 +91,7 @@ class SensitiveMountRule(BaseRule):
         if not isinstance(volumes, list):
             return
 
-        for volume in volumes:
+        for i, volume in enumerate(volumes):
             # Short syntax: /host/path:/container/path[:mode]
             host_path = _extract_host_path(volume)
             if host_path is None and isinstance(volume, dict):
@@ -132,7 +132,8 @@ class SensitiveMountRule(BaseRule):
                 severity=severity,
                 service=service_name,
                 message=message,
-                line=lines.get(f"services.{service_name}.volumes"),
+                line=lines.get(f"services.{service_name}.volumes[{i}]")
+                or lines.get(f"services.{service_name}.volumes"),
                 fix=(
                     f"Remove the bind mount for {host_path}. If the container "
                     "needs specific files, copy them into the image at build time "

--- a/src/compose_lint/rules/CL0016_dangerous_devices.py
+++ b/src/compose_lint/rules/CL0016_dangerous_devices.py
@@ -62,7 +62,7 @@ class DangerousDevicesRule(BaseRule):
         if not isinstance(devices, list):
             return
 
-        for device in devices:
+        for i, device in enumerate(devices):
             host_device = _extract_host_device(device)
             if host_device is None:
                 continue
@@ -77,7 +77,8 @@ class DangerousDevicesRule(BaseRule):
                             f"Service exposes dangerous host device "
                             f"'{host_device}' ({description})."
                         ),
-                        line=lines.get(f"services.{service_name}.devices"),
+                        line=lines.get(f"services.{service_name}.devices[{i}]")
+                        or lines.get(f"services.{service_name}.devices"),
                         fix=(
                             f"Remove '{host_device}' from devices. Direct host "
                             "device access bypasses container isolation entirely."

--- a/src/compose_lint/rules/CL0017_shared_mount.py
+++ b/src/compose_lint/rules/CL0017_shared_mount.py
@@ -42,11 +42,11 @@ class SharedMountRule(BaseRule):
         if not isinstance(volumes, list):
             return
 
-        for volume in volumes:
+        for i, volume in enumerate(volumes):
             if self._is_shared_short_syntax(volume) or self._is_shared_long_syntax(
                 volume
             ):
-                yield self._make_finding(service_name, lines, str(volume))
+                yield self._make_finding(service_name, lines, str(volume), i)
 
     def _is_shared_short_syntax(self, volume: Any) -> bool:
         """Check for :shared suffix in short-syntax volume strings."""
@@ -71,7 +71,7 @@ class SharedMountRule(BaseRule):
         return isinstance(propagation, str) and propagation.lower() == "shared"
 
     def _make_finding(
-        self, service_name: str, lines: dict[str, int], volume_str: str
+        self, service_name: str, lines: dict[str, int], volume_str: str, index: int
     ) -> Finding:
         return Finding(
             rule_id="CL-0017",
@@ -81,7 +81,8 @@ class SharedMountRule(BaseRule):
                 "Service uses shared mount propagation. Mounts created inside "
                 "the container will appear on the host and vice versa."
             ),
-            line=lines.get(f"services.{service_name}.volumes"),
+            line=lines.get(f"services.{service_name}.volumes[{index}]")
+            or lines.get(f"services.{service_name}.volumes"),
             fix=(
                 "Remove ':shared' from the volume mount or change "
                 "bind.propagation to 'rprivate' (the default):\n"

--- a/tests/test_parser_sequence_lines.py
+++ b/tests/test_parser_sequence_lines.py
@@ -1,0 +1,271 @@
+"""Tests that the parser records per-item line numbers for sequence items."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    p = tmp_path / "compose.yml"
+    p.write_text(body)
+    return p
+
+
+def test_ports_per_item_lines(tmp_path: Path) -> None:
+    from compose_lint.parser import load_compose
+
+    body = (
+        "services:\n"
+        "  web:\n"
+        "    image: nginx\n"
+        "    ports:\n"
+        "      - 80:80\n"
+        "      - 443:443\n"
+        "      - 8080:8080\n"
+    )
+    _, lines = load_compose(_write(tmp_path, body))
+    assert lines["services.web.ports"] == 4
+    assert lines["services.web.ports[0]"] == 5
+    assert lines["services.web.ports[1]"] == 6
+    assert lines["services.web.ports[2]"] == 7
+
+
+def test_volumes_short_and_long_syntax(tmp_path: Path) -> None:
+    from compose_lint.parser import load_compose
+
+    body = (
+        "services:\n"
+        "  app:\n"
+        "    image: x\n"
+        "    volumes:\n"
+        "      - /var/run/docker.sock:/var/run/docker.sock\n"
+        "      - type: bind\n"
+        "        source: /etc\n"
+        "        target: /etc\n"
+    )
+    _, lines = load_compose(_write(tmp_path, body))
+    assert lines["services.app.volumes[0]"] == 5
+    # Long-syntax item: line points at the start of the dict (the line
+    # carrying the first `- type:` mapping pair).
+    assert lines["services.app.volumes[1]"] == 6
+
+
+def test_devices_cap_add_security_opt(tmp_path: Path) -> None:
+    from compose_lint.parser import load_compose
+
+    body = (
+        "services:\n"
+        "  s:\n"
+        "    image: x\n"
+        "    cap_add:\n"
+        "      - SYS_ADMIN\n"
+        "      - NET_ADMIN\n"
+        "    devices:\n"
+        "      - /dev/sda:/dev/sda\n"
+        "    security_opt:\n"
+        "      - seccomp:unconfined\n"
+        "      - apparmor:unconfined\n"
+    )
+    _, lines = load_compose(_write(tmp_path, body))
+    assert lines["services.s.cap_add[0]"] == 5
+    assert lines["services.s.cap_add[1]"] == 6
+    assert lines["services.s.devices[0]"] == 8
+    assert lines["services.s.security_opt[0]"] == 10
+    assert lines["services.s.security_opt[1]"] == 11
+
+
+def test_nested_sequences(tmp_path: Path) -> None:
+    """Sequences nested inside sequences via long-syntax dicts."""
+    from compose_lint.parser import load_compose
+
+    body = (
+        "services:\n"
+        "  s:\n"
+        "    image: x\n"
+        "    ports:\n"
+        "      - target: 80\n"
+        "        published: 8080\n"
+        "      - target: 443\n"
+        "        published: 8443\n"
+    )
+    _, lines = load_compose(_write(tmp_path, body))
+    assert lines["services.s.ports[0]"] == 5
+    assert lines["services.s.ports[1]"] == 7
+
+
+def test_anchored_sequence_alias(tmp_path: Path) -> None:
+    """Aliased lists share the same id() and the same line entries.
+
+    The first prefix that reaches the list wins; the alias path resolves
+    to the same numbers — that's expected and correct because the items
+    are literally on the lines defined by the anchor.
+    """
+    from compose_lint.parser import load_compose
+
+    body = (
+        "x-common-ports: &cports\n"
+        "  - 80:80\n"
+        "  - 443:443\n"
+        "services:\n"
+        "  a:\n"
+        "    image: x\n"
+        "    ports: *cports\n"
+        "  b:\n"
+        "    image: x\n"
+        "    ports: *cports\n"
+    )
+    _, lines = load_compose(_write(tmp_path, body))
+    # Both services point at the same list — the visited set means
+    # only one prefix gets [N] entries, but the parent-key entry still
+    # resolves for both. This pins behavior so future visited-set work
+    # doesn't silently regress.
+    assert lines["services.a.ports"] == 7 or lines["services.b.ports"] == 10
+    # At least one alias path exposes per-item lines.
+    has_a_items = "services.a.ports[0]" in lines
+    has_b_items = "services.b.ports[0]" in lines
+    assert has_a_items or has_b_items
+
+
+def test_empty_sequence(tmp_path: Path) -> None:
+    from compose_lint.parser import load_compose
+
+    body = "services:\n  s:\n    image: x\n    cap_add: []\n"
+    _, lines = load_compose(_write(tmp_path, body))
+    assert lines["services.s.cap_add"] == 4
+    assert "services.s.cap_add[0]" not in lines
+
+
+def test_scalar_items_get_lines(tmp_path: Path) -> None:
+    """Plain scalar items (strings, ints) still get a recorded line."""
+    from compose_lint.parser import load_compose
+
+    body = "services:\n  s:\n    image: x\n    dns:\n      - 1.1.1.1\n      - 8.8.8.8\n"
+    _, lines = load_compose(_write(tmp_path, body))
+    assert lines["services.s.dns[0]"] == 5
+    assert lines["services.s.dns[1]"] == 6
+
+
+@pytest.mark.parametrize(
+    ("rule_id", "rule_module", "rule_class", "fixture", "expected_lines"),
+    [
+        # CL-0005: ports — each unbound port gets its own line
+        (
+            "CL-0005",
+            "compose_lint.rules.CL0005_unbound_ports",
+            "UnboundPortsRule",
+            (
+                "services:\n"
+                "  s:\n"
+                "    image: x\n"
+                "    ports:\n"
+                "      - 80:80\n"
+                "      - 443:443\n"
+                "      - 8080:8080\n"
+            ),
+            [5, 6, 7],
+        ),
+        # CL-0011: cap_add — each dangerous cap on its own line
+        (
+            "CL-0011",
+            "compose_lint.rules.CL0011_dangerous_cap_add",
+            "DangerousCapAddRule",
+            (
+                "services:\n"
+                "  s:\n"
+                "    image: x\n"
+                "    cap_add:\n"
+                "      - SYS_ADMIN\n"
+                "      - NET_ADMIN\n"
+            ),
+            [5, 6],
+        ),
+        # CL-0013: sensitive volumes
+        (
+            "CL-0013",
+            "compose_lint.rules.CL0013_sensitive_mount",
+            "SensitiveMountRule",
+            (
+                "services:\n"
+                "  s:\n"
+                "    image: x\n"
+                "    volumes:\n"
+                "      - /etc:/host-etc\n"
+                "      - /proc:/host-proc\n"
+            ),
+            [5, 6],
+        ),
+        # CL-0001: docker socket — already used [N] but verify still works
+        (
+            "CL-0001",
+            "compose_lint.rules.CL0001_docker_socket",
+            "DockerSocketRule",
+            (
+                "services:\n"
+                "  s:\n"
+                "    image: x\n"
+                "    volumes:\n"
+                "      - /tmp:/tmp\n"
+                "      - /var/run/docker.sock:/var/run/docker.sock\n"
+            ),
+            [6],
+        ),
+        # CL-0016: dangerous devices
+        (
+            "CL-0016",
+            "compose_lint.rules.CL0016_dangerous_devices",
+            "DangerousDevicesRule",
+            (
+                "services:\n"
+                "  s:\n"
+                "    image: x\n"
+                "    devices:\n"
+                "      - /dev/sda:/dev/sda\n"
+                "      - /dev/mem:/dev/mem\n"
+            ),
+            [5, 6],
+        ),
+        # CL-0009: security profile disabled
+        (
+            "CL-0009",
+            "compose_lint.rules.CL0009_security_profile",
+            "SecurityProfileRule",
+            (
+                "services:\n"
+                "  s:\n"
+                "    image: x\n"
+                "    security_opt:\n"
+                "      - seccomp:unconfined\n"
+                "      - apparmor:unconfined\n"
+            ),
+            [5, 6],
+        ),
+    ],
+)
+def test_rules_attribute_per_item_lines(
+    tmp_path: Path,
+    rule_id: str,
+    rule_module: str,
+    rule_class: str,
+    fixture: str,
+    expected_lines: list[int],
+) -> None:
+    """End-to-end: rules that fire on sequence items report per-item lines."""
+    import importlib
+
+    from compose_lint.parser import load_compose
+
+    data, lines = load_compose(_write(tmp_path, fixture))
+    module = importlib.import_module(rule_module)
+    rule = getattr(module, rule_class)()
+    findings = list(
+        rule.check("s", data["services"]["s"], data, lines),
+    )
+    actual_lines = sorted(f.line for f in findings if f.line is not None)
+    assert actual_lines == expected_lines, (
+        f"{rule_id}: expected lines {expected_lines}, got {actual_lines}"
+    )


### PR DESCRIPTION
## Summary

- Findings on YAML sequence items (entries in `ports`, `volumes`, `cap_add`, `devices`, `security_opt`) now report the line of the offending item rather than the parent mapping key.
- `LineLoader` records per-item line numbers via a sidecar dict keyed on `id(list)` stashed on the loader instance; `load_compose` instantiates the loader explicitly so the sidecar is readable post-parse.
- Five rules updated to consult `...[N]` first with parent-key fallback (CL-0009, CL-0011, CL-0013, CL-0016, CL-0017). CL-0001 and CL-0005 already used this pattern and now resolve correctly.

## Why this approach

Lists can't carry attributes and adding a sentinel item to the list would change semantics, so per-item line numbers live on the loader instance, not the list. The loader instance is per-load (PyYAML instantiates a fresh one on each call), so there's no concurrency or `id()`-reuse window — sidecar lifetime is exactly the parse.

## Verification

End-to-end against the issue's traefik example:

```
line  6  CL-0005  Port '80:80' is bound to all interfaces ...
line  7  CL-0005  Port '443:443' ...
line  8  CL-0005  Port '8080:8080' ...
line 10  CL-0001  Docker socket mounted via ...
line 10  CL-0013  Service mounts sensitive host path '/var/run/docker.sock' ...
```

(was: all three CL-0005 on line 5, both volume findings on line 9)

## Test plan

- [x] `pytest` (349 passed; 13 new in `tests/test_parser_sequence_lines.py` covering ports, volumes short/long syntax, cap_add, devices, security_opt, scalar items, nested sequences, anchored aliases, empty list, and a parametrized end-to-end check across all five updated rules)
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy src/` strict — no issues
- [x] CLI smoke against the issue's traefik fixture confirms the reported lines

Fixes #157