### PR TITLE
Coordinate CL-0003/0009 on mixed security_opt lists

### DIFF
--- a/src/compose_lint/fix.py
+++ b/src/compose_lint/fix.py
@@ -410,22 +410,31 @@ def _coordinate_security_opt(
     lines: dict[str, int],
     source_lines: list[str],
 ) -> _FixUnit | None:
-    """Merge CL-0003 + an all-disable CL-0009 ``security_opt`` into one edit.
+    """Merge CL-0003 + CL-0009 over one ``security_opt`` list into a single edit.
 
-    This is the case both per-finding fixers deliberately refuse (ADR-014): a
-    service whose ``security_opt`` entries are *all* profile-disables, which
-    therefore also lacks ``no-new-privileges``. CL-0009 would have to empty the
-    block and CL-0003 would have to append into a block of disables — each
-    non-idempotent on its own. The idempotent joint result is to replace every
-    disable item with a single ``- no-new-privileges:true``: CL-0009's removals
-    and CL-0003's addition expressed as one edit, which re-lints clean for both
-    rules.
+    Fires when a service's ``security_opt`` holds at least one profile-disable
+    (a CL-0009 finding) and lacks ``no-new-privileges`` (a CL-0003 finding).
+    Rewrites the whole item list to its surviving (non-disable) entries plus one
+    ``- no-new-privileges:true``: CL-0009's removals and CL-0003's addition
+    expressed as one edit, which re-lints clean for both rules.
+
+    Doing it jointly resolves two cases the per-finding fixers cannot:
+
+    - **All-disable** — every entry is a disable, so CL-0009 would have to empty
+      the block and CL-0003 would have to append into a block of disables, each
+      non-idempotent on its own (the only case coordinated before #261).
+    - **Mixed with a trailing disable** — CL-0003's append point (the line after
+      the list) meets the deletion of the last item when that item is a disable,
+      so the per-finding fixers mutually refuse and the file never converges
+      (issue #261 M1). A single edit has no internal boundary to collide on.
 
     Returns a coordinated :class:`_FixUnit` consuming both rules' findings, or
     ``None`` when the pattern does not apply or the block cannot be edited
-    unambiguously: anchored/merged service, flow-style ``security_opt``, or an
-    item span holding anything but sequence items (e.g. an interleaved comment a
-    whole-span replacement would drop).
+    unambiguously: anchored/merged service, flow-style ``security_opt``, a list
+    whose items do not map one-to-one onto source lines, an entry already naming
+    ``no-new-privileges`` (e.g. ``:false`` — appending the true form would
+    duplicate the key), or an item span holding anything but sequence items (an
+    interleaved full-line comment a whole-span replacement would drop).
     """
     cl0003 = [f for f in svc_findings if f.rule_id == "CL-0003"]
     cl0009 = [f for f in svc_findings if f.rule_id == "CL-0009"]
@@ -441,10 +450,10 @@ def _coordinate_security_opt(
     security_opt = service_config.get("security_opt")
     if not isinstance(security_opt, list) or not security_opt:
         return None
-    if not all(
+    if not any(
         str(opt).strip().lower() in DISABLED_SECURITY_PROFILES for opt in security_opt
     ):
-        return None
+        return None  # no profile-disable to remove: nothing to coordinate
 
     service_line = lines.get(f"services.{service}")
     so_line = lines.get(f"services.{service}.security_opt")
@@ -469,9 +478,29 @@ def _coordinate_security_opt(
     if any(raw.strip() and not _is_seq_item(raw) for raw in source_lines[so_line:last]):
         return None
 
-    new_item = f"{' ' * item_indent}- no-new-privileges:true\n"
+    # Map each parsed item to its (single, scalar) source line so the disable
+    # test uses the resolved value (quotes resolved). A count mismatch means an
+    # item we cannot place on one line — refuse rather than guess.
+    item_lines = [i for i in range(so_line, last) if _is_seq_item(source_lines[i])]
+    if len(item_lines) != len(security_opt):
+        return None
+    kept: list[str] = []
+    for idx, opt in zip(item_lines, security_opt, strict=True):
+        value = str(opt).strip().lower()
+        if value in DISABLED_SECURITY_PROFILES:
+            continue  # a disable CL-0009 removes
+        if value.startswith("no-new-privileges"):
+            # e.g. `no-new-privileges:false`: appending the true form would
+            # duplicate the key (mirrors CL-0003's per-finding refusal).
+            return None
+        kept.append(source_lines[idx])
+
+    # Surviving entries (verbatim, keeping any inline comments) plus one
+    # no-new-privileges:true, as a single replacement so the removals and the
+    # addition share no boundary to collide on.
+    replacement = "".join(kept) + f"{' ' * item_indent}- no-new-privileges:true\n"
     edit = replace_lines(
-        source_lines, so_line + 1, last, new_item, caveat=_SECURITY_OPT_COORD_CAVEAT
+        source_lines, so_line + 1, last, replacement, caveat=_SECURITY_OPT_COORD_CAVEAT
     )
     return _FixUnit([*cl0003, *cl0009], [edit], caveat_rule_id="CL-0009")
 

--- a/tests/test_fix.py
+++ b/tests/test_fix.py
@@ -487,9 +487,8 @@ def test_coordination_refuses_anchored_service(tmp_path: Path) -> None:
 
 
 def test_collect_edits_removes_one_item_keeps_others(tmp_path: Path) -> None:
-    # Two security_opt entries with the offending one first: CL-0009 removes just
-    # that item line (the list survives) and CL-0003 appends after the last item.
-    # The edits are on different lines and both apply.
+    # A mixed list (one disable, one legit) is coordinated into a single edit:
+    # the disable drops, the legit entry stays, no-new-privileges is added.
     findings, data, lines, text = _findings_for(
         tmp_path,
         "services:\n"
@@ -506,6 +505,57 @@ def test_collect_edits_removes_one_item_keeps_others(tmp_path: Path) -> None:
     assert "seccomp:unconfined" not in patched
     assert "label:type:svirt_apache" in patched
     assert "no-new-privileges:true" in patched
+
+
+def test_collect_edits_coordinates_mixed_trailing_disable(tmp_path: Path) -> None:
+    # A mixed list whose *last* item is a disable: the per-finding fixers used to
+    # mutually refuse because CL-0003's append point met the trailing CL-0009
+    # delete, leaving the HIGH unfixed and never converging (issue #261 M1).
+    # Coordination resolves both rules in one edit, keeping the legit entry.
+    source = (
+        "services:\n"
+        "  web:\n"
+        "    image: nginx:1.27\n"
+        "    security_opt:\n"
+        "      - seccomp:unconfined\n"
+        "      - label:type:svirt_apache\n"
+        "      - apparmor:unconfined\n"
+    )
+    findings, data, lines, text = _findings_for(tmp_path, source)
+    result = collect_edits(findings, data, lines, text, only={"CL-0003", "CL-0009"})
+    assert {"CL-0003", "CL-0009"} <= {f.rule_id for f in result.fixed}
+    patched = apply_edits(text, result.edits)
+    re_path = tmp_path / "patched.yml"
+    re_path.write_text(patched, encoding="utf-8")
+    re_data, re_lines = load_compose(re_path)
+    assert re_data["services"]["web"]["security_opt"] == [
+        "label:type:svirt_apache",
+        "no-new-privileges:true",
+    ]
+    # Idempotent: re-running over the patched file finds nothing to coordinate.
+    re_findings = run_rules(re_data, re_lines)
+    assert {"CL-0003", "CL-0009"}.isdisjoint({f.rule_id for f in re_findings})
+
+
+def test_coordination_refuses_existing_no_new_privileges_false(tmp_path: Path) -> None:
+    # A list already naming no-new-privileges:false must not be coordinated:
+    # appending the true form would duplicate the key. Coordination steps aside,
+    # so no no-new-privileges:true is added and CL-0003 is left for the human
+    # (it won't flip an explicit :false). CL-0009 still removes the disable.
+    findings, data, lines, text = _findings_for(
+        tmp_path,
+        "services:\n"
+        "  web:\n"
+        "    image: nginx:1.27\n"
+        "    security_opt:\n"
+        "      - seccomp:unconfined\n"
+        "      - no-new-privileges:false\n",
+    )
+    result = collect_edits(findings, data, lines, text, only={"CL-0003", "CL-0009"})
+    patched = apply_edits(text, result.edits)
+    assert "no-new-privileges:true" not in patched  # not coordinated
+    assert "no-new-privileges:false" in patched  # left intact
+    assert "CL-0003" in {f.rule_id for f in result.manual}
 
 
 def test_collect_edits_appends_to_compact_security_opt(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes part of #261 (**M1**).

## Problem

The CL-0003/CL-0009 per-finding fixers converge a *mixed* `security_opt` list (some profile-disables, some legitimate entries) only when a legit entry happens to be **last**. When the last item is a disable:

```yaml
services:
  web:
    security_opt:
      - seccomp:unconfined
      - label:user:x
      - apparmor:unconfined
```

CL-0003's append point (the line just after the list) equals the end boundary of the trailing CL-0009 item deletion, so the conflict rule (`_spans_conflict`) refuses both units. The result: only the first disable is removed, **the HIGH CL-0009 finding is left unfixed, and further `fix` passes make zero progress** (idempotent but never converges). The *same content with the legit entry last* fixes completely in one pass — so remediation depended purely on textual ordering.

## Fix

Generalize the existing `security_opt` coordination pass (added in #255 for the all-disable case) to **any list with ≥1 disable that also lacks `no-new-privileges`**. It rewrites the whole item list to its surviving entries (kept verbatim — inline comments included) plus one `- no-new-privileges:true`, as a **single edit** with no internal boundary to collide on. CL-0009's removals and CL-0003's addition are expressed jointly.

- Items are mapped one-to-one onto source lines, so disable detection uses the **parsed** value (quotes resolved); a count mismatch refuses rather than guessing.
- A list already naming `no-new-privileges` (e.g. `:false`) is refused to avoid duplicating the key (mirrors CL-0003's per-finding guard).
- The all-disable behavior is unchanged — it falls out as the empty-survivors case.

## Verification

- M1 reproduced end-to-end before the change (trailing disable survived, CL-0009 HIGH remained, no `no-new-privileges` added) and confirmed fixed after (both disables removed, legit entry kept, `no-new-privileges:true` added, re-lint clean, idempotent on a second pass).
- Regressions checked: legit-item-last and all-disable both still produce the correct result.
- Tests added in `test_fix.py`: mixed trailing-disable coordination + idempotency, and the `no-new-privileges:false` refusal; the legit-last test's comment updated to reflect the coordinated path.
- `ruff check`, `ruff format --check`, `mypy src/` (strict), full `pytest` (612 passed, 2 skipped).
- Corpus fix gate green over 6444 files (0 reparse failures, 0 non-idempotent, 0 new findings).