### PR TITLE
Bump README GitHub Action pin to v0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: tmatens/compose-lint@93e1c0dea75f123171f00d29f3d238080fbb6d04 # v0.5.2
+      - uses: tmatens/compose-lint@23da963b2ee586592eb1afe34b5a3b620e52966d # v0.7.0
         with:
           sarif-file: results.sarif
 ```


### PR DESCRIPTION
## Summary

Final post-tag README sync point. Updates `README.md:252` from the v0.5.2 SHA pin to the v0.7.0 SHA pin so users copy-pasting the GitHub Action snippet land on the release we just shipped.

- `tmatens/compose-lint@23da963b2ee586592eb1afe34b5a3b620e52966d # v0.7.0`

The SHA `23da963…` is the commit `v0.7.0` points at and matches what the auto-generated `bump-marketplace-smoke-pin` job wrote into `.github/workflows/marketplace-smoke.yml` in #200.

## Test plan

- [x] `git rev-parse v0.7.0^{commit}` matches the SHA in the diff
- [ ] CI green