### PR TITLE
Retitle the State of Compose teaser

### DIFF
--- a/docs/publishing/state-of-compose-devto.md
+++ b/docs/publishing/state-of-compose-devto.md
@@ -1,5 +1,5 @@
 ---
-title: "I scanned 6,444 public Docker Compose files. 91% of the ones that parse had a security finding."
+title: "9 in 10 Docker Compose files skip the basic security flags"
 published: false
 description: What real-world docker-compose.yml files actually look like, and why even the examples people copy ship insecure defaults.
 tags: docker, security, devops, opensource

--- a/docs/publishing/state-of-compose-hashnode.md
+++ b/docs/publishing/state-of-compose-hashnode.md
@@ -10,7 +10,7 @@ are the publish settings below.
 
 | Setting | Value |
 | --- | --- |
-| **Title** | I scanned 6,444 public Docker Compose files. 91% had a security finding. |
+| **Title** | 9 in 10 Docker Compose files skip the basic security flags |
 | **Subtitle** | An empirical look at how real-world Compose files are configured — and why even vendor copy-paste examples ship insecure defaults. |
 | **Canonical URL** | **The published dev.to post URL** (set under *Settings → Canonical URL*). This is mandatory — it points search authority at dev.to and stops Hashnode competing with it. |
 | **Tags** | docker, security, devops, opensource |


### PR DESCRIPTION
Updates the dev.to teaser title to **"9 in 10 Docker Compose files skip the basic security flags"** and mirrors it in the Hashnode settings file.

Punchier than the old scan/percentage headline, and it avoids the parsed-vs-all denominator question by leading with the hardening-flag finding directly (the triple fires on ~90% of parsed files).

Docs-only; no `pyproject.toml`/version change.

Part of #186.