### PR TITLE
Coordinate CL-0003 and CL-0009 fixes on all-disable security_opt

### DIFF
--- a/docs/adr/014-fix-remediation.md
+++ b/docs/adr/014-fix-remediation.md
@@ -186,6 +186,30 @@ three things we must produce — a diff, a write, and SARIF `artifactChanges` �
 and keeps the destructive operation in one auditable place rather than smeared
 across 21 rules.
 
+### Multi-rule coordination
+
+A few findings are jointly fixable even though each rule's per-finding fixer must
+refuse in isolation. The canonical case: a `security_opt` whose entries are *all*
+profile-disables (so the service also lacks `no-new-privileges`). CL-0009 alone
+would have to empty the block and CL-0003 alone would have to append into a block
+of disables — each non-idempotent (a second pass would re-fire the other rule).
+The engine runs a **coordination pass** before the per-finding pass: it groups a
+service's findings and, when it recognizes such a pattern, synthesizes one merged
+edit (here: replace every disable item with a single `- no-new-privileges:true`)
+that resolves all the grouped findings at once and re-lints clean. Consumed
+findings skip their own fixers.
+
+This does not weaken "non-overlapping within a file": the coordinator emits a
+single coherent edit, so `apply_edits` still never merges overlapping edits — the
+merge is decided up front by an engine pass that owns the cross-rule knowledge,
+not guessed at splice time. A coordinated group is also the unit of conflict
+resolution: if its edit conflicts with another unit's, the whole group is
+refused. Coordination only fires when every rule it spans is in scope (`--only`)
+and unsuppressed, so it never applies a change the user took out of scope. It
+refuses the same conditions the underlying fixers do (anchored/merged service,
+flow style) plus anything its whole-span rewrite would silently drop, such as a
+comment interleaved among the items.
+
 ---
 
 ## Part 3 — CLI shape and write semantics

--- a/src/compose_lint/fix.py
+++ b/src/compose_lint/fix.py
@@ -255,6 +255,33 @@ def block_span(source_lines: list[str], key_line: int) -> tuple[int, int]:
     return key_line, last
 
 
