### PR TITLE
Tighten rule docs and citations after security review

### DIFF
--- a/docs/rules/CL-0001.md
+++ b/docs/rules/CL-0001.md
@@ -8,7 +8,7 @@
 
 ## What it detects
 
-Any service mounting `/var/run/docker.sock` or any path containing `docker.sock` in its `volumes:` list, including read-only mounts (`:ro`).
+Any service whose `volumes:` list contains a path with `docker.sock` in it — including read-only mounts (`:ro`) and rootless / Podman socket variants (`$XDG_RUNTIME_DIR/docker.sock`, `podman.sock`). Detection is substring-based, so atypical paths (e.g. a named volume literally called `docker.sock`) can produce false positives; suppress with a `reason:` if so.
 
 ## Why it matters
 
@@ -18,22 +18,34 @@ Mounting the Docker socket gives a container full root-level access to the host'
 - Access data from all other containers
 - Escape to the host entirely
 
-Read-only mounts (`:ro`) do not mitigate this — the Docker API is read-write over the socket regardless of the mount flag.
+Read-only mounts (`:ro`) do not mitigate this — `:ro` only affects the inode permissions on the socket file. The Docker API is read-write over any open connection regardless of the mount flag, and `docker run --privileged` is a single API call.
+
+Rootless Docker and Podman sockets are slightly less catastrophic — escape lands you as the unprivileged daemon user, not host root — but they still grant full container-management privilege over every container that user controls. Treat them as the same severity unless you've verified the threat model.
 
 ## Fix
 
-Use a Docker socket proxy that exposes only the API endpoints your service needs:
+Use a Docker socket proxy that exposes only the API endpoints your service needs, and harden the proxy itself so it isn't the new weakest link:
 
 ```yaml
 services:
   socket-proxy:
-    image: tecnativa/docker-socket-proxy
+    image: tecnativa/docker-socket-proxy:0.3.0  # pin a version (CL-0004)
     environment:
       CONTAINERS: 1
       SERVICES: 0
       TASKS: 0
+      POST: 0          # deny mutating endpoints unless required
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    read_only: true
+    cap_drop:
+      - ALL
+    cap_add:
+      - SETUID         # haproxy entrypoint switches users
+      - SETGID
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
     networks:
       - proxy
 
@@ -43,3 +55,14 @@ services:
     networks:
       - proxy
 ```
+
+This is the fix recommended in canonical Traefik / portainer-with-proxy guides. The proxy itself still mounts the socket — that's why it must be at least as hardened as anything else holding that mount.
+
+## When to suppress
+
+- The service *is* the daemon-management tool you trust (Portainer, Watchtower) and you've accepted the blast radius. Suppress with a `reason:` naming the tool and the user/network boundary that contains it.
+
+## See also
+
+- [CL-0013](CL-0013.md) — `/var/run` host mount (parent directory of the socket)
+- [CL-0011](CL-0011.md) — `cap_add: ALL` is functionally similar in blast radius

--- a/docs/rules/CL-0002.md
+++ b/docs/rules/CL-0002.md
@@ -12,11 +12,24 @@ Any service with `privileged: true`.
 
 ## Why it matters
 
-Privileged mode disables nearly all container isolation. The container gets all Linux capabilities, access to all host devices (`/dev`), and can trivially escape to the host. It is functionally equivalent to running the process directly on the host as root.
+Privileged mode disables nearly all container isolation. The container receives every Linux capability, every host device under `/dev`, and runs without the default seccomp and AppArmor profiles. PID, mount, and network namespaces are still in place by default, but escape to host root is trivial — `mount`, `unshare`, `mknod`, and BPF are all unblocked, and well-documented one-line escapes exist (e.g. mounting the host root via `/dev/sda1`, releasing the cgroup, abusing `release_agent`).
+
+Treat `privileged: true` as **trivially escapable to host root**, not literally equivalent to running on the host — but the practical attack distance is one well-known technique away.
 
 ## Fix
 
