### PR TITLE
Auto-fix remediation (experimental): ADR-014, edit engine, CL-0007

### DIFF
--- a/docs/adr/014-fix-remediation.md
+++ b/docs/adr/014-fix-remediation.md
@@ -1,0 +1,489 @@
+# ADR-014: `fix` — Automated Remediation of Auto-Fixable Findings
+
+**Status:** Proposed
+
+**Context:** compose-lint tells a user what is wrong and how to fix it, but
+today the fix is prose the user applies by hand. Milestone 3 of the roadmap
+(`docs/ROADMAP.md`) proposes turning the unambiguous subset of findings into
+edits the tool applies itself. This is the project's strongest differentiation
+against KICS/Checkov/Trivy, which report Compose issues but do not remediate
+them.
+
+Three prior decisions constrain how `fix` can be built, and one open tension
+shapes how it should ship:
+
+- **ADR-003 (no ruamel.yaml).** The runtime depends only on PyYAML, and
+  `CommentedMap`/`CommentedSeq` round-trip types are explicitly banned from
+  leaking into the codebase. PyYAML's `safe_dump` discards comments, reflows
+  quoting, and reorders keys — so the "parse → mutate object → re-serialize"
+  remediation strategy is not available. A fixer must not destroy the parts of
+  the file it isn't fixing.
+- **ADR-011 (subcommand model).** `fix` is already named there as the
+  motivating case for `add_subparsers` — "a destructive variant with its own
+  flag set." That ADR supersedes the roadmap's older `--fix --apply` flag
+  spelling: `fix` is a subcommand, not a flag on `check`.
+- **SARIF history (#168).** `result.fixes[]` was *removed* in 0.6.0 because
+  SARIF 2.1.0 requires `artifactChanges` on every fix object, and
+  `Finding.fix` is human prose, not a machine-applicable patch. Re-introducing
+  SARIF fixes requires producing real structured edits — the same artifact a
+  fixer produces to write to disk.
+- **1.0 tension.** Per `docs/RELEASING.md`, 1.0 is a *contract freeze* (CLI,
+  config schema, JSON/SARIF shape), not a feature checklist. `fix` is additive
+  and correctness-risky. We do not want a half-built, destructive fixer to
+  become part of the frozen 1.0 surface, nor do we want to block 1.0 on it.
+
+The intent of this ADR is to decide the *mechanism*, *edit model*, *CLI shape*,
+*safe-rule set*, *refusal policy*, and *release strategy* for `fix`. The exact
+text each rule emits (placement within a service block, comment annotations) is
+left to implementation, except where it forces a decision here.
+
+**Decision:** Eight decisions.
+
+1. **Edit mechanism — surgical text patching, not re-serialization.** `fix`
+   computes minimal byte-range replacements against the original file text and
+   splices them in. It never re-dumps the document. Everything outside a
+   touched span is preserved byte-for-byte.
+2. **Edit model — a shared `TextEdit`.** A rule's fixer returns structured
+   edits `(start_line, start_col, end_line, end_col, replacement)` (1-indexed,
+   SARIF region convention). The same model renders three ways: a unified diff
+   (dry-run), an in-place write (`--apply`), and SARIF `artifactChanges`.
+3. **CLI shape — `compose-lint fix [FILE ...]`,** a subcommand per ADR-011.
+   Dry-run is the default and prints a unified diff to stdout; `--apply` writes
+   in place. `--only CL-XXXX` (repeatable) narrows the rule set.
+4. **Safe-rule set — every finding with a *mechanically safe* fix** (Part 4): a
+   single rewrite, determined entirely by the file, that resolves the finding
+   and leaves valid Compose — by adding a hardening directive or deleting a
+   security-weakening override. All 21 rules were evaluated; six qualify:
+   CL-0003, CL-0005, CL-0007, CL-0009, CL-0014, CL-0015. CL-0003 is
+   hardening-only; the other five change runtime behavior and ship a **mandatory
+   per-fix caveat** in the dry-run (Parts 3–4). Behavioral risk is carried to the
+   user via the caveat + experimental warning, not by excluding the fix. The
+   remaining fifteen stay report-only (ambiguous value, external lookup, granted
+   resource, secret relocation, or architectural).
+5. **1.0 relationship — `fix` does not gate 1.0.** Per `docs/RELEASING.md`, 1.0
+   is a contract freeze, and the contract (CLI, config, JSON/SARIF) is ready
+   independently of `fix`. 1.0 ships on stability; `fix` is promoted as the
+   headline of a later MINOR (target 1.1). The roadmap's remediation thesis is
+   satisfied by `fix` shipping in 1.x, not by it landing in `1.0.0`
+   specifically.
+6. **Release strategy — ship undocumented and experimental, gated in stages.**
+   `fix` lands on main behind a hidden subcommand (`argparse.SUPPRESS`) with a
+   loud stderr experimental warning, **explicitly excluded from the SemVer
+   contract**, and **gated behind `COMPOSE_LINT_EXPERIMENTAL=1` in its first
+   (single-rule) phase**. The gate relaxes in three stages (Part 5) as corpus
+   evidence accrues. This lets it merge incrementally and be dogfooded against
+   the corpus without making promises or blocking 1.0.
+7. **Refusal policy — refuse, never guess.** When a finding sits on an
+   anchored/merged service, in flow style that can't be edited unambiguously,
+   or anywhere the correct edit is not unique, `fix` leaves the file untouched
+   and reports the finding as manual-only. A wrong fix is worse than no fix.
+8. **SARIF — reintroduce `artifactChanges`** rendered from the `TextEdit`
+   model, restoring (correctly) what #168 removed.
+
+---
+
+## Part 1 — Edit mechanism
+
+### Option A — Surgical text patching *(chosen)*
+
+Treat the file as text; compute minimal `(region → replacement)` edits from the
+finding's location and splice them into the original bytes.
+
+Pros:
+- Honors ADR-003. No new dependency, no `CommentedMap` leakage, no need to
+  revisit the parser library decision.
+- Non-destructive by construction. Comments, key order, quoting style, blank
+  lines, and trailing whitespace outside the edited span are preserved. The
+  resulting diff is the diff a careful human would have written.
+- Reuses existing groundwork. `LineLoader` already captures per-key and
+  per-sequence-item positions (`parser.py`); `fix` is the write-side mirror of
+  that read-side tracking.
+- Produces the structured edit SARIF needs anyway (Part 7). One artifact, three
+  renderings.
+
+Cons:
+- Indentation, flow-vs-block style, and insertion-point must be inferred from
+  surrounding text rather than handed to us by a serializer. This is real work
+  and the source of most of the test surface.
+- Each fixer carries some text-shaping logic instead of just mutating a dict.
+  Mitigated by a shared helper layer (indent inference, list-item insertion,
+  scalar replacement) so individual rules stay small.
+
+### Option B — Parse, mutate, re-serialize with PyYAML
+
+Pros:
+- Fixers are trivial: mutate the dict, dump.
+
+Cons:
+- Destroys comments, reorders keys, reflows quoting and string styles across
+  the *entire* file, not just the fixed span. The diff is enormous and the user
+  cannot trust it. Disqualifying on its own.
+- Cannot represent "add `read_only: true` *here*" — only "the whole file now
+  looks like this."
+
+### Option C — Adopt ruamel.yaml round-trip mode
+
+Pros:
+- Purpose-built for comment-preserving round-trips.
+
+Cons:
+- Directly violates ADR-003 and the CLAUDE.md "no ruamel.yaml" rule (packaging
+  instability, round-trip types leaking into rule code). Reopening that decision
+  is out of scope and unjustified when text patching covers the safe-rule set.
+
+### Rationale (mechanism)
+
+The no-ruamel constraint already decided this; the ADR's job is to make it
+explicit and name the consequence: `fix` is a **text-patching engine, not a
+YAML emitter.** The cost (style inference) is bounded and testable; the benefit
+(trustworthy minimal diffs) is the whole point of an auto-fixer a user will run
+against files they care about.
+
+---
+
+## Part 2 — Edit model and the fixer interface
+
+A fixer is an optional capability a rule advertises. The proposed interface:
+
+```python
+@dataclass(frozen=True)
+class TextEdit:
+    start_line: int      # 1-indexed, SARIF region convention
+    start_col: int       # 1-indexed
+    end_line: int
+    end_col: int
+    replacement: str     # may be multi-line; "" for pure deletion
+    caveat: str | None = None   # behavioral note; set on behavior-changing fixes
+
+class BaseRule:
+    def fix(self, finding: Finding, data, lines, text: str) -> list[TextEdit] | None:
+        """Return edits that remediate `finding`, or None if not auto-fixable
+        / not safe to fix in this file (see refusal policy)."""
+        return None  # default: rule is report-only
+```
+
+Binding properties:
+
+- **Idempotent.** Applying the output of `fix --apply` and re-running `fix` must
+  produce zero edits. Re-linting a fixed file must not re-fire the same rule.
+  Both are asserted in the corpus regression gate (Part 6).
+- **Non-overlapping within a file.** Edits are collected across all rules, sorted
+  by position, and checked for overlap before application. Overlapping edits on
+  the same region are a refusal, not a merge.
+- **Applied bottom-up.** Edits are spliced from the last position to the first so
+  earlier offsets stay valid as later text changes length.
+- **Engine-owned application.** Rules produce `TextEdit`s; a single
+  `apply_edits(text, edits) -> str` in the engine performs the splice. Rules
+  never write files.
+- **Behavior-changing fixes carry a `caveat`.** A fixer whose edit alters what
+  the container does at runtime — not merely its hardening posture — MUST set
+  `caveat` to the failure mode it introduces (what can break, and how to avoid
+  it). The dry-run renderer surfaces it and marks the hunk (Part 3); hardening-
+  only fixes leave it unset.
+
+Rationale: a single position-based edit model is the common denominator of the
+three things we must produce — a diff, a write, and SARIF `artifactChanges` —
+and keeps the destructive operation in one auditable place rather than smeared
+across 21 rules.
+
+---
+
+## Part 3 — CLI shape and write semantics
+
+`compose-lint fix [FILE ...]`, registered alongside `check` and `init` via the
+`add_subparsers` work ADR-011 already calls for.
+
+Flags (v-experimental):
+
+| Flag | Behavior |
+|------|----------|
+| *(none)* | Dry-run. Print a unified diff of proposed edits to **stdout**; status to stderr. Writes nothing. |
+| `--apply` | Write edits in place. |
+| `--only CL-XXXX` | Restrict to the named rule(s); repeatable. |
+| `--config PATH` | Honor `.compose-lint.yml` so suppressed/excluded findings are not "fixed" (see Part 6). |
+
+### Behavior-changing fixes are flagged in the diff
+
+A fix that only tightens posture without changing what the container does at
+runtime (CL-0003) renders as an ordinary hunk. A fix that *changes runtime
+behavior* — CL-0005 alters network reachability, CL-0007 makes the rootfs
+unwritable — renders with a `⚠ behavior-changing` marker and its `caveat`
+printed inline above the hunk:
+
+```
+⚠ behavior-changing · CL-0007: read_only:true breaks the container if it writes
+  to its root filesystem. Declare writable paths via tmpfs/volumes first.
+--- docker-compose.yml
++++ docker-compose.yml
+@@ services.web @@
+     image: nginx:1.27
++    read_only: true
+```
+
+This is in addition to the global experimental warning (Part 5). The intent: a
+reader of the dry-run sees at a glance *which* edits are pure hardening and
+*which* could break their workload, before deciding to `--apply`. The same
+caveat text rides into SARIF as a `note`-level message on the fix (Part 7) so
+Code Scanning consumers see it too.
+
+### Write-flag naming — `--apply` *(chosen)*
+
+ADR-011 floated `--in-place`; the roadmap wrote `--apply`. This ADR settles on
+**`--apply`** and supersedes ADR-011's illustrative spelling.
+
+Pros:
+- Pairs with the dry-run mental model: *preview the diff, then apply it.*
+- Avoids sed's `-i`/`--in-place` connotation of unconditional, backup-free
+  mutation.
+
+Cons:
+- `-w`/`--write` (gofmt, prettier) is a common alternative spelling some users
+  will reach for first. Acceptable; documented in `fix --help`.
+
+### Exit codes (extends ADR-006)
+
+- Dry-run: **0** on success (diff printed or nothing to do), **2** on
+  usage/parse error. It does *not* exit 1 when edits are available — a deferred
+  `--check` mode (Out of scope) is the right home for "fail CI if unfixed."
+- `--apply`: **0** on a successful write (the findings were remediated), **2** on
+  usage/parse/write error.
+- Residual non-auto-fixable findings do **not** make `fix` exit 1. Consistent
+  with `init` (ADR-011): for `fix`, findings are the input, not the failure
+  signal. Use `check` for the pass/fail gate.
+
+Rationale: `fix` is an operation that produces an artifact (a diff or a modified
+file), like `init`, not a gate like `check`. Its exit codes follow the artifact
+model, and stdout/stderr follow the CLAUDE.md split (diff = data on stdout,
+status = stderr) — the second stdout-emitting mode CLAUDE.md and ADR-011
+anticipated. This is the point at which the text-mode banner gate in `cli.py`
+must either extend to cover `fix` or status lines move to stderr permanently;
+`fix` chooses the latter for its own output (no banner; diff only).
+
+---
+
+## Part 4 — Safe-rule set
+
+Auto-fix is offered for every finding with a **mechanically safe** fix:
+
+> a single rewrite, determined entirely by the file (no external lookup, no
+> value the author must choose), that resolves the finding and leaves a valid
+> Compose file — either by **adding a hardening directive** or by **deleting a
+> security-weakening override so the platform's secure default re-applies.**
+
+Behavioral risk is not handled by narrowing this set; it is handled by surfacing
+a caveat per fix and the global experimental warning (Parts 3, 5). Six rules
+qualify:
+
+| Rule | Edit primitive | Runtime behavior | Caveat |
+|------|----------------|------------------|--------|
+| **CL-0007** read-only fs | Insert `read_only: true` | **Changes** — rootfs becomes unwritable; breaks containers that write to it | **Required** |
+| **CL-0003** no-new-privileges | Append `no-new-privileges:true` to `security_opt:`, or create the list | Hardening-only — blocks setuid escalation; near-zero breakage | None |
+| **CL-0005** unbound ports | Prepend `127.0.0.1:` to the host side | **Changes** — drops non-local reachability; breaks intended LAN/remote access | **Required** |
+| **CL-0009** unconfined profile | Delete the `seccomp:unconfined` / `apparmor:unconfined` entry | **Changes** — default seccomp/AppArmor profile re-applies; a workload needing a blocked syscall may fail | **Required** |
+| **CL-0014** logging disabled | Delete `driver: none` | **Changes** — default logging driver re-enabled; logs collected again (disk/IO) | **Required** |
+| **CL-0015** healthcheck disabled | Delete the healthcheck `disable` | **Changes** — image's default healthcheck re-enabled; an unhealthy status can affect `depends_on`/orchestration | **Required** |
+
+Only CL-0003 is hardening-only; the other five change runtime behavior and ship
+a **mandatory dry-run caveat** (Part 3). Implementation groups by edit primitive,
+not severity: insertion (CL-0007) is the vertical slice, then the deletions
+(CL-0009/0014/0015 — structurally simplest, see below), then list-append/create
+(CL-0003), then the in-scalar edit (CL-0005, the riskiest to parse).
+
+**Why these six and not the other deletion rules.** The line is *revert a
+guardrail vs. revoke a granted resource*:
+
+- CL-0009/0014/0015 turn a **platform security default back on.** seccomp, logging,
+  and healthchecks apply whether or not the file mentions them; the finding is an
+  explicit *opt-out*, and deleting it restores the default. No compensating change
+  is needed for the service to stay well-formed.
+- CL-0002 (privileged), CL-0008 (host network), CL-0010 (host namespaces), CL-0011
+  (`cap_add`), CL-0013 (sensitive mount), CL-0016 (devices), CL-0017 (mount
+  propagation) **grant the container access to a host resource or capability** it
+  otherwise would not have. Deleting that strips function the author added on
+  purpose, the secure "default" restores no equivalent, and a compensating change
+  (specific caps, explicit port maps) is usually required. They fail the
+  definition and stay report-only.
+
+**Deletion fixers must leave a valid block or remove it whole.** Removing the sole
+entry of `security_opt:` / `logging:` must drop the now-empty parent key, not
+leave `security_opt: []`. If a deletion would leave a structurally partial block
+it cannot fully resolve (e.g. `logging.driver: none` alongside `logging.options`),
+the fixer **refuses** (Part 6) rather than emit a broken file.
+
+**Out of auto-fix scope (report-only).** The other fifteen rules fail the
+definition:
+
+- **Ambiguous value / external lookup:** CL-0004 (which version?), CL-0019 (digest
+  needs a registry), CL-0006 (which capabilities? — issue #4), CL-0012 (which
+  limit?), CL-0018 (which user? — deletion may not even resolve it).
+- **Revokes a granted resource** (above): CL-0002, CL-0008, CL-0010, CL-0011,
+  CL-0013, CL-0016, CL-0017.
+- **Context-dependent secret relocation:** CL-0020, CL-0021.
+- **Architectural:** CL-0001 (socket-proxy sidecar).
+
+Rationale: "mechanically safe" is a property of the *edit*, not the *risk* — every
+qualifying fix is unambiguous and leaves a valid file. Where the edit also changes
+behavior, the caveat carries that risk to the user rather than hiding the fix from
+them. Rules whose correct fix needs information the file doesn't contain stay
+report-only, where prose guidance already serves.
+
+---
+
+## Part 5 — Release strategy: undocumented and experimental
+
+`fix` is destructive and correctness-risky, and we want it on main early for
+incremental review and corpus dogfooding without (a) advertising a half-built
+fixer, (b) making SemVer promises about it, or (c) entangling it with the 1.0
+contract freeze. The decision is to ship it **hidden and experimental**, then
+promote.
+
+### Option A — Hidden subcommand + experimental warning, excluded from contract *(chosen)*
+
+- Registered with `help=argparse.SUPPRESS`, so it does not appear in
+  `compose-lint --help`. Absent from README and docs (except this ADR).
+- Every invocation prints a one-line stderr warning:
+  `warning: 'fix' is experimental and unstable; output and flags may change
+  without notice. Review the diff before --apply.`
+- `docs/RELEASING.md` is amended to state that **experimental subcommands are
+  not part of the SemVer contract** — their behavior, flags, and existence may
+  change in any release, including patch. 1.0 can freeze the rest of the surface
+  while `fix` matures behind this carve-out.
+- **Exposure relaxes in three stages** as corpus evidence accrues, never the
+  reverse:
+  1. *Phase 1* (engine + CL-0007): registration is **gated behind
+     `COMPOSE_LINT_EXPERIMENTAL=1`** *and* `SUPPRESS`ed — it cannot be
+     discovered or invoked by accident at all.
+  2. *Phase 2* (all six rules, corpus regression green): drop the env gate;
+     keep the subcommand hidden and the stderr warning.
+  3. *Phase 3* (promotion criteria met): remove `SUPPRESS`, document in README
+     and `--help`, enable SARIF fixes, announce in CHANGELOG, and bring `fix`
+     under the SemVer contract.
+
+Pros:
+- Mergeable in small slices (Part 6 phasing) with real CI and corpus testing,
+  not stranded on a long-lived branch.
+- No user relies on unfinished behavior; the curious can opt in; the contract is
+  untouched.
+- Cleanly decouples `fix` from the 1.0 decision — answers the open tension
+  directly: 1.0 ships when the contract is ready, `fix` promotes when *it's*
+  ready, independently.
+
+Cons:
+- A hidden command still exists in shipped artifacts; a determined user can find
+  and run it. The stderr warning and (optional) env gate are the mitigations —
+  acceptable for a non-default, dry-run-by-default operation.
+- Two states to track (experimental vs. promoted) and a documented promotion
+  step. Lightweight; the promotion criteria below make it mechanical.
+
+### Option B — Documented from day one, marked "experimental" in the docs
+
+Pros: honest discoverability; users can find and try it.
+
+Cons: invites bug reports and CI adoption against a moving target; pressure to
+keep early flag spellings; risks the surface drifting into the 1.0 freeze before
+it's ready. Premature for a destructive feature.
+
+### Option C — Long-lived feature branch until complete
+
+Pros: zero exposure.
+
+Cons: no CI on main, painful rebases, no incremental dogfooding against the
+corpus, big-bang merge risk. Worst option for a correctness-sensitive feature
+that benefits most from running against real files early.
+
+### Promotion criteria (experimental → documented + contract-covered)
+
+`fix` graduates — removing `SUPPRESS`, adding README/`--help` docs, enabling
+SARIF fixes (Part 7), announcing in CHANGELOG — when all hold:
+
+1. All six safe rules implemented, each with the corpus regression gate green.
+2. Corpus run: every auto-fixable finding either fixed-and-clean or explicitly
+   refused; **zero** fixed files fail to re-parse; **zero** non-idempotent fixes.
+3. Refusal policy (Part 6) exercised by tests for anchors, merge keys, and flow
+   style.
+4. `fix --apply` round-trips: fixed file re-lints with the targeted rules
+   silenced and no new findings introduced.
+5. **Full-corpus soak:** `fix` runs clean against at least one *fresh* full
+   corpus pull (the ~6.4k-file fetch, not just the committed snapshot fixtures).
+   The long-tail file shapes the snapshot can't capture must be exercised — and
+   refusal rate measured — before promotion.
+
+Until then, treat `fix` like an internal tool that happens to ship in the wheel.
+
+---
+
+## Part 6 — Refusal policy and the corpus gate
+
+**Refuse (leave untouched, report as manual-only) when:**
+
+- The finding's service inherits via merge key (`<<:`) or YAML anchor/alias, so
+  the edit's correct target (anchor vs. service) is ambiguous.
+- The relevant block is in flow style (`security_opt: [...]`,
+  `ports: ["8080:80"]`) and the minimal edit isn't unambiguous.
+- Two fixers want overlapping regions.
+- `${VAR}` interpolation sits inside the span to be edited (the resolved value
+  is unknown; CL-0005's port host could be a variable).
+
+**Respect suppression.** A finding suppressed or service-excluded via
+`.compose-lint.yml` (ADR-010) is never fixed — suppression is a deliberate human
+decision. `fix` loads config like `check` does.
+
+**Corpus regression gate** (new test, runs against `~/.cache/compose-lint-corpus/`
+fixtures, mirrors `test_corpus_snapshot`): for every file, fix → assert it still
+parses, re-lints with the targeted rules cleared, and a second `fix` is a no-op.
+This is the safety net that makes shipping `fix` defensible, and the reason
+experimental-on-main (Part 5) beats a branch.
+
+---
+
+## Out of scope for this ADR
+
+- **`fix --check`** (exit 1 if edits would be made, à la `black --check`) — a
+  CI-gate convenience; additive, defer until requested.
+- **`--backup` / `.bak` files** — rely on the user's VCS for v-experimental;
+  revisit if requested.
+- **Expanding the safe-rule set** beyond CL-0003/0005/0007 — each addition is its
+  own decision against the Part 4 bar.
+- **Capability profiles for CL-0006** (issue #4) — a prerequisite for ever
+  auto-fixing CL-0006, tracked separately.
+- **Interactive / per-finding confirmation** (`fix -i`) — adds a TTY dependency
+  story; the dry-run-then-apply flow covers the need.
+- **Exact emitted text and comment annotations** per rule — implementation
+  detail, except the style-matching constraints stated above.
+
+## Implementation notes (non-binding)
+
+- `cli.py`: register `fix` under the ADR-011 subparser with
+  `help=argparse.SUPPRESS`; emit the experimental stderr warning in its handler.
+  Guard registration on `COMPOSE_LINT_EXPERIMENTAL` for the first (single-rule)
+  phase; drop the env guard at Phase 2 (see Part 5 exposure stages).
+- Engine: add `apply_edits(text, edits) -> str` (sort, overlap-check, splice
+  bottom-up) and an edit-collection pass that calls `rule.fix(...)` for each
+  finding whose rule advertises a fixer.
+- Reuse `LineLoader` positions; where a fixer needs a column the loader doesn't
+  retain, extend the sidecar rather than re-parsing.
+- Diff rendering: stdlib `difflib.unified_diff` over original vs. patched text.
+  No new dependency.
+- SARIF: a `region` (`startLine`/`startColumn`/`endLine`/`endColumn`) plus
+  `artifactChanges[].replacements[]` built from each `TextEdit`; gate emission on
+  promotion so experimental edits don't leak into a contract-shaped artifact.
+- Phasing: (1) edit engine + CL-0007 behind the env gate; (2) deletions
+  CL-0009/0014/0015 + CL-0003; (3) CL-0005; (4) corpus gate; (5) SARIF +
+  promotion.
+- Tests: per-rule fix fixtures (block & flow style, 2- and 4-space indent,
+  present/absent target block), idempotency, refusal cases (anchor, merge key,
+  `${VAR}` in span), suppression respected, bare/`check`/`fix` argv routing,
+  exit codes.
+
+## Consequences
+
+- compose-lint gains remediation — the roadmap's strongest differentiator —
+  without a new runtime dependency and without reopening ADR-003.
+- The work merges to main in reviewable slices and is continuously validated
+  against real-world files, rather than accumulating on a branch.
+- 1.0 is unblocked: the contract can freeze with `fix` deliberately carved out as
+  experimental, and `fix` promotes on its own timeline via a documented,
+  mechanical criteria check.
+- A new destructive code path exists. It is dry-run by default, hidden,
+  warned-on, refusal-first, and corpus-gated — the mitigations are
+  proportionate, and `apply_edits` centralizes the risk in one tested function.

--- a/src/compose_lint/fix.py
+++ b/src/compose_lint/fix.py
@@ -11,10 +11,7 @@ rewrites a user's file is in a single, auditable place.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from compose_lint.models import TextEdit
+from compose_lint.models import TextEdit
 
 
 class OverlappingEditError(ValueError):
@@ -75,3 +72,131 @@ def apply_edits(text: str, edits: list[TextEdit]) -> str:
     for begin, end, edit in reversed(spans):
         result = result[:begin] + edit.replacement + result[end:]
     return result
+
+
+# --- Text-shaping helpers shared by rule fixers ---------------------------
+#
+# These operate on ``source_lines = text.splitlines(keepends=True)``: a
+# 1-indexed line ``n`` is ``source_lines[n - 1]``. They exist so individual
+# fixers infer indentation, block extent, and refusal conditions the same way
+# rather than each re-deriving them (ADR-014, Part 1: "a shared helper layer
+# so individual rules stay small").
+
+
+def line_indent(line: str) -> int:
+    """Return the number of leading spaces on ``line`` (newline-insensitive)."""
+    body = line.rstrip("\n")
+    return len(body) - len(body.lstrip(" "))
+
+
+def opens_block_body(line: str) -> bool:
+    """Return whether ``line`` is a ``key:`` header that opens a block body.
+
+    True when the colon is followed only by whitespace or a comment — meaning
+    the value lives in an indented block beneath it. False for an inline value,
+    flow collection (``{`` / ``[``), anchor (``&``), or alias (``*``) after the
+    colon, and for a line with no colon at all. A fixer that needs to insert
+    into or delete a block treats ``False`` as a refusal: there is no plain
+    block body to edit unambiguously.
+    """
+    body = line.rstrip("\n")
+    colon = body.find(":")
+    if colon == -1:
+        return False
+    trailing = body[colon + 1 :].strip()
+    return not trailing or trailing.startswith("#")
+
+
+def first_child_indent(source_lines: list[str], key_line: int) -> int | None:
+    """Return the indentation of the first child line under ``key_line``.
+
+    Walks forward from the line after ``key_line`` to the first non-blank line.
+    Returns its indent if it is deeper than ``key_line`` (a child), otherwise
+    ``None`` — meaning the block has no children (the next content is a sibling
+    or dedent). Blank lines are skipped; comment lines count as content, mirror-
+    ing the original CL-0007 behavior.
+    """
+    key_indent = line_indent(source_lines[key_line - 1])
+    for raw in source_lines[key_line:]:
+        if raw.strip() == "":
+            continue
+        indent = line_indent(raw)
+        if indent <= key_indent:
+            return None
+        return indent
+    return None
+
+
+def has_merge_key_child(source_lines: list[str], key_line: int) -> bool:
+    """Return whether the block under ``key_line`` has a merge-key (``<<``) child.
+
+    A merge key means the mapping inherits from a YAML anchor, so an edit's
+    correct target (the anchor vs. this block) is ambiguous and the fixer must
+    refuse (ADR-014 refusal policy). Only direct children — lines at the first
+    child indent — are considered.
+    """
+    key_indent = line_indent(source_lines[key_line - 1])
+    child_indent: int | None = None
+    for raw in source_lines[key_line:]:
+        if raw.strip() == "":
+            continue
+        indent = line_indent(raw)
+        if indent <= key_indent:
+            break
+        if child_indent is None:
+            child_indent = indent
+        if indent == child_indent and raw.strip().startswith("<<"):
+            return True
+    return False
+
+
+def is_anchored_or_merged(source_lines: list[str], key_line: int) -> bool:
+    """Return whether the block at ``key_line`` is one a fixer must refuse.
+
+    True when the key carries an inline value / flow collection / anchor / alias
+    instead of a plain block body, or when the block inherits via a merge key.
+    Combines :func:`opens_block_body` and :func:`has_merge_key_child` into the
+    single guard deletion and insertion fixers share.
+    """
+    return not opens_block_body(source_lines[key_line - 1]) or has_merge_key_child(
+        source_lines, key_line
+    )
+
+
+def block_span(source_lines: list[str], key_line: int) -> tuple[int, int]:
+    """Return the inclusive 1-indexed ``(first, last)`` line span of a block.
+
+    The span covers ``key_line`` and every following line indented deeper than
+    it. Blank lines interior to the block are included; a trailing run of blank
+    lines after the last child is excluded. Used to delete a block whole.
+    """
+    key_indent = line_indent(source_lines[key_line - 1])
+    last = key_line
+    for idx in range(key_line, len(source_lines)):
+        if source_lines[idx].strip() == "":
+            continue
+        if line_indent(source_lines[idx]) <= key_indent:
+            break
+        last = idx + 1
+    return key_line, last
+
+
+def delete_lines(
+    source_lines: list[str],
+    first: int,
+    last: int,
+    *,
+    caveat: str | None = None,
+) -> TextEdit:
+    """Return a :class:`TextEdit` that removes lines ``first``..``last`` whole.
+
+    The region runs from the start of ``first`` to the start of the line after
+    ``last`` so the trailing newline goes with the deleted lines. When ``last``
+    is the final line of a file with no trailing newline, the region ends at the
+    end of that line instead (there is no following line to anchor to).
+    """
+    if last < len(source_lines):
+        return TextEdit(first, 1, last + 1, 1, "", caveat=caveat)
+    # `last` is the final line: end at its end (its newline, if any, included).
+    end_col = len(source_lines[last - 1]) + 1
+    return TextEdit(first, 1, last, end_col, "", caveat=caveat)

--- a/src/compose_lint/fix.py
+++ b/src/compose_lint/fix.py
@@ -1,0 +1,77 @@
+"""Apply structured text edits produced by rule fixers (see ADR-014).
+
+The fix engine is deliberately a text-patching engine, not a YAML emitter:
+edits are spliced into the original file text so comments, key order, and
+formatting outside the touched span survive byte-for-byte. ADR-003 rules out a
+comment-preserving round-trip parser, so re-serialization is not an option.
+
+All destructive splicing lives in :func:`apply_edits` so the one operation that
+rewrites a user's file is in a single, auditable place.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from compose_lint.models import TextEdit
+
+
+class OverlappingEditError(ValueError):
+    """Raised when two edits target overlapping regions of the same file."""
+
+
+def _line_starts(text: str) -> list[int]:
+    """Return the absolute offset at which each 1-indexed line begins.
+
+    ``starts[0]`` is line 1's offset (always 0). A position on line ``n`` is
+    ``starts[n - 1] + (col - 1)``.
+    """
+    starts = [0]
+    for index, char in enumerate(text):
+        if char == "\n":
+            starts.append(index + 1)
+    return starts
+
+
+def _offset(starts: list[int], line: int, col: int) -> int:
+    """Convert a 1-indexed ``(line, col)`` position to an absolute offset."""
+    return starts[line - 1] + (col - 1)
+
+
+def apply_edits(text: str, edits: list[TextEdit]) -> str:
+    """Splice ``edits`` into ``text`` and return the result.
+
+    Edits are validated to be non-overlapping, then applied from the last
+    position to the first so earlier offsets stay valid as later text changes
+    length. Adjacent edits (one ending exactly where the next begins) are
+    allowed; genuinely overlapping regions raise :class:`OverlappingEditError`.
+    An empty ``edits`` list returns ``text`` unchanged.
+    """
+    if not edits:
+        return text
+
+    starts = _line_starts(text)
+    spans = [
+        (
+            _offset(starts, edit.start_line, edit.start_col),
+            _offset(starts, edit.end_line, edit.end_col),
+            edit,
+        )
+        for edit in edits
+    ]
+    spans.sort(key=lambda span: (span[0], span[1]))
+
+    prev_end = -1
+    for begin, end, _edit in spans:
+        if begin < prev_end:
+            raise OverlappingEditError(
+                f"edit starting at offset {begin} overlaps a prior edit "
+                f"ending at offset {prev_end}"
+            )
+        prev_end = end
+
+    result = text
+    for begin, end, edit in reversed(spans):
+        result = result[:begin] + edit.replacement + result[end:]
+    return result

--- a/src/compose_lint/models.py
+++ b/src/compose_lint/models.py
@@ -68,3 +68,22 @@ class Finding:
     references: list[str] = field(default_factory=list)
     suppressed: bool = False
     suppression_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class TextEdit:
+    """A single text replacement produced by a rule's fixer (see ADR-014).
+
+    Positions are 1-indexed and the region ``[start, end)`` is half-open,
+    following the SARIF region convention. A zero-width region
+    (``start == end``) is a pure insertion; an empty ``replacement`` is a pure
+    deletion. ``caveat``, when set, names a runtime-behavior change the edit
+    introduces and is surfaced in the dry-run diff and SARIF output.
+    """
+
+    start_line: int
+    start_col: int
+    end_line: int
+    end_col: int
+    replacement: str
+    caveat: str | None = None

--- a/src/compose_lint/rules/CL0007_read_only.py
+++ b/src/compose_lint/rules/CL0007_read_only.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from compose_lint.models import Finding, RuleMetadata, Severity
+from compose_lint.models import Finding, RuleMetadata, Severity, TextEdit
 from compose_lint.rules import BaseRule, register_rule
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+_CAVEAT = (
+    "read_only: true breaks the container if it writes to its root filesystem; "
+    "declare writable paths via tmpfs/volumes first."
+)
 
 OWASP_REF = (
     "https://cheatsheetseries.owasp.org/cheatsheets/"
@@ -64,3 +69,76 @@ class ReadOnlyFilesystemRule(BaseRule):
                 ),
                 references=[OWASP_REF, CIS_REF],
             )
+
+    def fix(
+        self,
+        finding: Finding,
+        data: dict[str, Any],
+        lines: dict[str, int],
+        text: str,
+    ) -> list[TextEdit] | None:
+        """Insert ``read_only: true`` as the first child of the service.
+
+        Refuses (returns ``None``) when the service is flow-style, anchored or
+        aliased, uses a merge key, has no determinable child indentation, or
+        already declares ``read_only`` (the explicit-value case is deferred).
+        The edit carries a caveat because making the rootfs read-only changes
+        runtime behavior (ADR-014).
+        """
+        service = finding.service
+        services = data.get("services")
+        if not isinstance(services, dict):
+            return None
+        service_config = services.get(service)
+        if not isinstance(service_config, dict):
+            return None
+        # read_only present but not True is a modify, not an insert; deferred.
+        if "read_only" in service_config:
+            return None
+
+        key_line = lines.get(f"services.{service}")
+        if key_line is None:
+            return None
+        source_lines = text.splitlines(keepends=True)
+        if not 1 <= key_line <= len(source_lines):
+            return None
+
+        key_body = source_lines[key_line - 1].rstrip("\n")
+        service_indent = len(key_body) - len(key_body.lstrip(" "))
+        colon = key_body.find(":")
+        if colon == -1:
+            return None
+        trailing = key_body[colon + 1 :].strip()
+        # An inline value, flow mapping ({), anchor (&) or alias (*) after the
+        # colon means there is no block body to insert a child into.
+        if trailing and not trailing.startswith("#"):
+            return None
+
+        # Walk the service block to find the child indentation and reject
+        # merge-key services (ambiguous edit target, ADR-014 refusal policy).
+        child_indent: int | None = None
+        for raw in source_lines[key_line:]:
+            body = raw.rstrip("\n")
+            if body.strip() == "":
+                continue
+            indent = len(body) - len(body.lstrip(" "))
+            if indent <= service_indent:
+                break
+            if child_indent is None:
+                child_indent = indent
+            if indent == child_indent and body.strip().startswith("<<"):
+                return None
+
+        if child_indent is None:
+            return None
+
+        return [
+            TextEdit(
+                start_line=key_line + 1,
+                start_col=1,
+                end_line=key_line + 1,
+                end_col=1,
+                replacement=f"{' ' * child_indent}read_only: true\n",
+                caveat=_CAVEAT,
+            )
+        ]

--- a/src/compose_lint/rules/CL0007_read_only.py
+++ b/src/compose_lint/rules/CL0007_read_only.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from compose_lint.fix import (
+    first_child_indent,
+    is_anchored_or_merged,
+)
 from compose_lint.models import Finding, RuleMetadata, Severity, TextEdit
 from compose_lint.rules import BaseRule, register_rule
 
@@ -103,32 +107,12 @@ class ReadOnlyFilesystemRule(BaseRule):
         if not 1 <= key_line <= len(source_lines):
             return None
 
-        key_body = source_lines[key_line - 1].rstrip("\n")
-        service_indent = len(key_body) - len(key_body.lstrip(" "))
-        colon = key_body.find(":")
-        if colon == -1:
-            return None
-        trailing = key_body[colon + 1 :].strip()
-        # An inline value, flow mapping ({), anchor (&) or alias (*) after the
-        # colon means there is no block body to insert a child into.
-        if trailing and not trailing.startswith("#"):
+        # Refuse inline/flow/anchored/merge-key services: no plain block body to
+        # insert a child into, or an ambiguous edit target (ADR-014).
+        if is_anchored_or_merged(source_lines, key_line):
             return None
 
-        # Walk the service block to find the child indentation and reject
-        # merge-key services (ambiguous edit target, ADR-014 refusal policy).
-        child_indent: int | None = None
-        for raw in source_lines[key_line:]:
-            body = raw.rstrip("\n")
-            if body.strip() == "":
-                continue
-            indent = len(body) - len(body.lstrip(" "))
-            if indent <= service_indent:
-                break
-            if child_indent is None:
-                child_indent = indent
-            if indent == child_indent and body.strip().startswith("<<"):
-                return None
-
+        child_indent = first_child_indent(source_lines, key_line)
         if child_indent is None:
             return None
 

--- a/src/compose_lint/rules/CL0009_security_profile.py
+++ b/src/compose_lint/rules/CL0009_security_profile.py
@@ -4,11 +4,25 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from compose_lint.fix import (
+    block_span,
+    delete_lines,
+    is_anchored_or_merged,
+    opens_block_body,
+)
 from compose_lint.models import Finding, RuleMetadata, Severity
 from compose_lint.rules import BaseRule, register_rule
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+    from compose_lint.models import TextEdit
+
+_CAVEAT = (
+    "Removing the unconfined entry re-applies the default seccomp/AppArmor "
+    "profile; a workload that relies on a syscall the default profile blocks "
+    "may fail."
+)
 
 OWASP_REF = (
     "https://cheatsheetseries.owasp.org/cheatsheets/"
@@ -103,3 +117,66 @@ class SecurityProfileRule(BaseRule):
                     CIS_SELINUX_REF,
                 ],
             )
+
+    def fix(
+        self,
+        finding: Finding,
+        data: dict[str, Any],
+        lines: dict[str, int],
+        text: str,
+    ) -> list[TextEdit] | None:
+        """Delete the unconfined ``security_opt`` entry the finding flags.
+
+        Removes just the offending list item when a legitimate entry remains,
+        or drops the whole ``security_opt:`` block when the offending entry is
+        the sole one (never leaving ``security_opt:`` empty). Refuses (returns
+        ``None``) for anchored/merged services, flow-style lists, and the
+        ambiguous case where every entry is offending but more than one exists —
+        collapsing that correctly would need the per-finding fixers to
+        coordinate, which they can't (ADR-014 refusal policy). The edit carries
+        a caveat because re-applying the default profile changes runtime
+        behavior.
+        """
+        service = finding.service
+        services = data.get("services")
+        if not isinstance(services, dict):
+            return None
+        service_config = services.get(service)
+        if not isinstance(service_config, dict):
+            return None
+        security_opt = service_config.get("security_opt")
+        if not isinstance(security_opt, list) or not security_opt:
+            return None
+
+        item_line = finding.line
+        so_line = lines.get(f"services.{service}.security_opt")
+        service_line = lines.get(f"services.{service}")
+        if item_line is None or so_line is None or service_line is None:
+            return None
+
+        source_lines = text.splitlines(keepends=True)
+        n = len(source_lines)
+        if not (1 <= service_line <= n and 1 <= so_line <= n and 1 <= item_line <= n):
+            return None
+
+        if is_anchored_or_merged(source_lines, service_line):
+            return None
+        if not opens_block_body(source_lines[so_line - 1]):
+            return None
+
+        disabled = sum(
+            1 for opt in security_opt if str(opt).strip().lower() in _DISABLED_PROFILES
+        )
+        legit_remaining = len(security_opt) - disabled
+
+        if legit_remaining >= 1:
+            # A legitimate entry survives, so the list stays non-empty: remove
+            # only this item's line.
+            if not source_lines[item_line - 1].lstrip().startswith("- "):
+                return None
+            return [delete_lines(source_lines, item_line, item_line, caveat=_CAVEAT)]
+        if len(security_opt) == 1:
+            # Sole entry is the offending one: drop the whole block.
+            first, last = block_span(source_lines, so_line)
+            return [delete_lines(source_lines, first, last, caveat=_CAVEAT)]
+        return None

--- a/src/compose_lint/rules/CL0014_logging_disabled.py
+++ b/src/compose_lint/rules/CL0014_logging_disabled.py
@@ -4,11 +4,24 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from compose_lint.fix import (
+    block_span,
+    delete_lines,
+    is_anchored_or_merged,
+    opens_block_body,
+)
 from compose_lint.models import Finding, RuleMetadata, Severity
 from compose_lint.rules import BaseRule, register_rule
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+    from compose_lint.models import TextEdit
+
+_CAVEAT = (
+    "Re-enabling logging restores the default driver; the container's logs are "
+    "collected again, which consumes disk and I/O."
+)
 
 DOCKER_REF = "https://docs.docker.com/engine/logging/configure/"
 OWASP_REF = "https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html"
@@ -65,3 +78,56 @@ class LoggingDisabledRule(BaseRule):
                 ),
                 references=[DOCKER_REF, OWASP_REF],
             )
+
+    def fix(
+        self,
+        finding: Finding,
+        data: dict[str, Any],
+        lines: dict[str, int],
+        text: str,
+    ) -> list[TextEdit] | None:
+        """Delete a ``logging:`` block whose only directive is ``driver: none``.
+
+        ``driver: none`` is an opt-out of the platform default, so removing the
+        block restores default logging. Refuses (returns ``None``) when the
+        block carries other keys (e.g. ``options:``) — deleting just the driver
+        would leave a structurally partial block we can't safely resolve — and
+        for anchored/merged services or flow-style blocks (ADR-014 refusal
+        policy). The edit carries a caveat because re-enabling logging changes
+        runtime behavior.
+        """
+        service = finding.service
+        services = data.get("services")
+        if not isinstance(services, dict):
+            return None
+        service_config = services.get(service)
+        if not isinstance(service_config, dict):
+            return None
+        logging_config = service_config.get("logging")
+        if not isinstance(logging_config, dict):
+            return None
+        driver = logging_config.get("driver")
+        if not (isinstance(driver, str) and driver.lower() == "none"):
+            return None
+
+        logging_line = lines.get(f"services.{service}.logging")
+        service_line = lines.get(f"services.{service}")
+        if logging_line is None or service_line is None:
+            return None
+
+        source_lines = text.splitlines(keepends=True)
+        n = len(source_lines)
+        if not (1 <= service_line <= n and 1 <= logging_line <= n):
+            return None
+
+        if is_anchored_or_merged(source_lines, service_line):
+            return None
+        if not opens_block_body(source_lines[logging_line - 1]):
+            return None
+
+        # Other keys alongside the driver -> partial block; refuse.
+        if len(logging_config) != 1:
+            return None
+
+        first, last = block_span(source_lines, logging_line)
+        return [delete_lines(source_lines, first, last, caveat=_CAVEAT)]

--- a/src/compose_lint/rules/CL0015_healthcheck_disabled.py
+++ b/src/compose_lint/rules/CL0015_healthcheck_disabled.py
@@ -4,11 +4,24 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from compose_lint.fix import (
+    block_span,
+    delete_lines,
+    is_anchored_or_merged,
+    opens_block_body,
+)
 from compose_lint.models import Finding, RuleMetadata, Severity
 from compose_lint.rules import BaseRule, register_rule
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+    from compose_lint.models import TextEdit
+
+_CAVEAT = (
+    "Re-enabling the healthcheck restores the image's default check; an "
+    "unhealthy status can affect depends_on conditions and orchestration."
+)
 
 CIS_REF_46 = (
     "CIS Docker Benchmark 4.6 — Add HEALTHCHECK instruction to container images"
@@ -73,3 +86,58 @@ class HealthcheckDisabledRule(BaseRule):
                 ),
                 references=[CIS_REF_46, CIS_REF_527],
             )
+
+    def fix(
+        self,
+        finding: Finding,
+        data: dict[str, Any],
+        lines: dict[str, int],
+        text: str,
+    ) -> list[TextEdit] | None:
+        """Delete a ``healthcheck:`` block whose only key disables the check.
+
+        ``disable: true`` (or ``test: ["NONE"]``) is an opt-out of the image's
+        default healthcheck, so removing the block restores it. Refuses (returns
+        ``None``) when the block carries other keys — deleting the disable would
+        strand them (e.g. an ``interval`` with no ``test``), a partial block we
+        can't safely resolve — and for anchored/merged services or flow-style
+        blocks (ADR-014 refusal policy). The edit carries a caveat because
+        re-enabling the healthcheck changes runtime behavior.
+        """
+        service = finding.service
+        services = data.get("services")
+        if not isinstance(services, dict):
+            return None
+        service_config = services.get(service)
+        if not isinstance(service_config, dict):
+            return None
+        healthcheck = service_config.get("healthcheck")
+        if not isinstance(healthcheck, dict):
+            return None
+
+        disable = healthcheck.get("disable")
+        test = healthcheck.get("test")
+        if not (disable is True or test == ["NONE"] or test == "NONE"):
+            return None
+
+        healthcheck_line = lines.get(f"services.{service}.healthcheck")
+        service_line = lines.get(f"services.{service}")
+        if healthcheck_line is None or service_line is None:
+            return None
+
+        source_lines = text.splitlines(keepends=True)
+        n = len(source_lines)
+        if not (1 <= service_line <= n and 1 <= healthcheck_line <= n):
+            return None
+
+        if is_anchored_or_merged(source_lines, service_line):
+            return None
+        if not opens_block_body(source_lines[healthcheck_line - 1]):
+            return None
+
+        # Other keys alongside the disable directive -> partial block; refuse.
+        if len(healthcheck) != 1:
+            return None
+
+        first, last = block_span(source_lines, healthcheck_line)
+        return [delete_lines(source_lines, first, last, caveat=_CAVEAT)]

--- a/src/compose_lint/rules/__init__.py
+++ b/src/compose_lint/rules/__init__.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-    from compose_lint.models import Finding, RuleMetadata
+    from compose_lint.models import Finding, RuleMetadata, TextEdit
 
 _registry: list[type[BaseRule]] = []
 
@@ -38,6 +38,22 @@ class BaseRule(abc.ABC):
         Yields Finding objects for each issue detected.
         """
         ...
+
+    def fix(
+        self,
+        finding: Finding,
+        data: dict[str, Any],
+        lines: dict[str, int],
+        text: str,
+    ) -> list[TextEdit] | None:
+        """Return edits that remediate ``finding``, or ``None``.
+
+        ``None`` means the rule has no fixer or cannot safely fix this
+        occurrence in this file (see the refusal policy in ADR-014). Rules
+        that only report findings inherit this default and produce no edits.
+        Fixers must be idempotent and must leave a valid Compose file.
+        """
+        return None
 
 
 def register_rule(cls: type[BaseRule]) -> type[BaseRule]:

--- a/tests/test_CL0007.py
+++ b/tests/test_CL0007.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
+from compose_lint.fix import apply_edits
 from compose_lint.parser import load_compose
 from compose_lint.rules.CL0007_read_only import ReadOnlyFilesystemRule
+
+if TYPE_CHECKING:
+    from compose_lint.models import TextEdit
 
 FIXTURES = Path(__file__).parent / "compose_files"
 
@@ -58,3 +63,96 @@ class TestReadOnlyFilesystemRule:
         assert meta.id == "CL-0007"
         assert meta.severity.value == "medium"
         assert len(meta.references) > 0
+
+
+class TestReadOnlyFix:
+    """Tests for the CL-0007 auto-fix (ADR-014)."""
+
+    def setup_method(self) -> None:
+        self.rule = ReadOnlyFilesystemRule()
+
+    def _fix(
+        self, tmp_path: Path, content: str, service: str = "web"
+    ) -> list[TextEdit] | None:
+        path = tmp_path / "docker-compose.yml"
+        path.write_text(content)
+        data, lines = load_compose(path)
+        findings = list(
+            self.rule.check(service, data["services"][service], data, lines)
+        )
+        assert findings, "expected CL-0007 to fire"
+        return self.rule.fix(findings[0], data, lines, content)
+
+    def test_inserts_read_only_two_space_indent(self, tmp_path: Path) -> None:
+        content = "services:\n  web:\n    image: nginx\n"
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        assert apply_edits(content, edits) == (
+            "services:\n  web:\n    read_only: true\n    image: nginx\n"
+        )
+
+    def test_inserts_read_only_four_space_indent(self, tmp_path: Path) -> None:
+        content = "services:\n    web:\n        image: nginx\n"
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        assert "        read_only: true\n" in apply_edits(content, edits)
+
+    def test_edit_carries_caveat(self, tmp_path: Path) -> None:
+        content = "services:\n  web:\n    image: nginx\n"
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        assert edits[0].caveat is not None
+        assert "read_only" in edits[0].caveat
+
+    def test_preserves_comments_and_siblings(self, tmp_path: Path) -> None:
+        content = (
+            "services:\n"
+            "  web:  # frontend\n"
+            "    image: nginx  # pinned\n"
+            "    ports:\n"
+            "      - 8080:80\n"
+        )
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        result = apply_edits(content, edits)
+        assert "# frontend" in result
+        assert "# pinned" in result
+        assert "      - 8080:80\n" in result
+
+    def test_fix_resolves_finding_and_is_idempotent(self, tmp_path: Path) -> None:
+        content = "services:\n  web:\n    image: nginx\n"
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        result = apply_edits(content, edits)
+        # The fixed file must still parse and now declare read_only.
+        fixed = tmp_path / "fixed.yml"
+        fixed.write_text(result)
+        data, lines = load_compose(fixed)
+        assert data["services"]["web"]["read_only"] is True
+        # Re-linting finds nothing, so re-running fix would be a no-op.
+        findings = list(self.rule.check("web", data["services"]["web"], data, lines))
+        assert findings == []
+
+    def test_refuses_flow_style_service(self, tmp_path: Path) -> None:
+        content = "services:\n  web: {image: nginx}\n"
+        assert self._fix(tmp_path, content) is None
+
+    def test_refuses_anchored_service(self, tmp_path: Path) -> None:
+        content = "services:\n  web: &websvc\n    image: nginx\n"
+        assert self._fix(tmp_path, content) is None
+
+    def test_refuses_merge_key_service(self, tmp_path: Path) -> None:
+        content = (
+            "x-base: &base\n"
+            "  image: nginx\n"
+            "services:\n"
+            "  web:\n"
+            "    <<: *base\n"
+            "    ports:\n"
+            "      - 8080:80\n"
+        )
+        assert self._fix(tmp_path, content) is None
+
+    def test_refuses_explicit_read_only_value(self, tmp_path: Path) -> None:
+        content = "services:\n  web:\n    read_only: false\n    image: nginx\n"
+        assert self._fix(tmp_path, content) is None

--- a/tests/test_CL0009.py
+++ b/tests/test_CL0009.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
+from compose_lint.fix import apply_edits
 from compose_lint.parser import load_compose
 from compose_lint.rules.CL0009_security_profile import SecurityProfileRule
+
+if TYPE_CHECKING:
+    from compose_lint.models import TextEdit
 
 FIXTURES = Path(__file__).parent / "compose_files"
 
@@ -162,3 +167,128 @@ class TestSecurityProfileRule:
             )
         )
         assert len(findings) == 0
+
+
+class TestSecurityProfileFix:
+    """Tests for the CL-0009 deletion fix (ADR-014)."""
+
+    def setup_method(self) -> None:
+        self.rule = SecurityProfileRule()
+
+    def _fix(
+        self, tmp_path: Path, content: str, service: str = "web"
+    ) -> list[TextEdit] | None:
+        path = tmp_path / "docker-compose.yml"
+        path.write_text(content)
+        data, lines = load_compose(path)
+        findings = list(
+            self.rule.check(service, data["services"][service], data, lines)
+        )
+        assert findings, "expected CL-0009 to fire"
+        return self.rule.fix(findings[0], data, lines, content)
+
+    def test_collapses_block_when_sole_entry(self, tmp_path: Path) -> None:
+        content = (
+            "services:\n"
+            "  web:\n"
+            "    image: nginx\n"
+            "    security_opt:\n"
+            "      - seccomp:unconfined\n"
+        )
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        # The now-empty security_opt block is dropped whole, not left as `[]`.
+        assert apply_edits(content, edits) == ("services:\n  web:\n    image: nginx\n")
+
+    def test_removes_only_offending_item_when_legit_remains(
+        self, tmp_path: Path
+    ) -> None:
+        content = (
+            "services:\n"
+            "  web:\n"
+            "    image: nginx\n"
+            "    security_opt:\n"
+            "      - seccomp:unconfined\n"
+            "      - no-new-privileges:true\n"
+        )
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        result = apply_edits(content, edits)
+        assert "seccomp:unconfined" not in result
+        assert "no-new-privileges:true" in result
+        assert "security_opt:" in result
+
+    def test_refuses_when_all_entries_offending_but_many(self, tmp_path: Path) -> None:
+        # Collapsing this correctly needs the two per-finding fixers to
+        # coordinate, which they can't — refuse rather than empty the block.
+        content = (
+            "services:\n"
+            "  web:\n"
+            "    image: nginx\n"
+            "    security_opt:\n"
+            "      - seccomp:unconfined\n"
+            "      - apparmor:unconfined\n"
+        )
+        assert self._fix(tmp_path, content) is None
+
+    def test_edit_carries_caveat(self, tmp_path: Path) -> None:
+        content = "services:\n  web:\n    security_opt:\n      - seccomp:unconfined\n"
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        assert edits[0].caveat is not None
+        assert "seccomp" in edits[0].caveat.lower()
+
+    def test_fix_resolves_finding_and_is_idempotent(self, tmp_path: Path) -> None:
+        content = (
+            "services:\n"
+            "  web:\n"
+            "    image: nginx\n"
+            "    security_opt:\n"
+            "      - seccomp:unconfined\n"
+        )
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        fixed = tmp_path / "fixed.yml"
+        fixed.write_text(apply_edits(content, edits))
+        data, lines = load_compose(fixed)
+        assert "security_opt" not in data["services"]["web"]
+        findings = list(self.rule.check("web", data["services"]["web"], data, lines))
+        assert findings == []
+
+    def test_preserves_comments_and_siblings(self, tmp_path: Path) -> None:
+        content = (
+            "services:\n"
+            "  web:  # frontend\n"
+            "    image: nginx  # pinned\n"
+            "    security_opt:\n"
+            "      - seccomp:unconfined\n"
+            "      - no-new-privileges:true  # keep\n"
+        )
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        result = apply_edits(content, edits)
+        assert "# frontend" in result
+        assert "# pinned" in result
+        assert "# keep" in result
+
+    def test_refuses_flow_style_list(self, tmp_path: Path) -> None:
+        content = "services:\n  web:\n    security_opt: [seccomp:unconfined]\n"
+        assert self._fix(tmp_path, content) is None
+
+    def test_refuses_anchored_service(self, tmp_path: Path) -> None:
+        content = (
+            "services:\n  web: &websvc\n    security_opt:\n      - seccomp:unconfined\n"
+        )
+        assert self._fix(tmp_path, content) is None
+
+    def test_refuses_merge_key_service(self, tmp_path: Path) -> None:
+        content = (
+            "x-base: &base\n"
+            "  image: nginx\n"
+            "services:\n"
+            "  web:\n"
+            "    <<: *base\n"
+            "    security_opt:\n"
+            "      - seccomp:unconfined\n"
+        )
+        assert self._fix(tmp_path, content) is None

--- a/tests/test_CL0014.py
+++ b/tests/test_CL0014.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
+from compose_lint.fix import apply_edits
 from compose_lint.parser import load_compose
 from compose_lint.rules.CL0014_logging_disabled import LoggingDisabledRule
+
+if TYPE_CHECKING:
+    from compose_lint.models import TextEdit
 
 FIXTURES = Path(__file__).parent / "compose_files"
 
@@ -57,3 +62,102 @@ class TestLoggingDisabledRule:
         meta = self.rule.metadata
         assert meta.id == "CL-0014"
         assert meta.severity.value == "medium"
+
+
+class TestLoggingDisabledFix:
+    """Tests for the CL-0014 deletion fix (ADR-014)."""
+
+    def setup_method(self) -> None:
+        self.rule = LoggingDisabledRule()
+
+    def _fix(
+        self, tmp_path: Path, content: str, service: str = "web"
+    ) -> list[TextEdit] | None:
+        path = tmp_path / "docker-compose.yml"
+        path.write_text(content)
+        data, lines = load_compose(path)
+        findings = list(
+            self.rule.check(service, data["services"][service], data, lines)
+        )
+        assert findings, "expected CL-0014 to fire"
+        return self.rule.fix(findings[0], data, lines, content)
+
+    def test_collapses_logging_block_when_driver_is_sole_key(
+        self, tmp_path: Path
+    ) -> None:
+        content = (
+            "services:\n  web:\n    image: nginx\n    logging:\n      driver: none\n"
+        )
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        # The whole logging block is dropped, not left as an empty `logging:`.
+        assert apply_edits(content, edits) == ("services:\n  web:\n    image: nginx\n")
+
+    def test_refuses_when_logging_has_other_keys(self, tmp_path: Path) -> None:
+        # Deleting only the driver would strand `options:` — a partial block.
+        content = (
+            "services:\n"
+            "  web:\n"
+            "    logging:\n"
+            "      driver: none\n"
+            "      options:\n"
+            "        max-size: 10m\n"
+        )
+        assert self._fix(tmp_path, content) is None
+
+    def test_edit_carries_caveat(self, tmp_path: Path) -> None:
+        content = "services:\n  web:\n    logging:\n      driver: none\n"
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        assert edits[0].caveat is not None
+        assert "logging" in edits[0].caveat.lower()
+
+    def test_fix_resolves_finding_and_is_idempotent(self, tmp_path: Path) -> None:
+        content = (
+            "services:\n  web:\n    image: nginx\n    logging:\n      driver: none\n"
+        )
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        fixed = tmp_path / "fixed.yml"
+        fixed.write_text(apply_edits(content, edits))
+        data, lines = load_compose(fixed)
+        assert "logging" not in data["services"]["web"]
+        findings = list(self.rule.check("web", data["services"]["web"], data, lines))
+        assert findings == []
+
+    def test_preserves_comments_and_siblings(self, tmp_path: Path) -> None:
+        content = (
+            "services:\n"
+            "  web:  # frontend\n"
+            "    image: nginx  # pinned\n"
+            "    logging:\n"
+            "      driver: none\n"
+            "  db:\n"
+            "    image: postgres\n"
+        )
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        result = apply_edits(content, edits)
+        assert "# frontend" in result
+        assert "# pinned" in result
+        assert "  db:\n    image: postgres\n" in result
+
+    def test_refuses_flow_style_logging(self, tmp_path: Path) -> None:
+        content = "services:\n  web:\n    logging: {driver: none}\n"
+        assert self._fix(tmp_path, content) is None
+
+    def test_refuses_anchored_service(self, tmp_path: Path) -> None:
+        content = "services:\n  web: &websvc\n    logging:\n      driver: none\n"
+        assert self._fix(tmp_path, content) is None
+
+    def test_refuses_merge_key_service(self, tmp_path: Path) -> None:
+        content = (
+            "x-base: &base\n"
+            "  image: nginx\n"
+            "services:\n"
+            "  web:\n"
+            "    <<: *base\n"
+            "    logging:\n"
+            "      driver: none\n"
+        )
+        assert self._fix(tmp_path, content) is None

--- a/tests/test_CL0015.py
+++ b/tests/test_CL0015.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
+from compose_lint.fix import apply_edits
 from compose_lint.parser import load_compose
 from compose_lint.rules.CL0015_healthcheck_disabled import HealthcheckDisabledRule
+
+if TYPE_CHECKING:
+    from compose_lint.models import TextEdit
 
 FIXTURES = Path(__file__).parent / "compose_files"
 
@@ -87,3 +92,101 @@ class TestHealthcheckDisabledRule:
             )
         )
         assert len(findings) == 0
