### PR TITLE
Upgrade bundled pip to latest before stripping it from the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN python3 -m venv /build-venv \
     && /build-venv/bin/pip install --no-cache-dir --require-hashes -r requirements-build.lock \
     && /build-venv/bin/python -m build --wheel --outdir /dist \
     && python3 -m venv /venv \
+    && /venv/bin/pip install --no-cache-dir --upgrade pip \
     && /venv/bin/pip install --no-cache-dir --require-hashes -r requirements.lock \
     && /venv/bin/pip install --no-cache-dir --no-deps /dist/*.whl \
     && rm -rf /venv/lib/python3.13/site-packages/pip \
@@ -51,7 +52,12 @@ RUN python3 -m venv /build-venv \
 # and nothing imports pip. We deliberately keep pip's .dist-info in
 # site-packages so SCA scanners can still identify pip and report CVEs
 # against it — deleting the metadata to make the image look vuln-free
-# would be scanner evasion, not remediation. Python 3.13 venvs do not
+# would be scanner evasion, not remediation. The venv-seeded pip is
+# upgraded to the latest release before stripping (the sanctioned
+# always-latest pip bootstrap exception, see AGENTS.md), so the retained
+# .dist-info reports a patched version: genuine remediation, not
+# evasion. The OpenVEX document still backstops any residual or
+# not-yet-fixed pip CVE (e.g. CVE-2026-3219). Python 3.13 venvs do not
 # ship setuptools or wheel by default, so pip is the only ambient
 # package to remove.
 


### PR DESCRIPTION
Defense-in-depth patch for code-scanning alert #85 (Docker Scout, CVE-2026-6357), companion to the VEX PR.

## Change

Add one line to the build stage, before the pip strip:

```dockerfile
&& /venv/bin/pip install --no-cache-dir --upgrade pip \
```

`python3 -m venv` seeds the Debian-bundled `pip 25.1.1`. The build deletes pip's executable code but deliberately keeps `.dist-info` for honest SCA identification. Upgrading pip to the latest release **before** the strip means the retained metadata reports a patched version, so Docker Scout stops flagging the CVEs fixed at/below that release:

| CVE | Fixed in pip |
|---|---|
| CVE-2025-8869 | 25.3 |
| CVE-2026-1703 | 26.0 |
| CVE-2026-6357 (alert #85) | 26.1 |

This is genuine remediation (real version change), not a `not_affected` assertion.

## Relationship to the VEX PR

This **does not replace** the OpenVEX document — it complements it:

- `CVE-2026-3219` has **no upstream fix** and stays VEX-covered.
- VEX remains the backstop for any future pip CVE in the window between disclosure and the next pip release.
- The companion VEX PR makes the pip subcomponent PURLs version-agnostic, so VEX keeps matching after this PR changes the in-image pip version. **Merge the VEX PR first** to avoid a brief window where `CVE-2026-3219` is uncovered.

## Notes

- Only `/venv` is copied to the final image, so `build-venv`'s pip is irrelevant to the scanned artifact.
- The unpinned `--upgrade pip` is the explicitly sanctioned always-latest bootstrap exception (AGENTS.md / CLAUDE.md "Dependency pinning"); lockfile installs still use `--require-hashes`.
- Docker isn't available locally; the **CI "Smoke test Dockerfile (amd64)"** check build-verifies this.