### PR TITLE
Mark missing trailing newline in the fix dry-run diff

### DIFF
--- a/src/compose_lint/fix.py
+++ b/src/compose_lint/fix.py
@@ -624,15 +624,26 @@ def render_file_diff(
     Behavior-changing fixes are announced above the diff with a
     ``⚠ behavior-changing`` line per ADR-014 so a reader sees which edits could
     alter runtime behavior before deciding to ``--apply``.
+
+    A content line without a trailing newline (a file with no final newline, the
+    common Compose case) is followed by git's ``\\ No newline at end of file``
+    marker. ``difflib`` omits it, which would otherwise glue that line and the
+    next onto one line and garble the diff (issue #261 M2).
     """
-    diff = "".join(
-        difflib.unified_diff(
-            original.splitlines(keepends=True),
-            patched.splitlines(keepends=True),
-            fromfile=path,
-            tofile=path,
-        )
-    )
+    chunks: list[str] = []
+    for line in difflib.unified_diff(
+        original.splitlines(keepends=True),
+        patched.splitlines(keepends=True),
+        fromfile=path,
+        tofile=path,
+    ):
+        # Header lines (`---`/`+++`/`@@`) always end in a newline; only a final
+        # content line can lack one. Re-terminate it and add the git sentinel.
+        if line.endswith("\n"):
+            chunks.append(line)
+        else:
+            chunks.append(line + "\n\\ No newline at end of file\n")
+    diff = "".join(chunks)
     if not diff:
         return ""
     banner = "".join(

--- a/tests/test_fix.py
+++ b/tests/test_fix.py
@@ -622,3 +622,24 @@ def test_render_file_diff_includes_caveat_banner_and_diff() -> None:
 def test_render_file_diff_empty_when_unchanged() -> None:
     text = "services:\n  web:\n    image: nginx:1.27\n"
     assert render_file_diff("docker-compose.yml", text, text, []) == ""
+
+
+def test_render_file_diff_marks_missing_trailing_newline() -> None:
+    # A file with no final newline must not glue the -/+ lines together; mirror
+    # git's "\ No newline at end of file" sentinel instead (issue #261 M2).
+    original = 'services:\n  web:\n    ports:\n      - "8080:80"'
+    patched = 'services:\n  web:\n    ports:\n      - "127.0.0.1:8080:80"'
+    out = render_file_diff("docker-compose.yml", original, patched, [])
+    assert '-      - "8080:80"\n' in out
+    assert '+      - "127.0.0.1:8080:80"\n' in out
+    assert out.count("\\ No newline at end of file") == 2
+    # No line glues the old and new content together.
+    assert '"8080:80"+' not in out
+
+
+def test_render_file_diff_no_spurious_newline_marker() -> None:
+    # A normal file (final newline present) keeps a clean diff, no sentinel.
+    original = "services:\n  web:\n    image: nginx:1.27\n"
+    patched = "services:\n  web:\n    read_only: true\n    image: nginx:1.27\n"
+    out = render_file_diff("docker-compose.yml", original, patched, [])
+    assert "No newline at end of file" not in out


### PR DESCRIPTION
Closes part of #261 (**M2**).

## Problem

`difflib.unified_diff` does not emit git's `\ No newline at end of file` sentinel. When the input lines (from `splitlines(keepends=True)`) lack a trailing `\n` — a Compose file with no final newline, which is common — the last hunk glues the removed and added content onto one line:

```
@@ -1,4 +1,4 @@
 services:
   web:
     ports:
-      - "8080:80"+      - "127.0.0.1:8080:80"
```

The dry-run diff is the user's primary signal before `--apply`, so garbling it is a real usability bug.

## Fix

Re-terminate any content line that lacks a newline and append the `\ No newline at end of file` marker, mirroring `git diff`:

```
-      - "8080:80"
\ No newline at end of file
+      - "127.0.0.1:8080:80"
\ No newline at end of file
```

Header lines (`---`/`+++`/`@@`) always end in a newline and are untouched; files that *do* end with a newline are unchanged (no spurious marker).

## Verification

- Reproduced before the change (lines glued) and confirmed fixed after (sentinel present, lines separated), checked end-to-end via `fix --only CL-0005` on a newline-less file.
- Tests added: the no-trailing-newline diff carries exactly two sentinels and never glues content; a normal (final-newline) diff carries none.
- `ruff check`, `ruff format --check`, `mypy src/` (strict), full `pytest` (612 passed, 2 skipped). Corpus fix gate green (unaffected — it exercises `apply_edits`, not diff rendering).