### PR TITLE
Make hardened docker run snippet copy-paste runnable

### DIFF
--- a/.github/workflows/publish-channel.yml
+++ b/.github/workflows/publish-channel.yml
@@ -169,17 +169,28 @@ jobs:
           platforms: linux/amd64
           load: true
           tags: composelint/compose-lint:channel-smoke
-      - name: Test — version output matches tag
+      # Every docker-smoke step uses the fully-hardened flag set documented
+      # in README.md ("Running with full hardening"). If a user copy-pastes
+      # that recipe and it breaks, this matrix fails the release gate. Keep
+      # these flags in sync with README.md — both should change together.
+      - name: Test — version output matches tag (hardened)
         env:
           TAG: ${{ inputs.tag }}
         run: |
           expected="compose-lint ${TAG#v}"
-          actual="$(docker run --rm composelint/compose-lint:channel-smoke --version)"
+          actual="$(docker run --rm \
+            --read-only \
+            --cap-drop ALL \
+            --security-opt no-new-privileges:true \
+            --network none \
+            --user 65532:65532 \
+            --pids-limit 256 \
+            composelint/compose-lint:channel-smoke --version)"
           if [ "${actual}" != "${expected}" ]; then
             echo "::error::Version mismatch: '${actual}' vs expected '${expected}'"
             exit 1
           fi
-      - name: Test — clean fixture exits 0
+      - name: Test — clean fixture exits 0 (hardened)
         run: |
           cat > /tmp/clean.yml <<'YAML'
           services:
@@ -196,9 +207,16 @@ jobs:
                 - /tmp
                 - /run
           YAML
-          docker run --rm -v /tmp/clean.yml:/src/docker-compose.yml \
+          docker run --rm \
+            --read-only \
+            --cap-drop ALL \
+            --security-opt no-new-privileges:true \
+            --network none \
+            --user 65532:65532 \
+            --pids-limit 256 \
+            -v /tmp/clean.yml:/src/docker-compose.yml:ro \
             composelint/compose-lint:channel-smoke
-      - name: Test — insecure fixture exits 1
+      - name: Test — insecure fixture exits 1 (hardened)
         run: |
           cat > /tmp/insecure.yml <<'YAML'
           services:
@@ -207,7 +225,14 @@ jobs:
               privileged: true
           YAML
           exit_code=0
-          docker run --rm -v /tmp/insecure.yml:/src/docker-compose.yml \
+          docker run --rm \
+            --read-only \
+            --cap-drop ALL \
+            --security-opt no-new-privileges:true \
+            --network none \
+            --user 65532:65532 \
+            --pids-limit 256 \
+            -v /tmp/insecure.yml:/src/docker-compose.yml:ro \
             composelint/compose-lint:channel-smoke || exit_code=$?
           if [ "${exit_code}" -ne 1 ]; then
             echo "::error::Expected exit 1 on insecure fixture, got ${exit_code}"
@@ -358,13 +383,20 @@ jobs:
           done
           echo "::error::cosign verify failed after 3 attempts"
           exit 1
-      - name: Verify — published image version matches tag
+      - name: Verify — published image version matches tag (hardened)
         env:
           DIGEST: ${{ steps.inspect.outputs.digest }}
           TAG: ${{ inputs.tag }}
         run: |
           expected="compose-lint ${TAG#v}"
-          actual="$(docker run --rm "composelint/compose-lint@${DIGEST}" --version)"
+          actual="$(docker run --rm \
+            --read-only \
+            --cap-drop ALL \
+            --security-opt no-new-privileges:true \
+            --network none \
+            --user 65532:65532 \
+            --pids-limit 256 \
+            "composelint/compose-lint@${DIGEST}" --version)"
           echo "Expected: ${expected}"
           echo "Actual:   ${actual}"
           if [ "${actual}" != "${expected}" ]; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -307,35 +307,64 @@ jobs:
           platforms: ${{ matrix.platform }}
           load: true
           tags: composelint/compose-lint:test
-      - name: Test — version output matches tag
+      # Every docker-smoke step uses the fully-hardened flag set documented
+      # in README.md ("Running with full hardening"). If a user copy-pastes
+      # that recipe and it breaks, this matrix fails the release gate. Keep
+      # these flags in sync with README.md — both should change together.
+      - name: Test — version output matches tag (hardened)
         run: |
           expected="compose-lint ${GITHUB_REF_NAME#v}"