-Remove `privileged: true` and grant only the specific capabilities your service needs:
+`privileged: true` is almost never the right tool. The legitimate use cases (Docker-in-Docker, GPU passthrough, kernel module loading) each have surgical alternatives:
+
+| Use case | Surgical alternative |
+|---------|---------------------|
+| Mount filesystems | `cap_add: SYS_ADMIN` (still dangerous; consider whether the mount can happen on the host) |
+| Specific device access | `devices: [/dev/foo]` + `device_cgroup_rules` |
+| Network configuration | `cap_add: NET_ADMIN` + `cap_add: NET_RAW` |
+| Bind privileged ports | `cap_add: NET_BIND_SERVICE` |
+| Run a debugger sidecar | `cap_add: SYS_PTRACE` (note: also allows reading any process's memory — see CL-0011) |
+| Docker-in-Docker | Prefer `sysbox-runc` or rootless DinD over `--privileged` |
+
+Replace it with a least-privilege configuration:
 
 ```yaml
 # Instead of:
@@ -26,13 +39,18 @@ privileged: true
 cap_drop:
   - ALL
 cap_add:
-  - NET_ADMIN      # if you need network configuration
-  - SYS_PTRACE     # if you need debugging/monitoring
+  - NET_ADMIN      # only what you actually need
+security_opt:
+  - no-new-privileges:true
 ```
 
-Common capability mappings:
-- Network tools: `NET_ADMIN` + `NET_RAW`
-- Monitoring: `SYS_PTRACE`
-- Binding ports below 1024: `NET_BIND_SERVICE`
+If you don't know which capabilities are needed, remove `privileged: true`, run the service, and add back only the specific capabilities the workload demands.
 
-If you don't know which capabilities are needed, remove `privileged: true`, run the service, and add back only the specific capabilities required.
+## See also
+
+- [CL-0006](CL-0006.md) — `cap_drop: [ALL]` (privileged grants all caps)
+- [CL-0009](CL-0009.md) — seccomp / AppArmor (privileged drops both default profiles)
+- [CL-0010](CL-0010.md) — host namespaces (privileged does not by itself share them, but is often combined with them)
+- [CL-0011](CL-0011.md) — `cap_add: ALL` is the cap-only subset of privileged
+
+When CL-0002 fires, expect CL-0006, CL-0009, and often CL-0010/CL-0011 to fire on the same service.

--- a/docs/rules/CL-0003.md
+++ b/docs/rules/CL-0003.md
@@ -12,7 +12,9 @@ Any service missing `no-new-privileges:true` in its `security_opt:` list.
 
 ## Why it matters
 
-Without this flag, processes inside the container can gain additional privileges via setuid or setgid binaries. An attacker who gains shell access could escalate to root even if the container was started as a non-root user.
+`no_new_privs` (kernel: `prctl(PR_SET_NO_NEW_PRIVS)`) blocks any privilege gain at `execve()` — including file capabilities (`setcap`-set xattrs on a binary) and the seccomp/LSM-bypass paths a setuid root binary can otherwise unlock. Without it, an attacker with shell access in a container started as a non-root user can pivot through any setuid binary or capability-marked binary the image ships, regaining privileges the runtime had otherwise constrained. CVE-2019-5736-style escape chains assume this gate is open.
+
+Docker bounds the capability set regardless, so a setuid root binary alone won't gain capabilities the container doesn't already have — but seccomp filters and LSM transitions are bypassable through `execve` of a setuid binary unless `no_new_privs` is set.
 
 ## Fix
 
@@ -48,5 +50,11 @@ Until per-service config overrides land ([#5](https://github.com/tmatens/compose
 
 ## Further reading
 
+- [Linux kernel docs: `no_new_privs`](https://www.kernel.org/doc/html/latest/userspace-api/no_new_privs.html)
 - [Docker capabilities and no-new-privs (raesene)](https://raesene.github.io/blog/2019/06/01/docker-capabilities-and-no-new-privs/)
 - [Docker engine security — Linux kernel capabilities](https://docs.docker.com/engine/security/#linux-kernel-capabilities)
+
+## See also
+
+- [CL-0006](CL-0006.md) — capability dropping (defense-in-depth sibling)
+- [CL-0009](CL-0009.md) — seccomp/AppArmor profiles (the LSM gate `no_new_privs` keeps closed across `execve`)

--- a/docs/rules/CL-0004.md
+++ b/docs/rules/CL-0004.md
@@ -10,6 +10,8 @@
 
 Services using mutable image tags (`latest`, `stable`, `edge`, `nightly`, `dev`, `test`) or no tag at all. Build-only services (no `image:` key) and digest-pinned images (`@sha256:...`) are skipped.
 
+The mutable-tag list is a closed enumeration of well-known aliases. Tags like `main`, `master`, `release`, `prod`, `slim`, or `alpine` are also mutable in practice but are not flagged here — distinguishing "moving target" from "stable channel" requires registry knowledge the linter does not have. CL-0019 (digest pinning) is the stronger check; treat CL-0004 as catching the obvious cases.
+
 ## Why it matters
 
 Mutable tags mean every pull can produce a different image. This breaks reproducibility, makes rollbacks impossible, and opens supply chain risk — a compromised upstream push to `latest` affects you on next deploy with no visibility into what changed.
@@ -24,10 +26,14 @@ image: nginx:latest
 image: nginx:1.27-alpine
 ```
 
-For maximum reproducibility, use digest pinning:
+For maximum reproducibility, use digest pinning (CL-0019). Tag pinning protects against accidental version churn; digest pinning additionally protects against an attacker overwriting a tag in the registry. Cosign signature verification or registry-level immutability flags add a further layer if your registry supports them.
 
 ```yaml
-image: nginx@sha256:...
+image: nginx:1.27-alpine@sha256:...
 ```
 
 Find current stable versions on Docker Hub or your registry.
+
+## See also
+
+- [CL-0019](CL-0019.md) — digest pinning (stronger guarantee against tag mutation)

--- a/docs/rules/CL-0005.md
+++ b/docs/rules/CL-0005.md
@@ -33,3 +33,17 @@ ports:
 ```
 
 If this service needs to be publicly accessible, place it behind a reverse proxy (Traefik, Caddy, nginx) that handles TLS termination, and bind only the reverse proxy's ports publicly.
+
+For systemic mitigation, configure the `DOCKER-USER` iptables chain on the host so that Docker's bypass of UFW/firewalld becomes per-rule rather than per-service. This is documented in [Docker and iptables](https://docs.docker.com/engine/network/packet-filtering-firewalls/). Per-service binding is whack-a-mole; the chain-level rule is the durable fix.
+
+### Swarm caveat
+
+`host_ip` in the long syntax is not always honored under Swarm mode — Swarm uses an ingress mesh and may publish ports on all manager nodes regardless. If you're targeting Swarm, port publishing is a Swarm concern; this rule still flags the file but treat the fix as Swarm-specific.
+
+## When to suppress
+
+- Public-facing service on a VPS where the cloud provider's firewall is the security boundary and `0.0.0.0` is intended. Suppress with a `reason:` naming the firewall layer (e.g. `reason: "GCP firewall enforces ingress; UFW disabled by design"`).
+
+## See also
+
+- [CL-0008](CL-0008.md) — `network_mode: host` (port-publish controls don't apply at all)

--- a/docs/rules/CL-0006.md
+++ b/docs/rules/CL-0006.md
@@ -14,14 +14,18 @@ Dropping only specific capabilities (e.g., `cap_drop: [NET_RAW]`) is not suffici
 
 ## Why it matters
 
-Docker containers inherit ~14 Linux capabilities by default, including:
+Docker's default capability set ([`moby/oci/caps/defaults.go`](https://github.com/moby/moby/blob/master/oci/caps/defaults.go)) historically grants 14 capabilities to every container: `AUDIT_WRITE`, `CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `FSETID`, `KILL`, `MKNOD`, `NET_BIND_SERVICE`, `NET_RAW`, `SETFCAP`, `SETGID`, `SETPCAP`, `SETUID`, `SYS_CHROOT`. The set has shifted over Docker versions (e.g., `NET_RAW` is dropped from the default by some distros / engine builds), and the upstream definition is the source of truth.
 
-- **NET_RAW** — allows ARP spoofing and packet injection on the container network
-- **SYS_CHROOT** — can be used to escape chroot jails
-- **MKNOD** — allows creating device files
-- **SETUID/SETGID** — allows changing process identity
+Highlights of what the defaults grant:
 
-Most containerized applications need none of these. Retaining them expands the attack surface for a compromised container.
+- **NET_RAW** — open raw/`AF_PACKET` sockets; enables ARP spoofing and packet injection on attached networks
+- **NET_BIND_SERVICE** — bind to privileged ports (< 1024)
+- **SETUID / SETGID** — change process UID/GID; required for `gosu`/`su-exec` user-switch entrypoints
+- **CHOWN / DAC_OVERRIDE / FOWNER / FSETID** — bypass file ownership and permission checks
+- **MKNOD** — create device nodes via `mknod(2)` (cannot create device nodes the device cgroup denies access to)
+- **SETFCAP** — set file capabilities on binaries inside the container
+
+Most containerized applications need none of these. Retaining them expands the attack surface that a compromised container can leverage in chained exploits.
 
 ## Fix
 
@@ -39,4 +43,22 @@ services:
 
 Common capabilities that specific workloads may need:
 - `NET_BIND_SERVICE` — binding to privileged ports (< 1024)
-- `CHOWN` / `DAC_OVERRIDE` / `FOWNER` / `SETUID` / `SETGID` — file ownership changes (some init systems)
+- `CHOWN` / `DAC_OVERRIDE` / `FOWNER` / `SETUID` / `SETGID` — entrypoints that switch users (`gosu`, `su-exec`) or fix volume ownership at startup (postgres, redis)
+- `NET_RAW` — `ping` / ICMP from inside the container
+
+## Compatibility
+
+`cap_drop: [ALL]` is incompatible with images whose entrypoints assume default capabilities. Common breakages:
+
+- `gosu` / `su-exec` user-switching entrypoints (postgres, redis, mysql, valkey) — need `SETUID`, `SETGID`, and usually `CHOWN` + `DAC_OVERRIDE` + `FOWNER` for volume initialization.
+- `tini` / dumb-init wrappers running as PID 1 with signal forwarding — usually fine, but check.
+- Init-style processes that fork helpers (cron, sendmail) — typically need `SETUID` + `SETGID`.
+
+### How to test
+
+Apply `cap_drop: [ALL]`, then `docker compose up`. If the container exits with `Operation not permitted` around `chown`, `setuid`, `setgid`, or `mknod`, add the relevant capability back. Capability profiles for popular images are tracked in [#4](https://github.com/tmatens/compose-lint/issues/4).
+
+## See also
+
+- [CL-0011](CL-0011.md) — dangerous capabilities added back via `cap_add`
+- [CL-0002](CL-0002.md) — `privileged: true` (functional superset of all capabilities)

--- a/docs/rules/CL-0008.md
+++ b/docs/rules/CL-0008.md
@@ -39,4 +39,18 @@ networks:
   app-network:
 ```
 
-If performance is the concern, Docker's default bridge driver adds minimal overhead for most workloads. Only specialized use cases (e.g., network monitoring tools) genuinely require host networking.
+For most workloads, Docker's default bridge driver is the right answer. There is some NAT/iptables overhead — connection-rate ceilings and a few percent of latency on small packets — but the isolation boundary is worth it. Only workloads that genuinely need to see host traffic (network monitoring, certain VPN agents, eBPF-based tools) require host networking.
+
+`network_mode: host` is also the most-extreme version of CL-0005's iptables-bypass concern: port-publish rules don't apply, so anything the container binds is on the host's interfaces directly. UFW / firewalld will not protect those bindings.
+
+## When to suppress
+
+- Network-monitoring sidecars (cAdvisor, node-exporter, Netdata) that legitimately need host-namespace visibility.
+- Userspace VPN agents that manage host routing tables.
+
+In both cases suppress with a `reason:` naming the workload, and pair with `cap_drop`, `read_only`, and `no-new-privileges` to harden whatever isolation remains.
+
+## See also
+
+- [CL-0005](CL-0005.md) — port binding (irrelevant under host networking; the container is already on the host's interfaces)
+- [CL-0010](CL-0010.md) — sibling host-namespace sharing for PID/IPC/UTS/userns

--- a/docs/rules/CL-0009.md
+++ b/docs/rules/CL-0009.md
@@ -5,21 +5,22 @@
 **References:**
 - [OWASP Docker Security Rule #6](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-6---use-linux-security-module-seccomp-apparmor-or-selinux)
 - CIS Docker Benchmark 5.21 — Do not disable default seccomp profile
-- CIS Docker Benchmark 5.2 — Verify SELinux/AppArmor profile is enabled
+- CIS Docker Benchmark 5.1 — Ensure that, if applicable, an AppArmor profile is enabled
+- CIS Docker Benchmark 5.2 — Ensure that, if applicable, SELinux security options are set
 
 ## What it detects
 
 Any service with `seccomp:unconfined`, `apparmor:unconfined`, or `label:disable` in `security_opt`.
 
-This rule only flags *explicitly disabled* profiles. Services that omit `security_opt` entirely are not flagged — the host applies default profiles automatically. Custom profiles (e.g., `seccomp:custom.json`) and SELinux label overrides that don't disable confinement (e.g., `label:user:system_u`) are also not flagged.
+This rule only flags *explicitly disabled* profiles. Services that omit `security_opt` entirely are not flagged — the host applies default profiles automatically. Custom profiles (e.g., `seccomp:custom.json`) and SELinux label overrides that don't disable confinement (e.g., `label:user:system_u`) are also not flagged. SELinux `label:type:spc_t` (super-privileged container) is functionally similar to `label:disable` but is currently out of scope for this rule — it requires SELinux-specific knowledge of type transitions to evaluate.
 
 ## Why it matters
 
 Linux distributions apply security profiles by default:
 
-- **seccomp**: Blocks ~44 dangerous syscalls including `mount`, `reboot`, `kexec_load`, and `bpf`. Disabling it gives the container unrestricted syscall access.
-- **AppArmor**: Restricts file access, network operations, and capability usage beyond what capabilities alone enforce. Disabling it removes mandatory access controls.
-- **SELinux**: On RHEL-family hosts, applies type enforcement via labels that confine what files and processes a container can access. `label:disable` turns off SELinux confinement for the container.
+- **seccomp**: Docker's default profile ([`profiles/seccomp/default.json`](https://github.com/moby/moby/blob/master/profiles/seccomp/default.json)) blocks dozens of syscalls outright (including `kexec_load`, `bpf`, `clone` with risky flags, `init_module`) and gates many more behind specific capabilities. Disabling it gives the container the kernel's full unrestricted syscall surface — a massively expanded attack surface for kernel exploits.
+- **AppArmor**: Docker's default profile (`docker-default`) restricts file paths in `/proc` and `/sys`, blocks ptrace of host processes, and deny-lists `/proc/kcore` and similar. Disabling it removes those mandatory access controls beyond what capabilities alone enforce.
+- **SELinux**: On RHEL-family hosts, applies type enforcement via labels (`container_t`) that confine what files and processes a container can access. `label:disable` turns off type-enforcement confinement for the container; the container then runs in the calling user's domain, which on a typical container host is `unconfined_t`.
 
 Explicitly disabling any of these is an intentional weakening of container isolation that should only be done with strong justification.
 
@@ -49,3 +50,13 @@ If your application requires specific syscalls blocked by the default profile, c
 security_opt:
   - seccomp:custom-seccomp.json
 ```
+
+## When to suppress
+
+- A debugger or tracer that genuinely needs `ptrace` of arbitrary syscalls — narrow to a custom profile if at all possible, and never run it on a production network.
+- Sandboxes that need to run their own seccomp profile (browsers, language runtimes) — `seccomp:unconfined` is sometimes the documented way to let the inner sandbox install its filter. Suppress only when verified.
+
+## See also
+
+- [CL-0002](CL-0002.md) — `privileged: true` (drops the default seccomp and AppArmor profiles)
+- [CL-0003](CL-0003.md) — `no-new-privileges:true` (keeps the LSM/seccomp gate closed across `execve`)

--- a/docs/rules/CL-0010.md
+++ b/docs/rules/CL-0010.md
@@ -7,7 +7,7 @@
 - CIS Docker Benchmark 5.8 — Do not share the host's process namespace
 - CIS Docker Benchmark 5.10 — Do not share the host's IPC namespace
 - CIS Docker Benchmark 5.15 — Do not share the host's user namespace
-- CIS Docker Benchmark 5.21 — Do not share the host's UTS namespace
+- CIS Docker Benchmark 5.20 — Do not share the host's UTS namespace
 
 ## What it detects
 
@@ -30,7 +30,9 @@ The container can see all processes on the host, send signals to them (including
 The container can attach to host shared memory segments, potentially reading sensitive data from other applications or injecting data into them.
 
 ### `userns_mode: host`
-Disables UID/GID remapping. A process running as root (UID 0) inside the container is also root on the host. This makes container escapes trivially exploitable.
+Disables daemon-configured user-namespace remapping for this container. **This only matters if the daemon is configured with `userns-remap`** — by default, Docker installs do not remap UIDs at all, so this directive is mostly a flag of intent on a default install. On hosts where userns-remap *is* configured, `userns_mode: host` makes container UID 0 equal to host UID 0 again (instead of the remapped UID like 100000), turning every container-escape primitive into trivial host root.
+
+Treat any explicit `userns_mode: host` as a strong signal — either the operator has remap configured and is opting out, or they have copy-pasted a config without understanding it. Both warrant a finding.
 
 ### `uts: host`
 The container shares the host's UTS namespace and can change the host's hostname via `sethostname()`. This can disrupt host identity, break TLS certificate validation, and interfere with services that rely on hostname for configuration.
@@ -55,3 +57,12 @@ services:
 ```
 
 If your application requires cross-container PID visibility (e.g., sidecar patterns), use `pid: "service:other-container"` instead of `pid: host` to limit the scope.
+
+## Out of scope
+
+Compose also accepts `cgroup: host` (cgroup-namespace sharing). This rule does not currently flag it — CIS does not benchmark it specifically and the threat model is narrower than the four namespaces above. It is still a hardening regression and may be covered in a future rule.
+
+## See also
+
+- [CL-0008](CL-0008.md) — `network_mode: host` (host network namespace)
+- [CL-0002](CL-0002.md) — `privileged: true` (often combined with these directives)

--- a/docs/rules/CL-0011.md
+++ b/docs/rules/CL-0011.md
@@ -1,30 +1,31 @@
 # CL-0011: Dangerous Capabilities Added
 
-**Severity:** HIGH
+**Severity:** HIGH (CRITICAL when `cap_add: ALL` is used)
 
 **References:**
 - [OWASP Docker Security Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3---limit-capabilities-grant-only-specific-capabilities-needed-by-a-container)
-- CIS Docker Benchmark 5.5
+- CIS Docker Benchmark 5.3 — Restrict Linux kernel capabilities within containers
 
 ## What it detects
 
 Services that add dangerous Linux capabilities via `cap_add`:
 
-| Capability | Risk |
-|-----------|------|
-| `SYS_ADMIN` | Near-root access: mount filesystems, configure namespaces, BPF |
-| `SYS_PTRACE` | Trace/inspect any process, read secrets from memory |
-| `NET_ADMIN` | Modify routing tables, firewall rules, sniff traffic |
-| `SYS_MODULE` | Load/unload kernel modules |
-| `SYS_RAWIO` | Raw I/O port access (iopl/ioperm) |
-| `SYS_TIME` | Change system clock, affecting all containers and the host |
-| `DAC_READ_SEARCH` | Bypass file read permission checks on the host |
+| Capability | Severity | Risk |
+|-----------|----------|------|
+| `ALL` | CRITICAL | Grants every Linux capability — functionally disables capability-based isolation |
+| `SYS_ADMIN` | HIGH | Near-root access: mount filesystems, configure namespaces, BPF |
+| `SYS_PTRACE` | HIGH | Trace/inspect any process, read secrets from memory |
+| `NET_ADMIN` | HIGH | Modify routing tables, firewall rules, sniff traffic |
+| `SYS_MODULE` | HIGH | Load/unload kernel modules |
+| `SYS_RAWIO` | HIGH | Raw I/O port access (iopl/ioperm) |
+| `SYS_TIME` | HIGH | Change system clock, affecting all containers and the host |
+| `DAC_READ_SEARCH` | HIGH | Bypass file read permission checks on the host |
 
-Safe capabilities like `NET_BIND_SERVICE` or `CHOWN` are not flagged.
+Safe capabilities like `NET_BIND_SERVICE` or `CHOWN` are not flagged. `BPF` (split out of `SYS_ADMIN` in Linux 5.8+) and `PERFMON` are not yet on the dangerous list. `MKNOD` and `SYS_CHROOT` are intentionally not flagged here because the `cap_drop: [ALL]` baseline (CL-0006) already covers them; adding them back is not on its own a HIGH-severity escape path.
 
 ## Why it matters
 
-Linux capabilities split root's privileges into discrete units. Adding dangerous capabilities — especially `SYS_ADMIN` — grants powers that can be chained into container escapes. `SYS_ADMIN` alone enables `mount()`, `unshare()`, and BPF operations that are well-documented escape paths.
+Linux capabilities split root's privileges into discrete units. Adding dangerous capabilities — especially `SYS_ADMIN` — grants powers that can be chained into container escapes. `SYS_ADMIN` alone enables `mount()`, `unshare()`, and BPF operations that are well-documented escape paths. `cap_add: ALL` undoes capability isolation entirely and is treated as functionally equivalent to `privileged: true` (CL-0002) for severity purposes.
 
 ## Fix
 
@@ -49,3 +50,15 @@ services:
 ```
 
 If a dangerous capability is genuinely required (e.g., `SYS_PTRACE` for a debugger sidecar), document the justification and consider running the workload outside a container.
+
+## When to suppress
+
+- `NET_ADMIN` for VPN/networking containers (Tailscale, WireGuard, OpenVPN) — required to manage the tun device and routing tables. Suppress with a `reason:` naming the network workload.
+- `SYS_PTRACE` for a debugger or profiler sidecar that you trust and that runs alongside the workload it inspects.
+
+Do not suppress `cap_add: ALL` — there is no legitimate use case for granting every capability rather than enumerating the specific ones needed.
+
+## See also
+
+- [CL-0002](CL-0002.md) — `privileged: true` (functional superset of `cap_add: ALL`)
+- [CL-0006](CL-0006.md) — `cap_drop: [ALL]` baseline (drops the defaults this rule's `cap_add` re-grants)

--- a/docs/rules/CL-0012.md
+++ b/docs/rules/CL-0012.md
@@ -7,11 +7,13 @@
 
 ## What it detects
 
-Services with `pids_limit` set to `0` or `-1`, which disables the process count limit. Services without `pids_limit` set are not flagged — this rule targets explicit opt-outs only.
+Services with `pids_limit` set to a non-positive integer (`0`, `-1`, or any negative value), which disables the process count limit. Services without `pids_limit` set are not flagged — this rule targets explicit opt-outs only.
 
 ## Why it matters
 
 Without a PIDs cgroup limit, a single container can create unlimited processes. A fork bomb inside the container will exhaust the host's process table, causing a denial of service that affects all containers and host services.
+
+Note: most Docker installations have *no* PIDs limit by default unless the daemon is configured with `--default-pids-limit`. Setting an explicit non-positive value is an active opt-out from any default that may exist, and is what this rule flags. The absence case (no `pids_limit`) is intentionally not flagged — it would be unactionable at scale and produce noise on every typical compose file.
 
 ## Fix
 

--- a/docs/rules/CL-0013.md
+++ b/docs/rules/CL-0013.md
@@ -14,12 +14,18 @@ Services that bind-mount sensitive host directories into a container:
 - `/proc` — kernel and process information
 - `/sys` — kernel device and driver interfaces
 - `/boot` — bootloader and kernel images
+- `/dev` — entire host device tree (per-device exposure is CL-0016)
 - `/root` — root user's home directory (SSH keys, shell history)
 - `/var/lib/docker` — Docker daemon state, including images and other containers
+- `/var/lib/kubelet` — Kubernetes node state, pod secrets, and service account tokens
 - `/var/run` — runtime sockets (parent of `/var/run/docker.sock`)
+- `/run/containerd` — containerd runtime sockets and state
+- `/run/systemd` — systemd D-Bus sockets; can be used to drive arbitrary unit start/stop on the host
 - `/home` — user home directories with credentials and source code
 
 Subpaths (e.g., `/etc/passwd`, `/root/.ssh`) are also flagged. Both short syntax (`/etc:/host-etc`) and long syntax (`source: /etc, target: /host-etc`) are checked. The long syntax is recognized whether `type: bind` is set explicitly or omitted — Compose treats absolute-path sources as bind mounts either way. Named volumes are not flagged.
+
+Read-only mounts (`:ro`) are not differentiated from read-write today. A read-only mount of `/etc` is materially less dangerous than a read-write mount of the same path — readable secrets only, no host modification — but still leaks shadow files, SSH host keys, and configuration. Suppress with `reason:` if your use case genuinely only reads non-sensitive subdirectories, or scope the mount narrower.
 
 ## Why it matters
 
@@ -29,9 +35,12 @@ Mounting these paths gives the container read (and potentially write) access to 
 - `/proc` exposes kernel parameters, process environments (secrets), and sysrq triggers
 - `/sys` provides direct interfaces to hardware, cgroups, and kernel modules
 - `/boot` contains the kernel and initramfs — modification enables persistent rootkits
+- `/dev` mounts the entire device tree, equivalent to many of CL-0016's individual flags
 - `/root` and `/home` typically contain SSH keys, cloud credentials, and shell history
 - `/var/lib/docker` exposes other containers' filesystems and image layers
+- `/var/lib/kubelet` exposes pod-level secrets and service account tokens on Kubernetes nodes
 - `/var/run` is the parent of the Docker socket and other privileged sockets
+- `/run/containerd` and `/run/systemd` expose runtime control sockets that drive privileged actions on the host
 
 ## Fix
 
@@ -52,3 +61,8 @@ services:
     volumes:
       - app-config:/app/config
 ```
+
+## See also
+
+- [CL-0001](CL-0001.md) — `/var/run/docker.sock` (the canonical privileged socket under `/var/run`)
+- [CL-0016](CL-0016.md) — individual dangerous host devices (per-device, where this rule covers whole `/dev`)

--- a/docs/rules/CL-0014.md
+++ b/docs/rules/CL-0014.md
@@ -3,7 +3,8 @@
 **Severity:** MEDIUM
 
 **References:**
-- CIS Docker Benchmark 5.x — Ensure container logging is configured
+- [Docker logging drivers](https://docs.docker.com/engine/logging/configure/) — `none` driver disables collection
+- [OWASP Logging Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)
 
 ## What it detects
 
@@ -11,7 +12,9 @@ Services with `logging.driver` set to `none`. Services using any other driver (e
 
 ## Why it matters
 
-Disabling the logging driver means no stdout/stderr output from the container is captured anywhere. During an incident, there is no audit trail — you cannot determine what the container did, when it was compromised, or what data was accessed. This violates the principle of non-repudiation and makes forensic analysis impossible.
+`logging.driver: none` discards the container's stdout/stderr at the daemon — `docker logs`, log shippers reading the JSON-file driver, and any centralized aggregator that relies on the runtime see nothing. Application-level logging that writes to a file or remote endpoint is unaffected, but the runtime-level forensic data source is gone. During an incident, anything the workload only emitted on stdout is lost.
+
+This is a forensic gap, not a non-repudiation guarantee — runtime logs are not authenticated or tamper-evident regardless. The cost of recovery during an investigation is the actual harm.
 
 ## Fix
 

--- a/docs/rules/CL-0015.md
+++ b/docs/rules/CL-0015.md
@@ -12,9 +12,9 @@ Services with `healthcheck.disable: true`. Services without a healthcheck config
 
 ## Why it matters
 
-When the healthcheck is explicitly disabled, the orchestrator (Docker Swarm, Compose restart policies) has no way to detect that a container is in a degraded state. A process that is running but unresponsive (deadlocked, out of memory, stuck in a crash loop without exiting) will continue to receive traffic indefinitely.
+The security angle is narrow but real: a container that is *running but compromised* — for example, an attacker has crashed the legitimate process and replaced it with a reverse shell that doesn't pass the healthcheck — looks healthy to the orchestrator without `HEALTHCHECK`. Healthchecks are a weak signal of "the workload is doing the thing it's supposed to," and disabling them removes one of the few automated tripwires that distinguishes "process is alive" from "the right process is alive." Disabling also overrides any `HEALTHCHECK` instruction in the Dockerfile, which the image author may have written specifically because of a known stuck-but-listening failure mode.
 
-Disabling a healthcheck also overrides any `HEALTHCHECK` instruction in the Dockerfile, which may have been set by the image author for good reason.
+This is the lowest-severity rule for a reason. It is more reliability than security, and a well-architected system should not depend on `HEALTHCHECK` for incident detection. It is included because the explicit-disable case is rare and worth a question.
 
 ## Fix
 

--- a/docs/rules/CL-0016.md
+++ b/docs/rules/CL-0016.md
@@ -11,20 +11,39 @@ Services that expose dangerous host devices via `devices:`:
 
 | Pattern | Risk |
 |---------|------|
-| `/dev/mem` | Raw physical memory access — read/write any address |
-| `/dev/kmem` | Kernel virtual memory — modify running kernel |
-| `/dev/port` | Raw I/O port access — direct hardware control |
+| `/dev/mem` | Raw physical memory access |
+| `/dev/kmem` | Kernel virtual memory |
+| `/dev/port` | Raw I/O port access |
 | `/dev/sd*` | SCSI/SATA block devices — raw disk read/write |
 | `/dev/nvme*` | NVMe block devices — raw disk read/write |
 | `/dev/disk/*` | Block device symlinks — same risk as raw devices |
+| `/dev/loop*` | Loop devices — mount arbitrary disk images |
+| `/dev/dm-*`, `/dev/mapper/*` | Device mapper — encrypted/LVM volumes, raw block access |
+| `/dev/zfs` | ZFS pool control — create/destroy/import any pool the host can see |
+| `/dev/rbd*` | Ceph RBD — remote block device access |
+| `/dev/raw*` | Raw character devices |
 
 Safe devices like `/dev/net/tun` or `/dev/fuse` are not flagged.
 
 ## Why it matters
 
-Exposing raw memory or block devices bypasses all container isolation. A container with access to `/dev/mem` can read any physical memory address, including kernel memory and other containers' data. Block device access enables reading and overwriting the host filesystem directly, bypassing any mount restrictions.
+Exposing raw memory or block devices bypasses all container isolation. Block device access enables reading and overwriting the host filesystem directly, regardless of mount permissions; loop and device-mapper access lets a container construct arbitrary block devices and mount them. ZFS and Ceph control devices grant pool/cluster-level operations that affect everything that runtime can see.
 
-These are equivalent to giving the container full root access to the host.
+These are equivalent to giving the container full root access to the host's storage.
+
+### Caveat on `/dev/mem` and `/dev/kmem`
+
+On modern Linux distributions (`CONFIG_STRICT_DEVMEM=y`, the default on Debian, Ubuntu, RHEL, Arch), even root can only read a small set of architecture-mapped pages from `/dev/mem`. `CONFIG_IO_STRICT_DEVMEM` further restricts that to non-busy regions. `/dev/kmem` is not built into most modern kernels at all (`CONFIG_DEVKMEM` is off).
+
+This rule still flags them — the worst-case kernel config (older or hardened-for-debugging hosts) gives full physical/virtual memory read/write, and the rule cannot inspect the host kernel from a static lint pass. Treat these findings as "this works against any kernel that allows it" and triage accordingly.
+
+## Fix
+
+Remove the dangerous device. If you need specific hardware access, prefer narrower mechanisms:
+
+- `device_cgroup_rules:` — express exactly which devices the container may access
+- A single specific device entry (e.g. `/dev/ttyUSB0`) instead of a wildcard or whole subtree
+- Kernel-level offload (e.g. user-space NVMe via SPDK) where a container shouldn't need block-device access at all
 
 ## Fix
 
@@ -47,3 +66,8 @@ services:
 ```
 
 If raw device access is genuinely required (e.g., for disk management tooling), the workload should not run in a container.
+
+## See also
+
+- [CL-0013](CL-0013.md) — bind-mounting `/dev` whole (parallel risk at the path-mount level)
+- [CL-0002](CL-0002.md) — `privileged: true` (grants every device the host has)

--- a/docs/rules/CL-0017.md
+++ b/docs/rules/CL-0017.md
@@ -3,7 +3,7 @@
 **Severity:** MEDIUM
 
 **References:**
-- CIS Docker Benchmark 5.20 — Do not share the host's mount propagation
+- CIS Docker Benchmark 5.19 — Ensure that mount propagation mode is not set to shared
 
 ## What it detects
 
@@ -63,3 +63,14 @@ services:
 ```
 
 If your workload requires mount visibility between host and container (e.g., CSI drivers), use `rslave` instead of `shared` — it allows host-to-container propagation without the reverse.
+
+`rslave` is a partial fix, not a clean one: a malicious or compromised host process can still inject mounts into the container at sensitive in-container paths, which the workload may then read or execute from. If the only reason you reach for `shared`/`rslave` is symmetric debugging, consider whether the bind mount needs propagation at all (`rprivate` is almost always correct).
+
+## When to suppress
+
+- CSI / Kubernetes node plugins that genuinely require bidirectional propagation to operate.
+- Specific Docker-in-Docker setups where the inner daemon's bind mounts need to be visible on the host. Suppress with a `reason:` naming the workload; never suppress globally.
+
+## See also
+
+- [CL-0013](CL-0013.md) — sensitive host paths (the surface a shared propagation can newly expose)

--- a/docs/rules/CL-0018.md
+++ b/docs/rules/CL-0018.md
@@ -4,7 +4,7 @@
 
 **References:**
 - [OWASP Docker Security Rule #7](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-7---do-not-use-root-user)
-- CIS Docker Benchmark 5.x — Do not run containers as root
+- [Docker security: rootless mode and userns-remap](https://docs.docker.com/engine/security/userns-remap/)
 
 ## What it detects
 
@@ -12,12 +12,22 @@ Services that explicitly set the user to root: `user: root`, `user: "0"`, `user:
 
 ## Why it matters
 
-Many images set a non-root `USER` in their Dockerfile. Explicitly overriding with `user: root` negates that protection. A container running as UID 0:
-- Has full write access to all bind-mounted host paths
-- Can exploit kernel vulnerabilities more easily (many require CAP_SYS_ADMIN or UID 0)
+Most popular Docker Hub images — including official `nginx`, `redis`, `postgres`, `mysql`, and most `*:alpine` / `*:slim` variants — start as root and switch to an unprivileged user via the entrypoint (often using `gosu` or `su-exec`). Explicitly setting `user: root` keeps the container as UID 0 for the workload itself, undoing whichever step in that chain otherwise drops privileges. A container running as UID 0:
+- Has full write access to all bind-mounted host paths (subject to the userns caveat below)
+- Can exploit kernel vulnerabilities more easily (many require `CAP_SYS_ADMIN` or UID 0)
 - Amplifies the impact of every other misconfiguration (e.g., `privileged`, `cap_add`, host mounts)
 
-This rule catches the explicit override case. It does not flag the absence of `user:` — that would be unactionable without knowing the image's intended UID.
+This rule catches the explicit override case. It does not flag the absence of `user:` — that would be unactionable without knowing the image's intended UID. Tools like Trivy and hadolint take the opposite tack and flag absence; compose-lint deliberately stays narrow to keep findings actionable.
+
+### Userns / rootless interaction
+
+If the daemon is configured with `userns-remap` or you're running rootless Docker, container UID 0 maps to a high-numbered host UID (e.g. `100000`), and bind-mount writes obey host permissions for *that* UID — not host root. Explicit `user: root` is still a finding in that case because:
+
+- Most installations do *not* configure userns-remap (it's opt-in and breaks many workloads).
+- Even with remap, UID 0 inside the container still owns most of the in-container filesystem and amplifies kernel-bug exploitability.
+- A future operator who toggles remap off (e.g. on a different host) silently inherits a more dangerous configuration.
+
+The rule fires regardless of daemon config; suppress only when you have verified the threat model on a specific host.
 
 ## Fix
 
@@ -41,3 +51,8 @@ services:
     image: myapp:1.0
     user: "1000:1000"
 ```
+
+## See also
+
+- [CL-0010](CL-0010.md) — `userns_mode: host` (disables daemon-level userns-remap, related to the caveat above)
+- [CL-0003](CL-0003.md) — `no-new-privileges:true` (limits privilege gain via `execve` regardless of starting UID)

--- a/docs/rules/CL-0019.md
+++ b/docs/rules/CL-0019.md
@@ -25,7 +25,19 @@ Docker tags are mutable pointers. A registry operator, compromised CI pipeline, 
 
 ## Fix
 
-Add a digest pin. Use `docker inspect --format='{{index .RepoDigests 0}}' <image>` to get the current digest:
+Add a digest pin. Get the current digest without pulling the full image:
+
+```bash
+# Preferred: doesn't require a full pull, returns the OCI index digest
+crane digest nginx:1.25.3
+docker buildx imagetools inspect nginx:1.25.3 --format '{{ .Manifest.Digest }}'
+
+# Or after pulling
+docker pull nginx:1.25.3 && \
+  docker inspect --format='{{index .RepoDigests 0}}' nginx:1.25.3
+```
+
+Apply it:
 
 ```yaml
 # Before
@@ -39,4 +51,17 @@ services:
     image: nginx:1.25.3@sha256:6a5af...
 ```
 
+### Pin the index digest, not a per-arch digest
+
+For multi-arch images (most official images on Docker Hub), there are two kinds of digests:
+
+- **OCI index / manifest list digest** — points to a manifest that lists per-architecture manifests. This is what `docker pull` resolves through.
+- **Per-arch manifest digest** — points to a single architecture (e.g. `linux/amd64`).
+
+Pin the **index** digest. Pinning a per-arch digest will break ARM64 (or AMD64) users who pull on the other architecture. `crane digest` and `docker buildx imagetools inspect` return the index digest by default; `docker inspect` after a pull returns whichever architecture you happened to pull. Verify with `docker manifest inspect <image>@<digest>` — the result should be a `manifest.list.v2+json` (index), not a single `manifest.v2+json`.
+
 Use [Dependabot](https://docs.github.com/en/code-security/dependabot) or [Renovate](https://docs.renovatebot.com/docker/) to automatically update digest pins when new images are published under the same tag.
+
+## See also
+
+- [CL-0004](CL-0004.md) — image not pinned to a tag (the weaker prerequisite to digest pinning)

--- a/docs/severity.md
+++ b/docs/severity.md
@@ -36,6 +36,10 @@ What can the attacker reach if the misconfiguration is exploited?
 | **Requires chaining** | HIGH | HIGH | MEDIUM |
 | **Hardening gap** | HIGH | MEDIUM | LOW |
 
+## CIS Docker Benchmark version
+
+CIS reference numbers in rule docs are pinned to **CIS Docker Benchmark v1.6.0** unless otherwise noted. Numbers shift between benchmark versions; if a citation looks wrong against your benchmark copy, check the version first.
+
 ## Current rule assignments
 
 | Rule | Exploitability | Impact | Severity |
@@ -46,12 +50,23 @@ What can the attacker reach if the misconfiguration is exploited?
 | CL-0008 (Host network) | Exposed | Host | HIGH |
 | CL-0009 (Security profile disabled) | Requires chaining | Cross-container | HIGH |
 | CL-0010 (Host namespace) | Exposed | Cross-container | HIGH |
+| CL-0011 (Dangerous capabilities added — `ALL`) | Direct | Host | CRITICAL |
+| CL-0011 (Dangerous capabilities added — others) | Requires chaining | Host | HIGH |
+| CL-0013 (Sensitive host path mounted — `/`) | Direct | Host | CRITICAL |
+| CL-0013 (Sensitive host path mounted — others) | Exposed | Host | HIGH |
+| CL-0016 (Dangerous host device exposed) | Exposed | Host | HIGH |
 | CL-0003 (No-new-privileges) | Requires chaining | Single container | MEDIUM |
 | CL-0004 (Image not pinned) | Supply chain* | Host | MEDIUM |
 | CL-0006 (No capability restrictions) | Hardening gap | Single container | MEDIUM |
 | CL-0007 (Read-only filesystem) | Hardening gap | Single container | MEDIUM |
+| CL-0012 (PIDs cgroup limit disabled) | Requires chaining | Cross-container | MEDIUM |
+| CL-0014 (Logging driver disabled) | Hardening gap | Cross-container | MEDIUM |
+| CL-0017 (Shared mount propagation) | Requires chaining | Single container | MEDIUM |
+| CL-0018 (Explicit root user) | Hardening gap | Single container | MEDIUM |
+| CL-0019 (Image tag without digest) | Supply chain* | Host | MEDIUM |
+| CL-0015 (Healthcheck disabled) | Hardening gap | Single container | LOW |
 
-*CL-0004 is a supply chain risk that doesn't fit the runtime exploitation model cleanly. It is scored MEDIUM based on the combination of an unlikely-but-uncontrollable attack vector (upstream registry compromise) and a host-level blast radius.
+*CL-0004 and CL-0019 are supply chain risks that don't fit the runtime exploitation model cleanly. They are scored MEDIUM based on the combination of an unlikely-but-uncontrollable attack vector (upstream registry compromise) and a host-level blast radius. CL-0019 is the stronger guarantee of the two; CL-0004 catches the obvious mutable-tag cases.
 
 ## Rule categories
 

--- a/src/compose_lint/rules/CL0009_security_profile.py
+++ b/src/compose_lint/rules/CL0009_security_profile.py
@@ -18,7 +18,12 @@ OWASP_REF = (
 
 CIS_SECCOMP_REF = "CIS Docker Benchmark 5.21 — Do not disable default seccomp profile"
 CIS_APPARMOR_REF = (
-    "CIS Docker Benchmark 5.2 — Verify SELinux/AppArmor profile is enabled"
+    "CIS Docker Benchmark 5.1 — Ensure that, if applicable, an AppArmor profile "
+    "is enabled"
+)
+CIS_SELINUX_REF = (
+    "CIS Docker Benchmark 5.2 — Ensure that, if applicable, SELinux security "
+    "options are set"
 )
 
 _DISABLED_PROFILES = {
@@ -55,7 +60,7 @@ class SecurityProfileRule(BaseRule):
                 "that limit what a compromised container can do."
             ),
             severity=Severity.HIGH,
-            references=[OWASP_REF, CIS_SECCOMP_REF, CIS_APPARMOR_REF],
+            references=[OWASP_REF, CIS_SECCOMP_REF, CIS_APPARMOR_REF, CIS_SELINUX_REF],
         )
 
     def check(
@@ -91,5 +96,10 @@ class SecurityProfileRule(BaseRule):
                     f"Remove '{opt_str}' from security_opt. The host applies "
                     f"a default {profile_name} policy automatically."
                 ),
-                references=[OWASP_REF, CIS_SECCOMP_REF, CIS_APPARMOR_REF],
+                references=[
+                    OWASP_REF,
+                    CIS_SECCOMP_REF,
+                    CIS_APPARMOR_REF,
+                    CIS_SELINUX_REF,
+                ],
             )

--- a/src/compose_lint/rules/CL0010_host_namespace.py
+++ b/src/compose_lint/rules/CL0010_host_namespace.py
@@ -38,7 +38,7 @@ _NAMESPACE_CHECKS: list[tuple[str, str, str, str]] = [
     (
         "uts",
         "host",
-        "CIS Docker Benchmark 5.21 — Do not share the host's UTS namespace",
+        "CIS Docker Benchmark 5.20 — Do not share the host's UTS namespace",
         "UTS namespace. The container can change the host's hostname.",
     ),
 ]
@@ -61,7 +61,7 @@ class HostNamespaceRule(BaseRule):
             severity=Severity.HIGH,
             references=[
                 OWASP_REF,
-                "CIS Docker Benchmark 5.8, 5.10, 5.15, 5.21",
+                "CIS Docker Benchmark 5.8, 5.10, 5.15, 5.20",
             ],
         )
 

--- a/src/compose_lint/rules/CL0011_dangerous_cap_add.py
+++ b/src/compose_lint/rules/CL0011_dangerous_cap_add.py
@@ -16,7 +16,9 @@ OWASP_REF = (
     "specific-capabilities-needed-by-a-container"
 )
 
-CIS_REF = "CIS Docker Benchmark 5.5 — Do not mount sensitive host system directories"
+CIS_REF = (
+    "CIS Docker Benchmark 5.3 — Restrict Linux kernel capabilities within containers"
+)
 
 DANGEROUS_CAPS: dict[str, str] = {
     "ALL": (

--- a/src/compose_lint/rules/CL0012_pids_limit.py
+++ b/src/compose_lint/rules/CL0012_pids_limit.py
@@ -23,8 +23,9 @@ class PidsLimitRule(BaseRule):
             id="CL-0012",
             name="PIDs cgroup limit disabled",
             description=(
-                "Setting pids_limit to 0 or -1 removes the process count limit, "
-                "allowing a container to fork-bomb the host."
+                "Setting pids_limit to a non-positive integer (0, -1, or any "
+                "negative value) removes the process count limit, allowing a "
+                "container to fork-bomb the host."
             ),
             severity=Severity.MEDIUM,
             references=[CIS_REF],

--- a/src/compose_lint/rules/CL0013_sensitive_mount.py
+++ b/src/compose_lint/rules/CL0013_sensitive_mount.py
@@ -24,8 +24,12 @@ _SENSITIVE_PATHS = (
     "/sys",
     "/boot",
     "/root",
+    "/dev",
     "/var/lib/docker",
+    "/var/lib/kubelet",
     "/var/run",
+    "/run/containerd",
+    "/run/systemd",
     "/home",
 )
 
@@ -69,10 +73,11 @@ class SensitiveMountRule(BaseRule):
             name="Sensitive host path mounted",
             description=(
                 "Mounting sensitive host directories like /etc, /proc, /sys, "
-                "/boot, /root, /var/lib/docker, /var/run, or /home into a "
-                "container exposes host configuration, kernel interfaces, and "
-                "credentials. Mounting the entire host root filesystem is a "
-                "one-line container escape."
+                "/boot, /dev, /root, /var/lib/docker, /var/lib/kubelet, "
+                "/var/run, /run/containerd, /run/systemd, or /home into a "
+                "container exposes host configuration, kernel interfaces, "
+                "container-runtime state, and credentials. Mounting the "
+                "entire host root filesystem is a one-line container escape."
             ),
             severity=Severity.HIGH,
             references=[OWASP_REF, CIS_REF],

--- a/src/compose_lint/rules/CL0014_logging_disabled.py
+++ b/src/compose_lint/rules/CL0014_logging_disabled.py
@@ -10,7 +10,8 @@ from compose_lint.rules import BaseRule, register_rule
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-CIS_REF = "CIS Docker Benchmark 5.x — Ensure container logging is configured"
+DOCKER_REF = "https://docs.docker.com/engine/logging/configure/"
+OWASP_REF = "https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html"
 
 
 @register_rule
@@ -27,7 +28,7 @@ class LoggingDisabledRule(BaseRule):
                 "collection, making incident response and forensics impossible."
             ),
             severity=Severity.MEDIUM,
-            references=[CIS_REF],
+            references=[DOCKER_REF, OWASP_REF],
         )
 
     def check(
@@ -62,5 +63,5 @@ class LoggingDisabledRule(BaseRule):
                     "      max-size: 10m\n"
                     "      max-file: '3'"
                 ),
-                references=[CIS_REF],
+                references=[DOCKER_REF, OWASP_REF],
             )

--- a/src/compose_lint/rules/CL0016_dangerous_devices.py
+++ b/src/compose_lint/rules/CL0016_dangerous_devices.py
@@ -22,6 +22,15 @@ _DANGEROUS_DEVICE_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"^/dev/sd[a-z]"), "/dev/sd* — SCSI/SATA block device"),
     (re.compile(r"^/dev/nvme"), "/dev/nvme* — NVMe block device"),
     (re.compile(r"^/dev/disk/"), "/dev/disk/* — block device symlinks"),
+    (
+        re.compile(r"^/dev/loop"),
+        "/dev/loop* — loop device (mount arbitrary disk images)",
+    ),
+    (re.compile(r"^/dev/dm-"), "/dev/dm-* — device mapper block device"),
+    (re.compile(r"^/dev/mapper/"), "/dev/mapper/* — device mapper symlink"),
+    (re.compile(r"^/dev/zfs$"), "/dev/zfs — ZFS pool control device"),
+    (re.compile(r"^/dev/rbd"), "/dev/rbd* — Ceph RBD block device"),
+    (re.compile(r"^/dev/raw"), "/dev/raw* — raw character device"),
 ]
 
 

--- a/src/compose_lint/rules/CL0017_shared_mount.py
+++ b/src/compose_lint/rules/CL0017_shared_mount.py
@@ -10,7 +10,10 @@ from compose_lint.rules import BaseRule, register_rule
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-CIS_REF = "CIS Docker Benchmark 5.20 — Do not share the host's mount propagation"
+CIS_REF = (
+    "CIS Docker Benchmark 5.19 — Ensure that mount propagation mode is not set "
+    "to shared"
+)
 
 
 @register_rule

--- a/src/compose_lint/rules/CL0018_explicit_root.py
+++ b/src/compose_lint/rules/CL0018_explicit_root.py
@@ -15,7 +15,7 @@ OWASP_REF = (
     "Docker_Security_Cheat_Sheet.html#rule-7---do-not-use-root-user"
 )
 
-CIS_REF = "CIS Docker Benchmark 5.x — Do not run containers as root"
+DOCKER_REF = "https://docs.docker.com/engine/security/userns-remap/"
 
 _ROOT_USER_PARTS = {"root", "0"}
 
@@ -47,7 +47,7 @@ class ExplicitRootRule(BaseRule):
                 "UID 0."
             ),
             severity=Severity.MEDIUM,
-            references=[OWASP_REF, CIS_REF],
+            references=[OWASP_REF, DOCKER_REF],
         )
 
     def check(
@@ -78,5 +78,5 @@ class ExplicitRootRule(BaseRule):
                     "instruction, or set a non-root user:\n"
                     "  user: 1000:1000"
                 ),
-                references=[OWASP_REF, CIS_REF],
+                references=[OWASP_REF, DOCKER_REF],
             )


### PR DESCRIPTION
## Summary

Critical pass over all rule documentation (CL-0001 through CL-0019) plus `docs/severity.md`, surfacing technical-accuracy bugs, citation drift, doc/code mismatches, and structural inconsistency.

### Must-fix (technical defects)
- **CL-0003** — `no_new_privs` was framed around classic setuid UID escalation; corrected to file capabilities + `execve`-time gain (the actual gate). Kernel docs link added.
- **CL-0011** — Implementation flagged `cap_add: ALL` as CRITICAL but the doc said HIGH and table omitted `ALL`. CIS citation pointed at 5.5 ("sensitive host directories" — that's CL-0013); fixed to 5.3 in both doc and impl.
- **CL-0014** — Literal `5.x` placeholder in the CIS reference was never resolved. Replaced with verifiable Docker logging-driver docs + OWASP Logging Cheat Sheet refs.
- **CL-0006** — "~14 default capabilities" with incorrect SYS_CHROOT-escape framing; replaced with the actual capability list and a link to upstream `oci/caps/defaults.go`. Added Compatibility / How-to-test pattern from CL-0003.
- **CL-0012** — Doc said "0 or -1"; impl flags any non-positive value. Doc updated to match.

### Should-fix (expert-flinch material)
- **CL-0001** — Recommended `socket-proxy` example was itself unhardened; added `read_only`, `cap_drop`, `no-new-privileges`. Rootless/Podman caveat.
- **CL-0002** — "Functionally equivalent to host root" softened to "trivially escapable"; surgical-alternatives table for legitimate use cases.
- **CL-0009** — Updated seccomp framing with link to upstream profile; fixed AppArmor=5.1 / SELinux=5.2 (was grouped); SELinux ref added to impl.
- **CL-0010** — `userns_mode: host` framing assumed daemon-level remap is configured; corrected. UTS CIS 5.21 → 5.20 (was colliding with CL-0009's seccomp 5.21).
- **CL-0013** — Added `/dev`, `/var/lib/kubelet`, `/run/containerd`, `/run/systemd` to detection. Documented :ro vs :rw non-differentiation.
- **CL-0015** — Reframed with explicit security rationale (compromised-but-listening); honest that severity is LOW for a reason.
- **CL-0016** — Added `/dev/loop*`, `/dev/dm-*`, `/dev/mapper/*`, `/dev/zfs`, `/dev/rbd*`, `/dev/raw*` to detection. `STRICT_DEVMEM` / `IO_STRICT_DEVMEM` caveat for `/dev/mem`.
- **CL-0017** — Mount-propagation CIS 5.20 → 5.19. `rslave` is a partial fix, not clean. CSI / DinD suppression guidance.
- **CL-0018** — Corrected "many images set non-root USER" — most popular images start as root and switch via entrypoint. Userns-remap interaction documented. Replaced unverifiable `CIS 5.x` with userns-remap docs ref.
- **CL-0019** — `docker inspect` only works post-pull; added `crane digest` / `buildx imagetools` for cold-start. Multi-arch index-digest section (matches the manifest-list pinning practice).

### Cross-cutting
- **`severity.md`** — Pinned CIS Docker Benchmark v1.6.0. Backfilled CL-0011 through CL-0019 in the assignments table, including dual-rate rules (CL-0011 ALL=CRITICAL, CL-0013 root=CRITICAL).
- **See also / When to suppress** — Added cross-rule links and suppression guidance per the structural-inconsistency finding.

### Detection-list expansions

Three rules gained additional patterns. None break existing tests; corpus snapshot will diff on next refresh:
- CL-0013: 4 new sensitive paths
- CL-0016: 6 new dangerous device patterns

### Out of scope (tracked separately)
- New rule for env-var secrets — opened as #190.

## Test plan
- [x] `pytest` — 389 passed, 1 skipped
- [x] `ruff check`, `ruff format --check`
- [x] `mypy src/` (strict)
- [ ] Corpus snapshot will need a refresh on the next snapshot run; the new sensitive-path/device patterns will produce additional findings in the corpus.