### PR TITLE
Wrap JSON output in a versioned envelope

### DIFF
--- a/docs/adr/015-machine-readable-output-contract.md
+++ b/docs/adr/015-machine-readable-output-contract.md
@@ -1,0 +1,72 @@
+# ADR-015: Machine-Readable Output Contract
+
+**Status:** Accepted
+
+**Context:** `check` emits three formats: `text` (human), `json`, and `sarif`
+(both machine-readable). The 1.0 release is a SemVer stability commitment —
+once tagged, breaking the shape of a machine-readable format requires a major
+version bump, because external consumers (CI pipelines, dashboards, scripts)
+parse it.
+
+Through 0.x the JSON output was a bare top-level array of finding objects:
+
+```json
+[ { "file": "...", "rule_id": "CL-0001", "severity": "critical", "...": "..." } ]
+```
+
+A bare array is the hardest shape to evolve. It has nowhere to carry run-level
+metadata — tool version, the files that failed to parse, or any future summary
+— so adding any of those later would move consumers from `data[i]` to
+`data["findings"][i]`, a breaking change. SARIF already carries this metadata
+(tool driver version, and `invocations[].toolExecutionNotifications` for parse
+errors), so JSON consumers were strictly worse off: a file that failed to parse
+was invisible in JSON, with exit code 2 the only signal.
+
+**Decision:** Before 1.0, wrap the JSON output in a versioned envelope:
+
+```json
+{
+  "version": "1",
+  "tool": { "name": "compose-lint", "version": "0.8.0" },
+  "findings": [ "..." ],
+  "errors": [ { "file": "...", "message": "..." } ]
+}
+```
+
+- `version` is the envelope schema version (a string). It is bumped **only** on
+  a breaking change to the shape. Adding a new top-level field (e.g. a future
+  `summary`) is additive and does **not** bump it — that is the point of the
+  envelope.
+- `findings[]` keeps the exact per-finding fields from 0.x: `file`, `line`,
+  `rule_id`, `severity`, `service`, `message`, `fix`, `references`,
+  `suppressed`, and `suppression_reason` (only when suppressed).
+- `errors[]` lists files that could not be parsed (the exit-2 cases),
+  mirroring SARIF's `toolExecutionNotifications`. ADR-013 "not applicable"
+  skips (Compose v1 / fragments, exit 0) are deliberately excluded — they are
+  not errors.
+
+The JSON envelope and the SARIF 2.1.0 log are the **frozen 1.0 contract**. Both
+change only additively post-1.0; any breaking change is a major version bump,
+recorded by superseding this ADR.
+
+The representation of fixes in SARIF (currently `result.properties.fix`,
+possibly moving to native `fixes[]`) is **out of scope here** and tracked with
+the auto-fix work in [ADR-014](014-fix-remediation.md).
+
+**Consequences:**
+
+- One-time breaking change to JSON consumers at the 0.x → 1.0 boundary (bare
+  array → object). This is deliberate: the last chance to make it before the
+  stability freeze.
+- JSON and SARIF now report parse failures symmetrically.
+- New run-level data (severity summary, timing, config path) can be added later
+  without a major bump.
+
+**Alternatives considered:**
+
+- *Freeze the bare array as-is.* Rejected: permanently forecloses run-level
+  metadata in JSON and leaves parse errors unreportable there.
+- *Add a `summary` block now.* Deferred: no consumer needs it yet, and the
+  envelope makes it a safe additive change whenever one does. Freezing its
+  exact shape (count semantics, severity keys) at 1.0 with no demand is
+  unnecessary surface.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,3 +49,42 @@ Excluded services still produce **SUPPRESSED** findings, with the per-service re
 - **Exact-match** service names. Unknown names produce a stderr warning but do not error, since Compose files and config evolve independently.
 - **Global `enabled: false` wins** over per-service exclusions: if a rule is disabled globally, every service is suppressed regardless of `exclude_services`.
 - **No inline suppression syntax** — there is no `# compose-lint: disable` comment form. Suppressions are tracked in config so reviewers can audit them.
+
+## Output formats
+
+`--format` selects the output (`text` default, `json`, `sarif`). Text writes a human banner, per-file summary, and verdict; `json` and `sarif` emit only the machine document on stdout so redirects stay clean.
+
+### JSON
+
+JSON output is a versioned envelope (see [ADR-015](adr/015-machine-readable-output-contract.md)):
+
+```json
+{
+  "version": "1",
+  "tool": { "name": "compose-lint", "version": "0.8.0" },
+  "findings": [
+    {
+      "file": "docker-compose.yml",
+      "line": 5,
+      "rule_id": "CL-0001",
+      "severity": "critical",
+      "service": "proxy",
+      "message": "...",
+      "fix": "...",
+      "references": ["..."],
+      "suppressed": false
+    }
+  ],
+  "errors": [
+    { "file": "broken.yml", "message": "missing 'services' key" }
+  ]
+}
+```
+
+- `version` is the envelope schema version. New top-level fields are added without bumping it; a bump signals a breaking change.
+- `findings[]` carries one object per finding; `suppression_reason` is present only on suppressed findings.
+- `errors[]` lists files that failed to parse (exit 2). Files skipped as not-applicable (Compose v1 / fragments, [ADR-013](adr/013-missing-services-key.md)) are not errors and do not appear here.
+
+### SARIF
+
+`--format sarif` emits a SARIF 2.1.0 log for GitHub Code Scanning. Parse failures appear as `invocations[].toolExecutionNotifications`; suppressed findings use the native `suppressions[]` array with the reason in `justification`.

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -14,6 +14,7 @@ from compose_lint.config import ConfigError, load_config
 from compose_lint.engine import filter_findings, run_rules
 from compose_lint.explain import UnknownRuleError, load_rule_doc
 from compose_lint.fix import apply_edits, collect_edits, render_file_diff
