### PR TITLE
Refuse CL-0014/0015 fix when block is the service's sole key

### DIFF
--- a/src/compose_lint/rules/CL0014_logging_disabled.py
+++ b/src/compose_lint/rules/CL0014_logging_disabled.py
@@ -129,5 +129,11 @@ class LoggingDisabledRule(BaseRule):
         if len(logging_config) != 1:
             return None
 
+        # Sole key of the service -> deleting the block would leave the service
+        # with a null body (`web:` with no mapping), which no longer parses as
+        # Compose. Refuse rather than emit invalid YAML (ADR-014).
+        if len(service_config) == 1:
+            return None
+
         first, last = block_span(source_lines, logging_line)
         return [delete_lines(source_lines, first, last, caveat=_CAVEAT)]

--- a/src/compose_lint/rules/CL0015_healthcheck_disabled.py
+++ b/src/compose_lint/rules/CL0015_healthcheck_disabled.py
@@ -140,5 +140,11 @@ class HealthcheckDisabledRule(BaseRule):
         if len(healthcheck) != 1:
             return None
 
+        # Sole key of the service -> deleting the block would leave the service
+        # with a null body (`web:` with no mapping), which no longer parses as
+        # Compose. Refuse rather than emit invalid YAML (ADR-014).
+        if len(service_config) == 1:
+            return None
+
         first, last = block_span(source_lines, healthcheck_line)
         return [delete_lines(source_lines, first, last, caveat=_CAVEAT)]

--- a/tests/test_CL0014.py
+++ b/tests/test_CL0014.py
@@ -106,11 +106,19 @@ class TestLoggingDisabledFix:
         assert self._fix(tmp_path, content) is None
 
     def test_edit_carries_caveat(self, tmp_path: Path) -> None:
-        content = "services:\n  web:\n    logging:\n      driver: none\n"
+        content = (
+            "services:\n  web:\n    image: nginx\n    logging:\n      driver: none\n"
+        )
         edits = self._fix(tmp_path, content)
         assert edits is not None
         assert edits[0].caveat is not None
         assert "logging" in edits[0].caveat.lower()
+
+    def test_refuses_when_block_is_services_sole_key(self, tmp_path: Path) -> None:
+        # Deleting the logging block would leave `web:` with a null body, which
+        # no longer parses as Compose (issue #261 H1). Refuse instead.
+        content = "services:\n  web:\n    logging:\n      driver: none\n"
+        assert self._fix(tmp_path, content) is None
 
     def test_fix_resolves_finding_and_is_idempotent(self, tmp_path: Path) -> None:
         content = (

--- a/tests/test_CL0015.py
+++ b/tests/test_CL0015.py
@@ -148,11 +148,23 @@ class TestHealthcheckDisabledFix:
         assert self._fix(tmp_path, content) is None
 
     def test_edit_carries_caveat(self, tmp_path: Path) -> None:
-        content = "services:\n  web:\n    healthcheck:\n      disable: true\n"
+        content = (
+            "services:\n"
+            "  web:\n"
+            "    image: nginx\n"
+            "    healthcheck:\n"
+            "      disable: true\n"
+        )
         edits = self._fix(tmp_path, content)
         assert edits is not None
         assert edits[0].caveat is not None
         assert "healthcheck" in edits[0].caveat.lower()
+
+    def test_refuses_when_block_is_services_sole_key(self, tmp_path: Path) -> None:
+        # Deleting the healthcheck block would leave `web:` with a null body,
+        # which no longer parses as Compose (issue #261 H1). Refuse instead.
+        content = "services:\n  web:\n    healthcheck:\n      disable: true\n"
+        assert self._fix(tmp_path, content) is None
 
     def test_fix_resolves_finding_and_is_idempotent(self, tmp_path: Path) -> None:
         content = (


### PR DESCRIPTION
Closes part of #261 (**H1**).

## Problem

The CL-0014 (logging) and CL-0015 (healthcheck) deletion fixers removed the disabling block whole, but never checked whether it was the service's *last* key. When it was, deleting it left the service with a null body — `web:` with no mapping — which no longer parses as Compose. `fix --apply` turned a clean, parsing file into invalid YAML, violating ADR-014's leave-valid-Compose invariant.

Reproduced end-to-end:

```yaml
services:
  web:
    logging:
      driver: none
```

```
$ COMPOSE_LINT_EXPERIMENTAL=1 compose-lint fix --apply --only CL-0014 c.yml
$ compose-lint check c.yml
Error: Not a valid Compose file: service 'web' must be a mapping
```

Partly masked under the all-rules pipeline (CL-0007's insert collides and both get refused), but surfaces with `--only`, or when `read_only` already exists.

## Fix

Add a `len(service_config) == 1` guard to both fixers, mirroring the existing partial-block (`len(...) != 1`) guard, so they refuse rather than empty a service. Legitimate multi-key cases still auto-fix unchanged.

## Verification

- Sole-key cases now refuse (manual review, file untouched, re-check exit 0); multi-key cases still auto-fix and re-parse clean.
- Regression tests added to `test_CL0014.py` / `test_CL0015.py`; two `test_edit_carries_caveat` cases updated off the now-refused sole-key shape.
- `ruff check`, `ruff format --check`, `mypy src/` (strict), full `pytest` (612 passed, 2 skipped).
- Corpus fix gate green over 6444 files (0 reparse failures, 0 non-idempotent, 0 new findings); CL-0014/0015 fix counts unchanged (21/20), confirming only the rare sole-key shape is newly refused.