### PR TITLE
Add CL-0003 and CL-0005 auto-fixers

### DIFF
--- a/src/compose_lint/rules/CL0003_no_new_privileges.py
+++ b/src/compose_lint/rules/CL0003_no_new_privileges.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from compose_lint.models import Finding, RuleMetadata, Severity
+from compose_lint.fix import (
+    block_span,
+    first_child_indent,
+    is_anchored_or_merged,
+    line_indent,
+    opens_block_body,
+)
+from compose_lint.models import Finding, RuleMetadata, Severity, TextEdit
 from compose_lint.rules import BaseRule, register_rule
 
 if TYPE_CHECKING:
@@ -74,3 +81,100 @@ class NoNewPrivilegesRule(BaseRule):
                 ),
                 references=[OWASP_REF, CIS_REF],
             )
+
+    def fix(
+        self,
+        finding: Finding,
+        data: dict[str, Any],
+        lines: dict[str, int],
+        text: str,
+    ) -> list[TextEdit] | None:
+        """Add ``no-new-privileges:true`` to the service's ``security_opt``.
+
+        Appends the entry to an existing block-style ``security_opt:`` list, or
+        creates the list as the service's first child when it is absent. This is
+        the only hardening-only fixer (ADR-014) — blocking setuid/setgid
+        escalation has near-zero breakage — so the edit carries no caveat.
+
+        Refuses (returns ``None``) for anchored/merged services, a flow-style or
+        non-list ``security_opt``, a service whose child indentation cannot be
+        determined, or a ``security_opt`` that already names ``no-new-privileges``
+        with a different value (appending the true form would duplicate the key).
+        """
+        service = finding.service
+        services = data.get("services")
+        if not isinstance(services, dict):
+            return None
+        service_config = services.get(service)
+        if not isinstance(service_config, dict):
+            return None
+
+        key_line = lines.get(f"services.{service}")
+        if key_line is None:
+            return None
+        source_lines = text.splitlines(keepends=True)
+        n = len(source_lines)
+        if not 1 <= key_line <= n:
+            return None
+        if is_anchored_or_merged(source_lines, key_line):
+            return None
+
+        if "security_opt" in service_config:
+            return self._append_to_existing(
+                service, service_config, lines, source_lines, n
+            )
+        return self._create_list(source_lines, key_line)
+
+    def _append_to_existing(
+        self,
+        service: str,
+        service_config: dict[str, Any],
+        lines: dict[str, int],
+        source_lines: list[str],
+        n: int,
+    ) -> list[TextEdit] | None:
+        """Append the entry to an existing block-style ``security_opt:`` list."""
+        security_opt = service_config.get("security_opt")
+        if not isinstance(security_opt, list):
+            return None
+        if any(
+            str(opt).strip().startswith("no-new-privileges") for opt in security_opt
+        ):
+            # Already named (e.g. `no-new-privileges:false`): appending the true
+            # form would duplicate the key. Leave it for the human.
+            return None
+
+        so_line = lines.get(f"services.{service}.security_opt")
+        if so_line is None or not 1 <= so_line <= n:
+            return None
+        if not opens_block_body(source_lines[so_line - 1]):
+            return None  # flow style or inline value: no block list to append to
+        item_indent = first_child_indent(source_lines, so_line)
+        if item_indent is None:
+            return None  # `security_opt:` with no items: nothing to append after
+
+        new_item = f"{' ' * item_indent}- no-new-privileges:true\n"
+        _first, last = block_span(source_lines, so_line)
+        last_line = source_lines[last - 1]
+        if last_line.endswith("\n"):
+            # The trailing newline makes the start of the next line addressable
+            # even when ``last`` is the final line of the file.
+            return [TextEdit(last + 1, 1, last + 1, 1, new_item)]
+        # Final list item has no trailing newline: append after it on a new line.
+        end_col = len(last_line) + 1
+        return [TextEdit(last, end_col, last, end_col, f"\n{new_item}")]
+
+    def _create_list(
+        self, source_lines: list[str], key_line: int
+    ) -> list[TextEdit] | None:
+        """Create ``security_opt:`` as the service's first child."""
+        child_indent = first_child_indent(source_lines, key_line)
+        if child_indent is None:
+            return None
+        service_indent = line_indent(source_lines[key_line - 1])
+        step = child_indent - service_indent
+        block = (
+            f"{' ' * child_indent}security_opt:\n"
+            f"{' ' * (child_indent + step)}- no-new-privileges:true\n"
+        )
+        return [TextEdit(key_line + 1, 1, key_line + 1, 1, block)]

