### PR TITLE
Skip full-line comments uniformly in fix block helpers

### DIFF
--- a/src/compose_lint/fix.py
+++ b/src/compose_lint/fix.py
@@ -132,6 +132,21 @@ def _is_seq_item(line: str) -> bool:
     return stripped == "-" or stripped.startswith("- ")
 
 
+def _is_blank_or_comment(line: str) -> bool:
+    """Return whether ``line`` is blank or a full-line ``#`` comment.
+
+    The block-shaping helpers below skip these uniformly. Neither a blank line
+    nor a comment contributes to a block's structure, so neither should set an
+    indent baseline, terminate a span, or be mistaken for a child. Handling them
+    inconsistently is the root cause of issue #261 H2/H3 (a comment interior to a
+    block truncated :func:`block_span`; a mis-indented comment poisoned the child
+    baseline in the anchor/merge guards). Inline comments (``key: value  # ...``)
+    are not full-line comments — those lines start with the key, not ``#``.
+    """
+    stripped = line.strip()
+    return stripped == "" or stripped.startswith("#")
+
+
 def first_child_indent(source_lines: list[str], key_line: int) -> int | None:
     """Return the indentation of the first child line under ``key_line``.
 
@@ -141,12 +156,12 @@ def first_child_indent(source_lines: list[str], key_line: int) -> int | None:
     when it is indented deeper than ``key_line`` *or* it sits at ``key_line``'s
     own indent and is a block-sequence item (``- ...``): YAML lets a sequence
     value share its key's indentation (the "compact" style), and those items are
-    still children of the key. Blank lines are skipped; comment lines count as
-    content, mirroring the original CL-0007 behavior.
+    still children of the key. Blank lines and full-line comments are skipped —
+    neither establishes block structure (issue #261).
     """
     key_indent = line_indent(source_lines[key_line - 1])
     for raw in source_lines[key_line:]:
-        if raw.strip() == "":
+        if _is_blank_or_comment(raw):
             continue
         indent = line_indent(raw)
         if indent > key_indent:
@@ -163,12 +178,13 @@ def has_merge_key_child(source_lines: list[str], key_line: int) -> bool:
     A merge key means the mapping inherits from a YAML anchor, so an edit's
     correct target (the anchor vs. this block) is ambiguous and the fixer must
     refuse (ADR-014 refusal policy). Only direct children — lines at the first
