### PR TITLE
Tighten fix-engine edge cases (issue #261 L1–L5)

### DIFF
--- a/src/compose_lint/fix.py
+++ b/src/compose_lint/fix.py
@@ -62,7 +62,9 @@ def apply_edits(text: str, edits: list[TextEdit]) -> str:
     position to the first so earlier offsets stay valid as later text changes
     length. Adjacent edits (one ending exactly where the next begins) are
     allowed; genuinely overlapping regions raise :class:`OverlappingEditError`.
-    An empty ``edits`` list returns ``text`` unchanged.
+    Two coincident insertions (same zero-width point) order deterministically by
+    their replacement text, so the result never depends on the order findings
+    arrived in. An empty ``edits`` list returns ``text`` unchanged.
     """
     if not edits:
         return text
@@ -76,7 +78,10 @@ def apply_edits(text: str, edits: list[TextEdit]) -> str:
         )
         for edit in edits
     ]
-    spans.sort(key=lambda span: (span[0], span[1]))
+    # Region first; the replacement is a final, content-derived tiebreak so
+    # coincident insertions order deterministically. Rule id would be ideal but
+    # is not carried on a TextEdit at the splice layer (issue #261 L2).
+    spans.sort(key=lambda span: (span[0], span[1], span[2].replacement))
 
     prev_end = -1
     for begin, end, _edit in spans:
@@ -103,7 +108,13 @@ def apply_edits(text: str, edits: list[TextEdit]) -> str:
 
 
 def line_indent(line: str) -> int:
-    """Return the number of leading spaces on ``line`` (newline-insensitive)."""
+    """Return the number of leading spaces on ``line`` (newline-insensitive).
+
+    Counts spaces only; a tab would not be measured as indentation. This is
+    safe because :func:`compose_lint.parser.load_compose` rejects tab
+    indentation before any fixer runs, so the fixers never see it (issue
+    #261 L3).
+    """
     body = line.rstrip("\n")
     return len(body) - len(body.lstrip(" "))
 
@@ -117,6 +128,11 @@ def opens_block_body(line: str) -> bool:
     colon, and for a line with no colon at all. A fixer that needs to insert
     into or delete a block treats ``False`` as a refusal: there is no plain
     block body to edit unambiguously.
+
+    Uses the first ``:`` on the line, so a quoted key that itself contains a
+    colon (``"a:b":``) is read as having an inline value and returns ``False``.
+    That is a safe over-refusal — the fixer falls back to manual review rather
+    than mis-editing — and the shape is rare (issue #261 L4).
     """
     body = line.rstrip("\n")
     colon = body.find(":")
@@ -353,13 +369,17 @@ def _spans_conflict(a: tuple[int, int], b: tuple[int, int]) -> bool:
       point they splice as independent, well-formed lines (e.g. CL-0007's
       ``read_only`` and CL-0003's ``security_opt``, both inserted as a service's
       first child). They are *not* refused.
-    - **An insertion touching a non-empty region's closed interval**
-      (``begin <= point <= end``) *is* a conflict. The motivating case: CL-0003
-      appends an entry at the line just after a ``security_opt`` block that
-      CL-0009 is collapsing whole — the insertion point equals the deletion's end
-      boundary, so applying both would orphan the appended entry beside the
-      removed parent key. :func:`apply_edits` uses half-open overlap and would
-      not catch this touch, so it is caught here (ADR-014: refuse, never guess).
+    - **An insertion touching a non-empty region's *end*** (``lo < point <= hi``)
+      *is* a conflict; touching its *start* (``point == lo``) is not. The
+      motivating end case: CL-0003 appends an entry at the line just after a
+      ``security_opt`` block that CL-0009 is collapsing whole — the insertion
+      point equals the deletion's end boundary, so applying both would orphan the
+      appended entry beside the removed parent key. :func:`apply_edits` uses
+      half-open overlap and would not catch that touch, so it is caught here
+      (ADR-014: refuse, never guess). An insertion at the *start* boundary lands
+      before the deleted region and composes cleanly — it is exactly what
+      :func:`apply_edits` already accepts — so refusing it only drops a safe fix
+      (issue #261 L1).
     - **Two non-empty regions** conflict on half-open overlap only; adjacency
       (one ending exactly where the next begins) composes fine and is allowed,
       matching :func:`apply_edits`.
@@ -370,7 +390,7 @@ def _spans_conflict(a: tuple[int, int], b: tuple[int, int]) -> bool:
         return False
     if a_empty or b_empty:
         point, lo, hi = (a[0], b[0], b[1]) if a_empty else (b[0], a[0], a[1])
-        return lo <= point <= hi
+        return lo < point <= hi
     return a[0] < b[1] and b[0] < a[1]
 
 

--- a/src/compose_lint/rules/CL0014_logging_disabled.py
+++ b/src/compose_lint/rules/CL0014_logging_disabled.py
@@ -94,7 +94,8 @@ class LoggingDisabledRule(BaseRule):
         would leave a structurally partial block we can't safely resolve — and
         for anchored/merged services or flow-style blocks (ADR-014 refusal
         policy). The edit carries a caveat because re-enabling logging changes
-        runtime behavior.
+        runtime behavior. A full-line comment sitting inside the block is removed
+        with it; it is treated as belonging to the block (issue #261 L5).
         """
         service = finding.service
         services = data.get("services")

--- a/src/compose_lint/rules/CL0015_healthcheck_disabled.py
+++ b/src/compose_lint/rules/CL0015_healthcheck_disabled.py
@@ -103,7 +103,9 @@ class HealthcheckDisabledRule(BaseRule):
         strand them (e.g. an ``interval`` with no ``test``), a partial block we
         can't safely resolve — and for anchored/merged services or flow-style
         blocks (ADR-014 refusal policy). The edit carries a caveat because
-        re-enabling the healthcheck changes runtime behavior.
+        re-enabling the healthcheck changes runtime behavior. A full-line comment
+        sitting inside the block is removed with it; it is treated as belonging
+        to the block (issue #261 L5).
         """
         service = finding.service
         services = data.get("services")

--- a/tests/test_fix.py
+++ b/tests/test_fix.py
@@ -9,6 +9,7 @@ import pytest
 from compose_lint.engine import run_rules
 from compose_lint.fix import (
     OverlappingEditError,
+    _spans_conflict,
     apply_edits,
     block_span,
     collect_edits,
@@ -100,6 +101,33 @@ def test_caveat_field_is_preserved() -> None:
     assert edit.caveat == "breaks writers"
     # A caveat does not change how the edit is applied.
     assert apply_edits("x: 1\n", [edit]) == "read_only: true\nx: 1\n"
+
+
+def test_coincident_insertions_order_deterministically() -> None:
+    # Two pure insertions at the same point must produce the same output whatever
+    # order they arrive in — pinned by the replacement tiebreak (issue #261 L2).
+    text = "x: 1\n"
+    a = TextEdit(1, 1, 1, 1, "aaa\n")
+    b = TextEdit(1, 1, 1, 1, "bbb\n")
+    assert apply_edits(text, [a, b]) == apply_edits(text, [b, a])
+    assert apply_edits(text, [a, b]) == "aaa\nbbb\nx: 1\n"
+
+
+def test_spans_conflict_boundaries() -> None:
+    # An insertion at a deletion's *start* composes (apply_edits accepts it), so
+    # it is not a conflict; touching its *end* would orphan content, so it is
+    # (issue #261 L1). Symmetric in the argument order.
+    region = (5, 10)
+    assert not _spans_conflict((5, 5), region)  # start boundary: allowed
+    assert _spans_conflict((10, 10), region)  # end boundary: conflict
+    assert _spans_conflict((7, 7), region)  # interior: conflict
+    assert not _spans_conflict((3, 3), region)  # before the region: allowed
+    assert not _spans_conflict((11, 11), region)  # after the region: allowed
+    # Order of the two spans must not matter.
+    assert _spans_conflict(region, (10, 10))
+    assert not _spans_conflict(region, (5, 5))
+    # Two pure insertions never conflict, even at the same point.
+    assert not _spans_conflict((5, 5), (5, 5))
 
 
 # --- Text-shaping helpers -------------------------------------------------
@@ -591,6 +619,24 @@ def test_collect_edits_refuses_bare_anchor_service(tmp_path: Path) -> None:
     result = collect_edits(findings, data, lines, text, only={"CL-0003", "CL-0007"})
     assert result.edits == []
     assert {"CL-0003", "CL-0007"} <= {f.rule_id for f in result.manual}
+
+
+def test_collect_edits_insertion_at_start_of_deletion_composes(tmp_path: Path) -> None:
+    # CL-0007 inserts read_only at the service's first-child point, which is the
+    # *start* of the logging block CL-0014 deletes. That boundary touch used to be
+    # refused, dropping both fixes; it now composes into valid YAML (issue #261 L1).
+    findings, data, lines, text = _findings_for(
+        tmp_path,
+        "services:\n  web:\n    logging:\n      driver: none\n    image: nginx:1.27\n",
+    )
+    result = collect_edits(findings, data, lines, text, only={"CL-0007", "CL-0014"})
+    assert {"CL-0007", "CL-0014"} <= {f.rule_id for f in result.fixed}
+    patched = apply_edits(text, result.edits)
+    re_path = tmp_path / "patched.yml"
+    re_path.write_text(patched, encoding="utf-8")
+    re_data, _ = load_compose(re_path)  # must still parse
+    assert re_data["services"]["web"]["read_only"] is True
+    assert "logging" not in re_data["services"]["web"]
 
 
 def test_collect_edits_caveats_dedup_and_carry_rule_id(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes part of #261 (**L1–L5**, batched).

The low-severity findings from the fix-engine review. None corrupts output today; L1/L2 are behavior/robustness, L3–L5 document conscious assumptions.

## L1 — `_spans_conflict` over-refused an insertion at a deletion's *start*
`fix.py` — `_spans_conflict` flagged `lo <= point <= hi`. An insertion at a non-empty region's **start** (`point == lo`) lands *before* the deleted region and composes cleanly — it is exactly what `apply_edits` already accepts — so refusing it only dropped a safe fix. Relaxed to `lo < point <= hi`: only touching the **end** boundary (where the insert would orphan content beside a removed parent key) is still a conflict. Concretely, CL-0007's `read_only` insert and a CL-0014 logging-block delete that share a boundary now both apply instead of both being refused.

## L2 — coincident insertions had no deterministic tiebreak
`apply_edits` sorted on `(begin, end)` only, so two pure insertions at the same point ordered by finding-iteration happenstance. Added the replacement text as a final tiebreak so the output never depends on input order. (Rule id would be ideal but is not carried on a `TextEdit` at the splice layer.)

## L3 / L4 / L5 — documentation of conscious assumptions
- **L3** — `line_indent` measures spaces only; safe because `load_compose` rejects tab indentation upstream.
- **L4** — `opens_block_body` keys on the first colon, a safe over-refusal for a quoted key containing a colon (`"a:b":`).
- **L5** — a full-line comment inside a CL-0014/0015 block is removed with the block (treated as belonging to it); noted in both fixer docstrings.

## Verification

- L1 confirmed: the read_only-insert / logging-delete boundary case now composes into valid YAML (was previously refused). L2 confirmed: both input orders of two coincident insertions yield identical output.
- Tests added: `_spans_conflict` boundary matrix, `apply_edits` determinism, and the L1 start-boundary integration case.
- `ruff check`, `ruff format --check`, `mypy src/` (strict), full `pytest` (613 passed, 2 skipped).
- Corpus fix gate green over 6444 files (0 reparse failures, 0 non-idempotent, 0 new findings).