+from compose_lint.formatters.json import build_json_log
 from compose_lint.formatters.json import format_findings as format_json
 from compose_lint.formatters.sarif import build_sarif_log
 from compose_lint.formatters.sarif import format_findings as format_sarif
@@ -383,7 +384,7 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
             print(format_aggregate_summary(all_file_findings, len(parse_errors)))
         print(format_verdict(all_file_findings, args.fail_on, len(parse_errors)))
     elif args.output_format == "json":
-        print(json.dumps(all_json, indent=2))
+        print(json.dumps(build_json_log(all_json, parse_errors), indent=2))
     elif args.output_format == "sarif":
         print(json.dumps(build_sarif_log(all_sarif, parse_errors), indent=2))
 

--- a/src/compose_lint/formatters/json.py
+++ b/src/compose_lint/formatters/json.py
@@ -4,8 +4,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from compose_lint import __version__
+
 if TYPE_CHECKING:
     from compose_lint.models import Finding
+
+# Envelope schema version (ADR-015). Bumped only on a breaking change to the
+# output shape; additive top-level fields do not bump it.
+SCHEMA_VERSION = "1"
 
 
 def format_findings(findings: list[Finding], filepath: str) -> list[dict[str, object]]:
@@ -27,3 +33,27 @@ def format_findings(findings: list[Finding], filepath: str) -> list[dict[str, ob
             entry["suppression_reason"] = f.suppression_reason
         results.append(entry)
     return results
+
+
+def build_json_log(
+    findings: list[dict[str, object]],
+    parse_errors: list[tuple[str, str]] | None = None,
+) -> dict[str, object]:
+    """Wrap findings in the top-level JSON output envelope (ADR-015).
+
+    The envelope exists so run-level metadata can be added over time without
+    breaking consumers: new top-level fields are additive and never change
+    ``version``. ``parse_errors`` entries ``(filepath, message)`` surface files
+    that could not be parsed (exit 2), mirroring the SARIF invocation
+    notifications; ADR-013 "not applicable" skips are not included.
+    """
+    errors = [
+        {"file": filepath, "message": message}
+        for filepath, message in (parse_errors or [])
+    ]
+    return {
+        "version": SCHEMA_VERSION,
+        "tool": {"name": "compose-lint", "version": __version__},
+        "findings": findings,
+        "errors": errors,
+    }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -155,7 +155,9 @@ class TestCLI:
         result = run_cli("--format", "json", str(FIXTURES / "valid_basic.yml"))
         assert result.returncode == 0
         data = json.loads(result.stdout)
-        assert isinstance(data, list)
+        assert data["version"] == "1"
+        assert data["tool"]["name"] == "compose-lint"
+        assert isinstance(data["findings"], list)
 
     def test_invalid_severity(self) -> None:
         result = run_cli("--fail-on", "invalid", str(FIXTURES / "valid_basic.yml"))
@@ -185,7 +187,9 @@ class TestCLI:
         )
         assert result.returncode in (0, 1)
         data = json.loads(result.stdout)
-        by_service = {f["service"]: f for f in data if f["rule_id"] == "CL-0003"}
+        by_service = {
+            f["service"]: f for f in data["findings"] if f["rule_id"] == "CL-0003"
+        }
         assert by_service["missing"]["suppressed"] is True
         assert (
             by_service["missing"]["suppression_reason"] == "entrypoint switches users"
@@ -290,6 +294,37 @@ class TestCLI:
         assert result.returncode == 2
         assert "skipped" in result.stdout.lower()
         assert "failed to parse" in result.stdout.lower()
+
+    def test_json_envelope_clean_run(self) -> None:
+        result = run_cli(
+            "--fail-on",
+            "low",
+            "--format",
+            "json",
+            str(FIXTURES / "safe_self_hosted.yml"),
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data["version"] == "1"
+        assert data["tool"]["name"] == "compose-lint"
+        assert data["tool"]["version"]
+        assert data["findings"] == []
+        assert data["errors"] == []
+
+    def test_json_errors_lists_parse_failures(self, tmp_path: Path) -> None:
+        bad = tmp_path / "bad.yml"
+        bad.write_text("services: [\n")
+        result = run_cli(
+            "--format",
+            "json",
+            str(FIXTURES / "valid_basic.yml"),
+            str(bad),
+        )
+        assert result.returncode == 2
+        data = json.loads(result.stdout)
+        assert len(data["errors"]) == 1
+        assert data["errors"][0]["file"] == str(bad)
+        assert data["errors"][0]["message"]
 
     def test_sarif_includes_parse_error_notifications(self, tmp_path: Path) -> None:
         bad = tmp_path / "bad.yml"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -35,14 +35,15 @@ class TestIntegration:
         result = run_cli("--format", "json", str(FIXTURES / "mixed.yml"))
         assert result.returncode == 1
         data = json.loads(result.stdout)
-        assert isinstance(data, list)
-        assert len(data) > 5
+        assert data["version"] == "1"
+        assert isinstance(data["findings"], list)
+        assert len(data["findings"]) > 5
 
-        rule_ids = {f["rule_id"] for f in data}
+        rule_ids = {f["rule_id"] for f in data["findings"]}
         assert "CL-0001" in rule_ids
         assert "CL-0002" in rule_ids
 
-        for finding in data:
+        for finding in data["findings"]:
             assert "file" in finding
             assert "rule_id" in finding
             assert "severity" in finding
@@ -97,7 +98,9 @@ class TestIntegration:
         result = run_cli("--format", "json", str(FIXTURES / "mixed.yml"))
         data = json.loads(result.stdout)
         db_port_findings = [
-            f for f in data if f["service"] == "db" and f["rule_id"] == "CL-0005"
+            f
+            for f in data["findings"]
+            if f["service"] == "db" and f["rule_id"] == "CL-0005"
         ]
         assert len(db_port_findings) == 0
 
@@ -116,7 +119,7 @@ class TestIntegration:
             "--format", "json", "--config", config, str(FIXTURES / "mixed.yml")
         )
         data = json.loads(result.stdout)
-        suppressed = [f for f in data if f.get("suppressed")]
+        suppressed = [f for f in data["findings"] if f.get("suppressed")]
         assert len(suppressed) > 0
         with_reason = [f for f in suppressed if f.get("suppression_reason")]
         assert any("SEC-1234" in f["suppression_reason"] for f in with_reason)
@@ -147,7 +150,7 @@ class TestIntegration:
             str(FIXTURES / "mixed.yml"),
         )
         data = json.loads(result.stdout)
-        suppressed = [f for f in data if f.get("suppressed")]
+        suppressed = [f for f in data["findings"] if f.get("suppressed")]
         assert len(suppressed) == 0
 
     def test_suppressed_findings_in_sarif(self) -> None:
@@ -170,5 +173,5 @@ class TestIntegration:
             str(FIXTURES / "valid_basic.yml"),
         )
         data = json.loads(result.stdout)
