### PR TITLE
Re-parse fix output before writing as an ADR-014 safety net

### DIFF
--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -13,7 +13,12 @@ from compose_lint import __version__
 from compose_lint.config import ConfigError, load_config
 from compose_lint.engine import filter_findings, run_rules
 from compose_lint.explain import UnknownRuleError, load_rule_doc
-from compose_lint.fix import apply_edits, collect_edits, render_file_diff
+from compose_lint.fix import (
+    apply_edits,
+    collect_edits,
+    render_file_diff,
+    reparse_or_error,
+)
 from compose_lint.formatters.json import build_json_log
 from compose_lint.formatters.json import format_findings as format_json
 from compose_lint.formatters.sarif import build_sarif_log
@@ -479,6 +484,26 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
             continue
 
         patched = apply_edits(text, result.edits)
+
+        # Safety net (ADR-014): re-parse the candidate before persisting it. If
+        # the combined edits do not produce valid Compose, that is a fixer bug,
+        # not user error — refuse the whole apply, write nothing, and surface the
+        # diff plus the parse error so it is diagnosable (issue #261).
+        guard_error = reparse_or_error(patched)
+        if guard_error is not None:
+            print(
+                render_file_diff(filepath, text, patched, result.caveats),
+                end="",
+                file=sys.stderr,
+            )
+            print(
+                f"Error: {filepath}: computed fix does not parse as Compose "
+                f"({guard_error}); no changes written",
+                file=sys.stderr,
+            )
+            had_parse_error = True
+            continue
+
         if args.apply:
             Path(filepath).write_text(patched, encoding="utf-8")
             print(

--- a/src/compose_lint/fix.py
+++ b/src/compose_lint/fix.py
@@ -670,3 +670,27 @@ def render_file_diff(
         f"⚠ behavior-changing · {rule_id}: {caveat}\n" for rule_id, caveat in caveats
     )
     return banner + diff
+
+
+def reparse_or_error(patched: str) -> str | None:
+    """Return a parse-error message if ``patched`` is not valid Compose, else None.
+
+    The fix engine's last safety net (ADR-014: a fixer must leave a valid Compose
+    file). Re-parsing the combined candidate text before it is written turns a
+    fixer bug from *silent corruption* into a *safe refusal* — it catches the
+    whole class of "emits invalid YAML", including a shape no test has hit yet,
+    rather than one bug at a time. The per-root-cause fixes (issue #261) still
+    matter; this is the net under them for the unknown next one.
+
+    It is deliberately a net, not a proof: parse success is weaker than
+    non-destructive, so a fixer that drops an unrelated key or comment and still
+    emits valid YAML passes this check. Catching *that* would need a structural
+    before/after comparison, which is a separate, heavier mechanism.
+    """
+    from compose_lint.parser import ComposeError, loads
+
+    try:
+        loads(patched)
+    except ComposeError as e:
+        return str(e)
+    return None

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -322,6 +322,21 @@ def load_compose(
     except OSError as e:
         raise ComposeError(f"Cannot read file: {e}") from e
 
+    return loads(content)
+
+
+def loads(content: str) -> tuple[dict[str, Any], dict[str, int]]:
+    """Parse and validate Compose from an in-memory string.
+
+    The string form of :func:`load_compose`: identical YAML parsing, line
+    capture, and Compose validation, but with no filesystem read. This lets the
+    fix engine re-parse its own candidate output before persisting it (ADR-014's
+    "leave a valid Compose file" safety net) without round-tripping through a
+    temporary file.
+
+    Raises:
+        ComposeError: If the text is not valid YAML or not a valid Compose file.
+    """
     # LineLoader is a yaml.SafeLoader subclass — this call cannot
     # deserialize arbitrary Python objects. The assertion makes that
     # invariant explicit so a future refactor can't silently break it.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 FIXTURES = Path(__file__).parent / "compose_files"
 
 
@@ -441,3 +443,25 @@ class TestFixSubcommand:
         assert result.returncode == 2
         assert "experimental" not in result.stderr.lower()
         assert f.read_text() == _BARE_SERVICE
+
+    def test_apply_refuses_to_write_invalid_compose(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # Safety net (ADR-014, issue #261): if the engine ever computes invalid
+        # Compose, --apply must refuse and leave the file untouched. Force a
+        # broken result to exercise the guard end-to-end (in-process so the
+        # patched engine is reachable).
+        from compose_lint import cli
+
+        f = tmp_path / "docker-compose.yml"
+        f.write_text(_BARE_SERVICE)
+        monkeypatch.setenv("COMPOSE_LINT_EXPERIMENTAL", "1")
+        monkeypatch.setattr(cli, "apply_edits", lambda text, edits: "services: [\n")
+        with pytest.raises(SystemExit) as exc:
+            cli.main(["fix", "--apply", str(f)])
+        assert exc.value.code == 2
+        assert "does not parse as Compose" in capsys.readouterr().err
+        assert f.read_text() == _BARE_SERVICE  # nothing written

--- a/tests/test_fix.py
+++ b/tests/test_fix.py
@@ -21,6 +21,7 @@ from compose_lint.fix import (
     line_indent,
     opens_block_body,
     render_file_diff,
+    reparse_or_error,
     replace_lines,
 )
 from compose_lint.models import TextEdit
@@ -689,3 +690,23 @@ def test_render_file_diff_no_spurious_newline_marker() -> None:
     patched = "services:\n  web:\n    read_only: true\n    image: nginx:1.27\n"
     out = render_file_diff("docker-compose.yml", original, patched, [])
     assert "No newline at end of file" not in out
+
+
+# --- reparse safety net ----------------------------------------------------
+
+
+def test_reparse_or_error_passes_valid_compose() -> None:
+    assert reparse_or_error("services:\n  web:\n    image: nginx:1.27\n") is None
+
+
+def test_reparse_or_error_flags_invalid_yaml() -> None:
+    msg = reparse_or_error("services: [\n")
+    assert msg is not None
+    assert "Invalid YAML" in msg
+
+
+def test_reparse_or_error_flags_not_compose() -> None:
+    # The H1 corruption shape — a service emptied to a null body.
+    msg = reparse_or_error("services:\n  web:\n")
+    assert msg is not None
+    assert "must be a mapping" in msg

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -14,9 +14,33 @@ from compose_lint.parser import (
     _collect_lines,
     _strip_lines,
     load_compose,
+    loads,
 )
 
 FIXTURES = Path(__file__).parent / "compose_files"
+
+
+class TestLoads:
+    """Tests for the in-memory string parser (parity with load_compose)."""
+
+    def test_parses_valid_string(self) -> None:
+        data, lines = loads("services:\n  web:\n    image: nginx:1.27\n")
+        assert data["services"]["web"]["image"] == "nginx:1.27"
+        # Line capture works the same as the path-based loader.
+        assert lines["services.web"] == 2
+
+    def test_raises_on_invalid_yaml(self) -> None:
+        with pytest.raises(ComposeError, match="Invalid YAML"):
+            loads("services: [\n")
+
+    def test_raises_on_invalid_compose(self) -> None:
+        # The H1 corruption shape: a service with a null body.
+        with pytest.raises(ComposeError, match="service 'web' must be a mapping"):
+            loads("services:\n  web:\n")
+
+    def test_raises_on_empty(self) -> None:
+        with pytest.raises(ComposeError, match="file is empty"):
+            loads("")
 
 
 class TestLoadCompose:


### PR DESCRIPTION
Implements the **round-trip guard** from the defense-in-depth consideration on #261 (layer 1: post-apply re-parse). Layer 2 (structural before/after equivalence) is deliberately deferred.

## Why

The #261 review showed that careful per-fixer guards *plus* a green 6444-file corpus gate still let three invalid-YAML shapes through (H1/H2/H3). Those root causes are now fixed, but the lesson generalizes: the next unknown fixer bug should fail **safe**, not corrupt a user's file.

## What

A backstop that enforces ADR-014's "fixers must leave a valid Compose file" invariant **at runtime**. In `_run_fix`, after computing a file's combined patched text and before persisting it, re-parse the candidate. If it doesn't parse as Compose:
- refuse the whole apply, **write nothing**,
- surface the diff plus the parse error on stderr,
- exit 2.

This converts a fixer bug from **silent corruption** (worst outcome) into **safe refusal** (acceptable), and catches the *class* — including a shape no test has hit — rather than one bug at a time. It runs in both dry-run and `--apply`.

- New `parser.loads(content)` — the string form of `load_compose` (identical parsing/validation, no filesystem read), so the guard re-parses **in memory** instead of round-tripping a temp file. `load_compose` now delegates to it.
- New `fix.reparse_or_error(patched)` — returns a parse-error message or `None`.

### Scope note (why layer 2 is deferred)

The guard is a **net, not a proof**: parse-success is weaker than non-destructive, so a fixer that drops an unrelated key/comment and still emits valid YAML would pass. Catching *that* needs a structural before/after tree comparison (Black `--safe` style) — more expensive, still comment-blind, and targeting an **unobserved** failure given the surgical-edit design. Deferred until there's evidence it's needed.

## Verification

- Guard confirmed: a normal fix passes and writes correctly; a forced-invalid result is refused with the file left untouched (in-process CLI test). `reparse_or_error` flags invalid YAML and the H1 empty-service shape.
- `ruff check`, `ruff format --check`, `mypy src/` (strict), full `pytest` (634 passed, 2 skipped).
- Corpus fix gate green over 6444 files (0 reparse failures, 0 non-idempotent, 0 new findings) — the guard adds no behavioral change to valid fixes.