### PR TITLE
Note idna/pyjwt fix in CHANGELOG [Unreleased] for 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   only (via `id`, `requests`, `tuf`, `twine`); the runtime package
   depends only on PyYAML, so published-package users are unaffected.
   (#214)
+- idna bumped to 3.15 in `requirements-dev.lock` for CVE-2026-45409,
+  and `pip-audit` now ignores the disputed `PYSEC-2025-183` advisory
+  against pyjwt 2.12.1 (the pyjwt maintainers dispute it because JWT
+  signing key length is chosen by the consuming application, not the
+  library; no fix version exists). Both packages are dev/publish
+  transitives; the runtime image is unaffected. (#224)
 
 ## [0.7.0] - 2026-05-01
 


### PR DESCRIPTION
## Summary

Adds a one-bullet Security entry to `[Unreleased]` for #224 (idna 3.11 → 3.15 and the disputed pyjwt `PYSEC-2025-183` ignore). #224 merged after #223 so its change wasn't captured in the release notes — without this fix-up the 0.7.1 GitHub Release would silently omit a security-relevant lockfile and pip-audit change.

`CHANGELOG.md` only. No code, no behaviour change.

## Test plan

- [ ] CI green
- [ ] DCO + signed-commit checks pass
- [ ] Squash-merge, then dispatch `release-prep.yml -f version=0.7.1`