### PR TITLE
Apply README hardened docker flags to release smoke tests

### DIFF
--- a/.github/workflows/publish-channel.yml
+++ b/.github/workflows/publish-channel.yml
@@ -169,17 +169,28 @@ jobs:
           platforms: linux/amd64
           load: true
           tags: composelint/compose-lint:channel-smoke
-      - name: Test — version output matches tag
+      # Every docker-smoke step uses the fully-hardened flag set documented
+      # in README.md ("Running with full hardening"). If a user copy-pastes
+      # that recipe and it breaks, this matrix fails the release gate. Keep
+      # these flags in sync with README.md — both should change together.
+      - name: Test — version output matches tag (hardened)
         env:
           TAG: ${{ inputs.tag }}
         run: |
           expected="compose-lint ${TAG#v}"
-          actual="$(docker run --rm composelint/compose-lint:channel-smoke --version)"
+          actual="$(docker run --rm \
+            --read-only \
+            --cap-drop ALL \
+            --security-opt no-new-privileges:true \
+            --network none \
+            --user 65532:65532 \
+            --pids-limit 256 \
+            composelint/compose-lint:channel-smoke --version)"
           if [ "${actual}" != "${expected}" ]; then
             echo "::error::Version mismatch: '${actual}' vs expected '${expected}'"
             exit 1
           fi
-      - name: Test — clean fixture exits 0
+      - name: Test — clean fixture exits 0 (hardened)
         run: |
           cat > /tmp/clean.yml <<'YAML'
           services:
@@ -196,9 +207,16 @@ jobs:
                 - /tmp
                 - /run
           YAML
-          docker run --rm -v /tmp/clean.yml:/src/docker-compose.yml \
+          docker run --rm \
+            --read-only \
+            --cap-drop ALL \
+            --security-opt no-new-privileges:true \
+            --network none \
+            --user 65532:65532 \
+            --pids-limit 256 \
+            -v /tmp/clean.yml:/src/docker-compose.yml:ro \
             composelint/compose-lint:channel-smoke
-      - name: Test — insecure fixture exits 1
+      - name: Test — insecure fixture exits 1 (hardened)
         run: |
           cat > /tmp/insecure.yml <<'YAML'
           services:
@@ -207,7 +225,14 @@ jobs:
               privileged: true
           YAML
           exit_code=0
-          docker run --rm -v /tmp/insecure.yml:/src/docker-compose.yml \
+          docker run --rm \
+            --read-only \
+            --cap-drop ALL \
+            --security-opt no-new-privileges:true \
+            --network none \
+            --user 65532:65532 \
+            --pids-limit 256 \
+            -v /tmp/insecure.yml:/src/docker-compose.yml:ro \
             composelint/compose-lint:channel-smoke || exit_code=$?
           if [ "${exit_code}" -ne 1 ]; then
             echo "::error::Expected exit 1 on insecure fixture, got ${exit_code}"
@@ -358,13 +383,20 @@ jobs:
           done
           echo "::error::cosign verify failed after 3 attempts"
           exit 1
-      - name: Verify — published image version matches tag
+      - name: Verify — published image version matches tag (hardened)
         env:
           DIGEST: ${{ steps.inspect.outputs.digest }}
           TAG: ${{ inputs.tag }}
         run: |
           expected="compose-lint ${TAG#v}"
-          actual="$(docker run --rm "composelint/compose-lint@${DIGEST}" --version)"
+          actual="$(docker run --rm \
+            --read-only \
+            --cap-drop ALL \
+            --security-opt no-new-privileges:true \
+            --network none \
+            --user 65532:65532 \
+            --pids-limit 256 \
+            "composelint/compose-lint@${DIGEST}" --version)"
           echo "Expected: ${expected}"
           echo "Actual:   ${actual}"
           if [ "${actual}" != "${expected}" ]; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -307,35 +307,64 @@ jobs:
           platforms: ${{ matrix.platform }}
           load: true
           tags: composelint/compose-lint:test
