### PR TITLE
Skip Compose v1 and fragments instead of failing (closes #155)

### DIFF
--- a/docs/adr/013-missing-services-key.md
+++ b/docs/adr/013-missing-services-key.md
@@ -1,0 +1,146 @@
+# ADR-013: Handling Compose Files Without a Top-Level `services:` Key
+
+**Status:** Accepted
+
+**Context:** Running compose-lint 0.5.2 over a 1,554-file real-world corpus
+from public GitHub repos showed that **18% of files (286 / 1,554)** failed
+with `Not a valid Compose file: missing 'services' key` and exited 2. Those
+files fall into two broadly recognisable buckets that a sweep-mode user
+(`compose-lint **/*.yml`, pre-commit, CI lint over a monorepo) does not
+care about:
+
+1. **Compose v1 files** — services declared at the top level, no
+   `services:` wrapper. Docker
+   [retired Compose v1 in 2023](https://www.docker.com/blog/new-docker-compose-v2-and-v1-deprecation/#compose-v-1-so-long-and-farewell-old-friend),
+   but plenty of v1 files are still in the wild.
+2. **Fragments / overrides** — partial files designed to be merged via
+   `extends:` or layered with `-f override.yml`. Top-level `volumes:`,
+   `networks:`, `version:`, or `x-*` blocks only.
+
+The status-quo behaviour conflated both of these with genuinely malformed
+input, made directory sweeps noisy, and — combined with multi-file
+fail-fast (issue #158) — silently dropped findings on later files in argv.
+Issue #155 enumerated four options for the policy. This ADR records the
+chosen one.
+
+**Decision:** Adopt **Option D** from #155: distinguish "not a v2/v3
+Compose file" from "broken Compose file" at the parser layer, and route
+the not-applicable case to a per-file skip with **exit 0**. Genuinely
+malformed input continues to **exit 2**.
+
+Concretely:
+
+- `parser.ComposeNotApplicableError` is introduced as a `ComposeError`
+  subtype. Existing callers that catch `ComposeError` continue to handle
+  the new case (no breakage); callers that want to special-case "skip"
+  catch the subtype.
+- `_validate_compose` invokes `_classify_missing_services(data)` when
+  `services:` is absent, returning either the new subtype (skip) or the
+  existing `ComposeError` (hard fail).
+- The CLI catches `ComposeNotApplicableError` per file, prints a
+  `<filepath>: Skipped: …` line to stderr, and `continue`s. The file is
+  not counted as a failure for exit-code purposes.
+
+**Heuristic for classifying a missing-`services:` file:**
+
+```text
+non_meta = top-level keys, excluding `__lines__`, fragment-skeleton keys
+           {version, name, volumes, networks, configs, secrets, include},
+           and anything starting with `x-`
+
+if non_meta is empty                                  → fragment skip
+elif every non_meta value is a mapping containing
+     at least one key from the v1 service-marker set  → v1 skip
+else                                                  → hard error
+                                                        ("missing 'services' key")
+```
+
+The v1 service-marker set is the set of v1-schema keys that strongly
+identify a top-level mapping value as a service definition (`image`,
+`build`, `command`, `entrypoint`, `ports`, `volumes`, `environment`,
+`env_file`, `depends_on`, `container_name`, `restart`, `links`, `expose`,
+`working_dir`, `user`, `cap_add`, `cap_drop`, `privileged`, `read_only`,
+`devices`, `security_opt`, `network_mode`, `networks`, `extends`).
+
+**Skip messages:**
+
+- Fragment: `Skipped: file appears to be a Compose fragment (no 'services:'
+  key; only top-level structural keys present). Fragments are typically
+  merged via 'extends:' or '-f' overlays and have no services to lint on
+  their own.`
+- v1: `Skipped: file appears to be Compose v1 (services declared at the
+  top level, no 'services:' wrapper). Docker retired Compose v1 in 2023;
+  compose-lint targets v2/v3. Migrate the file under a top-level
+  'services:' key to enable linting.`
+
+**Alternatives rejected:**
+
+- **Option A — status quo (hard-fail every missing-`services:` file).**
+  Loses 18% of real-world inputs in sweep mode. Conflates v1 and fragments
+  with malformed input under one error message users read as "your file is
+  broken."
+- **Option B — soft-skip everything as an info-level finding (exit 0).**
+  Hides genuinely broken files behind a low-severity finding. CI gates
+  scanning for non-zero exit codes wouldn't notice a malformed compose
+  that happens to drop `services:`.
+- **Option C — auto-detect v1 and lint it as if it were v2.** Recovers
+  more signal (v1 files do have hardening issues to flag), but commits
+  compose-lint to maintaining a v1-to-v2 shim for a format Docker has
+  retired. Adds a heuristic that will silently mis-lint borderline cases.
+  Worth revisiting only if users explicitly ask for v1 support; until
+  then, "skip with a clear migration message" is the right default.
+- **Lumping v1 and fragments under one skip message.** The v1 case has
+  remediation guidance (migrate under `services:`); the fragment case
+  does not. Two messages cost a few extra lines and pay off in clarity.
+
+**Rationale:**
+
+- Sweep-mode UX. `compose-lint **/*.yml` over a monorepo no longer
+  exits 2 on the first v1 file or `-f` overlay it encounters. This is
+  the workflow the corpus run exposed as broken.
+- Honest semantics. Exit 2 keeps meaning "the linter could not run on
+  this input"; exit 0 + skip means "the linter ran, this file is outside
+  scope, nothing to report." Distinct outcomes get distinct exit codes.
+  A single-file invocation against a v1 file exits 0 with a clear stderr
+  message — the file isn't broken, the linter just doesn't apply.
+- Defence-in-depth against masking real bugs. The "hard error" branch is
+  preserved for the unrecognised case (top-level mapping with non-meta
+  keys whose values aren't service-shaped). A user with a typo'd
+  `srvices:` still gets exit 2.
+- Public API stability. `ComposeNotApplicableError` subclasses
+  `ComposeError`, so library callers that already do
+  `except ComposeError` keep their behaviour; only callers that *want*
+  to discriminate need the new type.
+
+**Interaction with other work:**
+
+- **ADR-006 (exit codes)** is unchanged. Exit 2 still means "usage /
+  file errors"; this ADR carves out a subset that exits 0 because the
+  file isn't actually a usage error.
+- **#158 (multi-file fail-fast for `ComposeError`)** is independent. The
+  new skip path uses `continue`; the existing hard-fail path still calls
+  `sys.exit(2)`. When #158 lands, both paths will collect into the same
+  per-file outcome bookkeeping and the exit-code policy will be revisited
+  end-to-end.
+- **#156 (grouped text output)** will eventually want a "skipped files"
+  count in the aggregate footer. Out of scope here; the per-file stderr
+  line is enough signal until #156 lands.
+
+**Implementation notes (non-binding):**
+
+- `parser.py` exposes `_TOP_LEVEL_FRAGMENT_KEYS` and `_V1_SERVICE_MARKERS`
+  as module-private frozensets so the heuristic can be tuned in one
+  place.
+- Fixtures live alongside the existing invalid-Compose files in
+  `tests/compose_files/`: `fragment_volumes_only.yml` and
+  `legacy_v1_compose.yml`. The pre-existing `invalid_no_services.yml`
+  was repurposed to cover the unrecognised-shape branch (no `services:`,
+  no fragment-skeleton keys, no v1-shaped values).
+- The heuristic is intentionally narrow on the fragment side: a top-level
+  mapping with `version: "3"` and a single `volumes:` block is a
+  fragment; a top-level mapping with `mystery_key: 5` is not. False
+  positives on fragment detection silently lose findings, so the
+  whitelist of "what counts as fragment scaffolding" stays small and
+  obvious. The v1 side is broader because v1 files have visibly
+  service-shaped top-level values, which gives a cleaner positive
+  signal.

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -23,7 +23,7 @@ from compose_lint.formatters.text import (
 )
 from compose_lint.formatters.text import format_findings as format_text
 from compose_lint.models import Finding, Severity
-from compose_lint.parser import ComposeError, load_compose
+from compose_lint.parser import ComposeError, ComposeNotApplicableError, load_compose
 
 
 def _severity_type(value: str) -> Severity:
@@ -178,6 +178,13 @@ def main(argv: list[str] | None = None) -> NoReturn:
         except FileNotFoundError:
             print(f"Error: file not found: {filepath}", file=sys.stderr)
             sys.exit(2)
+        except ComposeNotApplicableError as e:
+            # v1 / fragment file: not malformed, just outside what we lint.
+            # Per ADR-013 this is exit 0 (skipped, not a parse error).
+            # Multi-file fail-fast for genuine ComposeError remains as-is
+            # pending #158.
+            print(f"{filepath}: {e}", file=sys.stderr)
+            continue
         except ComposeError as e:
             print(f"Error: {e}", file=sys.stderr)
             sys.exit(2)

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -12,6 +12,97 @@ class ComposeError(Exception):
     """Raised when a file is not a valid Docker Compose file."""
 
 
+class ComposeNotApplicableError(ComposeError):
+    """Raised when a file parses as YAML but is not a v2/v3 Compose file.
+
+    Covers Compose v1 files (services declared at top level, no `services:`
+    wrapper; Docker retired Compose v1 in 2023) and structural fragments
+    (e.g. files holding only `volumes:`, `networks:`, or `x-*` blocks for
+    use with `extends:` or `-f` overlays). The CLI maps this to a per-file
+    skip with exit 0, distinct from malformed input which still exits 2.
+    See ADR-013.
+    """
+
+
+# Keys that v2/v3 Compose places at the top level alongside `services:`.
+# A file containing only these (plus any `x-*` extension keys) is treated
+# as a structural fragment when `services:` is absent.
+_TOP_LEVEL_FRAGMENT_KEYS = frozenset(
+    {"version", "name", "volumes", "networks", "configs", "secrets", "include"}
+)
+
+# Keys that, when present in a top-level mapping value, identify that
+# value as a service definition. Drawn from the v1 Compose schema:
+# https://docs.docker.com/reference/compose-file/legacy-versions/. Used
+# only for v1 detection — v2/v3 files have a `services:` wrapper and
+# never reach this check.
+_V1_SERVICE_MARKERS = frozenset(
+    {
+        "image",
+        "build",
+        "command",
+        "entrypoint",
+        "ports",
+        "volumes",
+        "environment",
+        "env_file",
+        "depends_on",
+        "container_name",
+        "restart",
+        "links",
+        "expose",
+        "working_dir",
+        "user",
+        "cap_add",
+        "cap_drop",
+        "privileged",
+        "read_only",
+        "devices",
+        "security_opt",
+        "network_mode",
+        "networks",
+        "extends",
+    }
+)
+
+
+def _classify_missing_services(data: dict[str, Any]) -> ComposeError:
+    """Decide which error subtype to raise when `services:` is absent.
+
+    Returns either a fragment/v1 ComposeNotApplicableError (file parses
+    but the linter doesn't apply) or a plain ComposeError (file shape is
+    not recognisable as Compose at all). See ADR-013 for the heuristic.
+    """
+
+    def _is_meta(k: Any) -> bool:
+        if k == "__lines__":
+            return True
+        if not isinstance(k, str):
+            return False
+        return k in _TOP_LEVEL_FRAGMENT_KEYS or k.startswith("x-")
+
+    non_meta = [k for k in data if not _is_meta(k)]
+    if not non_meta:
+        return ComposeNotApplicableError(
+            "Skipped: file appears to be a Compose fragment "
+            "(no 'services:' key; only top-level structural keys present). "
+            "Fragments are typically merged via `extends:` or `-f` overlays "
+            "and have no services to lint on their own."
+        )
+    if all(
+        isinstance(data[k], dict)
+        and any(marker in data[k] for marker in _V1_SERVICE_MARKERS)
+        for k in non_meta
+    ):
+        return ComposeNotApplicableError(
+            "Skipped: file appears to be Compose v1 "
+            "(services declared at the top level, no 'services:' wrapper). "
+            "Docker retired Compose v1 in 2023; compose-lint targets v2/v3. "
+            "Migrate the file under a top-level `services:` key to enable linting."
+        )
+    return ComposeError("Not a valid Compose file: missing 'services' key")
+
+
 class LineLoader(yaml.SafeLoader):
     """YAML loader that captures line numbers for mapping keys and sequence items.
 
@@ -193,7 +284,7 @@ def _validate_compose(data: Any) -> dict[str, Any]:
         )
 
     if "services" not in data:
-        raise ComposeError("Not a valid Compose file: missing 'services' key")
+        raise _classify_missing_services(data)
 
     services = data["services"]
     if not isinstance(services, dict):

--- a/tests/compose_files/fragment_volumes_only.yml
+++ b/tests/compose_files/fragment_volumes_only.yml
@@ -1,0 +1,3 @@
+volumes:
+  data:
+    driver: local

--- a/tests/compose_files/invalid_no_services.yml
+++ b/tests/compose_files/invalid_no_services.yml
@@ -1,3 +1,2 @@
-volumes:
-  data:
-    driver: local
+foo: 5
+bar: "not a service mapping"

--- a/tests/compose_files/legacy_v1_compose.yml
+++ b/tests/compose_files/legacy_v1_compose.yml
@@ -1,0 +1,8 @@
+web:
+  image: nginx:1.27-alpine
+  ports:
+    - "8080:80"
+db:
+  image: postgres:16-alpine
+  environment:
+    POSTGRES_PASSWORD: example

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,6 +45,36 @@ class TestCLI:
         assert result.returncode == 2
         assert "services" in result.stderr.lower()
 
+    def test_fragment_file_skipped_with_exit_zero(self) -> None:
+        # ADR-013: fragments are skipped (exit 0) with a per-file stderr note,
+        # so a directory sweep doesn't fail because someone has a `-f` overlay.
+        result = run_cli(str(FIXTURES / "fragment_volumes_only.yml"))
+        assert result.returncode == 0
+        assert "fragment" in result.stderr.lower()
+
+    def test_legacy_v1_file_skipped_with_exit_zero(self) -> None:
+        # ADR-013: v1 files are skipped (exit 0). Stderr message must mention
+        # the 2023 retirement so users know the format isn't broken — Docker
+        # just stopped supporting it.
+        result = run_cli(str(FIXTURES / "legacy_v1_compose.yml"))
+        assert result.returncode == 0
+        assert "compose v1" in result.stderr.lower()
+        assert "2023" in result.stderr
+
+    def test_skipped_file_does_not_block_subsequent_lint(self) -> None:
+        # The point of exit-0 skip: in `compose-lint a.yml b.yml c.yml`, a
+        # fragment in the middle must not hide findings from the file after it.
+        result = run_cli(
+            str(FIXTURES / "valid_basic.yml"),
+            str(FIXTURES / "fragment_volumes_only.yml"),
+            str(FIXTURES / "insecure_privileged.yml"),
+        )
+        # insecure_privileged.yml has CL-0002 at HIGH (default fail-on),
+        # so the run must reach it and exit 1.
+        assert result.returncode == 1
+        assert "CL-0002" in result.stdout
+        assert "fragment" in result.stderr.lower()
+
     def test_valid_file_no_findings(self) -> None:
         result = run_cli(str(FIXTURES / "valid_basic.yml"))
         assert result.returncode == 0

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -10,6 +10,7 @@ import pytest
 
 from compose_lint.parser import (
     ComposeError,
+    ComposeNotApplicableError,
     _collect_lines,
     _strip_lines,
     load_compose,
@@ -76,9 +77,35 @@ class TestLoadCompose:
         with pytest.raises(ComposeError, match="file is empty"):
             load_compose(FIXTURES / "invalid_empty.yml")
 
-    def test_no_services_key(self) -> None:
+    def test_no_services_key_unrecognised_shape(self) -> None:
+        # Top-level mapping with neither `services:`, fragment-shaped keys,
+        # nor v1-shaped service mappings: still a hard error per ADR-013.
         with pytest.raises(ComposeError, match="missing 'services' key"):
             load_compose(FIXTURES / "invalid_no_services.yml")
+        # Specifically NOT the not-applicable subtype.
+        with pytest.raises(ComposeError) as excinfo:
+            load_compose(FIXTURES / "invalid_no_services.yml")
+        assert not isinstance(excinfo.value, ComposeNotApplicableError)
+
+    def test_fragment_skipped_as_not_applicable(self) -> None:
+        # ADR-013: a file containing only top-level structural keys
+        # (volumes/networks/configs/secrets/x-*) is a fragment for
+        # `extends:`/`-f` overlay use; the linter doesn't apply.
+        with pytest.raises(ComposeNotApplicableError, match="Compose fragment"):
+            load_compose(FIXTURES / "fragment_volumes_only.yml")
+
+    def test_legacy_v1_skipped_as_not_applicable(self) -> None:
+        # ADR-013: services declared at the top level (no `services:` wrapper)
+        # is the v1 schema. Docker retired Compose v1 in 2023; we skip rather
+        # than fail so directory sweeps don't drop downstream files.
+        with pytest.raises(ComposeNotApplicableError, match="Compose v1"):
+            load_compose(FIXTURES / "legacy_v1_compose.yml")
+
+    def test_not_applicable_is_a_compose_error_subtype(self) -> None:
+        # Callers that catch ComposeError still see fragment/v1 errors;
+        # callers that want to special-case "skip" can catch the subtype.
+        with pytest.raises(ComposeError):
+            load_compose(FIXTURES / "fragment_volumes_only.yml")
 
     def test_services_not_mapping(self) -> None:
         with pytest.raises(ComposeError, match="'services' must be a mapping"):


### PR DESCRIPTION
## Summary
- Closes #155 — adopts Option D from the issue: distinguish "not a v2/v3 Compose file" from "broken Compose file" at the parser layer
- v1 files (services at top-level, no `services:` wrapper) and structural fragments (only `volumes:` / `networks:` / `x-*` etc.) now exit 0 with a per-file stderr skip note, instead of hard-failing the whole invocation
- Genuinely unrecognised shapes (`{foo: 5, bar: "..."}`) still exit 2
- Fixes the silent-data-loss interaction with multi-file fail-fast: a v1 file or `-f` overlay in the middle of argv no longer hides findings on every later file
- v1 message names Docker's **2023** retirement (the issue text said 2017, which was the file-format change; the actual product retirement was 2023 per [Docker's blog](https://www.docker.com/blog/new-docker-compose-v2-and-v1-deprecation/))

## What's new
- `parser.ComposeNotApplicableError` — `ComposeError` subtype so existing `except ComposeError` callers keep working; only callers that want to special-case "skip" need the new type
- `parser._classify_missing_services` — implements the heuristic: strip metadata keys (`version`/`name`/`volumes`/`networks`/`configs`/`secrets`/`include`/`x-*`), then fragment if nothing remains, v1 if every remaining value is a service-shaped mapping, else hard error
- CLI catches the new subtype, prints a `<filepath>: Skipped: …` line to stderr, and `continue`s
- ADR-013 records the policy, the rejected alternatives, and how this interacts with ADR-006 and #158

## Corpus impact
286 of 1,554 real-world files in the #155 corpus run hit the old hard-fail. After this change, those files become `exit 0 + skip` instead of `exit 2 + dropped downstream findings`.

## Out of scope
- #158 (multi-file fail-fast for genuine `ComposeError`) — still uses today's `sys.exit(2)`. Both paths will be reconciled when #158 lands; ADR-013 calls this out
- #156 (skipped-files count in the aggregate footer) — per-file stderr line is enough signal until the formatter rewrite

## Test plan
- [x] `ruff check src/ tests/`
- [x] `ruff format --check src/ tests/`
- [x] `mypy src/` (strict)
- [x] `pytest` — 342 passed (+6 new)
- [x] New tests cover: fragment skip, v1 skip with 2023 callout, unrecognised shape still hard-fails, `ComposeNotApplicableError` is a `ComposeError` subtype, skipped file does not block subsequent files in a multi-file run