-          actual="$(docker run --rm composelint/compose-lint:test --version)"
+          actual="$(docker run --rm \
+            --read-only \
+            --cap-drop ALL \
+            --security-opt no-new-privileges:true \
+            --network none \
+            --user 65532:65532 \
+            --pids-limit 256 \
+            composelint/compose-lint:test --version)"
           echo "Expected: ${expected}"
           echo "Actual:   ${actual}"
           if [ "${actual}" != "${expected}" ]; then
             echo "::error::Version mismatch: image reports '${actual}', expected '${expected}'"
             exit 1
           fi
-      - name: Test — clean fixture exits 0
+      - name: Test — clean fixture exits 0 (hardened)
         run: |
           docker run --rm \
-            -v "${PWD}/tests/smoke/clean.yml":/src/docker-compose.yml \
+            --read-only \
+            --cap-drop ALL \
+            --security-opt no-new-privileges:true \
+            --network none \
+            --user 65532:65532 \
+            --pids-limit 256 \
+            -v "${PWD}/tests/smoke/clean.yml:/src/docker-compose.yml:ro" \
             composelint/compose-lint:test
-      - name: Test — insecure fixture exits 1
+      - name: Test — insecure fixture exits 1 (hardened)
         run: |
           exit_code=0
           docker run --rm \
-            -v "${PWD}/tests/smoke/insecure.yml":/src/docker-compose.yml \
+            --read-only \
+            --cap-drop ALL \
+            --security-opt no-new-privileges:true \
+            --network none \
+            --user 65532:65532 \
+            --pids-limit 256 \
+            -v "${PWD}/tests/smoke/insecure.yml:/src/docker-compose.yml:ro" \
             composelint/compose-lint:test || exit_code=$?
           if [ "${exit_code}" -ne 1 ]; then
             echo "::error::Expected exit code 1, got ${exit_code}"
             exit 1
           fi
-      - name: Test — SARIF output is valid JSON
+      - name: Test — SARIF output is valid JSON (hardened)
         run: |
           docker run --rm \
