### PR TITLE
Continue past parse errors in multi-file invocations (#158)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Multi-file invocations no longer fail-fast on the first parse error.
+  The CLI now records the failure, continues scanning the remaining
+  files, and exits 2 only after every input has been attempted. Per-file
+  error messages include the filepath; the text-mode aggregate footer
+  and verdict report how many files were skipped; SARIF output surfaces
+  parse failures via `runs[].invocations[].toolExecutionNotifications`
+  and sets `executionSuccessful: false`. A single-file invocation that
+  fails to parse still exits 2 with the same `Error:` line. (#158)
+
 ### Fixed
 
 - Findings on YAML sequence items (e.g. one entry in `ports:`,

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -169,6 +169,7 @@ def main(argv: list[str] | None = None) -> NoReturn:
     all_json: list[dict[str, object]] = []
     all_sarif: list[dict[str, object]] = []
     all_file_findings: list[tuple[list[Finding], str]] = []
+    parse_errors: list[tuple[str, str]] = []
     has_errors = False
     seen_services: set[str] = set()
 
@@ -176,18 +177,19 @@ def main(argv: list[str] | None = None) -> NoReturn:
         try:
             data, lines = load_compose(filepath)
         except FileNotFoundError:
-            print(f"Error: file not found: {filepath}", file=sys.stderr)
-            sys.exit(2)
+            msg = "file not found"
+            parse_errors.append((filepath, msg))
+            print(f"Error: {filepath}: {msg}", file=sys.stderr)
+            continue
         except ComposeNotApplicableError as e:
             # v1 / fragment file: not malformed, just outside what we lint.
             # Per ADR-013 this is exit 0 (skipped, not a parse error).
-            # Multi-file fail-fast for genuine ComposeError remains as-is
-            # pending #158.
             print(f"{filepath}: {e}", file=sys.stderr)
             continue
         except ComposeError as e:
-            print(f"Error: {e}", file=sys.stderr)
-            sys.exit(2)
+            parse_errors.append((filepath, str(e)))
+            print(f"Error: {filepath}: {e}", file=sys.stderr)
+            continue
 
         seen_services.update(data.get("services", {}).keys())
 
@@ -229,11 +231,13 @@ def main(argv: list[str] | None = None) -> NoReturn:
     if args.output_format == "text":
         if len(args.files) > 1:
             print()
-            print(format_aggregate_summary(all_file_findings))
-        print(format_verdict(all_file_findings, args.fail_on))
+            print(format_aggregate_summary(all_file_findings, len(parse_errors)))
+        print(format_verdict(all_file_findings, args.fail_on, len(parse_errors)))
     elif args.output_format == "json":
         print(json.dumps(all_json, indent=2))
     elif args.output_format == "sarif":
-        print(json.dumps(build_sarif_log(all_sarif), indent=2))
+        print(json.dumps(build_sarif_log(all_sarif, parse_errors), indent=2))
 
+    if parse_errors:
+        sys.exit(2)
     sys.exit(1 if has_errors else 0)

--- a/src/compose_lint/formatters/sarif.py
+++ b/src/compose_lint/formatters/sarif.py
@@ -117,9 +117,34 @@ def format_findings(
 
 def build_sarif_log(
     all_results: list[dict[str, Any]],
+    parse_errors: list[tuple[str, str]] | None = None,
 ) -> dict[str, Any]:
-    """Build a complete SARIF log object."""
+    """Build a complete SARIF log object.
+
+    parse_errors entries (filepath, message) become invocation
+    toolExecutionNotifications so SARIF consumers (GitHub code scanning)
+    can report files that were skipped during the run.
+    """
     rules, _ = _build_rules()
+
+    invocation: dict[str, Any] = {
+        "executionSuccessful": not parse_errors,
+    }
+    if parse_errors:
+        invocation["toolExecutionNotifications"] = [
+            {
+                "level": "error",
+                "message": {"text": message},
+                "locations": [
+                    {
+                        "physicalLocation": {
+                            "artifactLocation": {"uri": filepath},
+                        },
+                    },
+                ],
+            }
+            for filepath, message in parse_errors
+        ]
 
     return {
         "$schema": SARIF_SCHEMA,
@@ -134,6 +159,7 @@ def build_sarif_log(
                         "rules": rules,
                     },
                 },
+                "invocations": [invocation],
                 "results": all_results,
             },
         ],

--- a/src/compose_lint/formatters/text.py
+++ b/src/compose_lint/formatters/text.py
@@ -131,6 +131,7 @@ def format_summary(
 
 def format_aggregate_summary(
     file_findings: list[tuple[list[Finding], str]],
+    parse_error_count: int = 0,
 ) -> str:
     """Format a combined summary line across all scanned files (multi-file runs)."""
     total_files = len(file_findings)
@@ -149,28 +150,38 @@ def format_aggregate_summary(
     sep = _colorize("·", _DIM)
 
     if total_issues == 0 and suppressed_total == 0:
-        return f"{files_label}  {sep}  {_colorize('no issues found', _GREEN)}"
+        result = f"{files_label}  {sep}  {_colorize('no issues found', _GREEN)}"
+    else:
+        parts = []
+        for sev in (Severity.CRITICAL, Severity.HIGH, Severity.MEDIUM, Severity.LOW):
+            count = by_severity.get(sev.value, 0)
+            if count:
+                parts.append(_colorize(f"{count} {sev.value}", _COLORS[sev]))
 
-    parts = []
-    for sev in (Severity.CRITICAL, Severity.HIGH, Severity.MEDIUM, Severity.LOW):
-        count = by_severity.get(sev.value, 0)
-        if count:
-            parts.append(_colorize(f"{count} {sev.value}", _COLORS[sev]))
+        issue_word = "issue" if total_issues == 1 else "issues"
+        breakdown = f" ({', '.join(parts)})" if parts else ""
+        result = f"{files_label}  {sep}  {total_issues} {issue_word}{breakdown}"
+        if suppressed_total:
+            supp_text = f"{suppressed_total} suppressed (not counted)"
+            result += f"  {sep}  {_colorize(supp_text, _SUPPRESSED_COLOR)}"
 
-    issue_word = "issue" if total_issues == 1 else "issues"
-    breakdown = f" ({', '.join(parts)})" if parts else ""
-    result = f"{files_label}  {sep}  {total_issues} {issue_word}{breakdown}"
-    if suppressed_total:
-        supp_text = f"{suppressed_total} suppressed (not counted)"
-        result += f"  {sep}  {_colorize(supp_text, _SUPPRESSED_COLOR)}"
+    if parse_error_count:
+        file_word = "file" if parse_error_count == 1 else "files"
+        skip_text = f"{parse_error_count} {file_word} skipped (parse errors)"
+        result += f"  {sep}  {_colorize(skip_text, _COLORS[Severity.HIGH])}"
     return result
 
 
 def format_verdict(
     file_findings: list[tuple[list[Finding], str]],
     fail_on: Severity,
+    parse_error_count: int = 0,
 ) -> str:
-    """Return a pass/fail verdict line relative to the --fail-on threshold."""
+    """Return a pass/fail verdict line relative to the --fail-on threshold.
+
+    A non-zero parse_error_count forces the verdict to FAIL even when no
+    finding crosses the threshold — partial scans must not look clean.
+    """
     failing = sum(
         1
         for findings, _ in file_findings
@@ -179,11 +190,17 @@ def format_verdict(
     )
 
     sep = _colorize("·", _DIM)
-    if failing == 0:
+    fail_label = _colorize("✗ FAIL", _COLORS[Severity.HIGH])
+
+    parts: list[str] = []
+    if failing:
+        word = "finding" if failing == 1 else "findings"
+        parts.append(f"{failing} {word} at or above {fail_on.value}")
+    if parse_error_count:
+        file_word = "file" if parse_error_count == 1 else "files"
+        parts.append(f"{parse_error_count} {file_word} failed to parse")
+
+    if not parts:
         return f"{_colorize('✓ PASS', _GREEN)}  {sep}  threshold: {fail_on.value}"
 
-    word = "finding" if failing == 1 else "findings"
-    return (
-        f"{_colorize('✗ FAIL', _COLORS[Severity.HIGH])}  {sep}  "
-        f"{failing} {word} at or above {fail_on.value}"
-    )
+    return f"{fail_label}  {sep}  {f'  {sep}  '.join(parts)}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -148,6 +148,79 @@ class TestCLI:
         assert "--explain" in result.stderr
         assert "FILE" in result.stderr
 
+    def test_parse_error_does_not_block_subsequent_files(self, tmp_path: Path) -> None:
+        # Issue #158: a malformed file in argv must not silently mask
+        # findings on the parseable files that come after it.
+        bad = tmp_path / "bad.yml"
+        bad.write_text("services: [\n")
+        result = run_cli(
+            str(FIXTURES / "valid_basic.yml"),
+            str(bad),
+            str(FIXTURES / "insecure_privileged.yml"),
+        )
+        # CL-0002 (HIGH) from insecure_privileged must reach output.
+        assert "CL-0002" in result.stdout
+        # Parse error wins exit code.
+        assert result.returncode == 2
+        assert str(bad) in result.stderr
+
+    def test_parse_error_messages_include_filepath(self, tmp_path: Path) -> None:
+        bad = tmp_path / "broken.yml"
+        bad.write_text("services: [\n")
+        result = run_cli(str(bad))
+        assert result.returncode == 2
+        assert str(bad) in result.stderr
+
+    def test_missing_file_does_not_block_subsequent_files(self, tmp_path: Path) -> None:
+        result = run_cli(
+            "definitely-not-a-file.yml",
+            str(FIXTURES / "insecure_privileged.yml"),
+        )
+        assert result.returncode == 2
+        assert "definitely-not-a-file.yml" in result.stderr
+        assert "CL-0002" in result.stdout
+
+    def test_text_footer_reports_skipped_count(self, tmp_path: Path) -> None:
+        bad = tmp_path / "bad.yml"
+        bad.write_text("services: [\n")
+        result = run_cli(
+            str(FIXTURES / "valid_basic.yml"),
+            str(bad),
+        )
+        assert result.returncode == 2
+        assert "skipped" in result.stdout.lower()
+        assert "failed to parse" in result.stdout.lower()
+
+    def test_sarif_includes_parse_error_notifications(self, tmp_path: Path) -> None:
+        bad = tmp_path / "bad.yml"
+        bad.write_text("services: [\n")
+        result = run_cli(
+            "--format",
+            "sarif",
+            str(FIXTURES / "valid_basic.yml"),
+            str(bad),
+        )
+        assert result.returncode == 2
+        log = json.loads(result.stdout)
+        invocation = log["runs"][0]["invocations"][0]
+        assert invocation["executionSuccessful"] is False
+        notifications = invocation["toolExecutionNotifications"]
+        assert len(notifications) == 1
+        uri = notifications[0]["locations"][0]["physicalLocation"]["artifactLocation"][
+            "uri"
+        ]
+        assert uri == str(bad)
+
+    def test_sarif_clean_run_marks_execution_successful(self) -> None:
+        result = run_cli(
+            "--format",
+            "sarif",
+            str(FIXTURES / "valid_basic.yml"),
+        )
+        assert result.returncode == 0
+        log = json.loads(result.stdout)
+        assert log["runs"][0]["invocations"][0]["executionSuccessful"] is True
+
     def test_exclude_services_unknown_service_warns(self, tmp_path: Path) -> None:
         config = tmp_path / ".compose-lint.yml"
         config.write_text(


### PR DESCRIPTION
## Summary

- CLI's per-file loop now records parse failures and continues instead of `sys.exit(2)`-ing on the first one. A monorepo sweep no longer silently masks findings on every file after a single broken or unrelated YAML.
- Per-file `Error:` lines now include the filepath; text-mode aggregate footer reports `K file(s) skipped (parse errors)`; verdict reads `✗ FAIL · ... · K files failed to parse` so a partial scan never looks clean.
- SARIF output emits `runs[].invocations[].toolExecutionNotifications` for each parse failure and sets `executionSuccessful: false` — the slot GitHub code scanning reads for run-level errors.
- Exit codes: any parse failure → 2 (preserves today's contract for single-file invocations); else 1 if findings cross `--fail-on`, else 0.
- v1/fragment skip (ADR-013) is unchanged — `ComposeNotApplicableError` already continued the loop and is not a parse error.

## Verification

End-to-end against the issue's reproduction (`good.yml`, `bad.yml`, `good.yml`):

```
Error: /tmp/bad.yml: Invalid YAML: ...
... findings for both good.yml files ...
2 files scanned  ·  8 issues (8 medium)  ·  1 file skipped (parse errors)
✗ FAIL  ·  1 file failed to parse
exit=2
```

Old behaviour: third `good.yml` was silently skipped, exit 2 with no findings shown.

## Test plan

- [x] `pytest` (361 passed; 6 new in `tests/test_cli.py` covering: parse error doesn't block subsequent files, missing file doesn't block, filepath in error message, text footer reports skipped count, SARIF includes `toolExecutionNotifications` + `executionSuccessful: false`, clean SARIF run sets `executionSuccessful: true`)
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy src/` strict — no issues
- [x] CLI smoke against the issue's repro confirms the new behaviour

Fixes #158