### PR TITLE
Reject --explain combined with --format json or sarif

### DIFF
--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -271,6 +271,16 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
                 file=sys.stderr,
             )
             sys.exit(2)
+        # --explain emits human-readable rule prose to stdout (the requested
+        # artifact of this mode). There is no JSON/SARIF form, so reject those
+        # rather than silently printing markdown when one is requested.
+        if args.output_format != "text":
+            print(
+                "Error: --explain has no JSON or SARIF form; "
+                "use the default text output",
+                file=sys.stderr,
+            )
+            sys.exit(2)
         try:
             print(load_rule_doc(args.explain))
         except UnknownRuleError:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -213,6 +213,13 @@ class TestCLI:
         assert "unknown rule id" in result.stderr.lower()
         assert "CL-9999" in result.stderr
 
+    def test_explain_rejects_structured_format(self) -> None:
+        for fmt in ("json", "sarif"):
+            result = run_cli("--explain", "CL-0003", "--format", fmt)
+            assert result.returncode == 2, fmt
+            assert "no JSON or SARIF form" in result.stderr
+            assert result.stdout == ""
+
     def test_explain_rejects_malformed_id(self) -> None:
         result = run_cli("--explain", "not-a-rule")
         assert result.returncode == 2


### PR DESCRIPTION
## What

`--explain CL-XXXX` prints human-readable rule prose to **stdout** — the requested artifact of that mode, which the CLI output contract explicitly permits ("stdout carries data … artifacts in operations like fix or completion"). It has no JSON or SARIF form, but previously `--explain --format json` silently printed markdown and exited 0.

This rejects `--explain` + `--format json|sarif` with a usage error (exit 2), mirroring the existing `--explain` + FILE-args rejection. Default text output is unaffected.

Note: this deliberately does **not** move `--explain` to stderr — stdout is correct so `compose-lint --explain CL-0001 > rule.txt` keeps working (and is covered by an existing test).

## Checks
ruff/format/mypy clean; explain tests pass (added one for the rejection).