-            -v "${PWD}/tests/smoke/sarif-shape.yml":/src/docker-compose.yml \
+            --read-only \
+            --cap-drop ALL \
+            --security-opt no-new-privileges:true \
+            --network none \
+            --user 65532:65532 \
+            --pids-limit 256 \
+            -v "${PWD}/tests/smoke/sarif-shape.yml:/src/docker-compose.yml:ro" \
             composelint/compose-lint:test --format sarif --fail-on critical \
             | python3 -c "import sys, json; json.load(sys.stdin); print('Valid SARIF JSON')"
       - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   branch for `[0.0.0.0]` / `[*]` — Docker doesn't accept those forms and
   no test exercised them. `[::]` continues to match via the wildcard set.
   (#172)
+- README "Running with full hardening" snippet now uses
+  `composelint/compose-lint:0.6.0` instead of the
+  `composelint/compose-lint@sha256:<digest>` placeholder, so the recipe
+  is copy-paste runnable. A new note points users at Docker Hub or
+  `docker buildx imagetools inspect` if they want to substitute a digest
+  pin for full CL-0004 / CL-0019 satisfaction. The new tag form is
+  tracked as a fourth version sync point in `docs/RELEASING.md`.
 
 ## [0.6.0] - 2026-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   branch for `[0.0.0.0]` / `[*]` — Docker doesn't accept those forms and
   no test exercised them. `[::]` continues to match via the wildcard set.
   (#172)
+- Release docker-smoke jobs (`publish.yml`, `publish-channel.yml`) now
+  exercise the image with the full hardening flag set documented in the
+  README (`--read-only`, `--cap-drop ALL`, `--security-opt
+  no-new-privileges:true`, `--network none`, `--user 65532:65532`,
+  `--pids-limit 256`, plus `:ro` on bind mounts). A copy-paste regression
+  in the documented recipe will now fail the release gate. (#196)
 - README "Running with full hardening" snippet now uses
   `composelint/compose-lint:0.6.0` instead of the
   `composelint/compose-lint@sha256:<digest>` placeholder, so the recipe

--- a/README.md
+++ b/README.md
@@ -51,19 +51,20 @@ docker run --rm \
   --user 65532:65532 \
   --pids-limit 256 \
   -v "$(pwd):/src:ro" \
-  composelint/compose-lint@sha256:<digest>
+  composelint/compose-lint:0.6.0
 ```
 
 | Flag | Rule satisfied |
 |---|---|
 | `--security-opt no-new-privileges:true` | CL-0003 |
-| `@sha256:<digest>` | CL-0004, CL-0019 |
 | `--cap-drop ALL` | CL-0006 |
 | `--read-only` | CL-0007 |
 | `--pids-limit 256` | CL-0012 (defense-in-depth; rule fires only on `0`/`-1`) |
 | `--user 65532:65532` | CL-0018 (matches the image's existing default) |
 
 `--network none` and `:ro` on the bind mount are extra hardening — compose-lint never reaches the network and only reads its inputs.
+
+For full supply-chain reproducibility (and to satisfy CL-0004 / CL-0019), replace the `:0.6.0` tag with a digest pin: `composelint/compose-lint@sha256:<digest>`. Get the current digest from [Docker Hub](https://hub.docker.com/r/composelint/compose-lint/tags) or with `docker buildx imagetools inspect composelint/compose-lint:0.6.0 --format '{{json .Manifest}}' | jq -r '.digest'`.
 
 A Compose-form equivalent that lints clean across every rule lives in [`tests/compose_files/safe_self_hosted.yml`](https://github.com/tmatens/compose-lint/blob/main/tests/compose_files/safe_self_hosted.yml).
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -166,13 +166,15 @@ four before opening the bump PR.
 - [ ] `src/compose_lint/__init__.py` — `__version__ = "X.Y.Z"`
 - [ ] `README.md` — version references in copy-paste integration
       snippets. All need bumping each release; otherwise users land
-      on a stale version. Three forms exist:
+      on a stale version. Four forms exist:
       - `tmatens/compose-lint@<sha> # v0.X.Y` (GitHub Action snippet)
       - `rev: v0.X.Y` (pre-commit snippet)
       - `compose-lint==0.X.Y` (Forgejo Actions snippet — pip pin)
+      - `composelint/compose-lint:0.X.Y` (hardened `docker run` snippet
+        and the digest-lookup hint immediately below it)
 
-      Verify all three with:
-      `grep -nE 'v0\.[0-9]+\.[0-9]+|compose-lint==0\.[0-9]+\.[0-9]+' README.md`.
+      Verify all four with:
+      `grep -nE 'v0\.[0-9]+\.[0-9]+|compose-lint==0\.[0-9]+\.[0-9]+|composelint/compose-lint:0\.[0-9]+\.[0-9]+' README.md`.
 - [ ] `.github/workflows/marketplace-smoke.yml` — two
       `uses: tmatens/compose-lint@<sha> # vX.Y.Z` lines. Update both
       the full commit SHA and the trailing `# vX.Y.Z` comment. Get


### PR DESCRIPTION
## Summary

- The README "Running with full hardening" snippet used `composelint/compose-lint@sha256:<digest>` as a literal placeholder — broken on copy-paste, and no other snippet in the README pinned by digest. Replace it with `composelint/compose-lint:0.6.0` so the recipe runs as-written.
- Add a one-line note pointing users at Docker Hub or `docker buildx imagetools inspect …` if they want to substitute a digest pin for full CL-0004 / CL-0019 satisfaction. The flag-to-rule table loses the now-stale `@sha256:<digest>` row; the surrounding paragraph keeps the recommendation visible.
- Add `composelint/compose-lint:0.X.Y` as a fourth version sync point in `docs/RELEASING.md` and extend the README-bump verification grep to catch it alongside the existing three forms (`v0.X.Y`, `compose-lint==0.X.Y`).
- CHANGELOG entry under `[Unreleased] → Changed`.

## Test plan

- [x] `grep -nE 'v0\\.[0-9]+\\.[0-9]+|compose-lint==0\\.[0-9]+\\.[0-9]+|composelint/compose-lint:0\\.[0-9]+\\.[0-9]+' README.md` returns the four expected version references.
- [ ] Manually copy-paste the new hardened `docker run` snippet from the rendered README and confirm it lints successfully against a sample compose file.