### PR TITLE
Bump urllib3 to 2.7.0 in dev lockfile for CVE-2026-44431/44432

### DIFF
--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -1732,9 +1732,9 @@ uc-micro-py==2.0.0 \
     --hash=sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c \
     --hash=sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811
     # via linkify-it-py
-urllib3==2.6.3 \
-    --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
-    --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
+urllib3==2.7.0 \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
     # via
     #   id
     #   requests


### PR DESCRIPTION
## Problem

`pip-audit` (Security scan job) is failing on **every open PR**, not just one — most recently visible on #212:

```
Found 2 known vulnerabilities in 1 package
urllib3 2.6.3   CVE-2026-44431   Fix: 2.7.0
urllib3 2.6.3   CVE-2026-44432   Fix: 2.7.0
```

`urllib3==2.6.3` is hash-pinned in `requirements-dev.lock` as a transitive **dev/publish** dependency (`# via id, requests, tuf, twine`). Both CVEs are fixed in `2.7.0`. Because `pip-audit` checks the live advisory database, this fails CI regardless of a PR's contents, and the cascading `ci-ok` gate fails with it.

**Scope:** dev/CI only. The runtime package depends solely on PyYAML — `urllib3` is absent from `requirements.lock` — so published-package users are unaffected.

## Fix

Regenerated `requirements-dev.lock` with the documented `uv pip compile` command plus `--upgrade-package urllib3` for a minimal, targeted bump. The only change is the `urllib3` pin (`2.6.3` → `2.7.0`) and its two hashes; no other pins move. Both hashes were cross-checked against the official PyPI digests for `urllib3 2.7.0` (sdist + wheel). `urllib3 2.7.0` requires Python ≥ 3.10, compatible with `requires-python` and the 3.10 resolution target.

## Verification

Mirrored CI exactly in a clean venv:

- `pip install --require-hashes -r requirements-dev.lock` → succeeds (hashes valid & complete)
- `pip install --no-deps -e .` → succeeds
- `pip-audit --skip-editable` → **No known vulnerabilities found**, exit 0

Once merged, open PRs (including #212) just need a rebase to pick up the new lockfile and the Security scan will pass.