+def replace_lines(
+    source_lines: list[str],
+    first: int,
+    last: int,
+    replacement: str,
+    *,
+    caveat: str | None = None,
+) -> TextEdit:
+    """Return a :class:`TextEdit` that replaces lines ``first``..``last`` whole.
+
+    The region runs from the start of ``first`` to the start of the line after
+    ``last`` (its trailing newline included), so ``replacement`` substitutes for
+    those lines entirely. When ``last`` is the final line of a file with no
+    trailing newline, the region ends at that line's end instead (there is no
+    following line to anchor to) and a trailing newline on ``replacement`` is
+    dropped so the file does not gain one it never had. :func:`delete_lines` is
+    the empty-``replacement`` special case.
+    """
+    if last < len(source_lines):
+        return TextEdit(first, 1, last + 1, 1, replacement, caveat=caveat)
+    # `last` is the final line: end at its end (its newline, if any, included).
+    end_col = len(source_lines[last - 1]) + 1
+    if replacement.endswith("\n") and not source_lines[last - 1].endswith("\n"):
+        replacement = replacement[:-1]
+    return TextEdit(first, 1, last, end_col, replacement, caveat=caveat)
+
+
 def delete_lines(
     source_lines: list[str],
     first: int,
@@ -264,16 +291,12 @@ def delete_lines(
 ) -> TextEdit:
     """Return a :class:`TextEdit` that removes lines ``first``..``last`` whole.
 
-    The region runs from the start of ``first`` to the start of the line after
-    ``last`` so the trailing newline goes with the deleted lines. When ``last``
-    is the final line of a file with no trailing newline, the region ends at the
-    end of that line instead (there is no following line to anchor to).
+    The empty-``replacement`` case of :func:`replace_lines`: the region runs from
+    the start of ``first`` to the start of the line after ``last`` so the trailing
+    newline goes with the deleted lines (or to the final line's end when there is
+    no following line to anchor to).
     """
-    if last < len(source_lines):
-        return TextEdit(first, 1, last + 1, 1, "", caveat=caveat)
-    # `last` is the final line: end at its end (its newline, if any, included).
-    end_col = len(source_lines[last - 1]) + 1
-    return TextEdit(first, 1, last, end_col, "", caveat=caveat)
+    return replace_lines(source_lines, first, last, "", caveat=caveat)
 
 
 # --- Edit collection across a file's findings -----------------------------
@@ -331,6 +354,108 @@ def _spans_conflict(a: tuple[int, int], b: tuple[int, int]) -> bool:
     return a[0] < b[1] and b[0] < a[1]
 
 
+@dataclass(frozen=True)
+class _FixUnit:
+    """A group of findings resolved together by one set of edits.
+
+    Most units pair a single finding with the edits its rule's fixer produced. A
+    *coordinated* unit groups several findings across rules that one merged edit
+    resolves jointly (see :func:`_coordinate_security_opt`). The unit is the
+    granularity of conflict resolution: if its edits conflict with another unit's,
+    *all* of its findings are refused together. ``caveat_rule_id`` attributes the
+    units's caveats in the dry-run banner — the single finding's rule for a normal
+    unit, or the behavior-changing rule for a coordinated one.
+    """
+
+    findings: list[Finding]
+    edits: list[TextEdit]
+    caveat_rule_id: str
+
+
+# Caveat for the coordinated all-disable `security_opt` rewrite below. Defined
+# here (not imported from CL-0009) because rule modules import `fix`, not the
+# reverse; the wording covers the joint remove-disables + add-no-new-privileges
+# edit rather than CL-0009's single-item removal.
+_SECURITY_OPT_COORD_CAVEAT = (
+    "Replacing the unconfined entries re-applies the default seccomp/AppArmor/"
+    "SELinux profile; a workload that relies on a syscall the default profile "
+    "blocks may fail."
+)
+
+
+def _coordinate_security_opt(
+    service: str,
+    svc_findings: list[Finding],
+    data: dict[str, Any],
+    lines: dict[str, int],
+    source_lines: list[str],
+) -> _FixUnit | None:
+    """Merge CL-0003 + an all-disable CL-0009 ``security_opt`` into one edit.
+
+    This is the case both per-finding fixers deliberately refuse (ADR-014): a
+    service whose ``security_opt`` entries are *all* profile-disables, which
+    therefore also lacks ``no-new-privileges``. CL-0009 would have to empty the
+    block and CL-0003 would have to append into a block of disables — each
+    non-idempotent on its own. The idempotent joint result is to replace every
+    disable item with a single ``- no-new-privileges:true``: CL-0009's removals
+    and CL-0003's addition expressed as one edit, which re-lints clean for both
+    rules.
+
+    Returns a coordinated :class:`_FixUnit` consuming both rules' findings, or
+    ``None`` when the pattern does not apply or the block cannot be edited
+    unambiguously: anchored/merged service, flow-style ``security_opt``, or an
+    item span holding anything but sequence items (e.g. an interleaved comment a
+    whole-span replacement would drop).
+    """
+    cl0003 = [f for f in svc_findings if f.rule_id == "CL-0003"]
+    cl0009 = [f for f in svc_findings if f.rule_id == "CL-0009"]
+    if not cl0003 or not cl0009:
+        return None
+
+    services = data.get("services")
+    if not isinstance(services, dict):
+        return None
+    service_config = services.get(service)
+    if not isinstance(service_config, dict):
+        return None
+    security_opt = service_config.get("security_opt")
+    if not isinstance(security_opt, list) or not security_opt:
+        return None
+    if not all(
+        str(opt).strip().lower() in DISABLED_SECURITY_PROFILES for opt in security_opt
+    ):
+        return None
+
+    service_line = lines.get(f"services.{service}")
+    so_line = lines.get(f"services.{service}.security_opt")
+    n = len(source_lines)
+    if service_line is None or so_line is None:
+        return None
+    if not (1 <= service_line <= n and 1 <= so_line <= n):
+        return None
+    if is_anchored_or_merged(source_lines, service_line):
+        return None
+    if not opens_block_body(source_lines[so_line - 1]):
+        return None
+
+    item_indent = first_child_indent(source_lines, so_line)
+    if item_indent is None:
+        return None
+    _first, last = block_span(source_lines, so_line)
+    if last <= so_line:
+        return None  # `security_opt:` opened a body but has no item lines
+    # The body must be only sequence items (and blanks); refuse if a comment or
+    # other content sits among them so the whole-span replacement never drops it.
+    if any(raw.strip() and not _is_seq_item(raw) for raw in source_lines[so_line:last]):
+        return None
+
+    new_item = f"{' ' * item_indent}- no-new-privileges:true\n"
+    edit = replace_lines(
+        source_lines, so_line + 1, last, new_item, caveat=_SECURITY_OPT_COORD_CAVEAT
+    )
+    return _FixUnit([*cl0003, *cl0009], [edit], caveat_rule_id="CL-0009")
+
+
 def collect_edits(
     findings: Iterable[Finding],
     data: dict[str, Any],
@@ -347,10 +472,14 @@ def collect_edits(
     rule id is not in it are ignored entirely. Findings whose fixer returns
     ``None`` (report-only or a per-occurrence refusal) go to ``manual``.
 
-    Edits are then checked for conflicts across findings: if any edit of one
-    finding conflicts with any edit of another (see :func:`_spans_conflict`),
-    *both* findings are refused and moved to ``manual`` rather than guessing a
-    merge. The surviving edits are returned ready to apply.
+    Before the per-finding pass, a coordination pass groups cross-rule findings
+    that one merged edit resolves jointly where each rule's own fixer would refuse
+    (see :func:`_coordinate_security_opt`); consumed findings are not offered to
+    their own fixers. Edits are then checked for conflicts across *units* (a unit
+    is one finding's edits, or a coordinated group's): if any edit of one unit
+    conflicts with any edit of another (see :func:`_spans_conflict`), *all* of
+    both units' findings are refused and moved to ``manual`` rather than guessing
+    a merge. The surviving edits are returned ready to apply.
     """
     from compose_lint.rules import get_registered_rules
 
@@ -359,19 +488,38 @@ def collect_edits(
         rule = rule_cls()
         rules_by_id[rule.metadata.id] = rule
 
-    candidates: list[tuple[Finding, list[TextEdit]]] = []
+    eligible = [
+        finding
+        for finding in findings
+        if not finding.suppressed
+        and (only is None or finding.rule_id in only)
+        and finding.rule_id in rules_by_id
+    ]
+
+    source_lines = text.splitlines(keepends=True)
+
+    # Coordination pass first, per service, so consumed findings skip their own
+    # (refusing) fixers below.
+    units: list[_FixUnit] = []
+    consumed: set[int] = set()
+    by_service: dict[str, list[Finding]] = {}
+    for finding in eligible:
+        by_service.setdefault(finding.service, []).append(finding)
+    for service, svc_findings in by_service.items():
+        unit = _coordinate_security_opt(
+            service, svc_findings, data, lines, source_lines
+        )
+        if unit is not None:
+            units.append(unit)
+            consumed.update(id(finding) for finding in unit.findings)
+
     manual: list[Finding] = []
-    for finding in findings:
-        if finding.suppressed:
+    for finding in eligible:
+        if id(finding) in consumed:
             continue
-        if only is not None and finding.rule_id not in only:
-            continue
-        matched = rules_by_id.get(finding.rule_id)
-        if matched is None:
-            continue
-        edits = matched.fix(finding, data, lines, text)
+        edits = rules_by_id[finding.rule_id].fix(finding, data, lines, text)
         if edits:
-            candidates.append((finding, edits))
+            units.append(_FixUnit([finding], edits, caveat_rule_id=finding.rule_id))
         else:
             manual.append(finding)
 
@@ -386,27 +534,31 @@ def collect_edits(
             for edit in edits
         ]
 
-    spanned = [(finding, edits, spans_of(edits)) for finding, edits in candidates]
+    spanned = [(unit, spans_of(unit.edits)) for unit in units]
     refused: set[int] = set()
     for i in range(len(spanned)):
         for j in range(i + 1, len(spanned)):
-            if any(_spans_conflict(x, y) for x in spanned[i][2] for y in spanned[j][2]):
+            if any(_spans_conflict(x, y) for x in spanned[i][1] for y in spanned[j][1]):
                 refused.add(i)
                 refused.add(j)
 
     result = FixResult()
     seen_caveats: set[tuple[str, str]] = set()
-    for index, (finding, edits, _spans) in enumerate(spanned):
+    for index, (unit, _spans) in enumerate(spanned):
         if index in refused:
-            result.manual.append(finding)
+            result.manual.extend(unit.findings)
             continue
-        result.fixed.append(finding)
-        result.edits.extend(edits)
-        result.fixed_edits.append((finding, edits))
-        for edit in edits:
-            if edit.caveat and (finding.rule_id, edit.caveat) not in seen_caveats:
-                seen_caveats.add((finding.rule_id, edit.caveat))
-                result.caveats.append((finding.rule_id, edit.caveat))
+        result.fixed.extend(unit.findings)
+        result.edits.extend(unit.edits)
+        for finding in unit.findings:
+            result.fixed_edits.append((finding, unit.edits))
+        for edit in unit.edits:
+            if not edit.caveat:
+                continue
+            key = (unit.caveat_rule_id, edit.caveat)
+            if key not in seen_caveats:
+                seen_caveats.add(key)
+                result.caveats.append(key)
     result.manual.extend(manual)
     return result
 

--- a/tests/test_fix.py
+++ b/tests/test_fix.py
@@ -20,6 +20,7 @@ from compose_lint.fix import (
     line_indent,
     opens_block_body,
     render_file_diff,
+    replace_lines,
 )
 from compose_lint.models import TextEdit
 from compose_lint.parser import load_compose
@@ -238,6 +239,26 @@ def test_delete_lines_carries_caveat() -> None:
     assert delete_lines(lines, 1, 1, caveat="note").caveat == "note"
 
 
+def test_replace_lines_substitutes_span() -> None:
+    text = "a: 1\nold1\nold2\nb: 2\n"
+    lines = text.splitlines(keepends=True)
+    out = apply_edits(text, [replace_lines(lines, 2, 3, "new\n")])
+    assert out == "a: 1\nnew\nb: 2\n"
+
+
+def test_replace_lines_final_line_drops_added_newline() -> None:
+    text = "a: 1\nold"  # final line has no trailing newline
+    lines = text.splitlines(keepends=True)
+    # replacement carries a newline, but the original final line had none, so the
+    # result must not gain a trailing newline.
+    assert apply_edits(text, [replace_lines(lines, 2, 2, "new\n")]) == "a: 1\nnew"
+
+
+def test_replace_lines_carries_caveat() -> None:
+    lines = ["a: 1\n", "b: 2\n"]
+    assert replace_lines(lines, 1, 1, "x\n", caveat="note").caveat == "note"
+
+
 # --- collect_edits ---------------------------------------------------------
 
 
@@ -288,12 +309,11 @@ def test_collect_edits_skips_suppressed(tmp_path: Path) -> None:
     assert "CL-0007" not in {f.rule_id for f in result.fixed}
 
 
-def test_collect_edits_refuses_all_disabled_security_opt(tmp_path: Path) -> None:
-    # security_opt's sole entry is seccomp:unconfined (all entries disabled).
-    # Auto-fixing this needs the two per-finding fixers to coordinate (remove the
-    # disable AND add no-new-privileges) which they can't, so both step aside:
-    # CL-0003 declines to append a survivor and CL-0009 declines to empty the
-    # block. Both are left manual rather than producing a non-idempotent result.
+def test_collect_edits_coordinates_sole_disabled_security_opt(tmp_path: Path) -> None:
+    # security_opt's sole entry is seccomp:unconfined (all entries disabled), so
+    # both per-finding fixers refuse (CL-0003 won't append a survivor, CL-0009
+    # won't empty the block). The coordination pass merges them into one edit:
+    # replace the disable with no-new-privileges. Both findings are marked fixed.
     findings, data, lines, text = _findings_for(
         tmp_path,
         "services:\n"
@@ -304,11 +324,130 @@ def test_collect_edits_refuses_all_disabled_security_opt(tmp_path: Path) -> None
     )
     result = collect_edits(findings, data, lines, text, only={"CL-0003", "CL-0009"})
     fixed_rules = {f.rule_id for f in result.fixed}
-    manual_rules = {f.rule_id for f in result.manual}
-    assert "CL-0003" not in fixed_rules
-    assert "CL-0009" not in fixed_rules
-    assert {"CL-0003", "CL-0009"} <= manual_rules
+    assert {"CL-0003", "CL-0009"} <= fixed_rules
+    patched = apply_edits(text, result.edits)
+    assert "seccomp:unconfined" not in patched
+    assert "no-new-privileges:true" in patched
+    # The merged edit carries CL-0009's behavior-changing caveat.
+    assert any(rule_id == "CL-0009" and caveat for rule_id, caveat in result.caveats)
+    # Idempotent: the patched file re-lints clean for both rules and a second
+    # collection scoped to them produces no further edits.
+    re_path = tmp_path / "patched.yml"
+    re_path.write_text(patched, encoding="utf-8")
+    re_data, re_lines = load_compose(re_path)
+    re_findings = run_rules(re_data, re_lines)
+    assert {"CL-0003", "CL-0009"}.isdisjoint({f.rule_id for f in re_findings})
+    re_result = collect_edits(
+        re_findings, re_data, re_lines, patched, only={"CL-0003", "CL-0009"}
+    )
+    assert re_result.edits == []
+
+
+def test_collect_edits_coordinates_multiple_disabled_entries(tmp_path: Path) -> None:
+    # Two profile-disables and no no-new-privileges: the whole item list collapses
+    # to a single no-new-privileges entry (CL-0009 removals + CL-0003 add merged).
+    findings, data, lines, text = _findings_for(
+        tmp_path,
+        "services:\n"
+        "  web:\n"
+        "    image: nginx:1.27\n"
+        "    security_opt:\n"
+        "      - seccomp:unconfined\n"
+        "      - apparmor:unconfined\n",
+    )
+    result = collect_edits(findings, data, lines, text, only={"CL-0003", "CL-0009"})
+    patched = apply_edits(text, result.edits)
+    re_path = tmp_path / "patched.yml"
+    re_path.write_text(patched, encoding="utf-8")
+    re_data, _ = load_compose(re_path)
+    assert re_data["services"]["web"]["security_opt"] == ["no-new-privileges:true"]
+
+
+def test_collect_edits_coordinates_compact_all_disabled(tmp_path: Path) -> None:
+    # Compact block sequence (items at the key's own indent) that is all-disable.
+    findings, data, lines, text = _findings_for(
+        tmp_path,
+        "services:\n"
+        "  web:\n"
+        "    image: nginx:1.27\n"
+        "    security_opt:\n"
+        "    - seccomp:unconfined\n",
+    )
+    result = collect_edits(findings, data, lines, text, only={"CL-0003", "CL-0009"})
+    patched = apply_edits(text, result.edits)
+    re_path = tmp_path / "patched.yml"
+    re_path.write_text(patched, encoding="utf-8")
+    re_data, _ = load_compose(re_path)
+    assert re_data["services"]["web"]["security_opt"] == ["no-new-privileges:true"]
+
+
+def test_coordination_skipped_when_only_one_rule_selected(tmp_path: Path) -> None:
+    # Coordination needs both rules in scope. With only CL-0009, CL-0003 is not
+    # eligible, so the pass cannot add no-new-privileges; CL-0009 alone still
+    # refuses to empty the block and the finding is left manual.
+    findings, data, lines, text = _findings_for(
+        tmp_path,
+        "services:\n"
+        "  web:\n"
+        "    image: nginx:1.27\n"
+        "    security_opt:\n"
+        "      - seccomp:unconfined\n",
+    )
+    result = collect_edits(findings, data, lines, text, only={"CL-0009"})
     assert result.edits == []
+    assert "CL-0009" in {f.rule_id for f in result.manual}
+
+
+def test_coordination_skipped_when_one_side_suppressed(tmp_path: Path) -> None:
+    # Suppressing CL-0003 (a human decision) takes it out of scope, so the merge
+    # cannot run and CL-0009 falls back to its own (refusing) fixer.
+    source = (
+        "services:\n"
+        "  web:\n"
+        "    image: nginx:1.27\n"
+        "    security_opt:\n"
+        "      - seccomp:unconfined\n"
+    )
+    path = tmp_path / "docker-compose.yml"
+    path.write_text(source, encoding="utf-8")
+    data, lines = load_compose(path)
+    findings = run_rules(data, lines, disabled_rules={"CL-0003": "by policy"})
+    result = collect_edits(findings, data, lines, source, only={"CL-0003", "CL-0009"})
+    assert result.edits == []
+    assert "CL-0009" in {f.rule_id for f in result.manual}
+
+
+def test_coordination_refuses_interleaved_comment(tmp_path: Path) -> None:
+    # A comment among the items would be lost by a whole-span replacement, so the
+    # coordinator refuses and leaves the findings for manual remediation.
+    findings, data, lines, text = _findings_for(
+        tmp_path,
+        "services:\n"
+        "  web:\n"
+        "    image: nginx:1.27\n"
+        "    security_opt:\n"
+        "      - seccomp:unconfined\n"
+        "      # keep me\n"
+        "      - apparmor:unconfined\n",
+    )
+    result = collect_edits(findings, data, lines, text, only={"CL-0003", "CL-0009"})
+    assert result.edits == []
+    assert {"CL-0003", "CL-0009"} <= {f.rule_id for f in result.manual}
+
+
+def test_coordination_refuses_anchored_service(tmp_path: Path) -> None:
+    # An anchored service is never edited (re-anchoring risk), coordination too.
+    findings, data, lines, text = _findings_for(
+        tmp_path,
+        "services:\n"
+        "  web: &web\n"
+        "    image: nginx:1.27\n"
+        "    security_opt:\n"
+        "      - seccomp:unconfined\n",
+    )
+    result = collect_edits(findings, data, lines, text, only={"CL-0003", "CL-0009"})
+    assert result.edits == []
+    assert {"CL-0003", "CL-0009"} <= {f.rule_id for f in result.manual}
 
 
 def test_collect_edits_removes_one_item_keeps_others(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

A `security_opt` whose entries are *all* profile-disables left both auto-fixers refusing: CL-0009 alone would empty the block and CL-0003 alone would append into a block of disables — each non-idempotent (a second pass would re-fire the other rule). So the common all-`*:unconfined` case (made manual in #251) produced **no** auto-fix at all.

This is the "engine multi-rule coordination" follow-up flagged in #251.

## How

- **Coordination pass** in `collect_edits`, run before the per-finding pass. It groups a service's findings and, when it recognizes the all-disable pattern, synthesizes **one merged edit** — replace every disable item with a single `- no-new-privileges:true` — that resolves both rules' findings at once, re-lints clean, and is idempotent. Consumed findings skip their own (refusing) fixers.
- Edit collection is reorganized around a `_FixUnit` (a finding group plus its shared edits), which is now the granularity of conflict resolution: if a coordinated group's edit conflicts with another unit's, the whole group is refused.
- Added `replace_lines` as the general form of `delete_lines` to express the rewrite.
- ADR-014 documents the coordination pass and notes it does **not** weaken "non-overlapping within a file": the merge is decided up front by an engine pass that owns the cross-rule knowledge, not guessed at splice time, so `apply_edits` still never merges overlapping edits.

### Guards

Coordination fires only when every rule it spans is in scope (`--only`) and unsuppressed, so it never applies a change the user took out of scope. It refuses the same conditions the underlying fixers do (anchored/merged service, flow style) plus anything its whole-span rewrite would silently drop, such as a comment interleaved among the items.

## Tests

- Updated the former refusal test to assert coordination now fixes the sole-disable case; new tests for multiple disables, compact sequences, idempotency, `--only` gating, one-side-suppressed, interleaved-comment refusal, anchored-service refusal, and the `replace_lines` helper.
- Full suite: **600 passed, 2 skipped**. `ruff check`, `ruff format --check`, `mypy src/` (strict) all clean.
- **Corpus fix gate green over all 6447 files** (re-parse + idempotent + no-new-finding).