### PR TITLE
Use a single import style in text formatter tests

### DIFF
--- a/tests/test_text_formatter.py
+++ b/tests/test_text_formatter.py
@@ -8,12 +8,14 @@ severity-then-line ordering of findings within a service, and the verdict line
 
 from __future__ import annotations
 
+import sys
+
 import pytest
 
-import compose_lint.formatters.text as text
 from compose_lint.formatters.text import (
     _COLORS,
     _RESET,
+    _colorize,
     format_aggregate_summary,
     format_findings,
     format_verdict,
@@ -32,7 +34,7 @@ def _force_color(monkeypatch: pytest.MonkeyPatch) -> None:
         def isatty(self) -> bool:
             return True
 
-    monkeypatch.setattr(text.sys, "stdout", _Tty())
+    monkeypatch.setattr(sys, "stdout", _Tty())
     monkeypatch.delenv("NO_COLOR", raising=False)
     monkeypatch.delenv("FORCE_COLOR", raising=False)
 
@@ -44,7 +46,7 @@ def _no_tty(monkeypatch: pytest.MonkeyPatch) -> None:
         def isatty(self) -> bool:
             return False
 
-    monkeypatch.setattr(text.sys, "stdout", _NoTty())
+    monkeypatch.setattr(sys, "stdout", _NoTty())
 
 
 def _image_finding(severity: Severity) -> Finding:
@@ -183,7 +185,7 @@ def test_no_color_disables_color_even_on_a_tty(
 ) -> None:
     _force_color(monkeypatch)  # stdout looks like a tty
     monkeypatch.setenv("NO_COLOR", "1")
-    assert text._colorize("x", _RED) == "x"
+    assert _colorize("x", _RED) == "x"
 
 
 def test_force_color_enables_color_through_a_pipe(
@@ -192,21 +194,21 @@ def test_force_color_enables_color_through_a_pipe(
     _no_tty(monkeypatch)
     monkeypatch.delenv("NO_COLOR", raising=False)
     monkeypatch.setenv("FORCE_COLOR", "1")
-    assert text._colorize("x", _RED) == f"{_RED}x{_RESET}"
+    assert _colorize("x", _RED) == f"{_RED}x{_RESET}"
 
 
 def test_no_color_beats_force_color(monkeypatch: pytest.MonkeyPatch) -> None:
     _force_color(monkeypatch)
     monkeypatch.setenv("NO_COLOR", "1")
     monkeypatch.setenv("FORCE_COLOR", "1")
-    assert text._colorize("x", _RED) == "x"
+    assert _colorize("x", _RED) == "x"
 
 
 def test_force_color_zero_does_not_force(monkeypatch: pytest.MonkeyPatch) -> None:
     _no_tty(monkeypatch)
     monkeypatch.delenv("NO_COLOR", raising=False)
     monkeypatch.setenv("FORCE_COLOR", "0")
-    assert text._colorize("x", _RED) == "x"
+    assert _colorize("x", _RED) == "x"
 
 
 # --- quiet mode -----------------------------------------------------------


### PR DESCRIPTION
Resolves CodeQL code-scanning alert [#91](https://github.com/tmatens/compose-lint/security/code-scanning/91) — `py/import-and-import-from` (severity: *note*).

`tests/test_text_formatter.py` imported `compose_lint.formatters.text` both as a module alias (`import ... as text`) and via `from ... import (...)`. This drops the alias and imports the names directly:

- `_colorize` joins the existing from-import block
- the two stdout monkeypatches now target the `sys` singleton instead of `text.sys` — equivalent, since `text.sys is sys` is `True`

Behavior-preserving test hygiene; no `src/` changes. `ruff check`, `ruff format --check`, and `pytest tests/test_text_formatter.py` (21 passed) are green locally.