--- a/src/compose_lint/rules/CL0005_unbound_ports.py
+++ b/src/compose_lint/rules/CL0005_unbound_ports.py
@@ -5,11 +5,18 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any
 
-from compose_lint.models import Finding, RuleMetadata, Severity
+from compose_lint.fix import is_anchored_or_merged
+from compose_lint.models import Finding, RuleMetadata, Severity, TextEdit
 from compose_lint.rules import BaseRule, register_rule
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+_CAVEAT = (
+    "Binding to 127.0.0.1 drops the port's reachability from other hosts; "
+    "intended LAN or remote access breaks — front public exposure with a "
+    "reverse proxy and TLS instead."
+)
 
 OWASP_REF = (
     "https://cheatsheetseries.owasp.org/cheatsheets/"
@@ -154,3 +161,124 @@ class UnboundPortsRule(BaseRule):
             ),
             references=[OWASP_REF, CIS_REF],
         )
+
+    def fix(
+        self,
+        finding: Finding,
+        data: dict[str, Any],
+        lines: dict[str, int],
+        text: str,
+    ) -> list[TextEdit] | None:
+        """Bind a wildcard or unbound published port to ``127.0.0.1``.
+
+        Edits the port scalar in place: prepends ``127.0.0.1:`` when no host IP
+        is present, or replaces a wildcard host IP (``0.0.0.0``, ``[::]``, ``*``)
+        with ``127.0.0.1``. Only short-syntax string ports are handled. The edit
+        carries a caveat because dropping non-local reachability changes network
+        behavior (ADR-014).
+
+        Refuses (returns ``None``) for long-syntax mapping entries (adding
+        ``host_ip:`` is a different primitive), anchored/merged services, a port
+        line that is not a plain block-sequence scalar, and any scalar containing
+        ``$`` interpolation (the resolved host is unknown).
+        """
+        service = finding.service
+        services = data.get("services")
+        if not isinstance(services, dict):
+            return None
+        service_config = services.get(service)
+        if not isinstance(service_config, dict):
+            return None
+        if not isinstance(service_config.get("ports"), list):
+            return None
+
+        item_line = finding.line
+        service_line = lines.get(f"services.{service}")
+        if item_line is None or service_line is None:
+            return None
+        source_lines = text.splitlines(keepends=True)
+        n = len(source_lines)
+        if not (1 <= item_line <= n and 1 <= service_line <= n):
+            return None
+        if is_anchored_or_merged(source_lines, service_line):
+            return None
+
+        parsed = _scalar_span(source_lines[item_line - 1])
+        if parsed is None:
+            return None
+        scalar, scalar_col = parsed
+        if "$" in scalar:
+            return None  # variable interpolation: the resolved host is unknown
+
+        span = _host_ip_span(scalar)
+        if span is None:
+            return None
+        repl_start, repl_end, replacement = span
+        return [
+            TextEdit(
+                item_line,
+                scalar_col + repl_start,
+                item_line,
+                scalar_col + repl_end,
+                replacement,
+                caveat=_CAVEAT,
+            )
+        ]
+
+
+def _scalar_span(raw_line: str) -> tuple[str, int] | None:
+    """Return ``(scalar, col)`` for a block-sequence entry's scalar value.
+
+    ``col`` is the 1-indexed column where the scalar content begins (inside the
+    quote, if any). Strips a surrounding quote and a trailing ``# comment``.
+    Returns ``None`` when the line is not a plain ``- value`` entry.
+    """
+    line = raw_line.rstrip("\n")
+    idx = len(line) - len(line.lstrip(" "))
+    if idx >= len(line) or line[idx] != "-":
+        return None
+    idx += 1
+    if idx >= len(line) or line[idx] != " ":
+        return None  # need whitespace after the dash for a scalar entry
+    while idx < len(line) and line[idx] == " ":
+        idx += 1
+    if idx >= len(line):
+        return None
+
+    if line[idx] in ("'", '"'):
+        quote = line[idx]
+        close = line.find(quote, idx + 1)
+        if close == -1:
+            return None
+        return line[idx + 1 : close], idx + 2  # content starts past the quote
+    rest = line[idx:]
+    comment = rest.find(" #")
+    if comment != -1:
+        rest = rest[:comment]
+    scalar = rest.rstrip()
+    if not scalar:
+        return None
+    return scalar, idx + 1
+
+
+def _host_ip_span(scalar: str) -> tuple[int, int, str] | None:
+    """Return ``(start, end, replacement)`` for the host-IP edit within ``scalar``.
+
+    A zero-width ``(0, 0, "127.0.0.1:")`` prepends a bind address when none is
+    present; ``(0, len, "127.0.0.1")`` replaces a wildcard one. Returns ``None``
+    when the scalar is not a short-syntax port or already binds a real interface.
+    """
+    if scalar.startswith("["):
+        bracket = scalar.find("]:")
+        if bracket == -1 or not _is_wildcard_ip(scalar[: bracket + 1]):
+            return None
+        return 0, bracket + 1, "127.0.0.1"
+    match = _PORT_PATTERN.match(scalar)
+    if not match:
+        return None
+    ip = match.group("ip")
+    if ip is None:
+        return 0, 0, "127.0.0.1:"
+    if _is_wildcard_ip(ip):
+        return 0, len(ip), "127.0.0.1"
+    return None  # already bound to a specific interface