-    child indent — are considered.
+    child indent — are considered. Blank lines and full-line comments are skipped
+    so neither can set the child-indent baseline (issue #261 H3).
     """
     key_indent = line_indent(source_lines[key_line - 1])
     child_indent: int | None = None
     for raw in source_lines[key_line:]:
-        if raw.strip() == "":
+        if _is_blank_or_comment(raw):
             continue
         indent = line_indent(raw)
         if indent <= key_indent:
@@ -190,11 +206,13 @@ def has_anchor_child(source_lines: list[str], key_line: int) -> bool:
     child line that is a lone anchor (``&name``) or alias (``*name``); inline
     forms like ``key: &a value`` start with the key, not ``&``/``*``, and are
     not flagged. Only direct children (lines at the first child indent) count.
+    Blank lines and full-line comments are skipped so neither can set the
+    child-indent baseline (issue #261 H3).
     """
     key_indent = line_indent(source_lines[key_line - 1])
     child_indent: int | None = None
     for raw in source_lines[key_line:]:
-        if raw.strip() == "":
+        if _is_blank_or_comment(raw):
             continue
         indent = line_indent(raw)
         if indent <= key_indent:
@@ -234,15 +252,17 @@ def block_span(source_lines: list[str], key_line: int) -> tuple[int, int]:
     (YAML lets a sequence value share its key's indentation) — sibling items at
     that same indent are also children; the block then ends at the first line
     that dedents or is a same-indent non-item (a sibling mapping key). Blank
-    lines interior to the block are included; a trailing run of blank lines
-    after the last child is excluded. Used to delete a block whole.
+    lines and full-line comments interior to the block are included; a trailing
+    run of either after the last child is excluded. A comment is skipped rather
+    than treated as a dedent, so one sitting between a key and its child no
+    longer truncates the span (issue #261 H2). Used to delete a block whole.
     """
     key_indent = line_indent(source_lines[key_line - 1])
     compact = first_child_indent(source_lines, key_line) == key_indent
     last = key_line
     for idx in range(key_line, len(source_lines)):
         line = source_lines[idx]
-        if line.strip() == "":
+        if _is_blank_or_comment(line):
             continue
         indent = line_indent(line)
         if indent > key_indent:

--- a/tests/test_CL0007.py
+++ b/tests/test_CL0007.py
@@ -153,6 +153,38 @@ class TestReadOnlyFix:
         )
         assert self._fix(tmp_path, content) is None
 
+    def test_refuses_merge_key_behind_misindented_comment(self, tmp_path: Path) -> None:
+        # A mis-indented comment before the merge key must not hide it, which
+        # would let the fixer insert into an anchor-inheriting block and emit
+        # invalid YAML (issue #261 H3).
+        content = (
+            "x-base: &base\n"
+            "  restart: always\n"
+            "services:\n"
+            "  web:\n"
+            "        # over-indented comment\n"
+            "    <<: *base\n"
+            "    image: nginx\n"
+        )
+        assert self._fix(tmp_path, content) is None
+
+    def test_inserts_at_real_child_indent_past_leading_comment(
+        self, tmp_path: Path
+    ) -> None:
+        # A leading comment must not set the insertion indent; read_only lands at
+        # the real child's indent so the result still parses (issue #261).
+        content = "services:\n  web:\n    # note\n    image: nginx\n"
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        result = apply_edits(content, edits)
+        assert result == (
+            "services:\n  web:\n    read_only: true\n    # note\n    image: nginx\n"
+        )
+        fixed = tmp_path / "ok.yml"
+        fixed.write_text(result)
+        data, _ = load_compose(fixed)
+        assert data["services"]["web"]["read_only"] is True
+
     def test_refuses_explicit_read_only_value(self, tmp_path: Path) -> None:
         content = "services:\n  web:\n    read_only: false\n    image: nginx\n"
         assert self._fix(tmp_path, content) is None

--- a/tests/test_CL0014.py
+++ b/tests/test_CL0014.py
@@ -150,6 +150,25 @@ class TestLoggingDisabledFix:
         assert "# pinned" in result
         assert "  db:\n    image: postgres\n" in result
 
+    def test_collapses_through_interior_comment(self, tmp_path: Path) -> None:
+        # A comment between `logging:` and its child must not truncate the span,
+        # which would orphan `driver: none` and emit invalid YAML (issue #261 H2).
+        content = (
+            "services:\n"
+            "  web:\n"
+            "    image: nginx\n"
+            "    logging:\n"
+            "    # comment between key and child\n"
+            "      driver: none\n"
+        )
+        edits = self._fix(tmp_path, content)
+        assert edits is not None
+        result = apply_edits(content, edits)
+        assert result == "services:\n  web:\n    image: nginx\n"
+        fixed = tmp_path / "ok.yml"
+        fixed.write_text(result)
+        load_compose(fixed)  # must still parse
+
     def test_refuses_flow_style_logging(self, tmp_path: Path) -> None:
         content = "services:\n  web:\n    logging: {driver: none}\n"
         assert self._fix(tmp_path, content) is None

--- a/tests/test_fix.py
+++ b/tests/test_fix.py
@@ -145,11 +145,28 @@ def test_first_child_indent_compact_sequence() -> None:
     assert first_child_indent(["a:\n", "b:\n"], 1) is None
 
 
+def test_first_child_indent_skips_comments() -> None:
+    # A full-line comment before the first child is skipped, not counted as the
+    # child (issue #261): the real child's indent is returned.
+    lines = ["web:\n", "    # note\n", "  image: nginx\n"]
+    assert first_child_indent(lines, 1) == 2
+    # A comment that dedents to the key's indent must not be read as "no child".
+    lines = ["  web:\n", "  # note\n", "    image: nginx\n"]
+    assert first_child_indent(lines, 1) == 4
+
+
 def test_has_merge_key_child() -> None:
     merged = ["web:\n", "  <<: *base\n", "  image: nginx\n"]
     assert has_merge_key_child(merged, 1)
     plain = ["web:\n", "  image: nginx\n"]
     assert not has_merge_key_child(plain, 1)
+
+
+def test_has_merge_key_child_skips_leading_comment() -> None:
+    # A mis-indented comment before the merge key must not poison the child
+    # baseline and hide the `<<` (issue #261 H3).
+    merged = ["  web:\n", "        # over-indented\n", "    <<: *base\n"]
+    assert has_merge_key_child(merged, 1)
 
 
 def test_has_anchor_child() -> None:
@@ -160,6 +177,13 @@ def test_has_anchor_child() -> None:
     assert has_anchor_child(aliased, 1)
     # Inline `key: &a value` starts with the key, not `&`, so it is not flagged.
     assert not has_anchor_child(["web:\n", "    image: &img nginx\n"], 1)
+
+
+def test_has_anchor_child_skips_leading_comment() -> None:
+    # Same root cause as the merge-key case: a comment must not set the baseline
+    # that hides a bare anchor child (issue #261 H3).
+    anchored = ["  web:\n", "        # over-indented\n", "    &websvc\n"]
+    assert has_anchor_child(anchored, 1)
 
 
 def test_is_anchored_or_merged() -> None:
@@ -189,6 +213,18 @@ def test_block_span_covers_key_and_children() -> None:
 def test_block_span_excludes_trailing_blank_lines() -> None:
     lines = ["web:\n", "  image: x\n", "\n", "db:\n"]
     assert block_span(lines, 1) == (1, 2)
+
+
+def test_block_span_includes_interior_comment() -> None:
+    # A comment between a key and its child must not truncate the span (issue
+    # #261 H2): the block runs through its real child, comment included.
+    lines = [
+        "    logging:\n",  # 1
+        "    # comment between key and child\n",  # 2
+        "      driver: none\n",  # 3
+        "  db:\n",  # 4  sibling, dedented
+    ]
+    assert block_span(lines, 1) == (1, 3)
 
 
 def test_block_span_compact_sequence() -> None:


### PR DESCRIPTION
Closes part of #261 (**H2** and **H3** — one root cause).

## Problem

The four block-shaping helpers in `fix.py` (`first_child_indent`, `block_span`, `has_merge_key_child`, `has_anchor_child`) disagreed about full-line comments. Two distinct invalid-YAML bugs fell out of that:

**H2 — `block_span` truncates at an interior comment.** The loop skipped only blank lines, so a comment between a key and its child hit the dedent `break` and ended the span early.

```yaml
services:
  web:
    image: nginx
    logging:
    # comment between key and its child
      driver: none
```

`fix --apply --only CL-0014` deleted just `logging:`, orphaning `driver: none` → re-check fails. A corpus scan found ~335/6444 files with this at-risk shape. Also reachable via CL-0015 and the CL-0003/0009 coordination path.

**H3 — a mis-indented comment poisons the anchor/merge guard baseline.** `has_merge_key_child` / `has_anchor_child` let the first non-blank line set `child_indent`, so a comment at a non-child indent hid a real `<<:`/`&anchor`/`*alias` child.

```yaml
x-base: &base
  restart: always
services:
  web:
        # over-indented comment (8 spaces)
    <<: *base
    image: nginx
```

`is_anchored_or_merged(web)` returned `False`, so CL-0007 inserted `read_only: true` into a merge-inheriting block at the comment's indent → no longer parses.

## Fix

Add `_is_blank_or_comment` and skip both blank lines and full-line comments uniformly across all four helpers — neither establishes block structure, so neither should set an indent baseline, terminate a span, or be mistaken for a child. Inline comments (`key: value  # ...`) are unaffected; those lines start with the key, not `#`.

After the fix: H2 collapses the whole block (comment included) and re-parses; H3 is correctly detected as merge-inheriting and refused.

## Verification

- Both bugs reproduced end-to-end before the change (re-check exit 2) and confirmed fixed after (H2 collapses cleanly, H3 refuses; both re-check exit 0).
- Helper unit tests + end-to-end fixtures added: comment between a key and its child, comment dedented to the key's indent, over-indented comment before a merge key and before an anchor child.
- `ruff check`, `ruff format --check`, `mypy src/` (strict), full `pytest` (617 passed, 2 skipped).
- Corpus fix gate green over 6444 files (0 reparse failures, 0 non-idempotent, 0 new findings). The corrected child detection lets a few more real findings auto-fix (CL-0003 +5, CL-0007 +5), all re-parsing cleanly.