### PR TITLE
Triage surviving mutmut survivors to 96% kill rate

### DIFF
--- a/docs/mutation-testing.md
+++ b/docs/mutation-testing.md
@@ -36,22 +36,34 @@ At the time mutation testing was first introduced (compose-lint 0.6.0):
 - First run: **79 mutants, 53 killed (67%)**
 - After dead-branch removal and a loader test:
   **65 mutants, 54 killed (83%)**, 11 surviving
+- After triage of the 11 survivors (issue #178):
+  **53 mutants, 51 killed (96%)**, 2 surviving
 
-The 14-mutant drop and 6 extra kills came from:
+The drops and extra kills came from:
 
 - Deleting a dead defensive branch in `CL-0005 _is_wildcard_ip`
   (8 mutants no longer generated)
 - Adding `tests/test_rule_loader.py` to exercise `_load_rules`
   discovery (6 mutants killed)
+- Replacing `s.split(sep, 1)[0]` with `s.partition(sep)[0]` in
+  `_image.split_image_ref` and `CL-0018 _is_root_user` — same
+  behavior, idiom mutmut does not generate the same equivalent
+  mutants for (6 mutants no longer generated)
+- Removing the dead post-rstrip branch in `CL-0013 _is_sensitive`
+  and routing the literal-root case through the existing rstrip
+  path; trailing-slash fixture added to lock down normalisation
+  (5 mutants killed or no longer generated)
 
-The 11 remaining survivors fall into two buckets:
+The 2 remaining survivors are genuinely equivalent for our input space:
 
-- **Equivalent mutants** (6): `split(":", 1)` ≡ `split(":")`,
-  `split(":", 1)` ≡ `rsplit(":", 1)` for the valid Docker user/image
-  syntaxes our tests use. Semantically identical for our input space —
-  no test on legal input will distinguish them.
-- **Trailing-slash dead branches** in `CL-0013 _is_sensitive` (5):
-  minor cleanup opportunity in the path-normalisation logic.
+- `compose_lint.rules._image.x_split_image_ref__mutmut_5`:
+  `partition("@") → rpartition("@")`. Equivalent because OCI image
+  refs contain at most one `@` (digest separator); both partitions
+  yield the same first element.
+- `compose_lint.rules.CL0013_sensitive_mount.x__is_sensitive__mutmut_4`:
+  `rstrip("/") → rstrip("XX/XX")`. `rstrip` takes a set of chars; the
+  set `{X, /}` strips the same trailing `/` from every path we test
+  against, since no sensitive Docker host path ends in a literal `X`.
 
 ## When to run
 

--- a/src/compose_lint/rules/CL0013_sensitive_mount.py
+++ b/src/compose_lint/rules/CL0013_sensitive_mount.py
@@ -49,10 +49,8 @@ def _is_sensitive(host_path: str) -> str | None:
 
     Returns "/" for a literal root mount — the most sensitive path possible.
     """
-    if host_path == "/":
-        return "/"
     normalized = host_path.rstrip("/")
-    if normalized == "":
+    if not normalized:
         return "/"
     for sensitive in _SENSITIVE_PATHS:
         if normalized == sensitive or normalized.startswith(sensitive + "/"):

--- a/src/compose_lint/rules/CL0018_explicit_root.py
+++ b/src/compose_lint/rules/CL0018_explicit_root.py
@@ -28,7 +28,7 @@ def _is_root_user(user_str: str) -> bool:
     forms (root, 0, root:root, 0:0) all collapse to "is the user portion
     root?".
     """
-    user_part = user_str.split(":", 1)[0]
+    user_part = user_str.partition(":")[0]
     return user_part in _ROOT_USER_PARTS
 
 

--- a/src/compose_lint/rules/_image.py
+++ b/src/compose_lint/rules/_image.py
@@ -24,7 +24,7 @@ def split_image_ref(image: str) -> tuple[str, str | None]:
         localhost:5000/foo@sha256:...  -> ("localhost:5000/foo", None)
     """
     if "@" in image:
-        image = image.split("@", 1)[0]
+        image = image.partition("@")[0]
     if ":" not in image:
         return image, None
     name, _, candidate = image.rpartition(":")

--- a/tests/compose_files/insecure_sensitive_mount.yml
+++ b/tests/compose_files/insecure_sensitive_mount.yml
@@ -52,6 +52,10 @@ services:
     image: nginx:1.27-alpine
     volumes:
       - /root/.ssh:/keys:ro
+  mounts_etc_trailing_slash:
+    image: nginx:1.27-alpine
+    volumes:
+      - /etc/:/host-etc
   safe_volume:
     image: nginx:1.27-alpine
     volumes:

--- a/tests/test_CL0013.py
+++ b/tests/test_CL0013.py
@@ -90,6 +90,12 @@ class TestSensitiveMountRule:
         assert len(findings) == 1
         assert "/root/.ssh" in findings[0].message
 
+    def test_detects_etc_trailing_slash(self) -> None:
+        findings = self._check("mounts_etc_trailing_slash")
+        assert len(findings) == 1
+        assert "/etc" in findings[0].message
+        assert findings[0].severity == Severity.HIGH
+
     def test_safe_volume_no_findings(self) -> None:
         findings = self._check("safe_volume")
         assert len(findings) == 0


### PR DESCRIPTION
## Summary
- Resolves #178 — triages all 11 surviving mutants from the initial mutation-testing baseline.
- Kill rate: **65 mutants / 54 killed (83%) → 53 mutants / 51 killed (96%)**, with the 2 remaining survivors documented as genuinely equivalent for our input space.
- Removes a dead branch in `CL-0013 _is_sensitive` and refactors `split(sep, 1)[0]` → `partition(sep)[0]` in `_image.split_image_ref` and `CL-0018 _is_root_user` (same behaviour, idiom mutmut does not generate the same equivalents for).
- Adds a trailing-slash fixture/test (`mounts_etc_trailing_slash`) to lock down path normalisation.

## Test plan
- [x] `ruff check` / `ruff format --check`
- [x] `mypy src/` (strict)
- [x] `pytest` (389 passed, 1 skipped)
- [x] `scripts/snapshot.py verify` (no corpus-behaviour change)
- [x] `mutmut run` — 53 mutants, 51 killed (96%); 2 documented-equivalent survivors

Closes #178