### PR TITLE
Bump README copy-paste version pins to 0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ docker run --rm \
   --user 65532:65532 \
   --pids-limit 256 \
   -v "$(pwd):/src:ro" \
-  composelint/compose-lint:0.6.0
+  composelint/compose-lint:0.7.0
 ```
 
 | Flag | Rule satisfied |
@@ -64,7 +64,7 @@ docker run --rm \
 
 `--network none` and `:ro` on the bind mount are extra hardening — compose-lint never reaches the network and only reads its inputs.
 
-For full supply-chain reproducibility (and to satisfy CL-0004 / CL-0019), replace the `:0.6.0` tag with a digest pin: `composelint/compose-lint@sha256:<digest>`. Get the current digest from [Docker Hub](https://hub.docker.com/r/composelint/compose-lint/tags) or with `docker buildx imagetools inspect composelint/compose-lint:0.6.0 --format '{{json .Manifest}}' | jq -r '.digest'`.
+For full supply-chain reproducibility (and to satisfy CL-0004 / CL-0019), replace the `:0.7.0` tag with a digest pin: `composelint/compose-lint@sha256:<digest>`. Get the current digest from [Docker Hub](https://hub.docker.com/r/composelint/compose-lint/tags) or with `docker buildx imagetools inspect composelint/compose-lint:0.7.0 --format '{{json .Manifest}}' | jq -r '.digest'`.
 
 A Compose-form equivalent that lints clean across every rule lives in [`tests/compose_files/safe_self_hosted.yml`](https://github.com/tmatens/compose-lint/blob/main/tests/compose_files/safe_self_hosted.yml).
 
@@ -285,7 +285,7 @@ jobs:
         run: |
           apt-get update -qq
           apt-get install -yqq --no-install-recommends python3-pip
-          pip3 install --break-system-packages --no-cache-dir compose-lint==0.6.0
+          pip3 install --break-system-packages --no-cache-dir compose-lint==0.7.0
       - name: Run compose-lint
         run: compose-lint --fail-on high
 ```
@@ -304,7 +304,7 @@ compose-lint --format sarif docker-compose.yml > results.sarif
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/tmatens/compose-lint
-    rev: v0.5.2
+    rev: v0.7.0
     hooks:
       - id: compose-lint
 ```


### PR DESCRIPTION
## Summary

Updates the four version-bearing copy-paste integration snippets in `README.md` from `0.6.0` / `v0.5.2` to `0.7.0`, ahead of cutting the v0.7.0 tag:

- `composelint/compose-lint:0.7.0` (hardened `docker run` snippet, line 54)
- `composelint/compose-lint:0.7.0` x2 in the digest-lookup hint (line 67)
- `compose-lint==0.7.0` (Forgejo Actions pip pin, line 288)
- `rev: v0.7.0` (pre-commit snippet, line 307)

The fifth sync point — `tmatens/compose-lint@<sha> # vX.Y.Z` (line 252) — needs the post-tag commit SHA and is handled in a follow-up PR after the tag is pushed (same constraint as the auto-generated `bump-marketplace-smoke-pin` PR).

`docs/RELEASING.md` § "Version sync" lists these as release-blocker sync points; release-prep.yml only updates `pyproject.toml`, `__init__.py`, and `CHANGELOG.md`.

## Test plan

- [x] `grep -nE 'v0\.[0-9]+\.[0-9]+|compose-lint==0\.[0-9]+\.[0-9]+|composelint/compose-lint:0\.[0-9]+\.[0-9]+' README.md` shows only `0.7.0` / `v0.7.0` (except line 252 deferred to post-tag)
- [ ] CI green