### PR TITLE
Move corpus pipeline scripts in-repo under scripts/corpus/

### DIFF
--- a/scripts/corpus/README.md
+++ b/scripts/corpus/README.md
@@ -1,0 +1,51 @@
+# scripts/corpus/
+
+Pipeline that fetches real-world Docker Compose files from public GitHub repos and lints them with compose-lint. Outputs feed the **State of Docker Compose Security** report (`docs/state-of-compose.md`) and provide source material for the wild-fixture test set.
+
+Data lives outside the repo at `~/.cache/compose-lint-corpus/` (compose files, lint runs, index). Only this code is in git.
+
+## Pipeline
+
+Run in order; each step is idempotent.
+
+```bash
+python scripts/corpus/fetch.py              # longtail (random GH code search)
+python scripts/corpus/fetch_popular.py      # popular (>=50★, recent topics)
+python scripts/corpus/fetch_canonical.py    # canonical (curated upstream repos)
+python scripts/corpus/fetch_selfhosted.py   # selfhosted (curated app stores)
+python scripts/corpus/retier.py             # promote curated repos to correct tier
+python scripts/corpus/enrich_metadata.py    # backfill stars/pushed_at/topics
+python scripts/corpus/run.py                # lint everything → runs/<ts>/
+```
+
+If you only edited the curated lists, skip the fetches: `retier.py` then `make_tier_summary.py` regenerates per-tier numbers without re-linting.
+
+## Tiers
+
+- `canonical` — official upstream examples (what people copy from READMEs)
+- `popular` — high-star repos with compose files (production-adjacent code)
+- `selfhosted` — app-store / template-registry repos (home-lab threat model)
+- `longtail` — random GH code-search corpus (what the median wild file looks like)
+
+`retier.py` must run after fetches: the downloader keys on `blob_sha` first-write-wins, so a curated app-store template swept up earlier by `fetch_popular` would otherwise stay tagged `popular`.
+
+## Requirements
+
+- `gh` CLI authenticated (`gh auth status` shows a valid token)
+- A built compose-lint in the repo `.venv/` (or set `COMPOSE_LINT_BIN`)
+- Python 3.10+
+
+## Output layout
+
+```
+~/.cache/compose-lint-corpus/
+├── files/<sha256>.yml         # one unique compose file per content hash
+├── index.jsonl                # {content_hash, blob_sha, repo, path, url, size, tier, stars, pushed_at, default_branch, topics}
+└── runs/<UTC-timestamp>/
+    ├── results.jsonl          # per-file lint output (raw compose-lint JSON)
+    ├── summary.md             # whole-corpus aggregate
+    ├── tier_summary.md        # per-tier counts, severity, top-10 rules
+    └── meta.json              # tool version, timing, worker count
+```
+
+`results.jsonl` does NOT carry the tier — join against `index.jsonl` on `content_hash`. See `summary.md` for jq snippets.