+
+
+class TestHealthcheckDisabledFix:
+    """Tests for the CL-0015 deletion fix (ADR-014)."""
+
+    def setup_method(self) -> None:
+        self.rule = HealthcheckDisabledRule()
+
+    def _fix(
+        self, tmp_path: Path, content: str, service: str = "web"
+    ) -> list[TextEdit] | None:
+        path = tmp_path / "docker-compose.yml"
+        path.write_text(content)
+        data, lines = load_compose(path)
+        findings = list(
+            self.rule.check(service, data["services"][service], data, lines)
+        )
+        assert findings, "expected CL-0015 to fire"
+        return self.rule.fix(findings[0], data, lines, content)
+
+    def test_collapses_block_for_disable_true(self, tmp_path: Path) -> None:
+        content = (
+            "services:\n"
+            "  web:\n"
+            "    image: nginx\n"
+            "    healthcheck:\n"
+            "      disable: true\n"
+        )
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        assert apply_edits(content, edits) == ("services:\n  web:\n    image: nginx\n")
+
+    def test_collapses_block_for_test_none(self, tmp_path: Path) -> None:
+        content = (
+            "services:\n"
+            "  web:\n"
+            "    image: nginx\n"
+            "    healthcheck:\n"
+            '      test: ["NONE"]\n'
+        )
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        assert apply_edits(content, edits) == ("services:\n  web:\n    image: nginx\n")
+
+    def test_refuses_when_healthcheck_has_other_keys(self, tmp_path: Path) -> None:
+        # Deleting `test: ["NONE"]` would strand `interval:` — a partial block.
+        content = (
+            "services:\n"
+            "  web:\n"
+            "    healthcheck:\n"
+            '      test: ["NONE"]\n'
+            "      interval: 30s\n"
+        )
+        assert self._fix(tmp_path, content) is None
+
+    def test_edit_carries_caveat(self, tmp_path: Path) -> None:
+        content = "services:\n  web:\n    healthcheck:\n      disable: true\n"
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        assert edits[0].caveat is not None
+        assert "healthcheck" in edits[0].caveat.lower()
+
+    def test_fix_resolves_finding_and_is_idempotent(self, tmp_path: Path) -> None:
+        content = (
+            "services:\n"
+            "  web:\n"
+            "    image: nginx\n"
+            "    healthcheck:\n"
+            "      disable: true\n"
+        )
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        fixed = tmp_path / "fixed.yml"
+        fixed.write_text(apply_edits(content, edits))
+        data, lines = load_compose(fixed)
+        assert "healthcheck" not in data["services"]["web"]
+        findings = list(self.rule.check("web", data["services"]["web"], data, lines))
+        assert findings == []
+
+    def test_refuses_flow_style_healthcheck(self, tmp_path: Path) -> None:
+        content = "services:\n  web:\n    healthcheck: {disable: true}\n"
+        assert self._fix(tmp_path, content) is None
+
+    def test_refuses_anchored_service(self, tmp_path: Path) -> None:
+        content = "services:\n  web: &websvc\n    healthcheck:\n      disable: true\n"
+        assert self._fix(tmp_path, content) is None
+
+    def test_refuses_merge_key_service(self, tmp_path: Path) -> None:
+        content = (
+            "x-base: &base\n"
+            "  image: nginx\n"
+            "services:\n"
+            "  web:\n"
+            "    <<: *base\n"
+            "    healthcheck:\n"
+            "      disable: true\n"
+        )
+        assert self._fix(tmp_path, content) is None

