### PR TITLE
Narrow corpus fetch index-parse except to skip only bad lines

### DIFF
--- a/scripts/corpus/fetch.py
+++ b/scripts/corpus/fetch.py
@@ -130,8 +130,11 @@ def main() -> int:
             for line in f:
                 try:
                     blob_seen.add(json.loads(line)["blob_sha"])
-                except Exception:
-                    pass
+                except (json.JSONDecodeError, KeyError):
+                    # Skip a truncated or malformed index line (e.g. a
+                    # partial final record from an interrupted append);
+                    # it just won't dedupe that blob.
+                    continue
 
     todo = [v for k, v in candidates.items() if k[2] not in blob_seen]
     print(f"new to download: {len(todo)}", file=sys.stderr)


### PR DESCRIPTION
Resolves code-scanning alert #86 (CodeQL `py/empty-except`, `scripts/corpus/fetch.py:133`, severity: note).

## Problem

The dedup-index read used a bare catch-all with no comment:

```python
try:
    blob_seen.add(json.loads(line)["blob_sha"])
except Exception:
    pass
```

`except Exception: pass` swallows everything — `MemoryError`, attribute/typing bugs, etc. — not just the intended "this index line is unparsable" case, and gives a future reader no rationale.

## Fix

```python
except (json.JSONDecodeError, KeyError):
    # Skip a truncated or malformed index line (e.g. a
    # partial final record from an interrupted append);
    # it just won't dedupe that blob.
    continue
```

Catch only what `json.loads(line)["blob_sha"]` can actually raise on a bad record (`json.JSONDecodeError`, `KeyError`), document why, and `continue`. Behaviour for the expected case is unchanged; genuine bugs now surface instead of being hidden.

## Notes

- `scripts/` is not in CI's ruff scope (`ruff check src/ tests/`), so the pre-existing `E501`s in this file are out of scope and untouched here; this change adds no lint regression. CodeQL does scan `scripts/` (it raised this alert) and will re-evaluate on this PR.
- `python -m py_compile` passes; no behavioural change to the corpus tooling.