--- a/scripts/corpus/_common.py
+++ b/scripts/corpus/_common.py
@@ -1,0 +1,150 @@
+"""Shared helpers for the per-tier corpus fetchers.
+
+Each fetch_<tier>.py is responsible for producing a stream of "candidate"
+dicts shaped like a `gh search code` hit:
+
+    {"repository": {"nameWithOwner": "..."}, "path": "...", "sha": "<blob>", "url": "<blob_url>"}
+
+…and then calls `download_and_index(candidates, tier=...)` to dedupe,
+download, hash, and append to the shared `index.jsonl`.
+
+The `tier` field is appended to every new index entry so reports can
+slice rule-prevalence per tier without re-deriving provenance.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Iterable
+
+CACHE = Path.home() / ".cache" / "compose-lint-corpus"
+FILES = CACHE / "files"
+INDEX = CACHE / "index.jsonl"
+
+COMPOSE_FILENAMES = {
+    "docker-compose.yml",
+    "docker-compose.yaml",
+    "compose.yml",
+    "compose.yaml",
+}
+
+PER_FILE_TIMEOUT = 20
+MAX_FILE_BYTES = 256 * 1024
+DOWNLOAD_WORKERS = 16
+
+
+def load_seen_hashes() -> set[str]:
+    if not INDEX.exists():
+        return set()
+    seen: set[str] = set()
+    with INDEX.open() as f:
+        for line in f:
+            try:
+                seen.add(json.loads(line)["content_hash"])
+            except Exception:
+                continue
+    return seen
+
+
+def load_seen_blobs() -> set[str]:
+    if not INDEX.exists():
+        return set()
+    seen: set[str] = set()
+    with INDEX.open() as f:
+        for line in f:
+            try:
+                seen.add(json.loads(line)["blob_sha"])
+            except Exception:
+                continue
+    return seen
+
+
+def raw_url(blob_url: str) -> str:
+    return (
+        blob_url.replace("https://github.com/", "https://raw.githubusercontent.com/", 1)
+        .replace("/blob/", "/", 1)
+    )
+
+
+def _download(item: dict) -> tuple[dict, bytes | None, str | None]:
+    url = raw_url(item["url"])
+    req = urllib.request.Request(url, headers={"User-Agent": "compose-lint-corpus/1"})
+    try:
+        with urllib.request.urlopen(req, timeout=PER_FILE_TIMEOUT) as r:
+            data = r.read(MAX_FILE_BYTES + 1)
+        if len(data) > MAX_FILE_BYTES:
+            return item, None, "too_large"
+        return item, data, None
+    except urllib.error.HTTPError as e:
+        return item, None, f"http_{e.code}"
+    except Exception as e:
+        return item, None, type(e).__name__
+
+
+def download_and_index(
+    candidates: Iterable[dict],
+    *,
+    tier: str,
+    on_progress: int = 100,
+) -> dict[str, int]:
+    """Download `candidates` in parallel, write new files, append index entries.
+
+    Skips candidates whose blob_sha or content_hash is already indexed.
+    Returns a counter dict of {new, duplicate, too_large, http_*, ...}.
+
+    Optional metadata fields on each candidate are copied through to the
+    index entry when present (so fetchers that already know them — e.g.
+    fetch_popular has stars/pushed_at from `gh search repos` — don't
+    have to re-fetch later):
+
+      - ``stars``           — int
+      - ``pushed_at``       — ISO-8601 string
+      - ``default_branch``  — str
+      - ``topics``          — list[str]
+    """
+    FILES.mkdir(parents=True, exist_ok=True)
+    seen_hashes = load_seen_hashes()
+    seen_blobs = load_seen_blobs()
+
+    todo = [c for c in candidates if c["sha"] not in seen_blobs]
+    print(f"[{tier}] new to download: {len(todo)}", file=sys.stderr)
+
+    counts: dict[str, int] = {"new": 0, "duplicate": 0}
+    with INDEX.open("a") as idx, ThreadPoolExecutor(max_workers=DOWNLOAD_WORKERS) as pool:
+        futures = {pool.submit(_download, item): item for item in todo}
+        for fut in as_completed(futures):
+            item, data, err = fut.result()
+            if err:
+                counts[err] = counts.get(err, 0) + 1
+                continue
+            assert data is not None
+            content_hash = hashlib.sha256(data).hexdigest()
+            if content_hash in seen_hashes:
+                counts["duplicate"] += 1
+                continue
+            seen_hashes.add(content_hash)
+            (FILES / f"{content_hash}.yml").write_bytes(data)
+            entry = {
+                "content_hash": content_hash,
+                "blob_sha": item["sha"],
+                "repo": item["repository"]["nameWithOwner"],
+                "path": item["path"],
+                "url": item["url"],
+                "size": len(data),
+                "tier": tier,
+            }
+            for k in ("stars", "pushed_at", "default_branch", "topics"):
+                if k in item:
+                    entry[k] = item[k]
+            idx.write(json.dumps(entry) + "\n")
+            counts["new"] += 1
+            if counts["new"] % on_progress == 0:
+                print(f"[{tier}]   downloaded {counts['new']}", file=sys.stderr)
+
+    print(f"[{tier}] done: {counts}", file=sys.stderr)
+    return counts

--- a/scripts/corpus/backfill_tier.py
+++ b/scripts/corpus/backfill_tier.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Backfill `tier` on existing index.jsonl entries.
+
+The original fetch.py predates tiering. Every entry it produced came from
+the random gh-search-code method, so it maps cleanly to `tier: longtail`.
+This script adds the field in-place, leaving any entry that already has a
+tier untouched (so it's safe to rerun after new tiers have been added).
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+INDEX = Path.home() / ".cache" / "compose-lint-corpus" / "index.jsonl"
+DEFAULT_TIER = "longtail"
+
+
+def main() -> int:
+    if not INDEX.exists():
+        print(f"no index at {INDEX}", file=sys.stderr)
+        return 0
+
+    tmp = INDEX.with_suffix(".jsonl.tmp")
+    backfilled = 0
+    kept = 0
+    with INDEX.open() as src, tmp.open("w") as dst:
+        for line in src:
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                dst.write(line)
+                continue
+            if "tier" not in entry:
+                entry["tier"] = DEFAULT_TIER
+                backfilled += 1
+            else:
+                kept += 1
+            dst.write(json.dumps(entry) + "\n")
+    tmp.replace(INDEX)
+    print(f"backfilled {backfilled}; already-tagged {kept}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/corpus/enrich_metadata.py
+++ b/scripts/corpus/enrich_metadata.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Backfill per-repo metadata (stars, pushed_at, default_branch, topics)
+into existing index.jsonl entries that are missing these fields.
+
+Resolves the gap between fetcher versions: the original `fetch.py` and
+the early `fetch_canonical.py`/`fetch_selfhosted.py` writers stored only
+{content_hash, blob_sha, repo, path, url, size, tier}. Without per-repo
+metadata in-line, the report can't stratify popular by stars or filter
+out abandoned repos by recency without re-fetching everything.
+
+This script:
+  1. Loads index.jsonl, groups entries by repo.
+  2. For each unique repo missing any metadata field, calls
+     `gh api repos/{repo}` (cached + concurrent).
+  3. Rewrites index.jsonl with the metadata merged in.
+
+Idempotent: skips repos whose entries already have all fields populated.
+404s are tolerated — repo may have been deleted/renamed since fetch;
+the entry's tier and other fields stay intact.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+INDEX = Path.home() / ".cache" / "compose-lint-corpus" / "index.jsonl"
+META_FIELDS = ("stars", "pushed_at", "default_branch", "topics")
+WORKERS = 16
+GH_API_TIMEOUT = 30
+
+
+def gh_repo(repo: str) -> dict | None:
+    try:
+        out = subprocess.run(
+            ["gh", "api", "--cache", "24h", f"repos/{repo}"],
+            check=True, capture_output=True, text=True, timeout=GH_API_TIMEOUT,
+        ).stdout
+        return json.loads(out)
+    except subprocess.CalledProcessError as e:
+        msg = (e.stderr or "").strip()[:160]
+        if "Not Found" not in msg and "Moved Permanently" not in msg:
+            print(f"  gh api repos/{repo} failed: {msg}", file=sys.stderr)
+        return None
+    except subprocess.TimeoutExpired:
+        return None
+
+
+def extract(info: dict) -> dict:
+    return {
+        "stars": info.get("stargazers_count"),
+        "pushed_at": info.get("pushed_at"),
+        "default_branch": info.get("default_branch"),
+        "topics": info.get("topics") or [],
+    }
+
+
+def main() -> int:
+    if not INDEX.exists():
+        sys.exit(f"no index at {INDEX}")
+
+    entries = [json.loads(line) for line in INDEX.open()]
+    print(f"loaded {len(entries)} index entries", file=sys.stderr)
+
+    # Find repos missing any metadata field.
+    repos_seen: dict[str, bool] = {}  # repo -> needs_lookup
+    for e in entries:
+        repo = e["repo"]
+        if repo in repos_seen:
+            continue
+        repos_seen[repo] = any(f not in e for f in META_FIELDS)
+
+    todo = [r for r, needed in repos_seen.items() if needed]
+    print(f"unique repos: {len(repos_seen)}; needing lookup: {len(todo)}", file=sys.stderr)
+
+    metadata: dict[str, dict] = {}
+    with ThreadPoolExecutor(max_workers=WORKERS) as pool:
+        futures = {pool.submit(gh_repo, repo): repo for repo in todo}
+        done = 0
+        for fut in as_completed(futures):
+            repo = futures[fut]
+            info = fut.result()
+            if info:
+                metadata[repo] = extract(info)
+            done += 1
+            if done % 200 == 0:
+                print(f"  fetched {done}/{len(todo)}", file=sys.stderr)
+
+    print(f"got metadata for {len(metadata)}/{len(todo)} repos", file=sys.stderr)
+
+    # Rewrite index with metadata merged in.
+    tmp = INDEX.with_suffix(".jsonl.tmp")
+    enriched = 0
+    with tmp.open("w") as out:
+        for e in entries:
+            meta = metadata.get(e["repo"])
+            if meta:
+                for k, v in meta.items():
+                    if k not in e and v is not None:
+                        e[k] = v
+                enriched += 1
+            out.write(json.dumps(e) + "\n")
+    tmp.replace(INDEX)
+    print(f"enriched {enriched} entries", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/corpus/fetch.py
+++ b/scripts/corpus/fetch.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Fetch real-world Docker Compose files from GitHub via `gh search code`.
+
+Writes deduped file content into ~/.cache/compose-lint-corpus/files/<sha256>.yml
+and an index line per file into ~/.cache/compose-lint-corpus/index.jsonl.
+
+Idempotent: re-running adds new unique files without re-downloading.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+CACHE = Path.home() / ".cache" / "compose-lint-corpus"
+FILES = CACHE / "files"
+INDEX = CACHE / "index.jsonl"
+
+# Query buckets: vary filename, anchor term, and size range to bypass
+# GitHub's ~1000-results-per-query soft cap and pull a more diverse corpus.
+FILENAMES = ["docker-compose.yml", "docker-compose.yaml", "compose.yml", "compose.yaml"]
+ANCHORS = ["services:", "image:", "volumes:", "restart:", "ports:", "depends_on:"]
+SIZE_BUCKETS = ["<2", "2..5", "5..15", "15..50", ">50"]  # kilobytes
+
+PER_QUERY_LIMIT = 200            # gh search code page cap is ~1000; 200 keeps each call fast
+RATE_LIMIT_SLEEP = 70            # GH code search is 30 req/min; back off past one window
+PER_FILE_TIMEOUT = 20            # seconds for raw download
+MAX_FILE_BYTES = 256 * 1024      # skip giant files (>256 KB) — almost certainly not a real compose
+DOWNLOAD_WORKERS = 16
+GLOBAL_TIMEOUT_SECS = int(os.environ.get("FETCH_TIMEOUT", "1500"))  # 25 min default
+
+
+def load_existing() -> set[str]:
+    if not INDEX.exists():
+        return set()
+    seen: set[str] = set()
+    with INDEX.open() as f:
+        for line in f:
+            try:
+                seen.add(json.loads(line)["content_hash"])
+            except Exception:
+                continue
+    return seen
+
+
+def gh_search(anchor: str, filename: str, size: str | None, retry: bool = True) -> list[dict]:
+    cmd = [
+        "gh", "search", "code", anchor,
+        "--filename", filename,
+        "--limit", str(PER_QUERY_LIMIT),
+        "--json", "repository,path,sha,url",
+    ]
+    if size:
+        cmd += ["--size", size]
+    try:
+        out = subprocess.run(cmd, check=True, capture_output=True, text=True, timeout=120).stdout
+        return json.loads(out)
+    except subprocess.CalledProcessError as e:
+        stderr = e.stderr or ""
+        if "rate limit exceeded" in stderr and retry:
+            print(f"  rate-limited; sleeping {RATE_LIMIT_SLEEP}s", file=sys.stderr)
+            time.sleep(RATE_LIMIT_SLEEP)
+            return gh_search(anchor, filename, size, retry=False)
+        print(f"  search failed ({anchor!r} {filename} size={size}): {stderr.strip()[:160]}", file=sys.stderr)
+        return []
+    except subprocess.TimeoutExpired:
+        print(f"  search timed out ({anchor!r} {filename} size={size})", file=sys.stderr)
+        return []
+
+
+def raw_url(blob_url: str) -> str:
+    # https://github.com/OWNER/REPO/blob/SHA/PATH -> https://raw.githubusercontent.com/OWNER/REPO/SHA/PATH
+    return blob_url.replace("https://github.com/", "https://raw.githubusercontent.com/", 1).replace("/blob/", "/", 1)
+
+
+def download(item: dict) -> tuple[dict, bytes | None, str | None]:
+    url = raw_url(item["url"])
+    req = urllib.request.Request(url, headers={"User-Agent": "compose-lint-corpus/1"})
+    try:
+        with urllib.request.urlopen(req, timeout=PER_FILE_TIMEOUT) as r:
+            data = r.read(MAX_FILE_BYTES + 1)
+        if len(data) > MAX_FILE_BYTES:
+            return item, None, "too_large"
+        return item, data, None
+    except urllib.error.HTTPError as e:
+        return item, None, f"http_{e.code}"
+    except Exception as e:
+        return item, None, type(e).__name__
+
+
+def main() -> int:
+    FILES.mkdir(parents=True, exist_ok=True)
+    seen = load_existing()
+    start = time.monotonic()
+
+    # 1. Collect search hits across (anchor × filename × size) combos.
+    #    Stop early if too many recent queries returned only known repos.
+    candidates: dict[tuple[str, str, str], dict] = {}
+    queries = [(a, fn, sz) for a in ANCHORS for fn in FILENAMES for sz in SIZE_BUCKETS]
+    # interleave so a rate-limit pause isn't all on one filename
+    for qi, (anchor, fn, size) in enumerate(queries):
+        if time.monotonic() - start > GLOBAL_TIMEOUT_SECS:
+            print("global timeout reached during search", file=sys.stderr)
+            break
+        print(f"[{qi+1}/{len(queries)}] search anchor={anchor!r} filename={fn} size={size}", file=sys.stderr)
+        hits = gh_search(anchor, fn, size)
+        added = 0
+        for h in hits:
+            if Path(h["path"]).name not in FILENAMES:
+                continue
+            key = (h["repository"]["nameWithOwner"], h["path"], h["sha"])
+            if key not in candidates:
+                added += 1
+            candidates[key] = h
+        print(f"   +{added} new (total {len(candidates)})", file=sys.stderr)
+
+    print(f"unique candidates: {len(candidates)}", file=sys.stderr)
+
+    # 2. Download in parallel. Skip blob shas already seen via index (file already on disk).
+    blob_seen: set[str] = set()
+    if INDEX.exists():
+        with INDEX.open() as f:
+            for line in f:
+                try:
+                    blob_seen.add(json.loads(line)["blob_sha"])
+                except Exception:
+                    pass
+
+    todo = [v for k, v in candidates.items() if k[2] not in blob_seen]
+    print(f"new to download: {len(todo)}", file=sys.stderr)
+
+    new_count = 0
+    skipped = {"too_large": 0, "http_404": 0, "http_403": 0, "http_429": 0, "other": 0, "duplicate": 0}
+    with INDEX.open("a") as idx, ThreadPoolExecutor(max_workers=DOWNLOAD_WORKERS) as pool:
+        futures = {pool.submit(download, item): item for item in todo}
+        for fut in as_completed(futures):
+            if time.monotonic() - start > GLOBAL_TIMEOUT_SECS:
+                print("global timeout reached during download", file=sys.stderr)
+                for f in futures:
+                    f.cancel()
+                break
+            item, data, err = fut.result()
+            if err:
+                key = err if err in skipped else "other"
+                skipped[key] = skipped.get(key, 0) + 1
+                continue
+            assert data is not None
+            content_hash = hashlib.sha256(data).hexdigest()
+            if content_hash in seen:
+                skipped["duplicate"] += 1
+                continue
+            seen.add(content_hash)
+            (FILES / f"{content_hash}.yml").write_bytes(data)
+            idx.write(json.dumps({
+                "content_hash": content_hash,
+                "blob_sha": item["sha"],
+                "repo": item["repository"]["nameWithOwner"],
+                "path": item["path"],
+                "url": item["url"],
+                "size": len(data),
+                "tier": "longtail",
+            }) + "\n")
+            new_count += 1
+            if new_count % 100 == 0:
+                print(f"  downloaded {new_count}", file=sys.stderr)
+
+    print(f"\nfetched {new_count} new files; corpus now {len(seen)}; skipped {skipped}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/corpus/fetch_canonical.py
+++ b/scripts/corpus/fetch_canonical.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Fetch canonical Compose examples from a hand-curated upstream list.
+
+Tier purpose: answer "do the examples people copy-paste ship insecure
+defaults?" — high citation value at low N. Files are pulled from official
+docker-library example repos, vendor-curated chart repos, and the
+docker/awesome-compose reference set.
+
+Mechanism: for each curated repo, list the default-branch tree via
+`gh api repos/{repo}/git/trees/HEAD?recursive=1`, filter to compose
+filenames, and hand the candidates to the shared downloader.
+
+Idempotent: rerunning is cheap because the shared downloader skips
+blob_shas already in the index.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import COMPOSE_FILENAMES, download_and_index  # noqa: E402
+
+TIER = "canonical"
+
+# Curated upstream repos. Picked for "this is what new users copy from a
+# README." Each entry is a `owner/name` slug; default branch is resolved
+# at runtime so we don't hardcode `main` vs `master`.
+CURATED_REPOS = [
+    # Vendor reference sets
+    "docker/awesome-compose",
+    "bitnami/containers",
+    "linuxserver/docker-documentation",
+    # Docker Hub official-image docs (compose snippets in *.md + examples/)
+    "docker-library/docs",
+    # Popular self-host platforms whose docs are the canonical install path
+    "traefik/traefik",
+    "nextcloud/docker",
+    "louislam/uptime-kuma",
+    "gotify/server",
+    "dani-garcia/vaultwarden",
+    "jellyfin/jellyfin",
+    "grafana/grafana",
+    "pi-hole/docker-pi-hole",
+    # Official engine examples
+    "docker/compose",
+]
+
+
+def gh_api(path: str) -> dict | list | None:
+    try:
+        out = subprocess.run(
+            ["gh", "api", "--cache", "1h", path],
+            check=True, capture_output=True, text=True, timeout=120,
+        ).stdout
+        return json.loads(out)
+    except subprocess.CalledProcessError as e:
+        print(f"  gh api failed for {path}: {(e.stderr or '').strip()[:200]}", file=sys.stderr)
+        return None
+    except subprocess.TimeoutExpired:
+        print(f"  gh api timeout for {path}", file=sys.stderr)
+        return None
+
+
+def default_branch(repo: str) -> str | None:
+    info = gh_api(f"repos/{repo}")
+    if isinstance(info, dict):
+        return info.get("default_branch")
+    return None
+
+
+def list_compose_paths(repo: str, branch: str) -> list[dict]:
+    """Return [{path, sha}, ...] for every compose file in the repo tree."""
+    tree = gh_api(f"repos/{repo}/git/trees/{branch}?recursive=1")
+    if not isinstance(tree, dict):
+        return []
+    if tree.get("truncated"):
+        # Tree exceeded GitHub's response limit; we'll get most files but
+        # not all. Acceptable for canonical tier — these repos are small.
+        print(f"  warn: {repo} tree truncated", file=sys.stderr)
+    out = []
+    for entry in tree.get("tree", []):
+        if entry.get("type") != "blob":
+            continue
+        path = entry.get("path", "")
+        if Path(path).name in COMPOSE_FILENAMES:
+            out.append({"path": path, "sha": entry["sha"]})
+    return out
+
+
+def candidates_for_repo(repo: str) -> list[dict]:
+    branch = default_branch(repo)
+    if not branch:
+        return []
+    files = list_compose_paths(repo, branch)
+    print(f"  {repo}@{branch}: {len(files)} compose file(s)", file=sys.stderr)
+    info = gh_api(f"repos/{repo}") or {}
+    base = {
+        "stars": info.get("stargazers_count"),
+        "pushed_at": info.get("pushed_at"),
+        "default_branch": branch,
+        "topics": info.get("topics") or [],
+    }
+    return [
+        {
+            "repository": {"nameWithOwner": repo},
+            "path": f["path"],
+            "sha": f["sha"],
+            "url": f"https://github.com/{repo}/blob/{branch}/{f['path']}",
+            **base,
+        }
+        for f in files
+    ]
+
+
+def main() -> int:
+    candidates: list[dict] = []
+    for repo in CURATED_REPOS:
+        print(f"[canonical] {repo}", file=sys.stderr)
+        candidates.extend(candidates_for_repo(repo))
+    print(f"[canonical] candidates: {len(candidates)}", file=sys.stderr)
+    download_and_index(candidates, tier=TIER)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/corpus/fetch_popular.py
+++ b/scripts/corpus/fetch_popular.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Fetch Compose files from popular (highly-starred) GitHub repos.
+
+Tier purpose: answer "what does production-adjacent code look like?" —
+production code is private, but high-star public repos are the closest
+honest proxy. This is the tier most readers will trust as 'real.'
+
+Mechanism:
+  1. `gh search repos` across several topic facets (docker-compose,
+     selfhosted, etc.) sorted by stars, with stars>=MIN_STARS and
+     pushed within the recency window.
+  2. Dedupe by repo slug.
+  3. For each repo, walk the default-branch tree and pick out compose files.
+  4. Hand candidates to the shared downloader.
+
+Notes:
+  - `gh search repos` caps at 1000 results per query, but topic-faceted
+    queries rarely hit that ceiling at stars>=50, so we skip date-window
+    sharding here (unlike fetch.py).
+  - Tree walks are cached for 1h via `gh api --cache 1h`, so reruns are
+    fast and friendly to the rate limiter.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import COMPOSE_FILENAMES, download_and_index  # noqa: E402
+
+TIER = "popular"
+
+# Topic facets — each runs as a separate `gh search repos` query so we
+# can pull up to 1000 repos per facet before the API caps us.
+TOPICS = [
+    "docker-compose",
+    "compose",
+    "self-hosted",
+    "selfhosted",
+    "homelab",
+    "containers",
+]
+
+MIN_STARS = 50
+RECENCY_DAYS = 730  # 2 years
+PER_TOPIC_LIMIT = 1000  # gh search repos hard cap
+MAX_REPOS_PER_TREE_WALK = 2000  # safety: don't blow the API budget on a single run
+GH_API_TIMEOUT = 60
+
+
+def gh_search_repos(topic: str, pushed_after: str) -> list[dict]:
+    cmd = [
+        "gh", "search", "repos",
+        f"topic:{topic}",
+        "--sort", "stars",
+        "--order", "desc",
+        f"--stars=>={MIN_STARS}",
+        f"--updated=>={pushed_after}",
+        "--limit", str(PER_TOPIC_LIMIT),
+        "--json", "fullName,stargazersCount,defaultBranch,pushedAt",
+    ]
+    try:
+        out = subprocess.run(cmd, check=True, capture_output=True, text=True, timeout=120).stdout
+        return json.loads(out)
+    except subprocess.CalledProcessError as e:
+        print(f"  search repos failed (topic={topic}): {(e.stderr or '').strip()[:200]}", file=sys.stderr)
+        return []
+    except subprocess.TimeoutExpired:
+        print(f"  search repos timeout (topic={topic})", file=sys.stderr)
+        return []
+
+
+def gh_api(path: str) -> dict | list | None:
+    try:
+        out = subprocess.run(
+            ["gh", "api", "--cache", "1h", path],
+            check=True, capture_output=True, text=True, timeout=GH_API_TIMEOUT,
+        ).stdout
+        return json.loads(out)
+    except subprocess.CalledProcessError as e:
+        msg = (e.stderr or "").strip()[:200]
+        # Empty repos or 404s on the tree endpoint are common — log quietly.
+        if "Not Found" not in msg:
+            print(f"  gh api failed for {path}: {msg}", file=sys.stderr)
+        return None
+    except subprocess.TimeoutExpired:
+        return None
+
+
+def list_compose_paths(repo: str, branch: str) -> list[dict]:
+    tree = gh_api(f"repos/{repo}/git/trees/{branch}?recursive=1")
+    if not isinstance(tree, dict):
+        return []
+    out = []
+    for entry in tree.get("tree", []):
+        if entry.get("type") != "blob":
+            continue
+        path = entry.get("path", "")
+        if Path(path).name in COMPOSE_FILENAMES:
+            out.append({"path": path, "sha": entry["sha"]})
+    return out
+
+
+def collect_repos() -> dict[str, dict]:
+    """Run topic searches, dedupe by repo slug, return {fullName: meta}."""
+    pushed_after = (date.today() - timedelta(days=RECENCY_DAYS)).isoformat()
+    repos: dict[str, dict] = {}
+    for topic in TOPICS:
+        print(f"[popular] search topic={topic}", file=sys.stderr)
+        hits = gh_search_repos(topic, pushed_after)
+        added = 0
+        for h in hits:
+            slug = h["fullName"]
+            if slug not in repos:
+                repos[slug] = h
+                added += 1
+        print(f"   +{added} new (total {len(repos)})", file=sys.stderr)
+    return repos
+
+
+def main() -> int:
+    repos = collect_repos()
+    if len(repos) > MAX_REPOS_PER_TREE_WALK:
+        # Sort by stars desc and cap — we'd rather walk the most popular
+        # than starve the API budget on the long tail.
+        ranked = sorted(repos.values(), key=lambda r: r.get("stargazersCount", 0), reverse=True)
+        repos = {r["fullName"]: r for r in ranked[:MAX_REPOS_PER_TREE_WALK]}
+        print(f"[popular] capped tree walks at top {MAX_REPOS_PER_TREE_WALK} by stars", file=sys.stderr)
+
+    candidates: list[dict] = []
+    for i, (slug, meta) in enumerate(repos.items(), 1):
+        branch = meta.get("defaultBranch") or "main"
+        files = list_compose_paths(slug, branch)
+        if files:
+            print(f"[popular] [{i}/{len(repos)}] {slug} ({meta.get('stargazersCount', '?')}★): {len(files)} file(s)", file=sys.stderr)
+        for f in files:
+            candidates.append({
+                "repository": {"nameWithOwner": slug},
+                "path": f["path"],
+                "sha": f["sha"],
+                "url": f"https://github.com/{slug}/blob/{branch}/{f['path']}",
+                "stars": meta.get("stargazersCount"),
+                "pushed_at": meta.get("pushedAt"),
+                "default_branch": branch,
+            })
+
+    print(f"[popular] candidates: {len(candidates)}", file=sys.stderr)
+    download_and_index(candidates, tier=TIER)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/corpus/fetch_selfhosted.py
+++ b/scripts/corpus/fetch_selfhosted.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Fetch Compose files from self-hosted app-store / template registries.
+
+Tier purpose: distinct threat model from `popular`. The popular tier is
+"production-adjacent code on the open internet"; self-hosted is "what a
+home-lab user installs from a one-click template store on a LAN-exposed
+Pi or NAS." Same parser, different deployment context — defaults that
+ship in app-store templates are what end up running behind a Tailscale
+tunnel or, more often, a port-forward.
+
+Mechanism: hand-curated registry list (CasaOS AppStore, runtipi
+appstore, Cosmos AppStore, awesome-compose-style template aggregators).
+Each registry follows a `<root>/<app>/docker-compose.yml` convention, so
+a single tree walk + filename filter is sufficient — same pattern as
+fetch_canonical.py.
+
+Note on dedup: the shared downloader keys on blob_sha + content_hash.
+A compose file already pulled by canonical or popular keeps its first-
+claimed tier (this script can't reattribute it). For now that's the
+chosen tradeoff — the goal is to add new files, not relabel existing ones.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import COMPOSE_FILENAMES, download_and_index  # noqa: E402
+
+TIER = "selfhosted"
+
+# Curated registries — all known to publish compose files under a stable
+# `<root>/<app>/(docker-)compose.y(a)ml` layout. Picked for "this is what
+# a non-expert installs by clicking 'install' in a self-host UI."
+CURATED_REPOS = [
+    # CasaOS — large, actively-maintained app store; one compose per app
+    "IceWhaleTech/CasaOS-AppStore",
+    # runtipi — similar one-click home-server platform
+    "runtipi/runtipi-appstore",
+    # Cosmos — reverse-proxy + app launcher; ships a curated app library
+    "azukaar/Cosmos-Server",
+    # Yacht — Portainer alternative; templates live here
+    "SelfhostedPro/selfhosted_templates",
+    # DockSTARTer — opinionated home-server installer with per-app composes
+    "GhostWriters/DockSTARTer",
+    # Dockge — compose stack manager with example stacks
+    "louislam/dockge",
+    # Awesome-compose-style aggregators specifically for self-hosting
+    "Haxxnet/Compose-Examples",
+    # Self-hosted-friendly mediastack-style bundles
+    "geerlingguy/internet-pi",
+]
+
+
+def gh_api(path: str) -> dict | list | None:
+    try:
+        out = subprocess.run(
+            ["gh", "api", "--cache", "1h", path],
+            check=True, capture_output=True, text=True, timeout=120,
+        ).stdout
+        return json.loads(out)
+    except subprocess.CalledProcessError as e:
+        msg = (e.stderr or "").strip()[:200]
+        if "Not Found" not in msg:
+            print(f"  gh api failed for {path}: {msg}", file=sys.stderr)
+        return None
+    except subprocess.TimeoutExpired:
+        print(f"  gh api timeout for {path}", file=sys.stderr)
+        return None
+
+
+def default_branch(repo: str) -> str | None:
+    info = gh_api(f"repos/{repo}")
+    if isinstance(info, dict):
+        return info.get("default_branch")
+    return None
+
+
+def list_compose_paths(repo: str, branch: str) -> list[dict]:
+    tree = gh_api(f"repos/{repo}/git/trees/{branch}?recursive=1")
+    if not isinstance(tree, dict):
+        return []
+    if tree.get("truncated"):
+        # Some app stores have thousands of entries; if the tree is
+        # truncated we'll miss tail entries. Worth knowing.
+        print(f"  warn: {repo} tree truncated — some files will be missed", file=sys.stderr)
+    out = []
+    for entry in tree.get("tree", []):
+        if entry.get("type") != "blob":
+            continue
+        path = entry.get("path", "")
+        if Path(path).name in COMPOSE_FILENAMES:
+            out.append({"path": path, "sha": entry["sha"]})
+    return out
+
+
+def candidates_for_repo(repo: str) -> list[dict]:
+    branch = default_branch(repo)
+    if not branch:
+        return []
+    files = list_compose_paths(repo, branch)
+    print(f"  {repo}@{branch}: {len(files)} compose file(s)", file=sys.stderr)
+    info = gh_api(f"repos/{repo}") or {}
+    base = {
+        "stars": info.get("stargazers_count"),
+        "pushed_at": info.get("pushed_at"),
+        "default_branch": branch,
+        "topics": info.get("topics") or [],
+    }
+    return [
+        {
+            "repository": {"nameWithOwner": repo},
+            "path": f["path"],
+            "sha": f["sha"],
+            "url": f"https://github.com/{repo}/blob/{branch}/{f['path']}",
+            **base,
+        }
+        for f in files
+    ]
+
+
+def main() -> int:
+    candidates: list[dict] = []
+    for repo in CURATED_REPOS:
+        print(f"[selfhosted] {repo}", file=sys.stderr)
+        candidates.extend(candidates_for_repo(repo))
+    print(f"[selfhosted] candidates: {len(candidates)}", file=sys.stderr)
+    download_and_index(candidates, tier=TIER)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/corpus/make_tier_summary.py
+++ b/scripts/corpus/make_tier_summary.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Generate `tier_summary.md` for an existing run dir.
+
+Useful when run.py predates the tier_summary writer or when the index has
+been re-tiered since the last lint run. Reads results.jsonl + index.jsonl
+and writes/overwrites tier_summary.md in the given run dir.
+
+Usage:
+  python3 make_tier_summary.py <run_dir>
+  python3 make_tier_summary.py latest      # most recent run
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from run import load_index, summarize_tiers  # noqa: E402
+
+RUNS = Path.home() / ".cache" / "compose-lint-corpus" / "runs"
+
+
+def resolve_run(arg: str) -> Path:
+    if arg == "latest":
+        runs = sorted(RUNS.iterdir(), key=lambda p: p.name)
+        if not runs:
+            sys.exit("no runs found")
+        return runs[-1]
+    p = Path(arg)
+    if not p.is_absolute():
+        p = RUNS / arg
+    if not p.exists():
+        sys.exit(f"run dir not found: {p}")
+    return p
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        sys.exit(__doc__)
+    run_dir = resolve_run(argv[1])
+    results_path = run_dir / "results.jsonl"
+    if not results_path.exists():
+        sys.exit(f"no results.jsonl in {run_dir}")
+
+    results = [json.loads(line) for line in results_path.open()]
+    index = load_index()
+    summarize_tiers(run_dir, results, index)
+
+    out = run_dir / "tier_summary.md"
+    print(f"wrote {out} ({out.stat().st_size} bytes)", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/corpus/retier.py
+++ b/scripts/corpus/retier.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Reattribute index entries to the correct tier by curated-list priority.
+
+The fetchers dedupe on blob_sha (first-write-wins), so a compose file
+that exists in both a curated registry and a high-star repo may keep
+whichever tier's fetch ran first. That's wrong for analysis: we want
+canonical/selfhosted entries to stay tagged as such even when popular
+swept them up earlier.
+
+Priority (highest wins):
+    canonical > selfhosted > popular > longtail
+
+This script imports the curated `CURATED_REPOS` lists from the
+canonical and self-hosted fetchers and re-tags any entry whose `repo`
+appears in those lists. Popular and longtail tiers are left alone —
+they're the residual buckets, not curated lists.
+
+Idempotent: rerunning produces no changes.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+import fetch_canonical  # noqa: E402
+import fetch_selfhosted  # noqa: E402
+
+INDEX = Path.home() / ".cache" / "compose-lint-corpus" / "index.jsonl"
+
+# Higher number = higher priority. Used to gate downgrades.
+PRIORITY = {"canonical": 4, "selfhosted": 3, "popular": 2, "longtail": 1, "unknown": 0}
+
+
+def main() -> int:
+    if not INDEX.exists():
+        sys.exit(f"no index at {INDEX}")
+
+    canonical_repos = set(fetch_canonical.CURATED_REPOS)
+    selfhosted_repos = set(fetch_selfhosted.CURATED_REPOS)
+
+    # Sanity: a repo shouldn't be in both lists. If it is, canonical wins
+    # (canonical is the upstream-truth tier; selfhosted is one rung down).
+    overlap = canonical_repos & selfhosted_repos
+    if overlap:
+        print(f"warn: repos in both curated lists, canonical wins: {sorted(overlap)}", file=sys.stderr)
+
+    entries = [json.loads(line) for line in INDEX.open()]
+
+    desired_for: dict[str, str] = {}
+    for repo in selfhosted_repos:
+        desired_for[repo] = "selfhosted"
+    for repo in canonical_repos:  # overwrites selfhosted entries on overlap
+        desired_for[repo] = "canonical"
+
+    changed = 0
+    by_change: dict[tuple[str, str], int] = {}
+    for e in entries:
+        desired = desired_for.get(e["repo"])
+        if not desired:
+            continue
+        current = e.get("tier", "unknown")
+        if current == desired:
+            continue
+        # Only promote, never demote (so a future curated list shrink
+        # doesn't reset a deliberate canonical tag back to popular).
+        if PRIORITY[desired] <= PRIORITY[current]:
+            continue
+        e["tier"] = desired
+        changed += 1
+        by_change[(current, desired)] = by_change.get((current, desired), 0) + 1
+
+    if changed == 0:
+        print("no changes — index already correctly tiered", file=sys.stderr)
+        return 0
+
+    tmp = INDEX.with_suffix(".jsonl.tmp")
+    with tmp.open("w") as out:
+        for e in entries:
+            out.write(json.dumps(e) + "\n")
+    tmp.replace(INDEX)
+
+    print(f"retiered {changed} entries:", file=sys.stderr)
+    for (frm, to), n in sorted(by_change.items()):
+        print(f"  {frm:>10s}  ->  {to:<10s}  {n}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/corpus/run.py
+++ b/scripts/corpus/run.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Run compose-lint over every file in the corpus, write per-file JSONL + summary.md.
+
+Output goes to ~/.cache/compose-lint-corpus/runs/<timestamp>/:
+  results.jsonl   - one line per file with full lint output
+  errors.jsonl    - parse errors / crashes (separate so they don't pollute findings)
+  summary.md      - human-readable aggregate (rule counts, severity dist, top examples)
+  meta.json       - run params (compose-lint version, file count, timing)
+
+Designed to be referenceable from a future Claude session: stable layout, jq-friendly JSONL.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from collections import Counter, defaultdict
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from datetime import datetime, timezone
+from pathlib import Path
+
+CACHE = Path.home() / ".cache" / "compose-lint-corpus"
+FILES = CACHE / "files"
+INDEX = CACHE / "index.jsonl"
+RUNS = CACHE / "runs"
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPOSE_LINT = os.environ.get(
+    "COMPOSE_LINT_BIN",
+    str(REPO_ROOT / ".venv" / "bin" / "compose-lint"),
+)
+PER_FILE_TIMEOUT = 30
+WORKERS = int(os.environ.get("LINT_WORKERS", "8"))
+GLOBAL_TIMEOUT_SECS = int(os.environ.get("LINT_TIMEOUT", "1500"))  # 25 min
+
+
+def lint_one(path_str: str) -> dict:
+    path = Path(path_str)
+    t0 = time.monotonic()
+    try:
+        proc = subprocess.run(
+            [COMPOSE_LINT, "--format", "json", "--fail-on", "low", str(path)],
+            capture_output=True, text=True, timeout=PER_FILE_TIMEOUT,
+        )
+        elapsed = time.monotonic() - t0
+        result: dict = {
+            "content_hash": path.stem,
+            "exit_code": proc.returncode,
+            "elapsed_ms": int(elapsed * 1000),
+        }
+        # exit 0/1 → JSON on stdout; exit 2 → usage/parse error on stderr
+        if proc.returncode in (0, 1):
+            try:
+                result["lint"] = json.loads(proc.stdout) if proc.stdout.strip() else None
+            except json.JSONDecodeError as e:
+                result["error"] = f"json_decode: {e}"
+                result["stdout_head"] = proc.stdout[:500]
+        else:
+            result["error"] = "usage_or_parse"
+            result["stderr"] = proc.stderr.strip()[:1000]
+        return result
+    except subprocess.TimeoutExpired:
+        return {"content_hash": path.stem, "error": "timeout", "elapsed_ms": PER_FILE_TIMEOUT * 1000}
+    except Exception as e:
+        return {"content_hash": path.stem, "error": f"{type(e).__name__}: {e}"}
+
+
+def load_index() -> dict[str, dict]:
+    out: dict[str, dict] = {}
+    if not INDEX.exists():
+        return out
+    with INDEX.open() as f:
+        for line in f:
+            try:
+                rec = json.loads(line)
+                out[rec["content_hash"]] = rec
+            except Exception:
+                continue
+    return out
+
+
+def summarize(run_dir: Path, results: list[dict], index: dict[str, dict], started_at: str, elapsed: float) -> None:
+    total = len(results)
+    parse_errors = [r for r in results if r.get("error") == "usage_or_parse"]
+    timeouts = [r for r in results if r.get("error") == "timeout"]
+    crashes = [r for r in results if r.get("error") and r["error"] not in ("usage_or_parse", "timeout")]
+    linted = [r for r in results if r.get("lint") is not None]
+
+    rule_counts: Counter[str] = Counter()
+    severity_counts: Counter[str] = Counter()
+    rule_examples: dict[str, list[tuple[str, str, int]]] = defaultdict(list)  # rule_id -> [(repo, path, line)]
+    findings_per_file: list[int] = []
+    files_with_findings = 0
+    files_clean = 0
+
+    for r in linted:
+        lint = r["lint"]
+        findings = lint if isinstance(lint, list) else lint.get("findings", [])
+        findings_per_file.append(len(findings))
+        if findings:
+            files_with_findings += 1
+        else:
+            files_clean += 1
+        for f in findings:
+            rid = f.get("rule_id", "?")
+            rule_counts[rid] += 1
+            severity_counts[(f.get("severity") or "?").lower()] += 1
+            if len(rule_examples[rid]) < 3:
+                meta = index.get(r["content_hash"], {})
+                rule_examples[rid].append((
+                    meta.get("repo", "?"),
+                    meta.get("path", "?"),
+                    f.get("line") or f.get("line_number") or 0,
+                ))
+
+    avg_findings = sum(findings_per_file) / len(findings_per_file) if findings_per_file else 0
+    median_findings = sorted(findings_per_file)[len(findings_per_file) // 2] if findings_per_file else 0
+
+    lines = [
+        f"# compose-lint corpus run — {started_at}",
+        "",
+        f"- Corpus location: `{FILES}`",
+        f"- Run directory: `{run_dir}`",
+        f"- Tool: `{COMPOSE_LINT}` (compose-lint {get_cl_version()})",
+        f"- Wall time: {elapsed:.1f}s",
+        "",
+        "## Counts",
+        "",
+        f"- Total files: **{total}**",
+        f"- Successfully linted: **{len(linted)}**",
+        f"  - Files with findings: {files_with_findings}",
+        f"  - Files clean: {files_clean}",
+        f"- Parse / usage errors (exit 2): **{len(parse_errors)}**",
+        f"- Timeouts (>{PER_FILE_TIMEOUT}s): **{len(timeouts)}**",
+        f"- Crashes / other: **{len(crashes)}**",
+        "",
+        f"- Findings per file: avg {avg_findings:.2f}, median {median_findings}, max {max(findings_per_file or [0])}",
+        "",
+        "## Severity distribution",
+        "",
+    ]
+    for sev in ("critical", "high", "medium", "low"):
+        lines.append(f"- {sev}: {severity_counts.get(sev, 0)}")
+    lines += ["", "## Rule hit counts (descending)", ""]
+    if rule_counts:
+        lines.append("| Rule | Hits | Files | Example |")
+        lines.append("| --- | ---: | ---: | --- |")
+        # files-affected per rule
+        files_per_rule: Counter[str] = Counter()
+        for r in linted:
+            seen = set()
+            lint = r["lint"]
+            findings = lint if isinstance(lint, list) else lint.get("findings", [])
+            for f in findings:
+                rid = f.get("rule_id", "?")
+                if rid not in seen:
+                    files_per_rule[rid] += 1
+                    seen.add(rid)
+        for rid, n in rule_counts.most_common():
+            ex = rule_examples.get(rid, [])
+            ex_str = ", ".join(f"{repo}#{path}:{line}" for repo, path, line in ex[:1])
+            lines.append(f"| `{rid}` | {n} | {files_per_rule[rid]} | {ex_str} |")
+    else:
+        lines.append("_No findings._")
+
+    lines += ["", "## Parse errors (sample of first 10)", ""]
+    for r in parse_errors[:10]:
+        meta = index.get(r["content_hash"], {})
+        msg = (r.get("stderr") or "").splitlines()[0] if r.get("stderr") else ""
+        lines.append(f"- `{meta.get('repo','?')}` / `{meta.get('path','?')}` — {msg[:200]}")
+
+    if crashes:
+        lines += ["", "## Crashes / unexpected errors", ""]
+        for r in crashes[:20]:
+            meta = index.get(r["content_hash"], {})
+            lines.append(f"- `{meta.get('repo','?')}` / `{meta.get('path','?')}` — {r.get('error')}")
+
+    lines += [
+        "",
+        "## Result schema",
+        "",
+        "Each line in `results.jsonl` is one of:",
+        "- successful lint: `{content_hash, exit_code, elapsed_ms, lint: [<finding>, ...]}`",
+        "  (`lint` is the raw compose-lint JSON array — empty array means clean)",
+        "- parse / usage error: `{content_hash, error: \"usage_or_parse\", stderr}`",
+        "- timeout / crash: `{content_hash, error: \"timeout\" | \"<ExceptionName>\"}`",
+        "",
+        "Each line in `~/.cache/compose-lint-corpus/index.jsonl` is the source mapping:",
+        "`{content_hash, blob_sha, repo, path, url, size}`.",
+        "",
+        "## How to query results in a future session",
+        "",
+        "```bash",
+        f"RUN={run_dir}",
+        f"IDX={INDEX}",
+        "",
+        "# all findings for rule CL-0001",
+        "jq -c '.lint[]? | select(.rule_id==\"CL-0001\")' $RUN/results.jsonl",
+        "",
+        "# files where compose-lint exited 2 (parse / usage error)",
+        "jq -c 'select(.error==\"usage_or_parse\") | {hash: .content_hash, err: .stderr}' \\",
+        "  $RUN/results.jsonl",
+        "",
+        "# top 20 files by finding count, with source repo",
+        "jq -c 'select(.lint) | {h: .content_hash, n: (.lint | length)}' $RUN/results.jsonl \\",
+        "  | jq -s 'sort_by(-.n) | .[0:20]' \\",
+        "  | jq -c '.[]' \\",
+        "  | while read row; do h=$(jq -r .h <<<\"$row\"); n=$(jq -r .n <<<\"$row\"); \\",
+        "      src=$(jq -c \"select(.content_hash==\\\"$h\\\") | {repo,path}\" $IDX); \\",
+        "      echo \"$n $src\"; done",
+        "",
+        "# read the actual compose file for a finding",
+        "cat ~/.cache/compose-lint-corpus/files/<content_hash>.yml",
+        "```",
+    ]
+
+    (run_dir / "summary.md").write_text("\n".join(lines))
+
+
+def summarize_tiers(run_dir: Path, results: list[dict], index: dict[str, dict]) -> None:
+    """Write tier_summary.md: per-tier counts, severity dist, top rules.
+
+    Joins results.jsonl entries to index entries by content_hash and groups
+    by `tier`. Untagged entries fall into 'unknown' so missing index rows
+    are visible rather than silently dropped.
+    """
+    by_tier: dict[str, dict] = defaultdict(lambda: {
+        "total": 0, "parsed": 0, "parse_errors": 0, "timeouts": 0,
+        "clean": 0, "with_findings": 0, "findings": 0,
+        "rules": Counter(), "severity": Counter(),
+    })
+
+    for r in results:
+        tier = index.get(r["content_hash"], {}).get("tier", "unknown")
+        b = by_tier[tier]
+        b["total"] += 1
+        if r.get("error") == "usage_or_parse":
+            b["parse_errors"] += 1
+            continue
+        if r.get("error") == "timeout":
+            b["timeouts"] += 1
+            continue
+        if r.get("lint") is None:
+            continue  # other crash; counted in 'total' only
+        b["parsed"] += 1
+        lint = r["lint"]
+        findings = lint if isinstance(lint, list) else lint.get("findings", [])
+        if findings:
+            b["with_findings"] += 1
+        else:
+            b["clean"] += 1
+        for f in findings:
+            b["findings"] += 1
+            b["rules"][f.get("rule_id", "?")] += 1
+            b["severity"][(f.get("severity") or "?").lower()] += 1
+
+    lines = [
+        f"# compose-lint per-tier summary — {run_dir.name}",
+        "",
+        "Joined `results.jsonl` × `index.jsonl` on `content_hash`, grouped by `tier`.",
+        "",
+        "## Counts per tier",
+        "",
+        "| tier | total | parsed | parse-err | clean | w/findings | findings | per-parsed |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for tier in sorted(by_tier):
+        b = by_tier[tier]
+        per_parsed = b["findings"] / b["parsed"] if b["parsed"] else 0
+        lines.append(
+            f"| `{tier}` | {b['total']} | {b['parsed']} | {b['parse_errors']} | "
+            f"{b['clean']} | {b['with_findings']} | {b['findings']} | {per_parsed:.2f} |"
+        )
+
+    lines += ["", "## Severity distribution per tier", "",
+              "| tier | critical | high | medium | low |",
+              "| --- | ---: | ---: | ---: | ---: |"]
+    for tier in sorted(by_tier):
+        s = by_tier[tier]["severity"]
+        lines.append(f"| `{tier}` | {s.get('critical',0)} | {s.get('high',0)} | "
+                     f"{s.get('medium',0)} | {s.get('low',0)} |")
+
+    lines += ["", "## Top 10 rules per tier", ""]
+    for tier in sorted(by_tier):
+        rules = by_tier[tier]["rules"]
+        if not rules:
+            continue
+        lines += [f"### `{tier}`", "", "| Rule | Hits |", "| --- | ---: |"]
+        for rid, n in rules.most_common(10):
+            lines.append(f"| `{rid}` | {n} |")
+        lines.append("")
+
+    (run_dir / "tier_summary.md").write_text("\n".join(lines))
+
+
+def get_cl_version() -> str:
+    try:
+        out = subprocess.run([COMPOSE_LINT, "--version"], capture_output=True, text=True, timeout=5).stdout.strip()
+        # `compose-lint --version` prints "compose-lint X.Y.Z"; strip the prefix
+        return out.removeprefix("compose-lint ").strip() or out
+    except Exception:
+        return "unknown"
+
+
+def main() -> int:
+    if not FILES.exists() or not any(FILES.iterdir()):
+        print(f"no files in {FILES} — run fetch.py first", file=sys.stderr)
+        return 1
+
+    paths = sorted(FILES.glob("*.yml"))
+    print(f"linting {len(paths)} files with {WORKERS} workers", file=sys.stderr)
+
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    run_dir = RUNS / ts
+    run_dir.mkdir(parents=True, exist_ok=True)
+    results_path = run_dir / "results.jsonl"
+
+    start = time.monotonic()
+    results: list[dict] = []
+    with results_path.open("w") as out, ProcessPoolExecutor(max_workers=WORKERS) as pool:
+        futures = {pool.submit(lint_one, str(p)): p for p in paths}
+        done = 0
+        for fut in as_completed(futures):
+            if time.monotonic() - start > GLOBAL_TIMEOUT_SECS:
+                print("global lint timeout reached", file=sys.stderr)
+                for f in futures:
+                    f.cancel()
+                break
+            r = fut.result()
+            results.append(r)
+            out.write(json.dumps(r) + "\n")
+            done += 1
+            if done % 200 == 0:
+                print(f"  linted {done}/{len(paths)}", file=sys.stderr)
+
+    elapsed = time.monotonic() - start
+    print(f"linted {len(results)} files in {elapsed:.1f}s", file=sys.stderr)
+
+    index = load_index()
+    summarize(run_dir, results, index, ts, elapsed)
+    summarize_tiers(run_dir, results, index)
+
+    (run_dir / "meta.json").write_text(json.dumps({
+        "started_at": ts,
+        "elapsed_seconds": elapsed,
+        "compose_lint_version": get_cl_version(),
+        "compose_lint_path": COMPOSE_LINT,
+        "files_total": len(paths),
+        "files_processed": len(results),
+        "workers": WORKERS,
+        "per_file_timeout": PER_FILE_TIMEOUT,
+    }, indent=2))
+
+    print(f"\nresults: {run_dir}", file=sys.stderr)
+    print(f"  summary.md  ({(run_dir / 'summary.md').stat().st_size} bytes)", file=sys.stderr)
+    print(f"  tier_summary.md  ({(run_dir / 'tier_summary.md').stat().st_size} bytes)", file=sys.stderr)
+    print(f"  results.jsonl  ({results_path.stat().st_size} bytes)", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Brings the corpus fetch/retier/enrich/lint pipeline in-repo at `scripts/corpus/`. Previously it lived at `~/.cache/compose-lint-corpus/scripts/`, outside git — fine while it was a personal tool, blocks third-party reproduction of the State of Docker Compose Security report (#186).
- The cache directory keeps holding only data (`files/`, `index.jsonl`, `runs/`); no third-party compose files enter the repo.
- The lone user-specific path in `run.py` (`~/code/compose-lint/.venv/bin/compose-lint`) is now derived from `__file__` relative to the repo root, with a `COMPOSE_LINT_BIN` env var escape hatch for cron contexts.
- Adds `scripts/corpus/README.md` documenting the pipeline order, tier model, and output layout.

Pre-req for #186 — the report's reproducibility appendix and the planned quarterly refresh cron need this.

## Test plan

- [x] `python3 scripts/corpus/retier.py` — succeeds from new path (printed `no changes`)
- [x] `run.COMPOSE_LINT` resolves to `<repo>/.venv/bin/compose-lint` when imported from in-repo location
- [ ] CI: `ruff check`, `ruff format --check`, `mypy src/`, `pytest` all pass (these scripts live outside `src/` so should not regress mypy/pytest, but ruff covers them)
- [ ] Smoke after merge: re-run a full `fetch_canonical → retier → enrich_metadata → run.py` cycle from main to confirm cron-shape reproducibility