--- a/tests/test_fix.py
+++ b/tests/test_fix.py
@@ -1,0 +1,71 @@
+"""Tests for the fix edit engine (ADR-014)."""
+
+from __future__ import annotations
+
+import pytest
+
+from compose_lint.fix import OverlappingEditError, apply_edits
+from compose_lint.models import TextEdit
+
+
+def test_no_edits_returns_text_unchanged() -> None:
+    text = "services:\n  web:\n    image: nginx\n"
+    assert apply_edits(text, []) == text
+
+
+def test_pure_insertion() -> None:
+    text = "a: 1\nb: 2\n"
+    # Zero-width region at the start of line 3 (just past the final newline).
+    edit = TextEdit(3, 1, 3, 1, "c: 3\n")
+    assert apply_edits(text, [edit]) == "a: 1\nb: 2\nc: 3\n"
+
+
+def test_pure_deletion_removes_whole_line() -> None:
+    text = "a: 1\nbad: x\nb: 2\n"
+    # Delete line 2 by replacing [line2:col1, line3:col1) with nothing.
+    edit = TextEdit(2, 1, 3, 1, "")
+    assert apply_edits(text, [edit]) == "a: 1\nb: 2\n"
+
+
+def test_in_scalar_replacement() -> None:
+    text = "ports:\n  - 0.0.0.0:8080:80\n"
+    # Replace the seven characters "0.0.0.0" (cols 5-11) on line 2.
+    edit = TextEdit(2, 5, 2, 12, "127.0.0.1")
+    assert apply_edits(text, [edit]) == "ports:\n  - 127.0.0.1:8080:80\n"
+
+
+def test_multiple_non_overlapping_edits() -> None:
+    text = "a: 1\nb: 2\n"
+    edits = [
+        TextEdit(2, 1, 2, 1, "x\n"),
+        TextEdit(3, 1, 3, 1, "y\n"),
+    ]
+    # Order of the input list must not matter; result is deterministic.
+    assert apply_edits(text, edits) == "a: 1\nx\nb: 2\ny\n"
+    assert apply_edits(text, list(reversed(edits))) == "a: 1\nx\nb: 2\ny\n"
+
+
+def test_adjacent_edits_are_allowed() -> None:
+    text = "abcdef\n"
+    edits = [
+        TextEdit(1, 1, 1, 3, "AB"),  # replaces "ab"
+        TextEdit(1, 3, 1, 5, "CD"),  # replaces "cd", begins where the prior ends
+    ]
+    assert apply_edits(text, edits) == "ABCDef\n"
+
+
+def test_overlapping_edits_raise() -> None:
+    text = "abcdef\n"
+    edits = [
+        TextEdit(1, 1, 1, 4, "X"),  # covers cols 1-3
+        TextEdit(1, 2, 1, 5, "Y"),  # starts inside the first region
+    ]
+    with pytest.raises(OverlappingEditError):
+        apply_edits(text, edits)
+
+
+def test_caveat_field_is_preserved() -> None:
+    edit = TextEdit(1, 1, 1, 1, "read_only: true\n", caveat="breaks writers")
+    assert edit.caveat == "breaks writers"
+    # A caveat does not change how the edit is applied.
+    assert apply_edits("x: 1\n", [edit]) == "read_only: true\nx: 1\n"

