### PR TITLE
Add VEX not_affected for CVE-2026-6357; version-agnostic pip PURLs

### DIFF
--- a/.vex/compose-lint.openvex.json
+++ b/.vex/compose-lint.openvex.json
@@ -3,8 +3,8 @@
   "@id": "https://github.com/tmatens/compose-lint/.vex/compose-lint.openvex.json",
   "author": "Todd Matens <tmatens@gmail.com>",
   "role": "Project Maintainer",
-  "timestamp": "2026-04-25T00:00:00Z",
-  "version": 3,
+  "timestamp": "2026-05-15T00:00:00Z",
+  "version": 4,
   "tooling": "hand-authored",
   "statements": [
     {
@@ -16,13 +16,13 @@
         {
           "@id": "pkg:oci/compose-lint?repository_url=index.docker.io/composelint/compose-lint",
           "subcomponents": [
-            { "@id": "pkg:pypi/pip@25.1.1" }
+            { "@id": "pkg:pypi/pip" }
           ]
         },
         {
           "@id": "pkg:docker/composelint/compose-lint",
           "subcomponents": [
-            { "@id": "pkg:pypi/pip@25.1.1" }
+            { "@id": "pkg:pypi/pip" }
           ]
         }
       ],
@@ -39,13 +39,13 @@
         {
           "@id": "pkg:oci/compose-lint?repository_url=index.docker.io/composelint/compose-lint",
           "subcomponents": [
-            { "@id": "pkg:pypi/pip@25.1.1" }
+            { "@id": "pkg:pypi/pip" }
           ]
         },
         {
           "@id": "pkg:docker/composelint/compose-lint",
           "subcomponents": [
-            { "@id": "pkg:pypi/pip@25.1.1" }
+            { "@id": "pkg:pypi/pip" }
           ]
         }
       ],
@@ -62,19 +62,42 @@
         {
           "@id": "pkg:oci/compose-lint?repository_url=index.docker.io/composelint/compose-lint",
           "subcomponents": [
-            { "@id": "pkg:pypi/pip@25.1.1" }
+            { "@id": "pkg:pypi/pip" }
           ]
         },
         {
           "@id": "pkg:docker/composelint/compose-lint",
           "subcomponents": [
-            { "@id": "pkg:pypi/pip@25.1.1" }
+            { "@id": "pkg:pypi/pip" }
           ]
         }
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_not_present",
       "impact_statement": "Same mitigation as CVE-2025-8869 and CVE-2026-1703: the pip archive-handling code lives in /venv/lib/python3.13/site-packages/pip/ which is removed at container build time. Only the .dist-info metadata directory is retained for SCA scanner identification; the executable code paths exercised by this CVE are physically absent from the runtime image. The distroless runtime (no shell, nonroot entrypoint /venv/bin/compose-lint) makes pip both absent and unreachable."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-6357",
+        "description": "pip inclusion of functionality from untrusted control sphere"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/compose-lint?repository_url=index.docker.io/composelint/compose-lint",
+          "subcomponents": [
+            { "@id": "pkg:pypi/pip" }
+          ]
+        },
+        {
+          "@id": "pkg:docker/composelint/compose-lint",
+          "subcomponents": [
+            { "@id": "pkg:pypi/pip" }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Same mitigation as CVE-2025-8869, CVE-2026-1703 and CVE-2026-3219: the affected pip code in /venv/lib/python3.13/site-packages/pip/ is removed during the container build stage; only the .dist-info metadata directory is retained for SCA scanner identification. At runtime `import pip` raises ModuleNotFoundError and no pip binary is present. The distroless runtime (no shell, no package manager, nonroot entrypoint /venv/bin/compose-lint) makes the vulnerable code both physically absent from the image and unreachable by execution path."
     }
   ]
 }


### PR DESCRIPTION
Resolves code-scanning alert #85 (Docker Scout, CVE-2026-6357, MEDIUM / CVSS 5.3).

## Context

`CVE-2026-6357` (pip "inclusion of functionality from untrusted control sphere", fixed in pip 26.1) is flagged against the `pip 25.1.1` `.dist-info` retained in the runtime image. This is the **4th instance of an already-handled class**: the Dockerfile deletes pip's executable code and CLI at build time and keeps only `.dist-info` for honest SCA identification (deleting it would be scanner evasion per the Dockerfile comment); the runtime is distroless + nonroot, so the code is physically absent and unreachable.

## Change

1. **Add a 4th statement** for `CVE-2026-6357` — `not_affected` / `vulnerable_code_not_present`, same product `@id`s, following the established `impact_statement` boilerplate.
2. **Make every pip subcomponent PURL version-agnostic** (`pkg:pypi/pip@25.1.1` → `pkg:pypi/pip`) across all four statements.
3. Bump document `version` 3 → 4, refresh `timestamp`.

## Why version-agnostic PURLs

The `vulnerable_code_not_present` justification does not depend on the pip version — the code is removed regardless of which pip the build seeds. More importantly, this is **coupled with the companion PR** that upgrades the bundled pip (defense-in-depth patch for the same alert): once the in-image pip is no longer `25.1.1`, version-pinned subcomponents would stop matching and **the unfixable `CVE-2026-3219` (no upstream fix) would resurface**. A version-less PURL is broader, strictly safer (still matches `25.1.1` today), and future-proof.

## Merge ordering

Merge **this PR before** the Dockerfile pip-upgrade PR. If the pip upgrade lands first, the existing `@25.1.1` statements briefly stop covering `CVE-2026-3219` until this merges.

## Validation

`.vex/compose-lint.openvex.json` is valid JSON; all 4 statements are `not_affected` / `vulnerable_code_not_present` with `pkg:pypi/pip` subcomponents. The scheduled Docker Scout workflow consumes this doc via `vex-location` and re-uploads SARIF with the alert suppressed; the doc is also cosign-attested per ADR-012.