### PR TITLE
Harden fixers against real-world YAML and add corpus fix gate

### DIFF
--- a/src/compose_lint/fix.py
+++ b/src/compose_lint/fix.py
@@ -23,6 +23,16 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
 
+# security_opt directives that disable a default platform profile — CL-0009's
+# territory. Shared here so CL-0003 can decline to append into a block whose
+# entries are *all* profile-disables: CL-0009 will act on those, and appending a
+# survivor first would let a second `fix` pass delete them (breaking idempotency,
+# ADR-014). Values are matched against `str(opt).strip().lower()`.
+DISABLED_SECURITY_PROFILES = frozenset(
+    {"seccomp:unconfined", "apparmor:unconfined", "label:disable"}
+)
+
+
 class OverlappingEditError(ValueError):
     """Raised when two edits target overlapping regions of the same file."""
 
@@ -116,23 +126,34 @@ def opens_block_body(line: str) -> bool:
     return not trailing or trailing.startswith("#")
 
 
+def _is_seq_item(line: str) -> bool:
+    """Return whether ``line`` is a block-sequence entry (``-`` or ``- ...``)."""
+    stripped = line.lstrip()
+    return stripped == "-" or stripped.startswith("- ")
+
+
 def first_child_indent(source_lines: list[str], key_line: int) -> int | None:
     """Return the indentation of the first child line under ``key_line``.
 
     Walks forward from the line after ``key_line`` to the first non-blank line.
-    Returns its indent if it is deeper than ``key_line`` (a child), otherwise
-    ``None`` — meaning the block has no children (the next content is a sibling
-    or dedent). Blank lines are skipped; comment lines count as content, mirror-
-    ing the original CL-0007 behavior.
+    Returns its indent if it is a child, otherwise ``None`` — meaning the block
+    has no children (the next content is a sibling or dedent). A line is a child
+    when it is indented deeper than ``key_line`` *or* it sits at ``key_line``'s
+    own indent and is a block-sequence item (``- ...``): YAML lets a sequence
+    value share its key's indentation (the "compact" style), and those items are
+    still children of the key. Blank lines are skipped; comment lines count as
+    content, mirroring the original CL-0007 behavior.
     """
     key_indent = line_indent(source_lines[key_line - 1])
     for raw in source_lines[key_line:]:
         if raw.strip() == "":
             continue
         indent = line_indent(raw)
-        if indent <= key_indent:
-            return None
-        return indent
+        if indent > key_indent:
+            return indent
+        if indent == key_indent and _is_seq_item(raw):
+            return indent
+        return None
     return None
 
 
@@ -159,34 +180,78 @@ def has_merge_key_child(source_lines: list[str], key_line: int) -> bool:
     return False
 
 
+def has_anchor_child(source_lines: list[str], key_line: int) -> bool:
+    """Return whether the block under ``key_line`` has a bare anchor/alias child.
+
+    A mapping can carry its anchor on the line *after* the key (``svc:`` then a
+    lone ``&svc`` as the first child) rather than inline. That anchors the whole
+    mapping, so inserting a new first child before it would re-anchor the wrong
+    node and break the file — the fixer must refuse (ADR-014). Detects a direct
+    child line that is a lone anchor (``&name``) or alias (``*name``); inline
+    forms like ``key: &a value`` start with the key, not ``&``/``*``, and are
+    not flagged. Only direct children (lines at the first child indent) count.
+    """
+    key_indent = line_indent(source_lines[key_line - 1])
+    child_indent: int | None = None
+    for raw in source_lines[key_line:]:
+        if raw.strip() == "":
+            continue
+        indent = line_indent(raw)
+        if indent <= key_indent:
+            break
+        if child_indent is None:
+            child_indent = indent
+        if indent == child_indent:
+            stripped = raw.strip()
+            if stripped.startswith("&") or stripped.startswith("*"):
+                return True
+    return False
+
+
 def is_anchored_or_merged(source_lines: list[str], key_line: int) -> bool:
     """Return whether the block at ``key_line`` is one a fixer must refuse.
 
     True when the key carries an inline value / flow collection / anchor / alias
-    instead of a plain block body, or when the block inherits via a merge key.
-    Combines :func:`opens_block_body` and :func:`has_merge_key_child` into the
-    single guard deletion and insertion fixers share.
+    instead of a plain block body, when the block inherits via a merge key, or
+    when it is anchored by a lone ``&anchor`` child line. Combines
+    :func:`opens_block_body`, :func:`has_merge_key_child`, and
+    :func:`has_anchor_child` into the single guard deletion and insertion fixers
+    share.
     """