--- a/tests/test_fix.py
+++ b/tests/test_fix.py
@@ -4,7 +4,17 @@ from __future__ import annotations
 
 import pytest
 
-from compose_lint.fix import OverlappingEditError, apply_edits
+from compose_lint.fix import (
+    OverlappingEditError,
+    apply_edits,
+    block_span,
+    delete_lines,
+    first_child_indent,
+    has_merge_key_child,
+    is_anchored_or_merged,
+    line_indent,
+    opens_block_body,
+)
 from compose_lint.models import TextEdit
 
 
@@ -69,3 +79,91 @@ def test_caveat_field_is_preserved() -> None:
     assert edit.caveat == "breaks writers"
     # A caveat does not change how the edit is applied.
     assert apply_edits("x: 1\n", [edit]) == "read_only: true\nx: 1\n"
+
+
+# --- Text-shaping helpers -------------------------------------------------
+
+
+def test_line_indent_counts_leading_spaces() -> None:
+    assert line_indent("foo: 1\n") == 0
+    assert line_indent("    foo: 1\n") == 4
+    assert line_indent("  - item\n") == 2
+    assert line_indent("\n") == 0
+
+
+def test_opens_block_body_true_for_bare_key_or_comment() -> None:
+    assert opens_block_body("web:\n")
+    assert opens_block_body("  web:  # frontend\n")
+
+
+def test_opens_block_body_false_for_inline_flow_anchor_alias() -> None:
+    assert not opens_block_body("web: nginx\n")  # inline value
+    assert not opens_block_body("web: {image: nginx}\n")  # flow mapping
+    assert not opens_block_body("web: &anchor\n")  # anchor
+    assert not opens_block_body("web: *alias\n")  # alias
+    assert not opens_block_body("just text\n")  # no colon
+
+
+def test_first_child_indent() -> None:
+    lines = ["web:\n", "  image: nginx\n", "  ports:\n", "    - 80\n"]
+    assert first_child_indent(lines, 1) == 2
+    # No deeper line after the key -> no children.
+    assert first_child_indent(["web:\n", "db:\n"], 1) is None
+    # Blank lines are skipped when locating the first child.
+    assert first_child_indent(["web:\n", "\n", "    image: x\n"], 1) == 4
+
+
+def test_has_merge_key_child() -> None:
+    merged = ["web:\n", "  <<: *base\n", "  image: nginx\n"]
+    assert has_merge_key_child(merged, 1)
+    plain = ["web:\n", "  image: nginx\n"]
+    assert not has_merge_key_child(plain, 1)
+
+
+def test_is_anchored_or_merged() -> None:
+    assert is_anchored_or_merged(["web: &a\n", "  image: x\n"], 1)  # anchor
+    assert is_anchored_or_merged(["web:\n", "  <<: *base\n"], 1)  # merge key
+    assert not is_anchored_or_merged(["web:\n", "  image: x\n"], 1)  # plain block
+
+
+def test_block_span_covers_key_and_children() -> None:
+    lines = [
+        "services:\n",  # 1
+        "  web:\n",  # 2
+        "    image: nginx\n",  # 3
+        "    logging:\n",  # 4
+        "      driver: none\n",  # 5
+        "  db:\n",  # 6
+    ]
+    # The web block runs from line 2 through its last child (line 5).
+    assert block_span(lines, 2) == (2, 5)
+    # The logging sub-block is lines 4-5.
+    assert block_span(lines, 4) == (4, 5)
+
+
+def test_block_span_excludes_trailing_blank_lines() -> None:
+    lines = ["web:\n", "  image: x\n", "\n", "db:\n"]
+    assert block_span(lines, 1) == (1, 2)
+
+
+def test_delete_lines_removes_whole_lines() -> None:
+    text = "a: 1\nbad: x\nb: 2\n"
+    lines = text.splitlines(keepends=True)
+    assert apply_edits(text, [delete_lines(lines, 2, 2)]) == "a: 1\nb: 2\n"
+
+
+def test_delete_lines_spans_multiple_lines() -> None:
+    text = "keep: 1\nlogging:\n  driver: none\nkeep2: 2\n"
+    lines = text.splitlines(keepends=True)
+    assert apply_edits(text, [delete_lines(lines, 2, 3)]) == "keep: 1\nkeep2: 2\n"
+
+
+def test_delete_lines_final_line_without_trailing_newline() -> None:
+    text = "a: 1\nb: 2"  # no trailing newline on the last line
+    lines = text.splitlines(keepends=True)
+    assert apply_edits(text, [delete_lines(lines, 2, 2)]) == "a: 1\n"
+
+
+def test_delete_lines_carries_caveat() -> None:
+    lines = ["a: 1\n", "b: 2\n"]
+    assert delete_lines(lines, 1, 1, caveat="note").caveat == "note"


