### PR TITLE
Route CLI through argparse subcommands with a check default

### DIFF
--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -58,13 +58,27 @@ def _effective_config_path(explicit: str | None) -> Path | None:
     return p if p.exists() else None
 
 
-def _build_parser() -> argparse.ArgumentParser:
-    """Build the argument parser."""
-    parser = argparse.ArgumentParser(
-        prog="compose-lint",
+# Subcommands recognized by the argv shim. Bare `compose-lint <file>` is kept
+# working as an implicit `check` (ADR-011): when the first non-flag token is
+# not one of these, the shim prepends `check`.
+_SUBCOMMANDS = ("check",)
+
+# Flags handled by the top-level parser, not `check`. A flag-only invocation
+# carrying one of these (e.g. `compose-lint --version`) is left untouched so the
+# top-level parser sees it; any other flag-only invocation routes to `check`.
+_GLOBAL_FLAGS = frozenset({"-h", "--help", "--version"})
+
+
+def _add_check_subparser(
+    subparsers: argparse._SubParsersAction,  # type: ignore[type-arg]
+) -> None:
+    """Register the `check` subcommand (the default lint operation)."""
+    check = subparsers.add_parser(
+        "check",
+        help="lint Docker Compose file(s) for security issues (default)",
         description="A security-focused linter for Docker Compose files.",
     )
-    parser.add_argument(
+    check.add_argument(
         "files",
         nargs="*",
         metavar="FILE",
@@ -74,32 +88,32 @@ def _build_parser() -> argparse.ArgumentParser:
             "docker-compose.yml, or docker-compose.yaml."
         ),
     )
-    parser.add_argument(
+    check.add_argument(
         "--format",
         choices=["text", "json", "sarif"],
         default="text",
         dest="output_format",
         help="output format (default: text)",
     )
-    parser.add_argument(
+    check.add_argument(
         "--fail-on",
         type=_severity_type,
         default=Severity.HIGH,
         metavar="{" + ",".join(s.value for s in Severity) + "}",
         help="minimum severity to trigger exit 1 (default: high)",
     )
-    parser.add_argument(
+    check.add_argument(
         "--config",
         metavar="PATH",
         help="path to .compose-lint.yml config file",
     )
-    parser.add_argument(
+    check.add_argument(
         "--skip-suppressed",
         action="store_true",
         default=False,
         help="hide suppressed findings from output",
     )
-    verbosity = parser.add_mutually_exclusive_group()
+    verbosity = check.add_mutually_exclusive_group()
     verbosity.add_argument(
         "-v",
         "--verbose",
@@ -122,7 +136,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "users. No effect on JSON or SARIF output."
         ),
     )
-    parser.add_argument(
+    check.add_argument(
         "--explain",
         metavar="CL-XXXX",
         help=(
@@ -130,19 +144,54 @@ def _build_parser() -> argparse.ArgumentParser:
             "Cannot be combined with FILE arguments."
         ),
     )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the top-level argument parser and its subcommands."""
+    parser = argparse.ArgumentParser(
+        prog="compose-lint",
+        description="A security-focused linter for Docker Compose files.",
+    )
     parser.add_argument(
         "--version",
         action="version",
         version=f"%(prog)s {__version__}",
     )
+    subparsers = parser.add_subparsers(dest="command", metavar="COMMAND")
+    _add_check_subparser(subparsers)
     return parser
+
+
+def _normalize_argv(argv: list[str]) -> list[str]:
+    """Rewrite ``argv`` so bare invocations route to the ``check`` subcommand.
+
+    Preserves the pre-subcommand CLI: ``compose-lint <file>``,
+    ``compose-lint -q``, and ``compose-lint --explain CL-XXXX`` keep working as
+    ``check``. An explicit subcommand (``check ...``) is left untouched, as is a
+    flag-only invocation of a global flag (``--version``, ``--help``) so the
+    top-level parser handles it. The heuristic keys off the first non-flag
+    token, mirroring ADR-011's implementation note.
+    """
+    if not argv:
+        return ["check"]
+    first_positional = next((tok for tok in argv if not tok.startswith("-")), None)
+    if first_positional in _SUBCOMMANDS:
+        return argv
+    if first_positional is None and _GLOBAL_FLAGS.intersection(argv):
+        return argv
+    return ["check", *argv]
 
 
 def main(argv: list[str] | None = None) -> NoReturn:
     """Main entry point for the CLI."""
     parser = _build_parser()
-    args = parser.parse_args(argv)
+    raw = sys.argv[1:] if argv is None else argv
+    args = parser.parse_args(_normalize_argv(raw))
+    _run_check(args)
 
+
+def _run_check(args: argparse.Namespace) -> NoReturn:
+    """Run the `check` operation: lint files and exit with the verdict code."""
     if args.explain is not None:
         if args.files:
             print(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,11 +31,37 @@ class TestCLI:
         assert __version__ in result.stdout
 
     def test_fail_on_help_lists_severity_choices(self) -> None:
-        result = run_cli("--help")
+        # --fail-on belongs to the `check` subcommand now (ADR-011); its help
+        # surface is `check --help`, not the top-level help.
+        result = run_cli("check", "--help")
         assert result.returncode == 0
         # The metavar should advertise the valid values, not a bare FAIL_ON.
         assert "--fail-on {low,medium,high,critical}" in result.stdout
         assert "FAIL_ON" not in result.stdout
+
+    def test_top_level_help_lists_check_subcommand(self) -> None:
+        result = run_cli("--help")
+        assert result.returncode == 0
+        assert "check" in result.stdout
+
+    def test_explicit_check_subcommand_lints(self) -> None:
+        result = run_cli("check", str(FIXTURES / "insecure_privileged.yml"))
+        assert result.returncode == 1
+        assert "CL-0002" in result.stdout
+
+    def test_bare_invocation_still_lints(self) -> None:
+        # The argv shim must keep `compose-lint <file>` working as `check`.
+        bare = run_cli(str(FIXTURES / "insecure_privileged.yml"))
+        explicit = run_cli("check", str(FIXTURES / "insecure_privileged.yml"))
+        assert bare.returncode == explicit.returncode == 1
+        assert bare.stdout == explicit.stdout
+
+    def test_flag_only_invocation_routes_to_check(self) -> None:
+        # `compose-lint -q` (no file, no subcommand) must still reach check and
+        # fall through to compose-file discovery, not error at the top level.
+        result = run_cli("-q")
+        assert result.returncode == 2
+        assert "no compose files found" in result.stderr.lower()
 
     def test_verbose_and_quiet_are_mutually_exclusive(self) -> None:
         result = run_cli("-v", "-q", str(FIXTURES / "insecure_socket.yml"))


### PR DESCRIPTION
## What

Converts the flat top-level `argparse` parser into a subcommand parser:

- The lint operation becomes the explicit **`check`** subcommand.
- A small argv shim (`_normalize_argv`) prepends `check` for bare invocations, so the pre-subcommand CLI keeps working **unchanged**:
  - `compose-lint <file>` → `check <file>`
  - `compose-lint -q` → `check -q` (still falls through to compose-file discovery)
  - `compose-lint --explain CL-XXXX` → `check --explain CL-XXXX`
- `--version` and `--help` stay on the top-level parser; `--fail-on`, `--format`, `--config`, `--skip-suppressed`, `-v`/`-q`, and `--explain` move under `check`.

## Why

This is the `add_subparsers` groundwork **ADR-011** calls for ("the one-time cost of introducing subparsers is paid back by `fix` alone"). It's landed now, on its own, to unblock the experimental **`fix`** subcommand (ADR-014) and to isolate the argv-routing change for review. The `init` subcommand (ADR-011's actual deliverable) remains future work.

No user-facing behavior change.

## Notes

- The `--help` surface intentionally grows (top-level lists subcommands; `compose-lint check --help` documents the lint flags) — exactly the trade-off ADR-011 accepts.
- Pathological edge case from ADR-011: a compose file literally named `check` collides with the subcommand name; workaround is `./check`. Documented in the ADR; not handled here.

## Tests

- Updated `test_fail_on_help_lists_severity_choices` to target `check --help` (the flag moved).
- Added: top-level help lists `check`, explicit `check` lints, bare invocation matches explicit `check` byte-for-byte, flag-only invocation routes to `check`.
- All four gates green: `ruff check`, `ruff format --check`, `mypy src/` (strict), `pytest` (557 passed, 1 skipped).