--- a/tests/test_CL0003.py
+++ b/tests/test_CL0003.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
+from compose_lint.fix import apply_edits
 from compose_lint.parser import load_compose
 from compose_lint.rules.CL0003_no_new_privileges import NoNewPrivilegesRule
+
+if TYPE_CHECKING:
+    from compose_lint.models import TextEdit
 
 FIXTURES = Path(__file__).parent / "compose_files"
 
@@ -80,3 +85,134 @@ class TestNoNewPrivilegesRule:
     def test_has_references(self) -> None:
         assert len(self.rule.metadata.references) > 0
         assert "owasp" in self.rule.metadata.references[0].lower()
+
+
+class TestNoNewPrivilegesFix:
+    """Tests for the CL-0003 append/create fix (ADR-014)."""
+
+    def setup_method(self) -> None:
+        self.rule = NoNewPrivilegesRule()
+
+    def _fix(
+        self, tmp_path: Path, content: str, service: str = "web"
+    ) -> list[TextEdit] | None:
+        path = tmp_path / "docker-compose.yml"
+        path.write_text(content)
+        data, lines = load_compose(path)
+        findings = list(
+            self.rule.check(service, data["services"][service], data, lines)
+        )
+        assert findings, "expected CL-0003 to fire"
+        return self.rule.fix(findings[0], data, lines, content)
+
+    def test_creates_security_opt_when_absent(self, tmp_path: Path) -> None:
+        content = "services:\n  web:\n    image: nginx\n"
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        assert apply_edits(content, edits) == (
+            "services:\n"
+            "  web:\n"
+            "    security_opt:\n"
+            "      - no-new-privileges:true\n"
+            "    image: nginx\n"
+        )
+
+    def test_create_uses_existing_indentation_step(self, tmp_path: Path) -> None:
+        content = "services:\n    web:\n        image: nginx\n"
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        result = apply_edits(content, edits)
+        assert "        security_opt:\n" in result
+        assert "            - no-new-privileges:true\n" in result
+
+    def test_appends_to_existing_list(self, tmp_path: Path) -> None:
+        content = (
+            "services:\n"
+            "  web:\n"
+            "    image: nginx\n"
+            "    security_opt:\n"
+            "      - label:type:svirt_apache_t\n"
+        )
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        assert apply_edits(content, edits) == (
+            "services:\n"
+            "  web:\n"
+            "    image: nginx\n"
+            "    security_opt:\n"
+            "      - label:type:svirt_apache_t\n"
+            "      - no-new-privileges:true\n"
+        )
+
+    def test_no_caveat_hardening_only(self, tmp_path: Path) -> None:
+        content = "services:\n  web:\n    image: nginx\n"
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        assert all(edit.caveat is None for edit in edits)
+
+    def test_append_to_final_line_without_trailing_newline(
+        self, tmp_path: Path
+    ) -> None:
+        content = (
+            "services:\n"
+            "  web:\n"
+            "    security_opt:\n"
+            "      - label:type:svirt_apache_t"  # no trailing newline
+        )
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        result = apply_edits(content, edits)
+        assert result.endswith(
+            "      - label:type:svirt_apache_t\n      - no-new-privileges:true\n"
+        )
+
+    def test_preserves_comments_and_siblings(self, tmp_path: Path) -> None:
+        content = (
+            "services:\n"
+            "  web:  # frontend\n"
+            "    image: nginx  # pinned\n"
+            "    security_opt:\n"
+            "      - label:type:svirt_apache_t  # keep\n"
+        )
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        result = apply_edits(content, edits)
+        assert "# frontend" in result
+        assert "# pinned" in result
+        assert "# keep" in result
+
+    def test_fix_resolves_finding_and_is_idempotent(self, tmp_path: Path) -> None:
+        content = "services:\n  web:\n    image: nginx\n"
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        fixed = tmp_path / "fixed.yml"
+        fixed.write_text(apply_edits(content, edits))
+        data, lines = load_compose(fixed)
+        assert "no-new-privileges:true" in data["services"]["web"]["security_opt"]
+        findings = list(self.rule.check("web", data["services"]["web"], data, lines))
+        assert findings == []
+
+    def test_refuses_flow_style_security_opt(self, tmp_path: Path) -> None:
+        content = "services:\n  web:\n    security_opt: [label:disable]\n"
+        assert self._fix(tmp_path, content) is None
+
+    def test_refuses_existing_no_new_privileges_false(self, tmp_path: Path) -> None:
+        content = (
+            "services:\n  web:\n    security_opt:\n      - no-new-privileges:false\n"
+        )
+        assert self._fix(tmp_path, content) is None
+
+    def test_refuses_anchored_service(self, tmp_path: Path) -> None:
+        content = "services:\n  web: &websvc\n    image: nginx\n"
+        assert self._fix(tmp_path, content) is None
+
+    def test_refuses_merge_key_service(self, tmp_path: Path) -> None:
+        content = (
+            "x-base: &base\n"
+            "  image: nginx\n"
+            "services:\n"
+            "  web:\n"
+            "    <<: *base\n"
+            "    image: nginx\n"
+        )
+        assert self._fix(tmp_path, content) is None

