### PR TITLE
Add the experimental fix subcommand (dry-run and --apply)

### DIFF
--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 from typing import NoReturn
@@ -12,6 +13,7 @@ from compose_lint import __version__
 from compose_lint.config import ConfigError, load_config
 from compose_lint.engine import filter_findings, run_rules
 from compose_lint.explain import UnknownRuleError, load_rule_doc
+from compose_lint.fix import apply_edits, collect_edits, render_file_diff
 from compose_lint.formatters.json import format_findings as format_json
 from compose_lint.formatters.sarif import build_sarif_log
 from compose_lint.formatters.sarif import format_findings as format_sarif
@@ -58,15 +60,40 @@ def _effective_config_path(explicit: str | None) -> Path | None:
     return p if p.exists() else None
 
 
-# Subcommands recognized by the argv shim. Bare `compose-lint <file>` is kept
-# working as an implicit `check` (ADR-011): when the first non-flag token is
-# not one of these, the shim prepends `check`.
-_SUBCOMMANDS = ("check",)
-
 # Flags handled by the top-level parser, not `check`. A flag-only invocation
 # carrying one of these (e.g. `compose-lint --version`) is left untouched so the
 # top-level parser sees it; any other flag-only invocation routes to `check`.
 _GLOBAL_FLAGS = frozenset({"-h", "--help", "--version"})