-    return not opens_block_body(source_lines[key_line - 1]) or has_merge_key_child(
-        source_lines, key_line
+    return (
+        not opens_block_body(source_lines[key_line - 1])
+        or has_merge_key_child(source_lines, key_line)
+        or has_anchor_child(source_lines, key_line)
     )
 
 
 def block_span(source_lines: list[str], key_line: int) -> tuple[int, int]:
     """Return the inclusive 1-indexed ``(first, last)`` line span of a block.
 
-    The span covers ``key_line`` and every following line indented deeper than
-    it. Blank lines interior to the block are included; a trailing run of blank
-    lines after the last child is excluded. Used to delete a block whole.
+    The span covers ``key_line`` and every following child line. Lines indented
+    deeper than ``key_line`` are children. When the block is a *compact*
+    sequence — its first child is a ``- ...`` item at ``key_line``'s own indent
+    (YAML lets a sequence value share its key's indentation) — sibling items at
+    that same indent are also children; the block then ends at the first line
+    that dedents or is a same-indent non-item (a sibling mapping key). Blank
+    lines interior to the block are included; a trailing run of blank lines
+    after the last child is excluded. Used to delete a block whole.
     """
     key_indent = line_indent(source_lines[key_line - 1])
+    compact = first_child_indent(source_lines, key_line) == key_indent
     last = key_line
     for idx in range(key_line, len(source_lines)):
-        if source_lines[idx].strip() == "":
+        line = source_lines[idx]
+        if line.strip() == "":
             continue
-        if line_indent(source_lines[idx]) <= key_indent:
-            break
-        last = idx + 1
+        indent = line_indent(line)
+        if indent > key_indent:
+            last = idx + 1
+            continue
+        if compact and indent == key_indent and _is_seq_item(line):
+            last = idx + 1
+            continue
+        break
     return key_line, last
 
 

--- a/src/compose_lint/rules/CL0003_no_new_privileges.py
+++ b/src/compose_lint/rules/CL0003_no_new_privileges.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from compose_lint.fix import (
+    DISABLED_SECURITY_PROFILES,
     block_span,
     first_child_indent,
     is_anchored_or_merged,
@@ -142,6 +143,15 @@ class NoNewPrivilegesRule(BaseRule):
         ):
             # Already named (e.g. `no-new-privileges:false`): appending the true
             # form would duplicate the key. Leave it for the human.
+            return None
+        if security_opt and all(
+            str(opt).strip().lower() in DISABLED_SECURITY_PROFILES
+            for opt in security_opt
+        ):
+            # Every entry is a profile-disable CL-0009 will remove. If we append
+            # a survivor now, a second `fix` pass would let CL-0009 delete those
+            # entries one by one — non-idempotent (ADR-014). Refuse; the user (or
+            # CL-0009) clears the block first, then CL-0003 creates a fresh list.
             return None
 
         so_line = lines.get(f"services.{service}.security_opt")

--- a/src/compose_lint/rules/CL0009_security_profile.py
+++ b/src/compose_lint/rules/CL0009_security_profile.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from compose_lint.fix import (
-    block_span,
+    DISABLED_SECURITY_PROFILES,
     delete_lines,
     is_anchored_or_merged,
     opens_block_body,
@@ -39,12 +39,6 @@ CIS_SELINUX_REF = (
     "CIS Docker Benchmark 5.2 — Ensure that, if applicable, SELinux security "
     "options are set"
 )
-
-_DISABLED_PROFILES = {
-    "seccomp:unconfined",
-    "apparmor:unconfined",
-    "label:disable",
-}
 
 _PROFILE_DISPLAY_NAME = {
     "seccomp": "seccomp",
@@ -90,7 +84,7 @@ class SecurityProfileRule(BaseRule):
 
         for i, opt in enumerate(security_opt):
             opt_str = str(opt).strip().lower()
-            if opt_str not in _DISABLED_PROFILES:
+            if opt_str not in DISABLED_SECURITY_PROFILES:
                 continue
             profile_key = opt_str.split(":", 1)[0]
             profile_name = _PROFILE_DISPLAY_NAME[profile_key]
@@ -127,15 +121,17 @@ class SecurityProfileRule(BaseRule):
     ) -> list[TextEdit] | None:
         """Delete the unconfined ``security_opt`` entry the finding flags.
 
-        Removes just the offending list item when a legitimate entry remains,
-        or drops the whole ``security_opt:`` block when the offending entry is
-        the sole one (never leaving ``security_opt:`` empty). Refuses (returns
-        ``None``) for anchored/merged services, flow-style lists, and the
-        ambiguous case where every entry is offending but more than one exists —
-        collapsing that correctly would need the per-finding fixers to
-        coordinate, which they can't (ADR-014 refusal policy). The edit carries
-        a caveat because re-applying the default profile changes runtime
-        behavior.
+        Removes just the offending list item when a legitimate entry survives,
+        so the list stays non-empty. Refuses (returns ``None``) for
+        anchored/merged services, flow-style lists, and — crucially — when
+        *every* entry is a profile-disable (``legit_remaining == 0``). In that
+        case the block would have to be emptied, but CL-0003 fires on the same
+        service (no ``no-new-privileges``) and would recreate ``security_opt``
+        on the next pass, so collapsing here is non-idempotent; the idempotent
+        end state (replace the disables with ``no-new-privileges``) needs a merge
+        the per-finding fixers can't perform. Both rules step aside and leave the
+        block for the user (ADR-014: refuse, never guess). The edit carries a
+        caveat because re-applying the default profile changes runtime behavior.
         """
         service = finding.service
         services = data.get("services")
@@ -165,7 +161,9 @@ class SecurityProfileRule(BaseRule):
             return None
 
         disabled = sum(
-            1 for opt in security_opt if str(opt).strip().lower() in _DISABLED_PROFILES
+            1
+            for opt in security_opt
+            if str(opt).strip().lower() in DISABLED_SECURITY_PROFILES
         )
         legit_remaining = len(security_opt) - disabled
 
@@ -175,8 +173,7 @@ class SecurityProfileRule(BaseRule):
             if not source_lines[item_line - 1].lstrip().startswith("- "):
                 return None
             return [delete_lines(source_lines, item_line, item_line, caveat=_CAVEAT)]
-        if len(security_opt) == 1:
-            # Sole entry is the offending one: drop the whole block.
-            first, last = block_span(source_lines, so_line)
-            return [delete_lines(source_lines, first, last, caveat=_CAVEAT)]
+        # legit_remaining == 0: emptying the block would leave CL-0003 to
+        # recreate it next pass (non-idempotent), and the right end state needs a
+        # cross-rule merge. Refuse and leave it for manual remediation.
         return None

--- a/tests/test_CL0003.py
+++ b/tests/test_CL0003.py
@@ -202,6 +202,25 @@ class TestNoNewPrivilegesFix:
         )
         assert self._fix(tmp_path, content) is None
 
+    def test_refuses_all_disabled_security_opt(self, tmp_path: Path) -> None:
+        # Every entry is a profile-disable CL-0009 will remove. Appending a
+        # survivor now would let a second pass delete those entries (CL-0009 then
+        # sees a legit entry) — non-idempotent. Refuse; the block is left as-is.
+        content = (
+            "services:\n"
+            "  web:\n"
+            "    security_opt:\n"
+            "      - seccomp:unconfined\n"
+            "      - apparmor:unconfined\n"
+        )
+        assert self._fix(tmp_path, content) is None
+
+    def test_anchor_child_service_refused(self, tmp_path: Path) -> None:
+        # Service anchored by a lone `&anchor` first child: inserting before it
+        # would re-anchor the wrong node.
+        content = "services:\n  web:\n    &websvc\n    image: nginx\n"
+        assert self._fix(tmp_path, content) is None
+
     def test_refuses_anchored_service(self, tmp_path: Path) -> None:
         content = "services:\n  web: &websvc\n    image: nginx\n"
         assert self._fix(tmp_path, content) is None

--- a/tests/test_CL0009.py
+++ b/tests/test_CL0009.py
@@ -187,7 +187,12 @@ class TestSecurityProfileFix:
         assert findings, "expected CL-0009 to fire"
         return self.rule.fix(findings[0], data, lines, content)
 
-    def test_collapses_block_when_sole_entry(self, tmp_path: Path) -> None:
+    def test_refuses_sole_offending_entry(self, tmp_path: Path) -> None:
+        # A lone unconfined entry would empty the block. CL-0003 fires on the
+        # same service (no no-new-privileges) and would recreate security_opt on
+        # a second pass, so collapsing here is non-idempotent; the idempotent
+        # end state needs a cross-rule merge the per-finding fixers can't do.
+        # Refuse and leave it for manual remediation (ADR-014).
         content = (
             "services:\n"
             "  web:\n"
@@ -195,10 +200,7 @@ class TestSecurityProfileFix:
             "    security_opt:\n"
             "      - seccomp:unconfined\n"
         )
-        edits = self._fix(tmp_path, content)
-        assert edits is not None
-        # The now-empty security_opt block is dropped whole, not left as `[]`.
-        assert apply_edits(content, edits) == ("services:\n  web:\n    image: nginx\n")
+        assert self._fix(tmp_path, content) is None
 
     def test_removes_only_offending_item_when_legit_remains(
         self, tmp_path: Path
@@ -232,26 +234,32 @@ class TestSecurityProfileFix:
         assert self._fix(tmp_path, content) is None
 
     def test_edit_carries_caveat(self, tmp_path: Path) -> None:
-        content = "services:\n  web:\n    security_opt:\n      - seccomp:unconfined\n"
+        content = (
+            "services:\n  web:\n    security_opt:\n"
+            "      - seccomp:unconfined\n      - no-new-privileges:true\n"
+        )
         edits = self._fix(tmp_path, content)
         assert edits is not None
         assert edits[0].caveat is not None
         assert "seccomp" in edits[0].caveat.lower()
 
     def test_fix_resolves_finding_and_is_idempotent(self, tmp_path: Path) -> None:
+        # A legit entry survives, so CL-0009 removes only the offending item and
+        # the block stays non-empty.
         content = (
             "services:\n"
             "  web:\n"
             "    image: nginx\n"
             "    security_opt:\n"
             "      - seccomp:unconfined\n"
+            "      - no-new-privileges:true\n"
         )
         edits = self._fix(tmp_path, content)
         assert edits is not None
         fixed = tmp_path / "fixed.yml"
         fixed.write_text(apply_edits(content, edits))
         data, lines = load_compose(fixed)
-        assert "security_opt" not in data["services"]["web"]
+        assert data["services"]["web"]["security_opt"] == ["no-new-privileges:true"]
         findings = list(self.rule.check("web", data["services"]["web"], data, lines))
         assert findings == []
 

--- a/tests/test_corpus_fix.py
+++ b/tests/test_corpus_fix.py
@@ -1,0 +1,106 @@
+"""ADR-014 Part 6 corpus regression gate for `compose-lint fix`.
+
+Skipped unless ``COMPOSE_LINT_CORPUS`` points at a corpus cache root whose
+``files/`` holds real Compose files (same gating style as
+``test_corpus_snapshot``). For every lintable file it runs the fix engine and
+asserts the three safety invariants that make shipping ``fix`` defensible
+(ADR-014 Parts 5–6):
+
+1. the patched text re-parses,
+2. a second collection is a no-op (idempotent), and
+3. the fix introduces no new finding.
+
+This is the long-tail safety net the committed snapshot fixtures can't provide;
+run it locally before promoting ``fix``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from compose_lint.engine import run_rules
+from compose_lint.fix import apply_edits, collect_edits
+from compose_lint.parser import (
+    ComposeError,
+    ComposeNotApplicableError,
+    load_compose,
+)
+
+CORPUS_ENV = os.environ.get("COMPOSE_LINT_CORPUS")
+
+pytestmark = pytest.mark.skipif(not CORPUS_ENV, reason="COMPOSE_LINT_CORPUS not set")
+
+
+def _corpus_files() -> list[Path]:
+    root = Path(CORPUS_ENV).expanduser()  # type: ignore[arg-type]
+    files_dir = root / "files"
+    return sorted(files_dir.glob("*.yml")) if files_dir.is_dir() else []
+
+
+def test_fix_corpus_regression(tmp_path: Path) -> None:
+    files = _corpus_files()
+    if not files:
+        pytest.skip(f"no corpus files under {CORPUS_ENV}")
+
+    patched_path = tmp_path / "patched.yml"
+    reparse_failures: list[str] = []
+    non_idempotent: list[str] = []
+    introduced: list[str] = []
+    fixed_files = 0
+
+    for path in files:
+        try:
+            data, lines = load_compose(path)
+        except (ComposeError, ComposeNotApplicableError, FileNotFoundError):
+            continue
+        text = path.read_text(encoding="utf-8")
+        findings = run_rules(data, lines)
+        result = collect_edits(findings, data, lines, text)
+        if not result.edits:
+            continue
+        fixed_files += 1
+        patched = apply_edits(text, result.edits)
+
+        # (1) re-parses
+        patched_path.write_text(patched, encoding="utf-8")
+        try:
+            re_data, re_lines = load_compose(patched_path)
+        except (ComposeError, ComposeNotApplicableError) as exc:
+            reparse_failures.append(f"{path.name}: {exc}")
+            continue
+        re_findings = run_rules(re_data, re_lines)
+
+        # (2) idempotent
+        if collect_edits(re_findings, re_data, re_lines, patched).edits:
+            non_idempotent.append(path.name)
+
+        # (3) no new finding introduced
+        before = {(f.rule_id, f.service, f.message) for f in findings}
+        after = {(f.rule_id, f.service, f.message) for f in re_findings}
+        new = after - before
+        if new:
+            introduced.append(f"{path.name}: {sorted(new)[:2]}")
+
+    problems = []
+    if reparse_failures:
+        problems.append(
+            f"{len(reparse_failures)} fixed files fail to re-parse: "
+            + "; ".join(reparse_failures[:5])
+        )
+    if non_idempotent:
+        problems.append(
+            f"{len(non_idempotent)} non-idempotent fixes: "
+            + ", ".join(non_idempotent[:5])
+        )
+    if introduced:
+        problems.append(
+            f"{len(introduced)} fixes introduce a new finding: "
+            + "; ".join(introduced[:5])
+        )
+    assert not problems, (
+        f"fix corpus regressions across {fixed_files} fixed files:\n"
+        + "\n".join(problems)
+    )

--- a/tests/test_fix.py
+++ b/tests/test_fix.py
@@ -14,6 +14,7 @@ from compose_lint.fix import (
     collect_edits,
     delete_lines,
     first_child_indent,
+    has_anchor_child,
     has_merge_key_child,
     is_anchored_or_merged,
     line_indent,
@@ -132,6 +133,17 @@ def test_first_child_indent() -> None:
     assert first_child_indent(["web:\n", "\n", "    image: x\n"], 1) == 4
 
 
+def test_first_child_indent_compact_sequence() -> None:
+    # A block sequence value may sit at its key's own indent (compact style);
+    # those `- item` lines are still children.
+    compact = ["security_opt:\n", "- seccomp:unconfined\n"]
+    assert first_child_indent(compact, 1) == 0
+    indented_compact = ["  security_opt:\n", "  - seccomp:unconfined\n"]
+    assert first_child_indent(indented_compact, 1) == 2
+    # A same-indent non-item line is a sibling, not a child.
+    assert first_child_indent(["a:\n", "b:\n"], 1) is None
+
+
 def test_has_merge_key_child() -> None:
     merged = ["web:\n", "  <<: *base\n", "  image: nginx\n"]
     assert has_merge_key_child(merged, 1)
@@ -139,9 +151,22 @@ def test_has_merge_key_child() -> None:
     assert not has_merge_key_child(plain, 1)
 
 
+def test_has_anchor_child() -> None:
+    # Anchor carried on the line after the key (anchors the whole mapping).
+    anchored = ["web:\n", "    &websvc\n", "    image: nginx\n"]
+    assert has_anchor_child(anchored, 1)
+    aliased = ["web:\n", "    *base\n"]
+    assert has_anchor_child(aliased, 1)
+    # Inline `key: &a value` starts with the key, not `&`, so it is not flagged.
+    assert not has_anchor_child(["web:\n", "    image: &img nginx\n"], 1)
+
+
 def test_is_anchored_or_merged() -> None:
-    assert is_anchored_or_merged(["web: &a\n", "  image: x\n"], 1)  # anchor
+    assert is_anchored_or_merged(["web: &a\n", "  image: x\n"], 1)  # inline anchor
     assert is_anchored_or_merged(["web:\n", "  <<: *base\n"], 1)  # merge key
+    assert is_anchored_or_merged(
+        ["web:\n", "  &websvc\n", "  image: x\n"], 1
+    )  # anchor child
     assert not is_anchored_or_merged(["web:\n", "  image: x\n"], 1)  # plain block
 
 
@@ -163,6 +188,31 @@ def test_block_span_covers_key_and_children() -> None:
 def test_block_span_excludes_trailing_blank_lines() -> None:
     lines = ["web:\n", "  image: x\n", "\n", "db:\n"]
     assert block_span(lines, 1) == (1, 2)
+
+
+def test_block_span_compact_sequence() -> None:
+    # Compact block sequence: items share the key's indent. The span must cover
+    # the key and its items, ending at the next sibling key.
+    lines = [
+        "  web:\n",  # 1
+        "    image: nginx\n",  # 2
+        "    security_opt:\n",  # 3  (4-space indent)
+        "    - seccomp:unconfined\n",  # 4  (compact item at 4-space indent)
+        "    - apparmor:unconfined\n",  # 5
+        "    environment:\n",  # 6  (sibling key ends the sequence)
+    ]
+    assert block_span(lines, 3) == (3, 5)
+
+
+def test_block_span_compact_sequence_with_nested_item() -> None:
+    # Long-syntax item under a compact sequence keeps its deeper continuation.
+    lines = [
+        "    ports:\n",  # 1
+        "    - target: 80\n",  # 2  compact item
+        "      published: 80\n",  # 3  deeper continuation of the item
+        "    other:\n",  # 4  sibling key
+    ]
+    assert block_span(lines, 1) == (1, 3)
 
 
 def test_delete_lines_removes_whole_lines() -> None:
@@ -238,11 +288,12 @@ def test_collect_edits_skips_suppressed(tmp_path: Path) -> None:
     assert "CL-0007" not in {f.rule_id for f in result.fixed}
 
 
-def test_collect_edits_refuses_append_into_collapsing_block(tmp_path: Path) -> None:
-    # security_opt's sole entry is seccomp:unconfined: CL-0009 collapses the
-    # whole block while CL-0003 wants to append no-new-privileges to it. The two
-    # edits touch at the deletion boundary, so both must be refused (left manual)
-    # rather than produce an orphaned list entry.
+def test_collect_edits_refuses_all_disabled_security_opt(tmp_path: Path) -> None:
+    # security_opt's sole entry is seccomp:unconfined (all entries disabled).
+    # Auto-fixing this needs the two per-finding fixers to coordinate (remove the
+    # disable AND add no-new-privileges) which they can't, so both step aside:
+    # CL-0003 declines to append a survivor and CL-0009 declines to empty the
+    # block. Both are left manual rather than producing a non-idempotent result.
     findings, data, lines, text = _findings_for(
         tmp_path,
         "services:\n"
@@ -280,6 +331,41 @@ def test_collect_edits_removes_one_item_keeps_others(tmp_path: Path) -> None:
     assert "seccomp:unconfined" not in patched
     assert "label:type:svirt_apache" in patched
     assert "no-new-privileges:true" in patched
+
+
+def test_collect_edits_appends_to_compact_security_opt(tmp_path: Path) -> None:
+    # Compact block sequence (items at the key's indent): CL-0003 must append a
+    # compact item and the result must re-parse and clear CL-0003.
+    findings, data, lines, text = _findings_for(
+        tmp_path,
+        "services:\n"
+        "  web:\n"
+        "    image: nginx:1.27\n"
+        "    security_opt:\n"
+        "    - label:type:svirt_apache_t\n",
+    )
+    result = collect_edits(findings, data, lines, text, only={"CL-0003"})
+    assert "CL-0003" in {f.rule_id for f in result.fixed}
+    patched = apply_edits(text, result.edits)
+    re_path = tmp_path / "patched.yml"
+    re_path.write_text(patched, encoding="utf-8")
+    re_data, re_lines = load_compose(re_path)
+    assert re_data["services"]["web"]["security_opt"] == [
+        "label:type:svirt_apache_t",
+        "no-new-privileges:true",
+    ]
+
+
+def test_collect_edits_refuses_bare_anchor_service(tmp_path: Path) -> None:
+    # A service anchored by a lone `&anchor` first child: inserting a first child
+    # before it would re-anchor the wrong node, so the fixers refuse.
+    findings, data, lines, text = _findings_for(
+        tmp_path,
+        "services:\n  web:\n    &websvc\n    image: nginx:1.27\n",
+    )
+    result = collect_edits(findings, data, lines, text, only={"CL-0003", "CL-0007"})
+    assert result.edits == []
+    assert {"CL-0003", "CL-0007"} <= {f.rule_id for f in result.manual}
 
 
 def test_collect_edits_caveats_dedup_and_carry_rule_id(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

A soak of the `fix` engine across the **full ~6.4k-file corpus** (the ADR-014 Part 6 / Part 5 promotion check) surfaced three correctness bugs in the fixers merged in #246/#247. This PR fixes all three and adds the corpus regression gate that catches them.

### 1. Compact block sequences

`block_span`/`first_child_indent` only treated *deeper*-indented lines as children. A `security_opt:` whose items sit at the key's own indent — the common "compact" YAML style:

```yaml
security_opt:
- seccomp:unconfined
```

was mishandled: CL-0009's sole-entry collapse deleted only the `security_opt:` line and **orphaned the item** (invalid YAML), and CL-0003 couldn't append. Both helpers now recognize `- item` lines at the key's indent as children.

### 2. Bare anchor child

A service anchored by a lone `&anchor` line as its first child:

```yaml
workspace:
  &workspace
  image: ...
```

wasn't caught by `is_anchored_or_merged`, so inserting a first child before the anchor broke it. New `has_anchor_child` guard detects `&name`/`*name` child lines and refuses.

### 3. CL-0003/CL-0009 non-idempotency

A `security_opt` of only `*:unconfined` entries made CL-0003 append `no-new-privileges:true`; on a **second** `fix` pass that added survivor let CL-0009 delete each unconfined item (it now saw a legit entry). Both rules now **step aside** when every entry is a profile-disable — the idempotent end state (replace the disables *and* add `no-new-privileges`) needs a cross-rule merge the per-finding model can't perform (ADR-014: refuse, never guess). The shared `DISABLED_SECURITY_PROFILES` set moves to `fix.py`.

## Corpus gate

`tests/test_corpus_fix.py` — ADR-014 Part 6 regression gate, env-gated on `COMPOSE_LINT_CORPUS` (skipped in CI, like `test_corpus_snapshot`). For every lintable file it asserts: the patched text **re-parses**, a **second collection is a no-op** (idempotent), and **no new finding is introduced**. It now passes clean across all **6,444 files** (was 13 violations: 2 reparse failures, 11 non-idempotent).

## Coverage trade-off (intentional)

CL-0009's auto-fix is now conservative: it fixes the **mixed** case (remove an unconfined item while a legit entry survives) but **refuses** an all-`unconfined` `security_opt` (sole or many), since that always co-fires CL-0003 and can't be resolved idempotently per-finding. Recovering this common case needs **engine-level multi-rule coordination** (combine CL-0009's item-delete with CL-0003's append into one non-empty block) — a documented pre-promotion enhancement, not in scope here. The refusal rate is now measurable via the gate for that future work.

## Not in this PR

The check-finding snapshot (`tests/corpus_snapshot.json.gz`) is stale (predates v0.7.0 + a corpus refresh) — orthogonal maintenance, unrelated to these fixer-only changes, and CI-skipped.

## Tests

- Unit: compact-sequence `block_span`/`first_child_indent`, `has_anchor_child`, CL-0003 all-disabled + anchor-child refusal, CL-0009 sole/all-disabled refusal + mixed-case fix.
- Engine: compact `security_opt` append round-trips; bare-anchor service refused; all-disabled block refused.
- All four gates green: `ruff check`, `ruff format --check`, `mypy src/` (strict), `pytest` (579 passed, 2 skipped); corpus gate green over 6,444 files.