--- a/tests/test_CL0005.py
+++ b/tests/test_CL0005.py
@@ -3,9 +3,15 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
+from compose_lint.fix import apply_edits
+from compose_lint.models import Finding, Severity
 from compose_lint.parser import load_compose
 from compose_lint.rules.CL0005_unbound_ports import UnboundPortsRule
+
+if TYPE_CHECKING:
+    from compose_lint.models import TextEdit
 
 FIXTURES = Path(__file__).parent / "compose_files"
 
@@ -85,3 +91,155 @@ class TestUnboundPortsRule:
     def test_long_ipv6_loopback_no_findings(self) -> None:
         findings = self._check("long_ipv6_loopback")
         assert len(findings) == 0
+
+
+class TestUnboundPortsFix:
+    """Tests for the CL-0005 in-scalar bind fix (ADR-014)."""
+
+    def setup_method(self) -> None:
+        self.rule = UnboundPortsRule()
+
+    def _fix(
+        self, tmp_path: Path, content: str, service: str = "web"
+    ) -> list[TextEdit] | None:
+        path = tmp_path / "docker-compose.yml"
+        path.write_text(content)
+        data, lines = load_compose(path)
+        findings = list(
+            self.rule.check(service, data["services"][service], data, lines)
+        )
+        assert findings, "expected CL-0005 to fire"
+        return self.rule.fix(findings[0], data, lines, content)
+
+    def test_prepends_when_no_bind_address(self, tmp_path: Path) -> None:
+        content = "services:\n  web:\n    ports:\n      - 8080:80\n"
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        assert apply_edits(content, edits) == (
+            "services:\n  web:\n    ports:\n      - 127.0.0.1:8080:80\n"
+        )
+
+    def test_replaces_ipv4_wildcard(self, tmp_path: Path) -> None:
+        content = "services:\n  web:\n    ports:\n      - 0.0.0.0:8080:80\n"
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        assert apply_edits(content, edits) == (
+            "services:\n  web:\n    ports:\n      - 127.0.0.1:8080:80\n"
+        )
+
+    def test_replaces_ipv6_wildcard(self, tmp_path: Path) -> None:
+        content = "services:\n  web:\n    ports:\n      - '[::]:8080:80'\n"
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        assert apply_edits(content, edits) == (
+            "services:\n  web:\n    ports:\n      - '127.0.0.1:8080:80'\n"
+        )
+
+    def test_preserves_protocol_suffix(self, tmp_path: Path) -> None:
+        content = "services:\n  web:\n    ports:\n      - 0.0.0.0:53:53/udp\n"
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        assert "127.0.0.1:53:53/udp" in apply_edits(content, edits)
+
+    def test_quoted_scalar_edited_inside_quotes(self, tmp_path: Path) -> None:
+        content = 'services:\n  web:\n    ports:\n      - "8080:80"\n'
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        assert apply_edits(content, edits) == (
+            'services:\n  web:\n    ports:\n      - "127.0.0.1:8080:80"\n'
+        )
+
+    def test_preserves_trailing_comment(self, tmp_path: Path) -> None:
+        content = "services:\n  web:\n    ports:\n      - 8080:80  # public\n"
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        result = apply_edits(content, edits)
+        assert "127.0.0.1:8080:80" in result
+        assert "# public" in result
+
+    def test_edit_carries_caveat(self, tmp_path: Path) -> None:
+        content = "services:\n  web:\n    ports:\n      - 8080:80\n"
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        assert edits[0].caveat is not None
+        assert "127.0.0.1" in edits[0].caveat
+
+    def test_fix_resolves_finding_and_is_idempotent(self, tmp_path: Path) -> None:
+        content = "services:\n  web:\n    ports:\n      - 0.0.0.0:8080:80\n"
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        fixed = tmp_path / "fixed.yml"
+        fixed.write_text(apply_edits(content, edits))
+        data, lines = load_compose(fixed)
+        findings = list(self.rule.check("web", data["services"]["web"], data, lines))
+        assert findings == []
+
+    def test_only_targeted_port_is_edited(self, tmp_path: Path) -> None:
+        content = (
+            "services:\n"
+            "  web:\n"
+            "    ports:\n"
+            "      - 127.0.0.1:5432:5432\n"
+            "      - 8080:80\n"
+        )
+        # The first port is already bound, so only the second fires and is fixed.
+        path = tmp_path / "docker-compose.yml"
+        path.write_text(content)
+        data, lines = load_compose(path)
+        findings = list(self.rule.check("web", data["services"]["web"], data, lines))
+        assert len(findings) == 1
+        edits = self.rule.fix(findings[0], data, lines, content)
+        assert edits is not None
+        assert apply_edits(content, edits) == (
+            "services:\n"
+            "  web:\n"
+            "    ports:\n"
+            "      - 127.0.0.1:5432:5432\n"
+            "      - 127.0.0.1:8080:80\n"
+        )
+
+    def test_refuses_variable_interpolation(self, tmp_path: Path) -> None:
+        # The check's numeric host:container regex never matches a $-bearing
+        # port, so no finding fires through it. Exercise the fixer's
+        # interpolation guard directly with a hand-built finding.
+        content = "services:\n  web:\n    ports:\n      - ${HOST_IP}:8080:80\n"
+        path = tmp_path / "docker-compose.yml"
+        path.write_text(content)
+        data, lines = load_compose(path)
+        line = lines.get("services.web.ports[0]")
+        assert line is not None
+        finding = Finding(
+            rule_id="CL-0005",
+            severity=Severity.HIGH,
+            service="web",
+            message="unbound",
+            line=line,
+        )
+        assert self.rule.fix(finding, data, lines, content) is None
+
+    def test_refuses_long_syntax(self, tmp_path: Path) -> None:
+        content = (
+            "services:\n"
+            "  web:\n"
+            "    ports:\n"
+            "      - target: 80\n"
+            "        published: 8080\n"
+            "        host_ip: 0.0.0.0\n"
+        )
+        assert self._fix(tmp_path, content) is None
+
+    def test_refuses_anchored_service(self, tmp_path: Path) -> None:
+        content = "services:\n  web: &websvc\n    ports:\n      - 8080:80\n"
+        assert self._fix(tmp_path, content) is None
+
+    def test_refuses_merge_key_service(self, tmp_path: Path) -> None:
+        content = (
+            "x-base: &base\n"
+            "  image: nginx\n"
+            "services:\n"
+            "  web:\n"
+            "    <<: *base\n"
+            "    ports:\n"
+            "      - 8080:80\n"
+        )
+        assert self._fix(tmp_path, content) is None