-        files = {f["file"] for f in data}
+        files = {f["file"] for f in data["findings"]}
         assert len(files) >= 1


### PR DESCRIPTION
## What

Wrap the `--format json` output in a versioned envelope before the 1.0 stability freeze. Closes the P0 from the GA readiness review: a bare top-level array cannot carry run-level metadata or report parse failures without a breaking change, so this is the last chance to fix the shape.

**Before** (bare array):
```json
[ { "rule_id": "CL-0001", "...": "..." } ]
```

**After** (envelope):
```json
{
  "version": "1",
  "tool": { "name": "compose-lint", "version": "0.8.0" },
  "findings": [ { "rule_id": "CL-0001", "...": "..." } ],
  "errors": [ { "file": "broken.yml", "message": "missing 'services' key" } ]
}
```

## Details

- `version` — envelope schema version. New top-level fields (e.g. a future `summary`) are additive and do **not** bump it; a bump signals a breaking change.
- `findings[]` — keeps every existing per-finding field unchanged (`file`, `line`, `rule_id`, `severity`, `service`, `message`, `fix`, `references`, `suppressed`, and `suppression_reason` when suppressed).
- `errors[]` — files that failed to parse (exit 2), mirroring SARIF's `toolExecutionNotifications`. Previously these were invisible in JSON; only the exit code signalled them. ADR-013 not-applicable skips (Compose v1 / fragments, exit 0) are excluded — they are not errors.

## ⚠️ Breaking change

JSON consumers move from `data[i]` to `data["findings"][i]`. Deliberate, and scoped to the 0.x → 1.0 boundary. SARIF is unchanged.

## Docs / decision

- `docs/adr/015-machine-readable-output-contract.md` records the contract, the additive-evolution policy, and freezes the JSON envelope + SARIF 2.1.0 log as the 1.0 surface. SARIF fix representation is deferred to ADR-014.
- `docs/configuration.md` gains an "Output formats" section documenting the JSON shape (the README already pointed here for it).

## Checks

`ruff check` / `ruff format --check` (src/ tests/), `mypy src/` (strict), and `pytest` (581 passed, 2 skipped) all pass locally. Existing JSON assertions updated; two envelope tests added (clean run, parse-error population).
