### PR TITLE
Document the compatibility and stability policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,11 +167,11 @@ If you need broad IaC coverage across Terraform, Kubernetes, and more, KICS cove
 | [CL-0012](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0012.md) | MEDIUM | PIDs cgroup limit disabled | — | 5.29 |
 | [CL-0013](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0013.md) | HIGH | Sensitive host path mounted | [Rule #8](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-8---set-filesystem-and-volumes-to-read-only) | 5.5 |
 | [CL-0014](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0014.md) | MEDIUM | Logging driver disabled | — | — |
-| [CL-0015](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0015.md) | LOW | Healthcheck disabled | — | 4.6, 5.27 |
+| [CL-0015](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0015.md) | LOW | Healthcheck disabled | — | 4.6, 5.26 |
 | [CL-0016](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0016.md) | HIGH | Dangerous host device exposed | — | 5.18 |
 | [CL-0017](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0017.md) | MEDIUM | Shared mount propagation | — | 5.20 |
 | [CL-0018](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0018.md) | MEDIUM | Explicit root user | [Rule #7](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-7---do-not-run-containers-with-a-root-user) | — |
-| [CL-0019](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0019.md) | MEDIUM | Image tag without digest | [Rule #13](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-13---enhance-supply-chain-security) | 5.27 |
+| [CL-0019](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0019.md) | MEDIUM | Image tag without digest | [Rule #13](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-13---enhance-supply-chain-security) | — |
 | [CL-0020](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0020.md) | HIGH | Credential-shaped env key with literal value | [Rule #11](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-11---use-secret-management-tools) | — |
 | [CL-0021](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0021.md) | HIGH | Credential embedded in connection-string env value | [Rule #11](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-11---use-secret-management-tools) | — |
 
@@ -214,6 +214,10 @@ compose-lint [OPTIONS] [FILE ...]
   --explain CL-XXXX            Print the full documentation for a single rule
   --version                    Show version and exit
 ```
+
+## Versioning & stability
+
+compose-lint follows [Semantic Versioning](https://semver.org/). From 1.0, the CLI, exit codes, config schema, and JSON/SARIF output are stable. New and tightened rules ship in MINOR releases, so pin a version or use `--fail-on` if you need deterministic CI. See [docs/compatibility.md](https://github.com/tmatens/compose-lint/blob/main/docs/compatibility.md) for the full stability promise and deprecation policy.
 
 Color is on when stdout is a terminal. Set `NO_COLOR` to disable it (even on a
 terminal) or `FORCE_COLOR` to force it through a pipe — e.g. into `less -R` or a

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -48,6 +48,9 @@ project-specific rule about new rules (see below). Pick the bump before
 you touch `pyproject.toml`; "what kind of release is this" is the first
 question to answer.
 
+The user-facing version of these guarantees — the stability promise and the
+deprecation lifecycle — lives in [compatibility.md](compatibility.md).
+
 ### Pre-1.0 (current)
 
 While the major version is `0`, the guarantees are weaker and the MINOR
@@ -116,10 +119,22 @@ Once `1.0.0` ships, the contract tightens:
 | Retire a rule ID                             | MINOR   | MAJOR    |
 | Change the default `--fail-on` threshold     | MINOR   | MAJOR    |
 | Drop a Python version                        | MINOR   | MAJOR    |
+| Add a field to JSON/SARIF output             | MINOR   | MINOR    |
+| Remove or rename a JSON/SARIF field          | MINOR   | MAJOR    |
+| Remove or rename a config key                | MINOR   | MAJOR    |
+| Deprecate a flag/key (keep it working)       | PATCH   | MINOR    |
 
 When in doubt pre-1.0, pick MINOR. When in doubt post-1.0, pick the
 higher bump — MAJOR costs the maintainer some release ceremony, but a
 too-low bump breaks users who trusted the version contract.
+
+### Deprecations
+
+Removing anything stable follows the deprecation lifecycle in
+[compatibility.md](compatibility.md#deprecation-lifecycle): announce it under
+`Deprecated` in `CHANGELOG.md`, emit a stderr `warning:` for user-invoked
+surfaces, keep it working for at least one MINOR, and remove it only in a MAJOR
+(listed under `Removed`).
 
 ## Pre-release checks
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -75,7 +75,7 @@ v1.0 is the **stability commitment**: the CLI surface, exit codes, configuration
 - **Stable, documented contract** — CLI flags, exit codes ([ADR-006](adr/006-exit-codes.md)), the `.compose-lint.yml` schema, and the JSON + SARIF output shapes are frozen and documented as the 1.0 surface. The JSON output gains a versioned envelope before the freeze, so run-level metadata (tool version, parse errors) can be added later without breaking consumers.
 - **`fix` resolved** — shipped as GA, or explicitly carved out as experimental with its own stability exemption, so the rest of the surface can stabilize independently ([ADR-014](adr/014-fix-remediation.md)).
 - **Grounding + severity audit complete** — every rule cites OWASP/CIS/Docker, and no severity change is pending that would alter a CI gate after the freeze.
-- **Documented upgrade/deprecation policy** — how rule additions, severity changes, and config changes are versioned post-1.0.
+- **Documented upgrade/deprecation policy** — the SemVer stability promise (rule additions, severity changes, config and output-shape changes) and the deprecation lifecycle, in [compatibility.md](compatibility.md).
 
 **At GA:** bump the PyPI classifier from `4 - Beta` to `5 - Production/Stable` in the version→1.0.0 commit, and publish a moving `v1` Action tag so users can pin `uses: tmatens/compose-lint@v1`.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,85 @@
+# Compatibility and Stability Policy
+
+compose-lint follows [Semantic Versioning](https://semver.org/). This page is
+the user-facing promise: what stays stable across upgrades, what may change, and
+how changes are signalled. The maintainer-facing bump-decision rules live in
+[RELEASING.md](RELEASING.md#choosing-the-version-number); this policy is the
+contract those rules implement.
+
+## The 1.0 commitment
+
+From `1.0.0` onward, the following are **stable** and change only under the
+SemVer rules below:
+
+- **CLI surface** — subcommands, flags, and their documented behavior.
+- **Exit codes** — the `0` / `1` / `2` contract ([ADR-006](adr/006-exit-codes.md))
+  and the default `--fail-on` threshold.
+- **Config schema** — the `.compose-lint.yml` keys and their semantics
+  ([ADR-010](adr/010-per-service-rule-overrides.md)).
+- **Machine output** — the JSON envelope and the SARIF 2.1.0 log shapes
+  ([ADR-015](adr/015-machine-readable-output-contract.md)).
+
+## What is explicitly NOT covered
+
+These may change in any release, including PATCH, without a major bump:
+
+- **Human text output** — the exact wording, layout, colour, and ordering of
+  `--format text`. It is for humans; parse JSON or SARIF if you need a stable
+  shape. (The JSON `version` field exists precisely so you can.)
+- **The experimental `fix` subcommand** — gated behind
+  `COMPOSE_LINT_EXPERIMENTAL`, prints a stderr warning, and is excluded from the
+  SemVer contract until promoted ([ADR-014](adr/014-fix-remediation.md)). Its
+  flags, output, and existence may change without notice.
+- **Internal Python API** — anything beyond `compose_lint.__version__` and the
+  documented CLI. compose-lint is a CLI / GitHub Action, not an importable
+  library; rule classes, the engine, parser, and formatters are implementation
+  details.
+
+## New findings are not a breaking change
+
+This is the most important expectation for CI users. compose-lint **adds and
+tightens rules in MINOR releases** — the same convention as Hadolint,
+ShellCheck, and ruff. A file that is clean on `1.2.0` may report new findings on
+`1.3.0`. That is intentional, not a contract break.
+
+Two escape hatches keep a pipeline deterministic:
+
+- **Pin the version** (`compose-lint==1.2.0`, or the digest-pinned Action /
+  image) for identical results across runs.
+- **Use `--fail-on`** to gate CI on a severity threshold, so new lower-severity
+  findings surface without failing the build.
+
+A rule's **severity** is part of the contract: post-1.0, *downgrading* a
+severity is a MINOR, but *upgrading* one (which can newly fail a pinned user's
+CI) is a MAJOR.
+
+## Deprecation lifecycle
+
+Nothing stable is removed without warning. When a flag, config key, output
+field, or rule is slated for removal:
+
+1. **Announce** — mark it deprecated under `Deprecated` in `CHANGELOG.md` and in
+   the relevant doc, in the release that introduces the deprecation.
+2. **Warn at runtime** — where the deprecated surface is user-invoked (a flag, a
+   config key), emit a one-line `warning:` to **stderr** when it is used, naming
+   the replacement. Warnings never change exit codes or stdout.
+3. **Grace period** — the deprecated surface keeps working for **at least one
+   MINOR release** after the announcement.
+4. **Remove** — removal happens only in a **MAJOR** release, listed under
+   `Removed` in `CHANGELOG.md`.
+
+Two things are never reused or quietly repurposed:
+
+- **Rule IDs** — `CL-XXXX` IDs are permanent; a retired rule's ID is never
+  reassigned ([ADR-005](adr/005-rule-id-scheme.md)). Retiring a rule is a MAJOR
+  change.
+- **Exit-code meanings** — `0` / `1` / `2` keep their meanings; adding a new
+  non-zero code is a MAJOR change.
+
+## Python versions
+
+Supported CPython versions track upstream: a version is added to the matrix
+within ~3 months of its October release (additive), and dropped at upstream
+end-of-life. Dropping a version is a MAJOR change post-1.0. The authoritative
+list is `requires-python` in `pyproject.toml`; see the
+[roadmap](ROADMAP.md#python-version-support) for the schedule.


### PR DESCRIPTION
## What

Adds the user-facing **compatibility and stability policy** — the named GA criterion that was written into the roadmap but had no document behind it.

The SemVer bump rules already existed in `docs/RELEASING.md`, but that's a maintainer-facing release doc, and it had no deprecation lifecycle. This adds a findable policy users can rely on at 1.0, without duplicating the bump table (it points to RELEASING.md as canonical).

## `docs/compatibility.md`

- **The 1.0 commitment** — CLI surface, exit codes (ADR-006), config schema (ADR-010), and the JSON envelope + SARIF shapes (ADR-015) are stable.
- **What's NOT covered** — human text output, the experimental `fix` subcommand (excluded per ADR-014), and the internal Python API.
- **New findings aren't a breaking change** — rules are added/tightened in MINORs (the Hadolint/ruff convention); pin a version or use `--fail-on` for deterministic CI. Severity *downgrade* = MINOR, *upgrade* = MAJOR.
- **Deprecation lifecycle** (new) — announce under `Deprecated`, emit a stderr `warning:`, keep working ≥1 MINOR, remove only in a MAJOR. Rule IDs and exit-code meanings are never reused.

## Supporting changes

- `docs/RELEASING.md` — cross-link to the policy, a `### Deprecations` pointer, and explicit cheat-sheet rows for output-shape, config-key, and deprecation changes.
- `docs/ROADMAP.md` — GA criterion now links the policy.
- `README.md` — a "Versioning & stability" section linking the policy. **Also completes #249**: the rules table still showed pre-correction CIS numbers — CL-0015 is **5.26** (not 5.27) and CL-0019 no longer carries a CIS citation.

## Checks

Docs-only change. `ruff check`/`format` (src/ tests/), `mypy src/`, and `pytest` (591 passed, 2 skipped) all pass locally.