### PR DESCRIPTION
## Summary

Add the CL-0003 (no-new-privileges) and CL-0005 (unbound ports) auto-fixers, extending the experimental `fix` engine landed in #246. Both remain **inert** — there is still no CLI entry point — so this only adds rule-level `fix()` methods and their tests.

## Why

ADR-014 lists six mechanically-safe fixers; #246 shipped the engine plus four (CL-0007/0009/0014/0015). This completes the set with the two remaining edit primitives:

- **CL-0003** — append `no-new-privileges:true` to a block `security_opt:` list, or create the list as the service's first child. The only **hardening-only** fixer, so no caveat.
- **CL-0005** — in-scalar edit: prepend `127.0.0.1:` when no host IP is present, or replace a wildcard one (`0.0.0.0`, `[::]`, `*`). Carries a caveat because it drops non-local reachability.

Both grounded in the existing OWASP/CIS references already cited by the rules.

## Type of change

- [x] Other: experimental auto-fix remediation (ADR-014), no user-facing behavior yet

## Checklist

- [x] Commits are signed (GitHub shows **Verified**)
- [x] One logical change per commit; no unrelated changes bundled in
- [x] `ruff check`, `ruff format --check`, `mypy src/`, and `pytest` all pass locally
- [x] New/changed behavior has tests (append/create/in-scalar paths + refusal cases)
- [x] No AI attribution anywhere (commits, comments, docs)

## Implementation notes

- Both reuse the shared `fix.py` block helpers (`is_anchored_or_merged`, `first_child_indent`, `block_span`, …) and the same refusal policy as the #246 fixers: anchored/merged services, flow-style/non-list blocks, and indeterminate indentation are left untouched.
- CL-0003 additionally refuses a `security_opt` that already names `no-new-privileges` with a conflicting value (e.g. `:false`), which would otherwise duplicate the key.
- CL-0005 handles only short-syntax string ports; long-syntax mapping entries (adding `host_ip:` is a different primitive) are refused. Its `${VAR}` guard is defensive — the check's numeric `host:container` regex never matches a `$`-bearing port, so no finding reaches the fixer through `check`; the guard is covered by a hand-built `Finding`.

## Breaking changes

None.