### PR TITLE
Enrich anchor text on outbound links in the hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A security-focused linter for `docker-compose.yml` and `compose.yaml`. Catches d
 
 In a scan of 1,405 public `docker-compose.yml` files on GitHub, **78% had at least one security finding** (45% HIGH or CRITICAL) — virtually all of those skip basic capability restrictions, 33% deploy images without a pinned digest, and 43% bind ports to all interfaces. compose-lint catches these in CI before they ship.
 
-Use it if you ship Compose to production, to ensure defense in depth in a homelab, or want a fast pre-merge gate on IaC. Same niche [Hadolint](https://github.com/hadolint/hadolint) occupies for Dockerfiles and [dclint](https://github.com/zavoloklom/docker-compose-linter) occupies for Compose schema and structure: zero-config, opinionated, fast, and grounded in [OWASP](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html) and [CIS](https://www.cisecurity.org/benchmark/docker) standards.
+Use it if you ship Compose to production, to ensure defense in depth in a homelab, or want a fast pre-merge gate on IaC. Fits the same niche as [Hadolint, the Dockerfile linter](https://github.com/hadolint/hadolint) and [dclint, the Compose schema linter](https://github.com/zavoloklom/docker-compose-linter): zero-config, opinionated, fast, and grounded in the [OWASP Docker Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html) and [CIS Docker Benchmark](https://www.cisecurity.org/benchmark/docker).
 
 ## Example Output
 


### PR DESCRIPTION
## Summary

Tier 3 SEO follow-up to the README work. Bare anchors like \`[OWASP]\` and \`[CIS]\` don't match what searchers actually type — readers Google 'OWASP Docker Security Cheat Sheet' or 'CIS Docker Benchmark', not the bare acronyms. Pulling those phrases into the anchor text:

- Helps the linked pages rank for their canonical search terms.
- Makes compose-lint's topical neighborhood clearer to search engines (we co-occur with the right keywords).
- Reads better as prose — readers know what they're about to click.

Same move for tool anchors: \`[Hadolint, the Dockerfile linter]\` and \`[dclint, the Compose schema linter]\` put each tool's actual category next to its name. The descriptive suffixes that used to live in surrounding prose ('occupies for Dockerfiles', 'occupies for Compose schema and structure') now live inside the anchors, and the previously-awkward 'Same niche X occupies and Y occupies' becomes the cleaner 'Fits the same niche as X and Y'.

One-line README diff.

## Stacking note

Stacked on top of #184 (the persona + stat-headline fixes). Base set to \`readme-hero-tweaks\` so the diff renders cleanly. Once #184 merges, this PR's base auto-retargets to \`main\`.

## Test plan

- [ ] Render README on github.com — sentence flows naturally with the longer anchor text and doesn't wrap awkwardly
- [ ] Click each enriched anchor — confirm all four URLs still resolve to the right pages