### PR TITLE
Track uv-compiled requirements lockfiles with Renovate pip-compile

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,9 @@
     "enabled": true,
     "schedule": ["before 4am on monday"]
   },
+  "pip-compile": {
+    "managerFilePatterns": ["/(^|/)requirements[\\w-]*\\.lock$/"]
+  },
   "packageRules": [
     {
       "description": "GitHub Actions: SHA-pin every uses: with version comment (CLAUDE.md).",
@@ -19,8 +22,8 @@
       "groupName": "github-actions"
     },
     {
-      "description": "Python runtime + dev deps batched into one PR.",
-      "matchManagers": ["pep621", "pip_requirements"],
+      "description": "Python runtime + dev deps batched into one PR. pip-compile tracks the uv-generated requirements*.lock files: their .lock extension is matched by no pip-family manager by default, leaving transitive pins (e.g. urllib3) invisible to Renovate and weekly lockFileMaintenance a no-op for these files.",
+      "matchManagers": ["pep621", "pip_requirements", "pip-compile"],
       "groupName": "python"
     },
     {
@@ -38,7 +41,7 @@
     },
     {
       "description": "Automerge low-risk routine updates once CI is green. Patch-level Python dep bumps, pinned-digest refreshes for GitHub Actions, and lockFileMaintenance go in without human review. Docker base images stay manual because the OCI manifest-list vs per-arch digest check (see MEMORY.md) is not mechanically verified in CI.",
-      "matchManagers": ["pep621", "pip_requirements", "github-actions"],
+      "matchManagers": ["pep621", "pip_requirements", "pip-compile", "github-actions"],
       "matchUpdateTypes": ["patch", "pin", "digest", "lockFileMaintenance"],
       "automerge": true,
       "automergeType": "pr",


### PR DESCRIPTION
## Why

PR #214 had to bump `urllib3 2.6.3 → 2.7.0` (CVE-2026-44431 / CVE-2026-44432) **by hand** because Renovate never opened it. Root cause is structural, not a timing fluke:

- **Transitive deps are invisible to `pep621`.** `urllib3` is not in `pyproject.toml` — it exists only in the compiled lockfile (`# via id, requests, tuf, twine`). The `pep621` manager only sees direct declarations.
- **`.lock` files match no pip-family manager by default.** `pip_requirements` matches `requirements*.txt`/`.pip`, not `.lock`. So `requirements.lock`, `requirements-dev.lock`, and `requirements-build.lock` were **entirely unmanaged**.
- **`lockFileMaintenance` was a silent no-op for them.** It only refreshes lockfiles a manager tracks; nothing tracked these, so the weekly maintenance never regenerated them.

Net: every transitive CVE in the dependency tree was — and would remain — invisible to Renovate.

## Change

Point the `pip-compile` manager at `requirements*.lock` and add it to the existing `python` group and automerge rules. The lockfiles already carry the autogenerated `# uv pip compile …` header, so Renovate can regenerate them with `uv` and weekly `lockFileMaintenance` becomes effective.

```jsonc
"pip-compile": { "managerFilePatterns": ["/(^|/)requirements[\\w-]*\\.lock$/"] }
```

`managerFilePatterns` is the current Renovate key (replaces the deprecated `fileMatch`).

## Effect

- Transitive pins (urllib3 and the rest of the tree) are now tracked.
- Weekly `lockFileMaintenance` refreshes all three uv lockfiles automatically.
- Patch / pin / digest / lockFileMaintenance updates automerge once CI is green (consistent with the existing rule); minor/major transitive bumps still open a PR for review.

## Validation

`renovate.json` is valid JSON. CI has no Renovate-config validation step (the config is consumed only by the bot), so this cannot be exercised in CI here; the manager, key, and regex were verified against current Renovate config docs.

Relationship: complements #214 (immediate CVE fix). This PR prevents the recurrence.