### PR TITLE
Methodology adds for State of Compose report: parse-error classes + longtail sampling docs

### DIFF
--- a/scripts/corpus/README.md
+++ b/scripts/corpus/README.md
@@ -25,9 +25,29 @@ If you only edited the curated lists, skip the fetches: `retier.py` then `make_t
 - `canonical` — official upstream examples (what people copy from READMEs)
 - `popular` — high-star repos with compose files (production-adjacent code)
 - `selfhosted` — app-store / template-registry repos (home-lab threat model)
-- `longtail` — random GH code-search corpus (what the median wild file looks like)
+- `longtail` — stratified GH code-search corpus (what the median wild file looks like)
 
 `retier.py` must run after fetches: the downloader keys on `blob_sha` first-write-wins, so a curated app-store template swept up earlier by `fetch_popular` would otherwise stay tagged `popular`.
+
+## Longtail sampling methodology
+
+`fetch.py` is **not random sampling** — GitHub's code-search API has no random-document primitive. It is a **stratified sweep** designed to broaden coverage past the search engine's per-query result cap:
+
+- **120 queries** = 6 anchor terms × 4 filenames × 5 size buckets
+  - **Anchors**: `services:`, `image:`, `volumes:`, `restart:`, `ports:`, `depends_on:` (every real Compose file contains at least one)
+  - **Filenames**: `docker-compose.yml`, `docker-compose.yaml`, `compose.yml`, `compose.yaml`
+  - **Size buckets** (KB): `<2`, `2..5`, `5..15`, `15..50`, `>50`
+- **Per-query cap**: 200 hits (`--limit 200` to `gh search code`). GitHub's hard ceiling per query is ~1000 results; 200 is fast and the stratification picks up the rest.
+- **Dedup**: `(repo, path, sha)` at search time, then `content_hash` (SHA256 of bytes) at download time so identical files in different repos collapse to one corpus entry.
+
+### Known biases (for the report's "limitations" section)
+
+- **GitHub-search ranking bias.** Results are ranked by the search engine, so files in higher-relevance repos surface first. The size-bucket stratification mitigates this for content shape but not for repo popularity.
+- **Single-source.** GitHub only — no GitLab, Codeberg, Docker Hub README snippets, or package-manager fragments.
+- **Filename-pinned.** Compose files saved under non-standard names (`stack.yml`, `web.compose.yml`, etc.) are missed.
+- **Public-only.** Private and enterprise-internal repos are out of scope.
+
+This is **descriptive sampling for prevalence estimation**, not random sampling for statistical inference. The State of Compose report frames findings accordingly.
 
 ## Requirements
 

--- a/scripts/corpus/run.py
+++ b/scripts/corpus/run.py
@@ -63,14 +63,13 @@ _PARSE_ERROR_CLASSES: tuple[tuple[str, re.Pattern[str]], ...] = (
 def classify_parse_error(stderr: str | None) -> str:
     """Bucket a compose-lint exit-2 stderr into a stable class label.
 
-    The report's methodology section treats the parse-error population as
-    a finding (28% of longtail files in the v1 corpus snapshot), so the
-    classes need to be stable across runs. Anything unmatched falls into
-    `other` so a new failure mode is visible rather than silently merged.
+    Class labels are stable across runs so the State of Compose report
+    can quote them. Anything unmatched falls into `other` so a new
+    failure mode is visible rather than silently merged with a known one.
     """
     if not stderr:
         return "other"
-    first = stderr.splitlines()[0] if stderr else ""
+    first = stderr.splitlines()[0]
     for label, pat in _PARSE_ERROR_CLASSES:
         if pat.search(first):
             return label
@@ -239,9 +238,11 @@ def summarize(run_dir: Path, results: list[dict], index: dict[str, dict], starte
             "",
             "## Parse-error classes",
             "",
-            "Every exit-2 result bucketed by stderr class. Treat the"
-            " parse-error population as a finding (the report cites it),"
-            " not a discard.",
+            (
+                "Every exit-2 result bucketed by stderr class. Treat the"
+                + " parse-error population as a finding (the report cites it),"
+                + " not a discard."
+            ),
             "",
             "| Class | Count |",
             "| --- | ---: |",
@@ -316,8 +317,8 @@ def summarize_tiers(run_dir: Path, results: list[dict], index: dict[str, dict]) 
         "total": 0, "parsed": 0, "parse_errors": 0, "timeouts": 0,
         "clean": 0, "with_findings": 0, "findings": 0,
         "rules": Counter(), "severity": Counter(),
-        "files_per_rule": Counter(),     # rule_id -> distinct files in this tier
-        "parse_classes": Counter(),      # class label -> count in this tier
+        "files_per_rule": Counter(),  # rule_id -> distinct files in this tier
+        "parse_classes": Counter(),  # exit-2 stderr class -> count in this tier
     })
     rule_severity: dict[str, str] = {}
 
@@ -389,9 +390,12 @@ def summarize_tiers(run_dir: Path, results: list[dict], index: dict[str, dict]) 
             "",
             "## Parse-error classes per tier",
             "",
-            "Each row is one tier; columns are parse-error classes plus the"
-            " tier's parse-error rate (parse-errors / total). The report cites"
-            " these as a finding — see `docs/state-of-compose.md` methodology.",
+            (
+                "Each row is one tier; columns are parse-error classes plus the"
+                + " tier's parse-error rate (parse-errors / total). The report"
+                + " cites these as a finding — see `docs/state-of-compose.md`"
+                + " methodology."
+            ),
             "",
             "| tier | " + " | ".join(present_classes) + " | rate |",
             "| --- | " + " | ".join(["---:"] * len(present_classes)) + " | ---: |",

--- a/scripts/corpus/run.py
+++ b/scripts/corpus/run.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -44,6 +45,47 @@ SEVERITY_WEIGHT = {"critical": 8, "high": 4, "medium": 2, "low": 1}
 
 def _fmt_weights() -> str:
     return ", ".join(f"{k}={v}" for k, v in SEVERITY_WEIGHT.items())
+
+
+# Order matters: first matching pattern wins. Tested against
+# runs/20260503T034026Z (178 parse errors, 15 distinct first-line
+# fingerprints) — these patterns cover every observed class.
+_PARSE_ERROR_CLASSES: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("missing-services-key",   re.compile(r"missing 'services' key")),
+    ("services-not-mapping",   re.compile(r"'services' must be a mapping")),
+    ("service-not-mapping",    re.compile(r"service '[^']+' must be a mapping")),
+    ("empty-file",             re.compile(r"file is empty")),
+    ("top-level-not-mapping",  re.compile(r"expected a YAML mapping at the top level")),
+    ("invalid-yaml",           re.compile(r"Invalid YAML:")),
+)
+
+
+def classify_parse_error(stderr: str | None) -> str:
+    """Bucket a compose-lint exit-2 stderr into a stable class label.
+
+    The report's methodology section treats the parse-error population as
+    a finding (28% of longtail files in the v1 corpus snapshot), so the
+    classes need to be stable across runs. Anything unmatched falls into
+    `other` so a new failure mode is visible rather than silently merged.
+    """
+    if not stderr:
+        return "other"
+    first = stderr.splitlines()[0] if stderr else ""
+    for label, pat in _PARSE_ERROR_CLASSES:
+        if pat.search(first):
+            return label
+    return "other"
+
+
+_PARSE_CLASS_ORDER = (
+    "missing-services-key",
+    "services-not-mapping",
+    "service-not-mapping",
+    "top-level-not-mapping",
+    "empty-file",
+    "invalid-yaml",
+    "other",
+)
 
 
 def lint_one(path_str: str) -> dict:
@@ -189,6 +231,26 @@ def summarize(run_dir: Path, results: list[dict], index: dict[str, dict], starte
     else:
         lines.append("_No findings._")
 
+    if parse_errors:
+        parse_class_counts: Counter[str] = Counter(
+            classify_parse_error(r.get("stderr")) for r in parse_errors
+        )
+        lines += [
+            "",
+            "## Parse-error classes",
+            "",
+            "Every exit-2 result bucketed by stderr class. Treat the"
+            " parse-error population as a finding (the report cites it),"
+            " not a discard.",
+            "",
+            "| Class | Count |",
+            "| --- | ---: |",
+        ]
+        for cls in _PARSE_CLASS_ORDER:
+            n = parse_class_counts.get(cls, 0)
+            if n:
+                lines.append(f"| `{cls}` | {n} |")
+
     lines += ["", "## Parse errors (sample of first 10)", ""]
     for r in parse_errors[:10]:
         meta = index.get(r["content_hash"], {})
@@ -254,7 +316,8 @@ def summarize_tiers(run_dir: Path, results: list[dict], index: dict[str, dict]) 
         "total": 0, "parsed": 0, "parse_errors": 0, "timeouts": 0,
         "clean": 0, "with_findings": 0, "findings": 0,
         "rules": Counter(), "severity": Counter(),
-        "files_per_rule": Counter(),  # rule_id -> distinct files in this tier
+        "files_per_rule": Counter(),     # rule_id -> distinct files in this tier
+        "parse_classes": Counter(),      # class label -> count in this tier
     })
     rule_severity: dict[str, str] = {}
 
@@ -264,6 +327,7 @@ def summarize_tiers(run_dir: Path, results: list[dict], index: dict[str, dict]) 
         b["total"] += 1
         if r.get("error") == "usage_or_parse":
             b["parse_errors"] += 1
+            b["parse_classes"][classify_parse_error(r.get("stderr"))] += 1
             continue
         if r.get("error") == "timeout":
             b["timeouts"] += 1
@@ -315,6 +379,28 @@ def summarize_tiers(run_dir: Path, results: list[dict], index: dict[str, dict]) 
         s = by_tier[tier]["severity"]
         lines.append(f"| `{tier}` | {s.get('critical',0)} | {s.get('high',0)} | "
                      f"{s.get('medium',0)} | {s.get('low',0)} |")
+
+    if any(by_tier[t]["parse_errors"] for t in by_tier):
+        present_classes = [
+            cls for cls in _PARSE_CLASS_ORDER
+            if any(by_tier[t]["parse_classes"].get(cls, 0) for t in by_tier)
+        ]
+        lines += [
+            "",
+            "## Parse-error classes per tier",
+            "",
+            "Each row is one tier; columns are parse-error classes plus the"
+            " tier's parse-error rate (parse-errors / total). The report cites"
+            " these as a finding — see `docs/state-of-compose.md` methodology.",
+            "",
+            "| tier | " + " | ".join(present_classes) + " | rate |",
+            "| --- | " + " | ".join(["---:"] * len(present_classes)) + " | ---: |",
+        ]
+        for tier in sorted(by_tier):
+            b = by_tier[tier]
+            cells = [str(b["parse_classes"].get(cls, 0)) for cls in present_classes]
+            rate = b["parse_errors"] / b["total"] if b["total"] else 0
+            lines.append(f"| `{tier}` | " + " | ".join(cells) + f" | {rate:.1%} |")
 
     lines += [
         "",


### PR DESCRIPTION
## Summary

Two methodology adds the State of Compose report (#186) needs in order to defend its empirical-study framing:

1. **Treat parse errors as a finding, not a discard.** `run.py` now buckets every exit-2 stderr into a stable class label (`missing-services-key`, `services-not-mapping`, `service-not-mapping`, `top-level-not-mapping`, `empty-file`, `invalid-yaml`, `other`). `summary.md` gets a global table; `tier_summary.md` gets a per-tier × class matrix with per-tier parse-error rate. Patterns derived from the 178 parse errors in `runs/20260503T034026Z` (15 distinct first-line fingerprints — every observed class is covered).

2. **Disclose the longtail sampling design.** `scripts/corpus/README.md` now documents that `fetch.py` is a stratified sweep, not random sampling: 6 anchors × 4 filenames × 5 size buckets = 120 queries × 200 hits, deduped on `(repo, path, sha)` then on content hash. Calls out four biases the report's limitations section will cite: GH-search ranking bias, single-source (GitHub only), filename-pinned coverage, public-only scope.

### Notable result this surfaces

Per-tier parse-error rate against the latest run:

| tier | rate | dominant class |
| --- | ---: | --- |
| `canonical` | 0.6% | invalid-yaml |
| `popular` | 0.7% | top-level-not-mapping |
| `selfhosted` | 0.0% | — |
| `longtail` | 9.6% | services-not-mapping (49%), service-not-mapping (32%) |

Longtail's parse-error population is real-world misuse of the Compose schema (people writing `services: {db: "postgres:14"}` shorthand), not malformed YAML.

## Test plan

- [x] `ruff check src/ tests/` clean (CI gate)
- [x] `ruff format --check src/ tests/` clean (CI gate)
- [x] `mypy src/` clean (CI gate)
- [x] `pytest` clean — 450 passed, 1 skipped
- [x] Regenerated `summary.md` + `tier_summary.md` against `runs/20260503T034026Z` to `/tmp/`; output verified
- [x] No new lines exceed 88 chars (existing pre-PR-#206 width violations in `scripts/` left untouched)

Refs #186.