### PR TITLE
Broaden README hero persona; fix stat headline accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 
 A security-focused linter for `docker-compose.yml` and `compose.yaml`. Catches dangerous misconfigurations before they reach production.
 
-In a scan of 1,405 public `docker-compose.yml` files on GitHub, **45% had at least one HIGH or CRITICAL security finding** — most commonly ports bound to all interfaces (43%), images deployed without a pinned digest (33%), or container capabilities never restricted (78%). compose-lint catches these in CI before they ship.
+In a scan of 1,405 public `docker-compose.yml` files on GitHub, **78% had at least one security finding** (45% HIGH or CRITICAL) — virtually all of those skip basic capability restrictions, 33% deploy images without a pinned digest, and 43% bind ports to all interfaces. compose-lint catches these in CI before they ship.
 
-Use it if you ship Compose to production, run a homelab with exposed services, or want a fast pre-merge gate on IaC. Same niche [Hadolint](https://github.com/hadolint/hadolint) occupies for Dockerfiles and [dclint](https://github.com/zavoloklom/docker-compose-linter) occupies for Compose schema and structure: zero-config, opinionated, fast, and grounded in [OWASP](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html) and [CIS](https://www.cisecurity.org/benchmark/docker) standards.
+Use it if you ship Compose to production, to ensure defense in depth in a homelab, or want a fast pre-merge gate on IaC. Same niche [Hadolint](https://github.com/hadolint/hadolint) occupies for Dockerfiles and [dclint](https://github.com/zavoloklom/docker-compose-linter) occupies for Compose schema and structure: zero-config, opinionated, fast, and grounded in [OWASP](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html) and [CIS](https://www.cisecurity.org/benchmark/docker) standards.
 
 ## Example Output
 


### PR DESCRIPTION
## Summary

Two follow-up fixes to the hero introduced in #183:

- **Persona was too narrow.** 'Use it if you ship Compose to production, run a homelab with exposed services...' implied the tool only helps stacks with internet exposure. Most rules — capability restrictions, read-only filesystems, image pinning, no privilege escalation, no Docker socket — are defense-in-depth that pays off equally for internal services, dev environments, and unreachable homelab stacks. Rephrased to 'to ensure defense in depth in a homelab'.

- **Stat headline / breakdown was severity-inconsistent.** The headline claimed '45% had at least one HIGH or CRITICAL finding' but the breakdown listed CL-0006 (78%, MEDIUM) and CL-0019 (33%, MEDIUM). A careful reader sees `78% > 45%` and gets suspicious. Lead instead with **78% had at least one security finding** (with `45% HIGH or CRITICAL` as a parenthetical) and reorder the breakdown so defense-in-depth findings come first: capabilities → digests → ports.

  Capabilities is rephrased as "virtually all of those skip basic capability restrictions" — CL-0006's 78% rate is exactly the any-finding population, so a literal `(78%)` next to it would look like a typo.

Two-line README diff.

## Test plan

- [ ] Render README on github.com — hero reads cleanly and the parenthetical doesn't break the rhythm
- [ ] Confirm the stats still match `~/.cache/compose-lint-corpus/runs/20260426T135015Z/summary.md`