### PR TITLE
Bump idna to 3.15; ignore disputed pyjwt PYSEC-2025-183

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,16 @@ jobs:
         # --skip-editable skips compose-lint itself (it isn't on PyPI
         # for the local install path); PyYAML and any future runtime
         # deps are still scanned.
-        run: pip-audit --skip-editable
+        #
+        # --ignore-vuln PYSEC-2025-183: disputed advisory against pyjwt
+        # claiming "weak encryption". The pyjwt maintainers dispute it
+        # because the encryption key length is chosen by the application
+        # consuming the library, not the library itself. There is no
+        # fix version. pyjwt is a transitive dev/publish dependency
+        # (via sigstore/tuf/twine) and not part of the runtime image.
+        # Remove this ignore if the OSV record is withdrawn or a fix
+        # release is published.
+        run: pip-audit --skip-editable --ignore-vuln PYSEC-2025-183
 
   # Fails the PR if `pyproject.toml` and `src/compose_lint/__init__.py`
   # disagree about the project version. The two strings drifted silently

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -468,9 +468,9 @@ id==1.6.1 \
     # via
     #   sigstore
     #   twine
-idna==3.11 \
-    --hash=sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea \
-    --hash=sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902
+idna==3.15 \
+    --hash=sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8 \
+    --hash=sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc
     # via
     #   email-validator
     #   requests


### PR DESCRIPTION
## Summary

Unblocks `pip-audit` on every PR after two new advisories landed against dev/publish transitives.

- **`idna 3.11` → `3.15`** for `CVE-2026-45409`. Regenerated `requirements-dev.lock` with the documented `uv pip compile` command plus `--upgrade-package idna`; only the `idna` pin and its hashes change.
- **`pyjwt 2.12.1` PYSEC-2025-183 ignored.** The advisory is **disputed by the maintainers** — it claims "weak encryption" but JWT signing key length is chosen by the application using the library, not by `pyjwt` itself. There is no fix version and 2.12.1 is still latest on PyPI. Added `--ignore-vuln PYSEC-2025-183` with a block comment recording the rationale and the removal trigger.

Both packages are dev/publish transitives (`idna` via requests/twine, `pyjwt` via sigstore/tuf/twine). The runtime package depends only on PyYAML, so published-package and container users are unaffected.

Same pattern as #214 (urllib3) and #208 (pip + drop CVE-2026-3219 ignore).

## Test plan

- [ ] CI green (security-scan no longer flags `idna 3.11` / `pyjwt 2.12.1`)
- [ ] DCO sign-off check passes
- [ ] Signed-commit check shows `G`
- [ ] After merge: rebase `changelog-prep-0.7.1` onto main, add a Security bullet for this change, force-push #223