### PR TITLE
Emit SARIF artifactChanges from fix engine edits

### DIFF
--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -361,7 +361,14 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
             print(format_summary(findings, filepath), flush=True)
             all_file_findings.append((findings, filepath))
         elif args.output_format == "sarif":
-            all_sarif.extend(format_sarif(findings, filepath))
+            # Structured SARIF fixes ride on the experimental fix engine, so they
+            # stay gated until the feature is promoted (ADR-014). Without the gate
+            # the output keeps the prose `properties.fix` only.
+            fixes = None
+            if _experimental_enabled():
+                text = Path(filepath).read_text(encoding="utf-8")
+                fixes = collect_edits(findings, data, lines, text).fixed_edits
+            all_sarif.extend(format_sarif(findings, filepath, fixes=fixes))
         else:
             all_json.extend(format_json(findings, filepath))
 

--- a/src/compose_lint/fix.py
+++ b/src/compose_lint/fix.py
@@ -289,12 +289,16 @@ class FixResult:
     findings dropped because their edit conflicted with another's. ``caveats``
     holds the deduplicated ``(rule_id, caveat)`` pairs for the behavior-changing
     edits among ``edits``, in first-seen order, for the dry-run banner.
+    ``fixed_edits`` pairs each accepted finding with its own edits, in the same
+    order as ``fixed``; the flattened ``edits`` loses that grouping, which
+    per-finding consumers (SARIF ``artifactChanges``) need.
     """
 
     edits: list[TextEdit] = field(default_factory=list)
     fixed: list[Finding] = field(default_factory=list)
     manual: list[Finding] = field(default_factory=list)
     caveats: list[tuple[str, str]] = field(default_factory=list)
+    fixed_edits: list[tuple[Finding, list[TextEdit]]] = field(default_factory=list)
 
 
 def _spans_conflict(a: tuple[int, int], b: tuple[int, int]) -> bool:
@@ -398,6 +402,7 @@ def collect_edits(
             continue
         result.fixed.append(finding)
         result.edits.extend(edits)
+        result.fixed_edits.append((finding, edits))
         for edit in edits:
             if edit.caveat and (finding.rule_id, edit.caveat) not in seen_caveats:
                 seen_caveats.add((finding.rule_id, edit.caveat))

--- a/src/compose_lint/formatters/sarif.py
+++ b/src/compose_lint/formatters/sarif.py
@@ -9,7 +9,9 @@ from compose_lint.models import Severity
 from compose_lint.rules import get_registered_rules
 
 if TYPE_CHECKING:
-    from compose_lint.models import Finding
+    from collections.abc import Sequence
+
+    from compose_lint.models import Finding, TextEdit
 
 SARIF_SCHEMA = (
     "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/"
@@ -70,13 +72,65 @@ def _build_rules() -> tuple[list[dict[str, Any]], dict[str, int]]:
     return rules, index_map
 
 
+def _build_fix(edits: list[TextEdit], filepath: str) -> dict[str, Any]:
+    """Build one SARIF ``fix`` object from a finding's :class:`TextEdit`s.
+
+    Each edit becomes a ``replacement``: ``TextEdit``'s half-open, 1-indexed
+    ``[start, end)`` region maps directly onto SARIF's ``deletedRegion`` (whose
+    ``endColumn`` is likewise the column *after* the region), so no coordinate
+    translation is needed. A non-empty ``replacement`` supplies
+    ``insertedContent``; a pure deletion omits it. Any per-edit ``caveat``
+    becomes the fix's ``description`` so a SARIF consumer sees the
+    behavior-changing warning the dry-run diff shows.
+    """
+    replacements: list[dict[str, Any]] = []
+    caveats: list[str] = []
+    for edit in edits:
+        replacement: dict[str, Any] = {
+            "deletedRegion": {
+                "startLine": edit.start_line,
+                "startColumn": edit.start_col,
+                "endLine": edit.end_line,
+                "endColumn": edit.end_col,
+            },
+        }
+        if edit.replacement:
+            replacement["insertedContent"] = {"text": edit.replacement}
+        replacements.append(replacement)
+        if edit.caveat and edit.caveat not in caveats:
+            caveats.append(edit.caveat)
+
+    fix: dict[str, Any] = {
+        "artifactChanges": [
+            {
+                "artifactLocation": {"uri": filepath},
+                "replacements": replacements,
+            },
+        ],
+    }
+    if caveats:
+        fix["description"] = {"text": " ".join(caveats)}
+    return fix
+
+
 def format_findings(
     findings: list[Finding],
     filepath: str,
+    fixes: Sequence[tuple[Finding, list[TextEdit]]] | None = None,
 ) -> list[dict[str, Any]]:
-    """Format findings as SARIF result objects."""
+    """Format findings as SARIF result objects.
+
+    When ``fixes`` is given (each entry pairs a finding with the edits a fixer
+    produced for it, e.g. ``FixResult.fixed_edits``), the matching result gains a
+    schema-valid ``fixes[]`` carrying the concrete ``artifactChanges``. Findings
+    without structured edits, and every finding when ``fixes`` is ``None``, keep
+    the human-readable ``properties.fix`` guidance string and nothing more. The
+    caller gates whether to pass ``fixes`` at all (experimental until the ``fix``
+    feature is promoted), so the default output shape is unchanged.
+    """
     rules, index_map = _build_rules()
     results: list[dict[str, Any]] = []
+    edits_by_finding = {id(finding): edits for finding, edits in (fixes or [])}
 
     for f in findings:
         result: dict[str, Any] = {
@@ -96,6 +150,10 @@ def format_findings(
 
         if f.fix:
             result["properties"] = {"fix": f.fix}
+
+        edits = edits_by_finding.get(id(f))
+        if edits:
+            result["fixes"] = [_build_fix(edits, filepath)]
 
         if f.suppressed:
             result["suppressions"] = [

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -14,7 +15,7 @@ from compose_lint.formatters.sarif import (
     build_sarif_log,
     format_findings,
 )
-from compose_lint.models import Finding, Severity
+from compose_lint.models import Finding, Severity, TextEdit
 
 FIXTURES = Path(__file__).parent / "compose_files"
 SARIF_SCHEMA_PATH = Path(__file__).parent / "fixtures" / "sarif-schema-2.1.0.json"
@@ -97,6 +98,81 @@ class TestFormatFindings:
             )
             results = format_findings([finding], "test.yml")
             assert results[0]["level"] == expected_level
+
+
+class TestStructuredFixes:
+    """Tests for SARIF ``fixes[].artifactChanges`` from the fix engine."""
+
+    def test_insertion_maps_to_replacement(self) -> None:
+        f = _sample_finding()
+        edit = TextEdit(3, 1, 3, 1, "    read_only: true\n")
+        results = format_findings([f], "docker-compose.yml", fixes=[(f, [edit])])
+        fixes = results[0]["fixes"]
+        assert len(fixes) == 1
+        change = fixes[0]["artifactChanges"][0]
+        assert change["artifactLocation"]["uri"] == "docker-compose.yml"
+        rep = change["replacements"][0]
+        assert rep["deletedRegion"] == {
+            "startLine": 3,
+            "startColumn": 1,
+            "endLine": 3,
+            "endColumn": 1,
+        }
+        assert rep["insertedContent"]["text"] == "    read_only: true\n"
+
+    def test_pure_deletion_omits_inserted_content(self) -> None:
+        f = _sample_finding()
+        edit = TextEdit(5, 1, 6, 1, "")
+        results = format_findings([f], "x.yml", fixes=[(f, [edit])])
+        rep = results[0]["fixes"][0]["artifactChanges"][0]["replacements"][0]
+        assert rep["deletedRegion"]["startLine"] == 5
+        assert "insertedContent" not in rep
+
+    def test_multiple_edits_become_multiple_replacements(self) -> None:
+        f = _sample_finding()
+        edits = [TextEdit(3, 1, 3, 1, "a\n"), TextEdit(7, 1, 8, 1, "")]
+        results = format_findings([f], "x.yml", fixes=[(f, edits)])
+        replacements = results[0]["fixes"][0]["artifactChanges"][0]["replacements"]
+        assert len(replacements) == 2
+
+    def test_caveat_becomes_fix_description(self) -> None:
+        f = _sample_finding()
+        edit = TextEdit(3, 1, 3, 1, "x\n", caveat="changes runtime behavior")
+        results = format_findings([f], "x.yml", fixes=[(f, [edit])])
+        assert results[0]["fixes"][0]["description"]["text"] == (
+            "changes runtime behavior"
+        )
+
+    def test_no_caveat_omits_description(self) -> None:
+        f = _sample_finding()
+        edit = TextEdit(3, 1, 3, 1, "x\n")
+        results = format_findings([f], "x.yml", fixes=[(f, [edit])])
+        assert "description" not in results[0]["fixes"][0]
+
+    def test_finding_without_edits_has_no_fixes(self) -> None:
+        with_fix = _sample_finding()
+        without_fix = Finding(
+            rule_id="CL-0002",
+            severity=Severity.HIGH,
+            service="db",
+            message="privileged",
+            line=9,
+            fix="Drop privileged.",
+        )
+        edit = TextEdit(3, 1, 3, 1, "x\n")
+        results = format_findings(
+            [with_fix, without_fix],
+            "x.yml",
+            fixes=[(with_fix, [edit])],
+        )
+        assert "fixes" in results[0]
+        assert "fixes" not in results[1]
+        # the un-fixed finding keeps its prose guidance
+        assert results[1]["properties"]["fix"] == "Drop privileged."
+
+    def test_fixes_absent_when_argument_omitted(self) -> None:
+        results = format_findings([_sample_finding()], "x.yml")
+        assert "fixes" not in results[0]
 
 
 class TestBuildSarifLog:
@@ -207,6 +283,42 @@ class TestSarifCLI:
         }
         assert len(files) >= 2
 
+    def _run_sarif(self, *, experimental: bool) -> dict:
+        env = dict(os.environ)
+        if experimental:
+            env["COMPOSE_LINT_EXPERIMENTAL"] = "1"
+        else:
+            env.pop("COMPOSE_LINT_EXPERIMENTAL", None)
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "compose_lint",
+                "--format",
+                "sarif",
+                str(FIXTURES / "insecure_no_new_priv.yml"),
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        return json.loads(result.stdout)
+
+    def test_structured_fixes_emitted_under_experimental(self) -> None:
+        data = self._run_sarif(experimental=True)
+        results = data["runs"][0]["results"]
+        with_fixes = [r for r in results if "fixes" in r]
+        assert with_fixes, "expected structured fixes when experimental is enabled"
+        change = with_fixes[0]["fixes"][0]["artifactChanges"][0]
+        assert change["replacements"]
+
+    def test_structured_fixes_gated_off_by_default(self) -> None:
+        data = self._run_sarif(experimental=False)
+        results = data["runs"][0]["results"]
+        assert all("fixes" not in r for r in results)
+        # the prose guidance is still present
+        assert any("properties" in r for r in results)
+
 
 class TestSarifSchemaCompliance:
     """Validate emitted SARIF against the canonical OASIS 2.1.0 schema."""
@@ -250,5 +362,16 @@ class TestSarifSchemaCompliance:
         log = build_sarif_log(
             format_findings([_sample_finding()], "test.yml"),
             parse_errors=[("broken.yml", "could not parse")],
+        )
+        self._validate(log, tmp_path)
+
+    def test_log_with_structured_fix_validates(self, tmp_path: Path) -> None:
+        f = _sample_finding()
+        edits = [
+            TextEdit(3, 1, 3, 1, "    read_only: true\n", caveat="behavior change"),
+            TextEdit(5, 1, 6, 1, ""),
+        ]
+        log = build_sarif_log(
+            format_findings([f], "test.yml", fixes=[(f, edits)]),
         )
         self._validate(log, tmp_path)


### PR DESCRIPTION
## What

Render the fix engine's structured edits as schema-valid SARIF `fixes[].artifactChanges[].replacements[]`. Previously the SARIF formatter could only surface fix guidance as a prose `properties.fix` string; #168 removed the schema-invalid `fixes[]` precisely because no structured edits existed to populate it. The `fix` engine (ADR-014) now produces `TextEdit` records, so this restores `fixes[]` correctly.

## How

- **`sarif.py`** — `format_findings` takes an optional `fixes` argument and emits `fixes[].artifactChanges[].replacements[]`. `TextEdit`'s half-open, 1-indexed `[start, end)` region maps directly onto SARIF's `deletedRegion` (whose `endColumn` is likewise the column *after* the region), so no coordinate translation is needed. A non-empty `replacement` supplies `insertedContent`; a pure deletion omits it. A fixer's `caveat` becomes the fix `description` so a SARIF consumer sees the same behavior-changing warning the dry-run diff shows.
- **`fix.py`** — `FixResult` gains `fixed_edits`, pairing each accepted finding with its own edits; the flattened `edits` list loses the per-finding grouping `artifactChanges` needs.
- **`cli.py`** — the `check` SARIF path passes `fixed_edits` to the formatter **only under `COMPOSE_LINT_EXPERIMENTAL=1`**, so emission stays gated until the `fix` feature is promoted (ADR-014) and the default output shape is unchanged.

Matches the ADR-014 implementation plan (Implementation Notes, "SARIF: a `region` ... plus `artifactChanges[].replacements[]` built from each `TextEdit`; gate emission on promotion").

## Tests

- New `format_findings` unit tests: insertion→replacement region, pure-deletion omits `insertedContent`, multiple edits→multiple replacements, `caveat`→`description`, no-caveat omits description, finding-without-edits has no `fixes` (keeps prose), `fixes` absent when argument omitted.
- Schema compliance: a structured-fix log validates against the canonical OASIS SARIF 2.1.0 schema.
- CLI integration: structured fixes emitted under `COMPOSE_LINT_EXPERIMENTAL`, gated off by default.
- Full suite: 591 passed, 2 skipped. `ruff check`, `ruff format --check`, `mypy src/` (strict) all clean.