### PR TITLE
Group text output by service; document rule categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `-v` / `--verbose` flag for the text formatter. Default text output now
+  prints the fix block and reference URL only on the first occurrence of
+  each rule id within a file; subsequent occurrences carry
+  `(see fix above)` instead. `-v` restores today's per-finding fix
+  repetition for IDE tooling or local fix-it-now workflows. JSON and
+  SARIF output are unaffected. (#156)
+
 ### Changed
 
+- Text formatter groups findings by service under a per-file header.
+  Presence rules (e.g. CL-0001, CL-0002, CL-0005, CL-0019) render a
+  one-line source excerpt under the finding so the offending value is
+  visible inline. Pure-absence rules (CL-0003/4/6/7) skip the excerpt —
+  the violation is the absence — and rely on the fix block to show the
+  remediation. (#156)
+- `docs/severity.md` now distinguishes "absence" rules (fire when a
+  hardening directive is missing — high real-world hit rate) from
+  "explicit-disable" rules (fire only when a service opts into a
+  dangerous configuration — deliberately low hit rate by design). A
+  zero-hit run on an explicit-disable rule is expected, not a bug. (#159)
 - Multi-file invocations no longer fail-fast on the first parse error.
   The CLI now records the failure, continues scanning the remaining
   files, and exits 2 only after every input has been attempted. Per-file

--- a/README.md
+++ b/README.md
@@ -79,23 +79,26 @@ rules:
 running `compose-lint docker-compose.yml` produces:
 
 ```
-compose-lint 0.3.7
+compose-lint 0.5.2
 files: docker-compose.yml  ·  config: .compose-lint.yml  ·  fail-on: high
 
-docker-compose.yml:8  SUPPRESSED  CL-0001  Docker socket mounted via '/var/run/docker.sock:/var/run/docker.sock'. This gives the container full control over the Docker daemon.
-  service: traefik
-  reason: SEC-1234 approved — socket proxy planned for 2026-Q3
+docker-compose.yml
 
-docker-compose.yml:10  HIGH      CL-0005  Port '8080:80' is bound to all interfaces. Docker bypasses host firewalls (UFW/firewalld), potentially exposing this port to the public internet.
-  service: traefik
-  fix: Bind to localhost: 127.0.0.1:8080:80
-       If public access is needed, use a reverse proxy with TLS.
-  ref: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-5a---be-careful-when-mapping-container-ports-to-the-host-with-firewalls-like-ufw
+  service: traefik  (line 2)
+       8  SUPPRESSED  CL-0001  Docker socket mounted via '/var/run/docker.sock:/var/run/docker.sock'. This gives the container full control over the Docker daemon.
+          reason: SEC-1234 approved — socket proxy planned for 2026-Q3
+      10  HIGH        CL-0005  Port '8080:80' is bound to all interfaces. Docker bypasses host firewalls (UFW/firewalld), potentially exposing this port to the public internet.
+          10 │       - "8080:80"
+             │          ^^^^^^^
+          fix: Bind to localhost: 127.0.0.1:8080:80
+               If public access is needed, use a reverse proxy with TLS.
+          ref: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-5a---be-careful-when-mapping-container-ports-to-the-host-with-firewalls-like-ufw
+
 docker-compose.yml: 1 high  ·  1 suppressed (not counted)
 ✗ FAIL  ·  1 finding at or above high
 ```
 
-Exit code is `1` (one finding at or above the default `--fail-on high` threshold). Suppressed findings are shown for auditability but do not count toward the threshold.
+Exit code is `1` (one finding at or above the default `--fail-on high` threshold). Suppressed findings are shown for auditability but do not count toward the threshold. Findings are grouped by service; the fix block and reference URL print only once per rule id per file — pass `-v` / `--verbose` to repeat them on every finding.
 
 ## Rules
 

--- a/docs/severity.md
+++ b/docs/severity.md
@@ -53,6 +53,34 @@ What can the attacker reach if the misconfiguration is exploited?
 
 *CL-0004 is a supply chain risk that doesn't fit the runtime exploitation model cleanly. It is scored MEDIUM based on the combination of an unlikely-but-uncontrollable attack vector (upstream registry compromise) and a host-level blast radius.
 
+## Rule categories
+
+Rules fall into two categories with very different real-world hit rates. Both are by design — neither is a bug.
+
+### Absence rules — fire when a hardening directive is missing
+
+These rules trigger when a service does not declare a recommended hardening directive. The trigger condition is essentially `if 'foo' not in service_config: yield finding`, so they fire on the vast majority of unhardened services in the wild.
+
+- **CL-0003** — `security_opt: [no-new-privileges:true]` not set
+- **CL-0004** — `image:` not pinned to a tag
+- **CL-0006** — `cap_drop: [ALL]` not declared
+- **CL-0007** — `read_only: true` not set
+- **CL-0019** — `image:` not pinned to a digest
+
+CL-0001 (Docker socket) and CL-0002 (privileged) are technically presence-based, but the underlying patterns (mounting the socket, running privileged) are common enough that, in practice, they cluster with absence rules in frequency.
+
+### Explicit-disable rules — fire only when a service opts into a dangerous configuration
+
+These rules trigger only when a developer wrote something specifically dangerous — a config value that explicitly turns off a protection or grants unusual access. Real-world hit rates are very low (corpus testing on 1,554 real compose files showed several of these never firing). That is the design: they trade frequency for precision against deeply dangerous configurations, and a zero-hit run does not mean the rule is broken.
+
+- **CL-0012** — `pids_limit: 0` or `-1` (cgroup PID limit disabled)
+- **CL-0014** — `logging.driver: none`
+- **CL-0015** — `healthcheck.disable: true` or `test: ["NONE"]`
+- **CL-0016** — `devices:` mapping a sensitive host device (e.g. `/dev/mem`, `/dev/kmem`)
+- **CL-0017** — `volumes:` using `:rshared` (shared mount propagation)
+
+Other rules (CL-0005, CL-0008, CL-0009, CL-0010, CL-0011, CL-0013, CL-0018) are also presence-based but target patterns common enough in real compose files that they do not need this caveat.
+
 ## Overriding defaults
 
 ```yaml

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -99,6 +99,17 @@ def _build_parser() -> argparse.ArgumentParser:
         help="hide suppressed findings from output",
     )
     parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        default=False,
+        help=(
+            "in text mode, repeat the fix block and reference URL for every "
+            "finding instead of only the first occurrence per (file, rule). "
+            "No effect on JSON or SARIF output."
+        ),
+    )
+    parser.add_argument(
         "--explain",
         metavar="CL-XXXX",
         help=(
@@ -205,7 +216,7 @@ def main(argv: list[str] | None = None) -> NoReturn:
             findings = [f for f in findings if not f.suppressed]
 
         if args.output_format == "text":
-            output = format_text(findings, filepath)
+            output = format_text(findings, filepath, verbose=args.verbose)
             if output:
                 print(output)
             print(format_summary(findings, filepath))

--- a/src/compose_lint/formatters/text.py
+++ b/src/compose_lint/formatters/text.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import re
 import sys
+from pathlib import Path
 
 from compose_lint.models import Finding, Severity
 
@@ -20,6 +22,33 @@ _DIM = "\033[2m"
 
 # All active severity labels are padded to this width so finding columns align.
 _SEV_WIDTH = max(len(s.value) for s in Severity)  # len("critical") == 8
+
+# Rules whose finding identifies a specific config value the user wrote, so a
+# one-line source excerpt is rendered under the finding to show the offending
+# value inline. Pure-absence rules (CL-0003/4/6/7) have nothing to underline —
+# the violation is the absence — and are intentionally omitted. See
+# docs/severity.md "Rule categories" for the full taxonomy.
+_PRESENCE_RULES = frozenset(
+    {
+        "CL-0001",
+        "CL-0002",
+        "CL-0005",
+        "CL-0008",
+        "CL-0009",
+        "CL-0010",
+        "CL-0011",
+        "CL-0012",
+        "CL-0013",
+        "CL-0014",
+        "CL-0015",
+        "CL-0016",
+        "CL-0017",
+        "CL-0018",
+        "CL-0019",
+    }
+)
+
+_QUOTED = re.compile(r"'([^']+)'")
 
 
 def _colorize(text: str, code: str) -> str:
@@ -46,52 +75,132 @@ def format_header(
     return f"{_colorize(f'compose-lint {version}', _BOLD)}\n{params}\n"
 
 
-def format_findings(findings: list[Finding], filepath: str) -> str:
-    """Format findings as human-readable colored text."""
+def _read_source_lines(filepath: str) -> list[str] | None:
+    try:
+        return Path(filepath).read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return None
+
+
+def _excerpt(line_num: int, source_lines: list[str], message: str) -> list[str]:
+    """Render a one-line source excerpt, optionally with a caret.
+
+    Returns 1 or 2 already-colorized strings. The caret is rendered only when
+    the message contains a single-quoted substring that also appears in the
+    source line — a heuristic that hits cleanly on rules whose message names
+    the offending value (e.g. CL-0019 'postgres:9.6.9-alpine'), and falls
+    back to the bare line otherwise.
+    """
+    if line_num < 1 or line_num > len(source_lines):
+        return []
+    raw = source_lines[line_num - 1].rstrip()
+    line_label = str(line_num)
+    pad = " " * len(line_label)
+    bar = _colorize("│", _DIM)
+    out = [f"{_colorize(line_label, _DIM)} {bar} {raw}"]
+
+    match = _QUOTED.search(message)
+    if match:
+        needle = match.group(1)
+        col = raw.find(needle)
+        if col >= 0:
+            caret = " " * col + "^" * len(needle)
+            out.append(f"{pad} {bar} {_colorize(caret, _COLORS[Severity.HIGH])}")
+    return out
+
+
+def _service_sort_line(group: list[Finding]) -> int:
+    return min((f.line for f in group if f.line is not None), default=10**9)
+
+
+def format_findings(
+    findings: list[Finding],
+    filepath: str,
+    *,
+    verbose: bool = False,
+) -> str:
+    """Format findings as human-readable colored text grouped by file and service.
+
+    The fix block and reference URL are printed only on the first occurrence
+    of each rule id within a file; subsequent occurrences get a brief
+    `(see fix above)` marker. ``verbose=True`` restores per-finding fix
+    repetition for IDE tooling or local fix-it-now workflows.
+    """
     if not findings:
         return ""
 
-    lines: list[str] = []
+    source_lines = _read_source_lines(filepath)
 
+    by_service: dict[str, list[Finding]] = {}
     for f in findings:
-        if f.suppressed:
-            loc = f"{filepath}:{f.line}" if f.line else filepath
-            reason = f.suppression_reason or "disabled in .compose-lint.yml"
-            lines.append(
-                f"{_colorize(loc, _DIM)}  "
-                f"{_colorize('SUPPRESSED', _SUPPRESSED_COLOR)}  "
+        by_service.setdefault(f.service, []).append(f)
+
+    services_in_order = sorted(
+        by_service.items(), key=lambda kv: _service_sort_line(kv[1])
+    )
+
+    out: list[str] = []
+    out.append(_colorize(filepath, _BOLD))
+    out.append("")
+
+    seen_rules: set[str] = set()
+
+    for service, group in services_in_order:
+        svc_line = next((f.line for f in group if f.line is not None), None)
+        header_suffix = f"  ({_colorize('line', _DIM)} {svc_line})" if svc_line else ""
+        out.append(f"  {_colorize('service:', _DIM)} {service}{header_suffix}")
+
+        for f in group:
+            if f.suppressed:
+                reason = f.suppression_reason or "disabled in .compose-lint.yml"
+                line_label = str(f.line) if f.line else "?"
+                out.append(
+                    f"    {line_label.rjust(4)}  "
+                    f"{_colorize('SUPPRESSED', _SUPPRESSED_COLOR)}  "
+                    f"{_colorize(f.rule_id, _DIM)}  "
+                    f"{_colorize(f.message, _SUPPRESSED_COLOR)}"
+                )
+                out.append(f"          {_colorize('reason:', _DIM)} {reason}")
+                continue
+
+            severity_label = f.severity.value.upper().ljust(_SEV_WIDTH)
+            color = _COLORS.get(f.severity, "")
+            line_label = str(f.line) if f.line else "?"
+
+            already_shown = f.rule_id in seen_rules
+            show_fix = verbose or not already_shown
+            suffix = ""
+            if already_shown and not verbose and (f.fix or f.references):
+                suffix = f"   {_colorize('(see fix above)', _DIM)}"
+
+            out.append(
+                f"    {line_label.rjust(4)}  "
+                f"{_colorize(severity_label, color)}  "
                 f"{_colorize(f.rule_id, _DIM)}  "
-                f"{_colorize(f.message, _SUPPRESSED_COLOR)}"
+                f"{f.message}{suffix}"
             )
-            lines.append(f"  {_colorize('service:', _DIM)} {f.service}")
-            lines.append(f"  {_colorize('reason:', _DIM)} {reason}")
-            lines.append("")
-            continue
 
-        severity_label = f.severity.value.upper().ljust(_SEV_WIDTH)
-        color = _COLORS.get(f.severity, "")
-        loc = f"{filepath}:{f.line}" if f.line else filepath
+            if (
+                source_lines is not None
+                and f.rule_id in _PRESENCE_RULES
+                and f.line is not None
+            ):
+                for excerpt_line in _excerpt(f.line, source_lines, f.message):
+                    out.append(f"          {excerpt_line}")
 
-        lines.append(
-            f"{_colorize(loc, _BOLD)}  "
-            f"{_colorize(severity_label, color)}  "
-            f"{_colorize(f.rule_id, _DIM)}  "
-            f"{f.message}"
-        )
-        lines.append(f"  {_colorize('service:', _DIM)} {f.service}")
+            if show_fix and f.fix:
+                fix_lines = f.fix.split("\n")
+                out.append(f"          {_colorize('fix:', _DIM)} {fix_lines[0]}")
+                for fix_line in fix_lines[1:]:
+                    out.append(f"               {fix_line}")
+            if show_fix and f.references:
+                out.append(f"          {_colorize('ref:', _DIM)} {f.references[0]}")
 
-        if f.fix:
-            fix_lines = f.fix.split("\n")
-            lines.append(f"  {_colorize('fix:', _DIM)} {fix_lines[0]}")
-            for fix_line in fix_lines[1:]:
-                lines.append(f"       {fix_line}")
+            seen_rules.add(f.rule_id)
 
-        if f.references:
-            lines.append(f"  {_colorize('ref:', _DIM)} {f.references[0]}")
+        out.append("")
 
-        lines.append("")
-
-    return "\n".join(lines).rstrip()
+    return "\n".join(out).rstrip()
 
 
 def format_summary(
@@ -133,7 +242,12 @@ def format_aggregate_summary(
     file_findings: list[tuple[list[Finding], str]],
     parse_error_count: int = 0,
 ) -> str:
-    """Format a combined summary line across all scanned files (multi-file runs)."""
+    """Format a combined summary line across all scanned files (multi-file runs).
+
+    ``parse_error_count`` is the number of input files that could not be
+    parsed; surfaced inline as ``N skipped (failed to parse)`` so multi-file
+    runs make skipped files visible in the same place as the totals.
+    """
     total_files = len(file_findings)
     by_severity: dict[str, int] = {}
     suppressed_total = 0
@@ -149,26 +263,28 @@ def format_aggregate_summary(
     files_label = _colorize(f"{total_files} files scanned", _BOLD)
     sep = _colorize("·", _DIM)
 
-    if total_issues == 0 and suppressed_total == 0:
-        result = f"{files_label}  {sep}  {_colorize('no issues found', _GREEN)}"
-    else:
-        parts = []
-        for sev in (Severity.CRITICAL, Severity.HIGH, Severity.MEDIUM, Severity.LOW):
-            count = by_severity.get(sev.value, 0)
-            if count:
-                parts.append(_colorize(f"{count} {sev.value}", _COLORS[sev]))
-
-        issue_word = "issue" if total_issues == 1 else "issues"
-        breakdown = f" ({', '.join(parts)})" if parts else ""
-        result = f"{files_label}  {sep}  {total_issues} {issue_word}{breakdown}"
-        if suppressed_total:
-            supp_text = f"{suppressed_total} suppressed (not counted)"
-            result += f"  {sep}  {_colorize(supp_text, _SUPPRESSED_COLOR)}"
-
+    skipped_suffix = ""
     if parse_error_count:
-        file_word = "file" if parse_error_count == 1 else "files"
-        skip_text = f"{parse_error_count} {file_word} skipped (parse errors)"
-        result += f"  {sep}  {_colorize(skip_text, _COLORS[Severity.HIGH])}"
+        skipped_text = f"{parse_error_count} skipped (failed to parse)"
+        skipped_suffix = f"  {sep}  {_colorize(skipped_text, _COLORS[Severity.HIGH])}"
+
+    if total_issues == 0 and suppressed_total == 0:
+        body = _colorize("no issues found", _GREEN)
+        return f"{files_label}  {sep}  {body}{skipped_suffix}"
+
+    parts = []
+    for sev in (Severity.CRITICAL, Severity.HIGH, Severity.MEDIUM, Severity.LOW):
+        count = by_severity.get(sev.value, 0)
+        if count:
+            parts.append(_colorize(f"{count} {sev.value}", _COLORS[sev]))
+
+    issue_word = "issue" if total_issues == 1 else "issues"
+    breakdown = f" ({', '.join(parts)})" if parts else ""
+    result = f"{files_label}  {sep}  {total_issues} {issue_word}{breakdown}"
+    if suppressed_total:
+        supp_text = f"{suppressed_total} suppressed (not counted)"
+        result += f"  {sep}  {_colorize(supp_text, _SUPPRESSED_COLOR)}"
+    result += skipped_suffix
     return result
 
 
@@ -179,8 +295,8 @@ def format_verdict(
 ) -> str:
     """Return a pass/fail verdict line relative to the --fail-on threshold.
 
-    A non-zero parse_error_count forces the verdict to FAIL even when no
-    finding crosses the threshold — partial scans must not look clean.
+    A non-zero ``parse_error_count`` always forces a FAIL verdict, since the
+    CLI exits 2 in that case regardless of finding severity.
     """
     failing = sum(
         1
@@ -190,17 +306,27 @@ def format_verdict(
     )
 
     sep = _colorize("·", _DIM)
-    fail_label = _colorize("✗ FAIL", _COLORS[Severity.HIGH])
 
-    parts: list[str] = []
-    if failing:
-        word = "finding" if failing == 1 else "findings"
-        parts.append(f"{failing} {word} at or above {fail_on.value}")
     if parse_error_count:
-        file_word = "file" if parse_error_count == 1 else "files"
-        parts.append(f"{parse_error_count} {file_word} failed to parse")
+        skipped_word = "file" if parse_error_count == 1 else "files"
+        skipped_text = f"{parse_error_count} {skipped_word} skipped (failed to parse)"
+        if failing:
+            word = "finding" if failing == 1 else "findings"
+            return (
+                f"{_colorize('✗ FAIL', _COLORS[Severity.HIGH])}  {sep}  "
+                f"{failing} {word} at or above {fail_on.value}"
+                f"  {sep}  {_colorize(skipped_text, _COLORS[Severity.HIGH])}"
+            )
+        return (
+            f"{_colorize('✗ FAIL', _COLORS[Severity.HIGH])}  {sep}  "
+            f"{_colorize(skipped_text, _COLORS[Severity.HIGH])}"
+        )
 
-    if not parts:
+    if failing == 0:
         return f"{_colorize('✓ PASS', _GREEN)}  {sep}  threshold: {fail_on.value}"
 
-    return f"{fail_label}  {sep}  {f'  {sep}  '.join(parts)}"
+    word = "finding" if failing == 1 else "findings"
+    return (
+        f"{_colorize('✗ FAIL', _COLORS[Severity.HIGH])}  {sep}  "
+        f"{failing} {word} at or above {fail_on.value}"
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -148,6 +148,34 @@ class TestCLI:
         assert "--explain" in result.stderr
         assert "FILE" in result.stderr
 
+    def test_text_default_dedupes_fix_blocks_per_rule(self) -> None:
+        # Issue #156: in default text mode the fix block should print only on
+        # the first occurrence of each rule id within a file. Subsequent
+        # occurrences carry "(see fix above)" instead of repeating the block.
+        result = run_cli(str(FIXTURES / "mixed.yml"))
+        assert result.returncode == 1
+        # mixed.yml fires CL-0003 on multiple services; the prose fix line
+        # should appear exactly once.
+        assert result.stdout.count("- no-new-privileges:true") == 1
+        assert "(see fix above)" in result.stdout
+
+    def test_text_verbose_repeats_fix_blocks(self) -> None:
+        # Issue #156: -v / --verbose restores per-finding fix repetition for
+        # IDE tooling and local fix-it-now workflows.
+        default_result = run_cli(str(FIXTURES / "mixed.yml"))
+        verbose_result = run_cli("-v", str(FIXTURES / "mixed.yml"))
+        assert verbose_result.returncode == default_result.returncode
+        assert verbose_result.stdout.count("- no-new-privileges:true") > 1
+        assert "(see fix above)" not in verbose_result.stdout
+
+    def test_text_groups_findings_by_service(self) -> None:
+        # Issue #156: text output is grouped under per-service blocks rather
+        # than as a flat list. Each service in mixed.yml should have a
+        # `service: <name>` header preceding its findings.
+        result = run_cli(str(FIXTURES / "mixed.yml"))
+        for service in ("traefik", "web", "db"):
+            assert f"service: {service}" in result.stdout
+
     def test_parse_error_does_not_block_subsequent_files(self, tmp_path: Path) -> None:
         # Issue #158: a malformed file in argv must not silently mask
         # findings on the parseable files that come after it.


### PR DESCRIPTION
## Summary

- **#156** — Default text-mode output now groups findings under a per-file header → per-service blocks. The fix block + reference URL print only on the first occurrence of each rule id within a file; subsequent occurrences carry `(see fix above)`. Presence rules render a one-line source excerpt (with caret when the message contains a single-quoted substring, e.g. CL-0019 `'postgres:9.6.9-alpine'`); pure-absence rules (CL-0003/4/6/7) skip the excerpt — the violation is the absence. New `-v` / `--verbose` flag restores per-finding fix repetition for IDE tooling and local fix-it-now workflows. JSON and SARIF output, engine, rule logic, finding count, and exit codes are unchanged.
- **#159** — Adds a "Rule categories" section to `docs/severity.md` distinguishing absence rules (fire when a hardening directive is missing — high real-world hit rate) from explicit-disable rules (fire only when a service opts into a dangerous configuration — deliberately low hit rate). The taxonomy is referenced from `formatters/text.py:_PRESENCE_RULES`, which is why the two issues land together.

## Test plan

- [x] `pytest -q` — 364 passing (3 new CLI tests for dedup, verbose, and per-service grouping)
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy src/` clean
- [ ] Manual: `compose-lint tests/compose_files/mixed.yml` — verify per-service blocks, dedup of fix blocks, source excerpt with caret on CL-0019
- [ ] Manual: `compose-lint -v tests/compose_files/mixed.yml` — verify fix block repeats per finding, `(see fix above)` absent
- [ ] Manual: `compose-lint --format json tests/compose_files/mixed.yml | jq .` — verify JSON output unchanged
- [ ] Manual: `compose-lint --format sarif tests/compose_files/mixed.yml` — verify SARIF output unchanged

Closes #156
Closes #159