-      - name: Test — version output matches tag
+      # Every docker-smoke step uses the fully-hardened flag set documented
+      # in README.md ("Running with full hardening"). If a user copy-pastes
+      # that recipe and it breaks, this matrix fails the release gate. Keep
+      # these flags in sync with README.md — both should change together.
+      - name: Test — version output matches tag (hardened)
         run: |
           expected="compose-lint ${GITHUB_REF_NAME#v}"
-          actual="$(docker run --rm composelint/compose-lint:test --version)"
+          actual="$(docker run --rm \
+            --read-only \
+            --cap-drop ALL \
+            --security-opt no-new-privileges:true \
+            --network none \
+            --user 65532:65532 \
+            --pids-limit 256 \
+            composelint/compose-lint:test --version)"
           echo "Expected: ${expected}"
           echo "Actual:   ${actual}"
           if [ "${actual}" != "${expected}" ]; then
             echo "::error::Version mismatch: image reports '${actual}', expected '${expected}'"
             exit 1
           fi
-      - name: Test — clean fixture exits 0
+      - name: Test — clean fixture exits 0 (hardened)
         run: |
           docker run --rm \
-            -v "${PWD}/tests/smoke/clean.yml":/src/docker-compose.yml \
+            --read-only \
+            --cap-drop ALL \
+            --security-opt no-new-privileges:true \
+            --network none \
+            --user 65532:65532 \
+            --pids-limit 256 \
+            -v "${PWD}/tests/smoke/clean.yml:/src/docker-compose.yml:ro" \
             composelint/compose-lint:test
-      - name: Test — insecure fixture exits 1
+      - name: Test — insecure fixture exits 1 (hardened)
         run: |
           exit_code=0
           docker run --rm \
-            -v "${PWD}/tests/smoke/insecure.yml":/src/docker-compose.yml \
+            --read-only \
+            --cap-drop ALL \
+            --security-opt no-new-privileges:true \
+            --network none \
+            --user 65532:65532 \
+            --pids-limit 256 \
+            -v "${PWD}/tests/smoke/insecure.yml:/src/docker-compose.yml:ro" \
             composelint/compose-lint:test || exit_code=$?
           if [ "${exit_code}" -ne 1 ]; then
             echo "::error::Expected exit code 1, got ${exit_code}"
             exit 1
           fi
-      - name: Test — SARIF output is valid JSON
+      - name: Test — SARIF output is valid JSON (hardened)
         run: |
           docker run --rm \
-            -v "${PWD}/tests/smoke/sarif-shape.yml":/src/docker-compose.yml \
+            --read-only \
+            --cap-drop ALL \
+            --security-opt no-new-privileges:true \
+            --network none \
+            --user 65532:65532 \
+            --pids-limit 256 \
+            -v "${PWD}/tests/smoke/sarif-shape.yml:/src/docker-compose.yml:ro" \
             composelint/compose-lint:test --format sarif --fail-on critical \
             | python3 -c "import sys, json; json.load(sys.stdin); print('Valid SARIF JSON')"
       - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0


### PR DESCRIPTION
## Summary

- Every `docker run` in `publish.yml` and `publish-channel.yml` now uses the fully-hardened flag set documented in [README.md → Running with full hardening](https://github.com/tmatens/compose-lint/blob/main/README.md#running-with-full-hardening): `--read-only --cap-drop ALL --security-opt no-new-privileges:true --network none --user 65532:65532 --pids-limit 256`, plus `:ro` on bind mounts.
- The hardened invocation strictly subsumes vanilla `docker run`, so existing exit-code and SARIF-shape assertions still hold — this just guarantees the documented copy-paste recipe works on every release across both arches.
- A comment in each workflow points back to the README section as the source of truth so future edits stay in sync.
- `marketplace-smoke.yml` is unchanged: it exercises the GitHub Action wrapper, not direct `docker run`.

## Test plan

- [x] Locally built `composelint/compose-lint:test` from the project Dockerfile and ran all four hardened invocations against `tests/smoke/{clean,insecure,sarif-shape}.yml` plus the inline channel-smoke fixtures — exit codes 0/0/1/0 with valid SARIF, all matching the workflow assertions.
- [ ] CI matrix `docker-smoke` (amd64 + arm64) runs at next release.
- [ ] `publish-channel.yml` smoke runs at next channel publish.