### PR DESCRIPTION
## Summary

Begins the experimental **`compose-lint fix`** auto-remediation effort per
**ADR-014**. Lands incrementally; **draft** until the ADR is ratified, the safe
rules are implemented, and the corpus soak passes. Decoupled from 1.0 — `fix`
ships hidden + experimental and promotes on its own timeline (1.0 stays a
contract freeze).

## In this PR so far

- **ADR-014** (`docs/adr/014-fix-remediation.md`): surgical text patching (no
  ruamel, per ADR-003); a shared `TextEdit` model rendered as diff / in-place
  write / SARIF `artifactChanges`; dry-run default with `--apply`; hidden +
  experimental release gated behind `COMPOSE_LINT_EXPERIMENTAL`. Safe-rule set is
  every finding with a *mechanically safe* fix (six: CL-0003/0005/0007/0009/0014/0015);
  behavior-changing fixes carry a mandatory per-fix caveat surfaced in the
  dry-run and SARIF.
- **Edit engine**: `TextEdit` model, an optional no-op `BaseRule.fix()` hook
  (report-only rules unaffected), and `apply_edits()` — the single auditable
  function that splices non-overlapping edits bottom-up.
- **CL-0007 fixer**: inserts `read_only: true` at the inferred child indent with
  its caveat; refuses flow-style/anchored/aliased/merge-key services and the
  explicit-value case.

## Still to come

- Deletion fixers (CL-0009 / 0014 / 0015), then CL-0003 (insert-or-create-list),
  then CL-0005 (in-scalar).
- CLI `fix` subcommand — depends on the ADR-011 subparser refactor, done as its
  own commit when we get there.
- Corpus soak gate + SARIF `artifactChanges`, then promotion.

## Quality

`ruff check`, `ruff format --check`, `mypy src/` (strict), and `pytest`
(492 passed, 1 skipped) all green locally on every commit.