+
+# Stderr banner printed on every `fix` invocation (ADR-014, Part 5).
+_FIX_EXPERIMENTAL_WARNING = (
+    "warning: 'fix' is experimental and unstable; output and flags may change "
+    "without notice. Review the diff before --apply."
+)
+
+
+def _experimental_enabled() -> bool:
+    """Return whether the experimental `fix` subcommand is gated on.
+
+    Phase 1 of ADR-014 hides `fix` entirely unless ``COMPOSE_LINT_EXPERIMENTAL``
+    is set to ``1``, so it cannot be discovered or invoked by accident.
+    """
+    return os.environ.get("COMPOSE_LINT_EXPERIMENTAL") == "1"
+
+
+def _subcommands() -> set[str]:
+    """Return the subcommand names the argv shim should recognize.
+
+    Bare ``compose-lint <file>`` is kept working as an implicit ``check``
+    (ADR-011): when the first non-flag token is not one of these, the shim
+    prepends ``check``. ``fix`` is only recognized when experimental mode is on,
+    so without the env gate ``compose-lint fix ...`` falls through to ``check``
+    and fails as a missing file rather than exposing the hidden command.
+    """
+    commands = {"check"}
+    if _experimental_enabled():
+        commands.add("fix")
+    return commands
 
 
 def _add_check_subparser(
@@ -146,6 +173,46 @@ def _add_check_subparser(
     )
 
 
+def _add_fix_subparser(
+    subparsers: argparse._SubParsersAction,  # type: ignore[type-arg]
+) -> None:
+    """Register the hidden, experimental `fix` subcommand (ADR-014).
+
+    Omitting ``help=`` keeps it out of ``compose-lint --help``: argparse only
+    lists subparsers that were given a help string (passing
+    ``help=argparse.SUPPRESS`` instead renders a literal ``==SUPPRESS==`` row).
+    The caller also only registers it at all when experimental mode is enabled.
+    """
+    fix = subparsers.add_parser(
+        "fix",
+        description="Auto-remediate auto-fixable findings (experimental).",
+    )
+    fix.add_argument(
+        "files",
+        nargs="*",
+        metavar="FILE",
+        help="Docker Compose file(s) to fix (defaults to discovery, like check)",
+    )
+    fix.add_argument(
+        "--apply",
+        action="store_true",
+        default=False,
+        help="write fixes in place instead of printing a dry-run diff",
+    )
+    fix.add_argument(
+        "--only",
+        action="append",
+        metavar="CL-XXXX",
+        dest="only",
+        help="restrict fixes to the named rule(s); repeatable",
+    )
+    fix.add_argument(
+        "--config",
+        metavar="PATH",
+        help="path to .compose-lint.yml config file (suppressions are honored)",
+    )
+
+
 def _build_parser() -> argparse.ArgumentParser:
     """Build the top-level argument parser and its subcommands."""
     parser = argparse.ArgumentParser(
@@ -159,6 +226,8 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     subparsers = parser.add_subparsers(dest="command", metavar="COMMAND")
     _add_check_subparser(subparsers)
+    if _experimental_enabled():
+        _add_fix_subparser(subparsers)
     return parser
 
 
@@ -175,7 +244,7 @@ def _normalize_argv(argv: list[str]) -> list[str]:
     if not argv:
         return ["check"]
     first_positional = next((tok for tok in argv if not tok.startswith("-")), None)
-    if first_positional in _SUBCOMMANDS:
+    if first_positional in _subcommands():
         return argv
     if first_positional is None and _GLOBAL_FLAGS.intersection(argv):
         return argv
@@ -187,6 +256,8 @@ def main(argv: list[str] | None = None) -> NoReturn:
     parser = _build_parser()
     raw = sys.argv[1:] if argv is None else argv
     args = parser.parse_args(_normalize_argv(raw))
+    if args.command == "fix":
+        _run_fix(args)
     _run_check(args)
 
 
@@ -319,3 +390,94 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
     if parse_errors:
         sys.exit(2)
     sys.exit(1 if has_errors else 0)
+
+
+def _run_fix(args: argparse.Namespace) -> NoReturn:
+    """Run the experimental `fix` operation (ADR-014).
+
+    Dry-run by default: a unified diff of proposed edits goes to stdout and
+    status goes to stderr; nothing is written. ``--apply`` writes edits in
+    place. Suppressed/excluded findings (``.compose-lint.yml``) are never fixed.
+    Exit 0 on success, 2 on usage/parse error — findings are the input, not the
+    failure signal, so residual manual-only findings do not change the code.
+    """
+    print(_FIX_EXPERIMENTAL_WARNING, file=sys.stderr)
+
+    try:
+        disabled_rules, severity_overrides, excluded_services = load_config(args.config)
+    except ConfigError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(2)
+
+    if not args.files:
+        args.files = _discover_compose_files()
+        if not args.files:
+            print(
+                "Error: no Compose files found. Searched for: "
+                "compose.yml, compose.yaml, "
+                "docker-compose.yml, docker-compose.yaml",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
+    only = set(args.only) if args.only else None
+    had_parse_error = False
+
+    for filepath in args.files:
+        try:
+            data, lines = load_compose(filepath)
+        except FileNotFoundError:
+            print(f"Error: {filepath}: file not found", file=sys.stderr)
+            had_parse_error = True
+            continue
+        except ComposeNotApplicableError as e:
+            # v1 / fragment file: skipped, not an error (ADR-013).
+            print(f"{filepath}: {e}", file=sys.stderr)
+            continue
+        except ComposeError as e:
+            print(f"Error: {filepath}: {e}", file=sys.stderr)
+            had_parse_error = True
+            continue
+
+        text = Path(filepath).read_text(encoding="utf-8")
+        findings = run_rules(
+            data,
+            lines,
+            disabled_rules=disabled_rules,
+            severity_overrides=severity_overrides,
+            excluded_services=excluded_services,
+        )
+        result = collect_edits(findings, data, lines, text, only=only)
+
+        if not result.edits:
+            if result.manual:
+                print(
+                    f"{filepath}: nothing to auto-fix; "
+                    f"{len(result.manual)} finding(s) need manual review",
+                    file=sys.stderr,
+                )
+            else:
+                print(f"{filepath}: nothing to fix", file=sys.stderr)
+            continue
+
+        patched = apply_edits(text, result.edits)
+        if args.apply:
+            Path(filepath).write_text(patched, encoding="utf-8")
+            print(
+                f"{filepath}: applied {len(result.edits)} fix(es) across "
+                f"{len(result.fixed)} finding(s)",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                render_file_diff(filepath, text, patched, result.caveats),
+                end="",
+                flush=True,
+            )
+            print(
+                f"{filepath}: {len(result.edits)} fix(es) available; "
+                f"{len(result.manual)} finding(s) need manual review",
+                file=sys.stderr,
+            )
+
+    sys.exit(2 if had_parse_error else 0)

--- a/src/compose_lint/fix.py
+++ b/src/compose_lint/fix.py
@@ -6,12 +6,21 @@ formatting outside the touched span survive byte-for-byte. ADR-003 rules out a
 comment-preserving round-trip parser, so re-serialization is not an option.
 
 All destructive splicing lives in :func:`apply_edits` so the one operation that
-rewrites a user's file is in a single, auditable place.
+rewrites a user's file is in a single, auditable place. :func:`collect_edits`
+gathers the edits across all findings for a file, refusing any that conflict,
+and :func:`render_file_diff` turns the result into the dry-run unified diff.
 """
 
 from __future__ import annotations
 
-from compose_lint.models import TextEdit
+import difflib
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from compose_lint.models import Finding, TextEdit
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 class OverlappingEditError(ValueError):
@@ -200,3 +209,162 @@ def delete_lines(
     # `last` is the final line: end at its end (its newline, if any, included).
     end_col = len(source_lines[last - 1]) + 1
     return TextEdit(first, 1, last, end_col, "", caveat=caveat)
+
+
+# --- Edit collection across a file's findings -----------------------------
+
+
+@dataclass(frozen=True)
+class FixResult:
+    """The outcome of collecting fixers' edits for a single file.
+
+    ``edits`` are non-conflicting and ready to splice via :func:`apply_edits`.
+    ``fixed`` are the findings whose edits were accepted; ``manual`` are the
+    findings left for the user — report-only rules, per-occurrence refusals, and
+    findings dropped because their edit conflicted with another's. ``caveats``
+    holds the deduplicated ``(rule_id, caveat)`` pairs for the behavior-changing
+    edits among ``edits``, in first-seen order, for the dry-run banner.
+    """
+
+    edits: list[TextEdit] = field(default_factory=list)
+    fixed: list[Finding] = field(default_factory=list)
+    manual: list[Finding] = field(default_factory=list)
+    caveats: list[tuple[str, str]] = field(default_factory=list)
+
+
+def _spans_conflict(a: tuple[int, int], b: tuple[int, int]) -> bool:
+    """Return whether two ``(begin, end)`` offset spans conflict.
+
+    The danger cases, by edit shape:
+
+    - **Two pure insertions** (both zero-width) never conflict — even at the same
+      point they splice as independent, well-formed lines (e.g. CL-0007's
+      ``read_only`` and CL-0003's ``security_opt``, both inserted as a service's
+      first child). They are *not* refused.
+    - **An insertion touching a non-empty region's closed interval**
+      (``begin <= point <= end``) *is* a conflict. The motivating case: CL-0003
+      appends an entry at the line just after a ``security_opt`` block that
+      CL-0009 is collapsing whole — the insertion point equals the deletion's end
+      boundary, so applying both would orphan the appended entry beside the
+      removed parent key. :func:`apply_edits` uses half-open overlap and would
+      not catch this touch, so it is caught here (ADR-014: refuse, never guess).
+    - **Two non-empty regions** conflict on half-open overlap only; adjacency
+      (one ending exactly where the next begins) composes fine and is allowed,
+      matching :func:`apply_edits`.
+    """
+    a_empty = a[0] == a[1]
+    b_empty = b[0] == b[1]
+    if a_empty and b_empty:
+        return False
+    if a_empty or b_empty:
+        point, lo, hi = (a[0], b[0], b[1]) if a_empty else (b[0], a[0], a[1])
+        return lo <= point <= hi
+    return a[0] < b[1] and b[0] < a[1]
+
+
+def collect_edits(
+    findings: Iterable[Finding],
+    data: dict[str, Any],
+    lines: dict[str, int],
+    text: str,
+    *,
+    only: set[str] | None = None,
+) -> FixResult:
+    """Gather every fixer's edits for one file, refusing conflicts.
+
+    Each non-suppressed finding whose rule advertises a fixer is asked for its
+    edits. Suppressed/service-excluded findings are skipped (suppression is a
+    deliberate human decision; ADR-014). When ``only`` is given, findings whose
+    rule id is not in it are ignored entirely. Findings whose fixer returns
+    ``None`` (report-only or a per-occurrence refusal) go to ``manual``.
+
+    Edits are then checked for conflicts across findings: if any edit of one
+    finding conflicts with any edit of another (see :func:`_spans_conflict`),
+    *both* findings are refused and moved to ``manual`` rather than guessing a
+    merge. The surviving edits are returned ready to apply.
+    """
+    from compose_lint.rules import get_registered_rules
+
+    rules_by_id = {}
+    for rule_cls in get_registered_rules():
+        rule = rule_cls()
+        rules_by_id[rule.metadata.id] = rule
+
+    candidates: list[tuple[Finding, list[TextEdit]]] = []
+    manual: list[Finding] = []
+    for finding in findings:
+        if finding.suppressed:
+            continue
+        if only is not None and finding.rule_id not in only:
+            continue
+        matched = rules_by_id.get(finding.rule_id)
+        if matched is None:
+            continue
+        edits = matched.fix(finding, data, lines, text)
+        if edits:
+            candidates.append((finding, edits))
+        else:
+            manual.append(finding)
+
+    starts = _line_starts(text)
+
+    def spans_of(edits: list[TextEdit]) -> list[tuple[int, int]]:
+        return [
+            (
+                _offset(starts, edit.start_line, edit.start_col),
+                _offset(starts, edit.end_line, edit.end_col),
+            )
+            for edit in edits
+        ]
+
+    spanned = [(finding, edits, spans_of(edits)) for finding, edits in candidates]
+    refused: set[int] = set()
+    for i in range(len(spanned)):
+        for j in range(i + 1, len(spanned)):
+            if any(_spans_conflict(x, y) for x in spanned[i][2] for y in spanned[j][2]):
+                refused.add(i)
+                refused.add(j)
+
+    result = FixResult()
+    seen_caveats: set[tuple[str, str]] = set()
+    for index, (finding, edits, _spans) in enumerate(spanned):
+        if index in refused:
+            result.manual.append(finding)
+            continue
+        result.fixed.append(finding)
+        result.edits.extend(edits)
+        for edit in edits:
+            if edit.caveat and (finding.rule_id, edit.caveat) not in seen_caveats:
+                seen_caveats.add((finding.rule_id, edit.caveat))
+                result.caveats.append((finding.rule_id, edit.caveat))
+    result.manual.extend(manual)
+    return result
+
+
+def render_file_diff(
+    path: str,
+    original: str,
+    patched: str,
+    caveats: list[tuple[str, str]],
+) -> str:
+    """Render the dry-run output for one file: caveat banner + unified diff.
+
+    Returns ``""`` when ``original`` and ``patched`` are identical (no edits).
+    Behavior-changing fixes are announced above the diff with a
+    ``⚠ behavior-changing`` line per ADR-014 so a reader sees which edits could
+    alter runtime behavior before deciding to ``--apply``.
+    """
+    diff = "".join(
+        difflib.unified_diff(
+            original.splitlines(keepends=True),
+            patched.splitlines(keepends=True),
+            fromfile=path,
+            tofile=path,
+        )
+    )
+    if not diff:
+        return ""
+    banner = "".join(
+        f"⚠ behavior-changing · {rule_id}: {caveat}\n" for rule_id, caveat in caveats
+    )
+    return banner + diff

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -16,6 +17,18 @@ def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
         [sys.executable, "-m", "compose_lint", *args],
         capture_output=True,
         text=True,
+    )
+
+
+def run_cli_env(
+    env_extra: dict[str, str], *args: str
+) -> subprocess.CompletedProcess[str]:
+    """Run the CLI with extra environment variables (e.g. the experimental gate)."""
+    return subprocess.run(
+        [sys.executable, "-m", "compose_lint", *args],
+        capture_output=True,
+        text=True,
+        env={**os.environ, **env_extra},
     )
 
 
@@ -322,3 +335,67 @@ class TestCLI:
         )
         assert "unknown service 'does-not-exist'" in result.stderr
         assert "CL-0003" in result.stderr
+
+
+_EXPERIMENTAL = {"COMPOSE_LINT_EXPERIMENTAL": "1"}
+_BARE_SERVICE = "services:\n  web:\n    image: nginx:1.27\n"
+
+
+class TestFixSubcommand:
+    """Tests for the hidden, experimental `fix` subcommand (ADR-014)."""
+
+    def test_dry_run_prints_diff_to_stdout(self, tmp_path: Path) -> None:
+        f = tmp_path / "docker-compose.yml"
+        f.write_text(_BARE_SERVICE)
+        result = run_cli_env(_EXPERIMENTAL, "fix", str(f))
+        assert result.returncode == 0
+        # Diff (data) on stdout; warning + status (human) on stderr.
+        assert "+    read_only: true" in result.stdout
+        assert "⚠ behavior-changing · CL-0007" in result.stdout
+        assert "experimental" in result.stderr.lower()
+        # Dry-run writes nothing.
+        assert f.read_text() == _BARE_SERVICE
+
+    def test_apply_writes_file_and_emits_no_diff(self, tmp_path: Path) -> None:
+        f = tmp_path / "docker-compose.yml"
+        f.write_text(_BARE_SERVICE)
+        result = run_cli_env(_EXPERIMENTAL, "fix", "--apply", str(f))
+        assert result.returncode == 0
+        assert result.stdout == ""
+        patched = f.read_text()
+        assert "read_only: true" in patched
+        assert "no-new-privileges:true" in patched
+
+    def test_only_restricts_to_named_rule(self, tmp_path: Path) -> None:
+        f = tmp_path / "docker-compose.yml"
+        f.write_text(_BARE_SERVICE)
+        run_cli_env(_EXPERIMENTAL, "fix", "--apply", "--only", "CL-0007", str(f))
+        patched = f.read_text()
+        assert "read_only: true" in patched
+        assert "no-new-privileges" not in patched
+
+    def test_respects_config_suppression(self, tmp_path: Path) -> None:
+        f = tmp_path / "docker-compose.yml"
+        f.write_text(_BARE_SERVICE)
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text("rules:\n  CL-0007:\n    enabled: false\n")
+        run_cli_env(_EXPERIMENTAL, "fix", "--apply", "--config", str(config), str(f))
+        patched = f.read_text()
+        # CL-0007 suppressed => not fixed; CL-0003 still applied.
+        assert "read_only: true" not in patched
+        assert "no-new-privileges:true" in patched
+
+    def test_hidden_from_help_even_when_enabled(self) -> None:
+        result = run_cli_env(_EXPERIMENTAL, "--help")
+        assert result.returncode == 0
+        assert "fix" not in result.stdout
+
+    def test_unavailable_without_env_gate(self, tmp_path: Path) -> None:
+        f = tmp_path / "docker-compose.yml"
+        f.write_text(_BARE_SERVICE)
+        # Without the gate, `fix` is not a subcommand: the shim routes it to
+        # `check` as a (missing) file, so no fix runs and no warning prints.
+        result = run_cli("fix", str(f))
+        assert result.returncode == 2
+        assert "experimental" not in result.stderr.lower()
+        assert f.read_text() == _BARE_SERVICE

--- a/tests/test_fix.py
+++ b/tests/test_fix.py
@@ -2,20 +2,39 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
+from compose_lint.engine import run_rules
 from compose_lint.fix import (
     OverlappingEditError,
     apply_edits,
     block_span,
+    collect_edits,
     delete_lines,
     first_child_indent,
     has_merge_key_child,
     is_anchored_or_merged,
     line_indent,
     opens_block_body,
+    render_file_diff,
 )
 from compose_lint.models import TextEdit
+from compose_lint.parser import load_compose
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _findings_for(tmp_path: Path, source: str) -> tuple[list, dict, dict, str]:
+    """Parse ``source``, lint it, and return (findings, data, lines, text)."""
+    path = tmp_path / "docker-compose.yml"
+    path.write_text(source, encoding="utf-8")
+    data, lines = load_compose(path)
+    text = path.read_text(encoding="utf-8")
+    findings = run_rules(data, lines)
+    return findings, data, lines, text
 
 
 def test_no_edits_returns_text_unchanged() -> None:
@@ -167,3 +186,128 @@ def test_delete_lines_final_line_without_trailing_newline() -> None:
 def test_delete_lines_carries_caveat() -> None:
     lines = ["a: 1\n", "b: 2\n"]
     assert delete_lines(lines, 1, 1, caveat="note").caveat == "note"
+
+
+# --- collect_edits ---------------------------------------------------------
+
+
+def test_collect_edits_applies_safe_fixers(tmp_path: Path) -> None:
+    # A bare service triggers CL-0007 (insert read_only) and CL-0003 (create
+    # security_opt); both are first-child insertions at the same point and must
+    # both apply, producing valid YAML that re-lints clean for those rules.
+    findings, data, lines, text = _findings_for(
+        tmp_path,
+        "services:\n  web:\n    image: nginx:1.27\n",
+    )
+    result = collect_edits(findings, data, lines, text)
+    fixed_rules = {f.rule_id for f in result.fixed}
+    assert {"CL-0003", "CL-0007"} <= fixed_rules
+    patched = apply_edits(text, result.edits)
+    assert "read_only: true" in patched
+    assert "no-new-privileges:true" in patched
+    # Idempotent: the targeted rules no longer fire on the patched text, so a
+    # second collection produces no further edits.
+    re_path = tmp_path / "patched.yml"
+    re_path.write_text(patched, encoding="utf-8")
+    re_data, re_lines = load_compose(re_path)
+    re_findings = run_rules(re_data, re_lines)
+    assert {"CL-0003", "CL-0007"}.isdisjoint({f.rule_id for f in re_findings})
+    assert collect_edits(re_findings, re_data, re_lines, patched).edits == []
+
+
+def test_collect_edits_only_filters_by_rule(tmp_path: Path) -> None:
+    findings, data, lines, text = _findings_for(
+        tmp_path,
+        "services:\n  web:\n    image: nginx:1.27\n",
+    )
+    result = collect_edits(findings, data, lines, text, only={"CL-0007"})
+    assert {f.rule_id for f in result.fixed} == {"CL-0007"}
+    patched = apply_edits(text, result.edits)
+    assert "read_only: true" in patched
+    assert "no-new-privileges:true" not in patched
+
+
+def test_collect_edits_skips_suppressed(tmp_path: Path) -> None:
+    findings, data, lines, text = _findings_for(
+        tmp_path,
+        "services:\n  web:\n    image: nginx:1.27\n",
+    )
+    # Globally disable CL-0007 so its finding is suppressed, not removed.
+    suppressed = run_rules(data, lines, disabled_rules={"CL-0007": "by policy"})
+    result = collect_edits(suppressed, data, lines, text)
+    assert "CL-0007" not in {f.rule_id for f in result.fixed}
+
+
+def test_collect_edits_refuses_append_into_collapsing_block(tmp_path: Path) -> None:
+    # security_opt's sole entry is seccomp:unconfined: CL-0009 collapses the
+    # whole block while CL-0003 wants to append no-new-privileges to it. The two
+    # edits touch at the deletion boundary, so both must be refused (left manual)
+    # rather than produce an orphaned list entry.
+    findings, data, lines, text = _findings_for(
+        tmp_path,
+        "services:\n"
+        "  web:\n"
+        "    image: nginx:1.27\n"
+        "    security_opt:\n"
+        "      - seccomp:unconfined\n",
+    )
+    result = collect_edits(findings, data, lines, text, only={"CL-0003", "CL-0009"})
+    fixed_rules = {f.rule_id for f in result.fixed}
+    manual_rules = {f.rule_id for f in result.manual}
+    assert "CL-0003" not in fixed_rules
+    assert "CL-0009" not in fixed_rules
+    assert {"CL-0003", "CL-0009"} <= manual_rules
+    assert result.edits == []
+
+
+def test_collect_edits_removes_one_item_keeps_others(tmp_path: Path) -> None:
+    # Two security_opt entries with the offending one first: CL-0009 removes just
+    # that item line (the list survives) and CL-0003 appends after the last item.
+    # The edits are on different lines and both apply.
+    findings, data, lines, text = _findings_for(
+        tmp_path,
+        "services:\n"
+        "  web:\n"
+        "    image: nginx:1.27\n"
+        "    security_opt:\n"
+        "      - seccomp:unconfined\n"
+        "      - label:type:svirt_apache\n",
+    )
+    result = collect_edits(findings, data, lines, text, only={"CL-0003", "CL-0009"})
+    fixed_rules = {f.rule_id for f in result.fixed}
+    assert {"CL-0003", "CL-0009"} <= fixed_rules
+    patched = apply_edits(text, result.edits)
+    assert "seccomp:unconfined" not in patched
+    assert "label:type:svirt_apache" in patched
+    assert "no-new-privileges:true" in patched
+
+
+def test_collect_edits_caveats_dedup_and_carry_rule_id(tmp_path: Path) -> None:
+    findings, data, lines, text = _findings_for(
+        tmp_path,
+        "services:\n  web:\n    image: nginx:1.27\n",
+    )
+    result = collect_edits(findings, data, lines, text, only={"CL-0007"})
+    assert any(rule_id == "CL-0007" and caveat for rule_id, caveat in result.caveats)
+
+
+# --- render_file_diff ------------------------------------------------------
+
+
+def test_render_file_diff_includes_caveat_banner_and_diff() -> None:
+    original = "services:\n  web:\n    image: nginx:1.27\n"
+    patched = "services:\n  web:\n    read_only: true\n    image: nginx:1.27\n"
+    out = render_file_diff(
+        "docker-compose.yml",
+        original,
+        patched,
+        [("CL-0007", "rootfs becomes unwritable")],
+    )
+    assert "⚠ behavior-changing · CL-0007: rootfs becomes unwritable" in out
+    assert "+    read_only: true" in out
+    assert "--- docker-compose.yml" in out
+
+
+def test_render_file_diff_empty_when_unchanged() -> None:
+    text = "services:\n  web:\n    image: nginx:1.27\n"
+    assert render_file_diff("docker-compose.yml", text, text, []) == ""


### PR DESCRIPTION
## What

Wires the ADR-014 auto-remediation feature to a CLI entry point for the first time. The six fixers (CL-0003/0005/0007/0009/0014/0015) merged in #246/#247 were inert — nothing called `rule.fix()`. This adds the orchestration and the `fix` subcommand.

**Engine (`fix.py`):**
- `collect_edits(findings, data, lines, text, *, only=None) -> FixResult` — asks each non-suppressed finding's rule for edits, skips suppressed/excluded findings (suppression is a deliberate human decision), honors `--only`, and **refuses conflicts**. Conflict detection is closed-interval for an insertion touching a non-empty region (catches CL-0003 appending into a `security_opt` block CL-0009 is collapsing whole — the append lands exactly at the deletion boundary, which `apply_edits`' half-open check would miss), and half-open for two regions. Conflicting findings are left for manual review, never merged.
- `render_file_diff(path, original, patched, caveats)` — the dry-run unified diff (`difflib`) with a `⚠ behavior-changing` caveat banner per ADR-014 Part 3.

**CLI (`cli.py`):**
- A hidden `fix` subcommand, registered **only** when `COMPOSE_LINT_EXPERIMENTAL=1` (Phase 1 gate). Omitting `help=` keeps it out of `--help` (passing `argparse.SUPPRESS` as subparser help renders a literal `==SUPPRESS==` row instead — verified).
- Dry-run by default: diff → **stdout**, status + the one-line experimental warning → **stderr**. `--apply` writes in place; `--only CL-XXXX` (repeatable) narrows rules; `--config` honors suppressions.
- Exit **0** on success, **2** on usage/parse error — findings are the input, not the failure signal (consistent with `init`/ADR-011). No text-mode banner; the diff is the only stdout output — the second stdout-emitting mode CLAUDE.md/ADR-011 anticipated, routing status to stderr permanently for its own output.

## Conservative refusal (intentional)

When CL-0003's append point sits at the boundary of an adjacent deletable block (e.g. a following `logging: {driver: none}`), that block's fixer is also refused. This is the price of the ADR's **idempotency** guarantee — a second `--apply` must be a no-op rather than applying a deferred fix. Reducing this over-refusal (e.g. by changing CL-0003's append geometry) is corpus-soak / pre-promotion work, out of scope here.

## Still experimental / not in this PR

Per ADR-014's staged exposure: SARIF `artifactChanges`, README/`--help` docs, dropping the env gate, and the full-corpus soak are Phase 2–3. `fix` remains excluded from the SemVer contract.

## Tests

- `collect_edits`: applies safe fixers (CL-0007 + CL-0003 same-point insertions both land), `--only` filter, suppression skipped, the CL-0003/CL-0009 collapse-conflict refusal, the two-item case where both apply, caveat dedup/rule-id.
- `render_file_diff`: caveat banner + diff; empty when unchanged.
- CLI: dry-run diff→stdout / warning→stderr, `--apply` writes & emits no diff, `--only`, config suppression respected, hidden from `--help` even when enabled, unavailable without the env gate.
- Manually smoke-tested dry-run, `--apply`, idempotency (2nd run is a no-op), and YAML validity of the result.
- All four gates green: `ruff check`, `ruff format --check`, `mypy src/` (strict), `pytest` (571 passed, 1 skipped).
