### PR TITLE
Bump pip to 26.1.1 in dev lockfile; drop CVE-2026-3219 ignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,16 +169,7 @@ jobs:
         # --skip-editable skips compose-lint itself (it isn't on PyPI
         # for the local install path); PyYAML and any future runtime
         # deps are still scanned.
-        #
-        # --ignore-vuln CVE-2026-3219: pip-audit transitively requires
-        # pip via pip-api, so it ends up auditing pip itself (pinned at
-        # 26.0.1 in requirements-dev.lock). pip CVEs are out of scope
-        # for this project's supply chain — pip is not in the runtime
-        # lockfile and is explicitly stripped from the runtime Docker
-        # image (Dockerfile lines 42-43). No fixed pip version is yet
-        # published; remove this flag once pip 26.0.2+ ships and the
-        # dev lockfile is regenerated.
-        run: pip-audit --skip-editable --ignore-vuln CVE-2026-3219
+        run: pip-audit --skip-editable
 
   # Fails the PR if `pyproject.toml` and `src/compose_lint/__init__.py`
   # disagree about the project version. The two strings drifted silently

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -870,9 +870,9 @@ pathspec==1.0.4 \
     --hash=sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645 \
     --hash=sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723
     # via mypy
-pip==26.0.1 \
-    --hash=sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b \
-    --hash=sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8
+pip==26.1.1 \
+    --hash=sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb \
+    --hash=sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78
     # via pip-api
 pip-api==0.0.34 \
     --hash=sha256:8b2d7d7c37f2447373aa2cf8b1f60a2f2b27a84e1e9e0294a3f6ef10eb3ba6bb \


### PR DESCRIPTION
## Summary

- Regenerates \`requirements-dev.lock\` to bump pip from 26.0.1 to 26.1.1 (transitive via \`pip-api\`)
- Removes the now-obsolete \`--ignore-vuln CVE-2026-3219\` flag and its comment block from the security-scan workflow

## Why

Two pip CVEs were affecting the dev lockfile:

| CVE | Status before | Status after |
| --- | --- | --- |
| CVE-2026-3219 | already ignored, with a TODO to remove once pip 26.0.2+ ships | fixed in 26.1; ignore removed |
| CVE-2026-6357 | **newly disclosed**, was failing every open PR's security scan as of 2026-05-08 | fixed in 26.1.1 |

Verified locally with \`pip-audit --skip-editable\` against the new lockfile: **No known vulnerabilities found**.

## Why not just add another \`--ignore-vuln\`?

The existing comment block already says *"remove this flag once pip 26.0.2+ ships and the dev lockfile is regenerated"* — that condition is now satisfied. Stacking another ignore would grow tech debt; bumping the lockfile is what the original author planned for.

## Unblocks

PRs #206 and #207 are currently blocked on this same security scan failure.

## Test plan

- [ ] CI security scan job passes (the previously-failing job)
- [ ] No regressions in the rest of the matrix