### PR TITLE
Correct version-bump tooling docs to match reality

### DIFF
--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -32,13 +32,15 @@ That workflow requires the same per-channel environment approval.
 
 ### 3. Version source of truth
 
-`pyproject.toml` is the authoritative version. All other references
-(`src/compose_lint/__init__.py`, extension `package.json`, etc.) must match
-it. Use `scripts/bump-version.sh` to update all pre-release version files
-atomically — do not edit them by hand.
+`pyproject.toml` is the authoritative version, and `src/compose_lint/__init__.py`
+must match it. `scripts/bump-version.sh X.Y.Z` updates those two source-of-truth
+files; CI's `version-consistency` gate enforces that they agree.
 
-The `marketplace-smoke.yml` action pin is a post-release step (the commit SHA
-only exists once the tag is pushed). See `docs/RELEASING.md`.
+The README integration snippets also carry version pins (the pre-commit `rev:`,
+the `pip install` pin, the Docker image tag, and the Action `# vX.Y.Z` comment).
+Those are part of the release checklist in `docs/RELEASING.md`, not the script —
+bump them there. The Action commit-SHA pin and the `marketplace-smoke.yml` pin
+are post-release steps, since the SHA only exists once the tag is pushed.
 
 ### 4. Every artifact is signed and attested
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Bump the version in pyproject.toml and src/compose_lint/__init__.py.
+# Bump the two source-of-truth version files: pyproject.toml and
+# src/compose_lint/__init__.py. README snippets and the CHANGELOG are handled
+# by hand per the docs/RELEASING.md "Bump the version" checklist.
 # Usage: scripts/bump-version.sh X.Y.Z
 set -euo pipefail
 
@@ -23,6 +25,9 @@ echo "Bumped to ${version}:"
 grep '^version' "${root}/pyproject.toml"
 grep '__version__' "${root}/src/compose_lint/__init__.py"
 echo ""
-echo "Next: update CHANGELOG.md, then:"
-echo "  git add pyproject.toml src/compose_lint/__init__.py CHANGELOG.md"
+echo "Still to do by hand (see docs/RELEASING.md 'Bump the version'):"
+echo "  - README.md snippets: pre-commit rev:, pip ==, docker tag, Action # vX.Y.Z"
+echo "  - CHANGELOG.md: author the ${version} entry"
+echo "Then:"
+echo "  git add pyproject.toml src/compose_lint/__init__.py README.md CHANGELOG.md"
 echo "  git commit -S -m 'Prepare ${version} release'"


### PR DESCRIPTION
## What

`docs/DISTRIBUTION.md` claimed `scripts/bump-version.sh` updates "all pre-release version files atomically — do not edit them by hand" and referenced a nonexistent extension `package.json`. In fact the script only updates the two source-of-truth files (`pyproject.toml`, `src/compose_lint/__init__.py`) — and the README Action snippet's commit-SHA pin *can't* be set at bump time anyway.

- **DISTRIBUTION.md**: describe the script's real scope, drop the stale `package.json` reference, and point at the `docs/RELEASING.md` checklist for the README snippets (and the post-release SHA/marketplace pins).
- **bump-version.sh**: header + closing reminder now name the manual follow-ups (README snippets, CHANGELOG) so the script guides toward the full 4-place sync instead of implying it did everything.

No behavior change to the script's actual edits.

## Checks
`bash -n` clean; no Python changed.