### PR TITLE
Add apply-time safety layers to the fix engine

### DIFF
--- a/docs/adr/014-fix-remediation.md
+++ b/docs/adr/014-fix-remediation.md
@@ -462,6 +462,63 @@ experimental-on-main (Part 5) beats a branch.
 
 ---
 
+## Apply-time safety layers
+
+The corpus gate (Part 6) proves the invariants hold across ~1.5k real files
+*before* release. It cannot run on a user's machine against a file it has never
+seen. A fix can still break a running service four ways, and `--apply` defends
+each in turn — the first three at apply time, the corpus gate behind them:
+
+1. **Invalid file** — the patch is not valid Compose, so `docker compose`
+   refuses to start. Caught by the **parse net** (`reparse_or_error`): re-parse
+   the candidate; refuse and write nothing if it does not parse.
+2. **Collateral mutation** — the patch is valid Compose but a miscomputed splice
+   span dropped or mangled a key the fixer never meant to touch. The parse net
+   waves this through. Caught by **`verify_apply`'s structure check**: every
+   service the fix did not touch, and every top-level key outside `services`,
+   must parse identically before and after. This is the *cheap* form — it
+   confirms untouched config is unchanged, not that the *touched* services
+   changed in exactly the intended way (see Deferred, below).
+3. **Self-inconsistent fix** — the patch is valid and confined but does not
+   settle: a second `fix` pass would edit again, or the fix introduced a finding
+   the original lacked. Caught by **`verify_apply`'s converge + no-new-finding
+   checks** — the same two invariants the corpus gate enforces (Part 6), now
+   enforced at apply time so a live `--apply` carries the guarantee the gate only
+   proved over the corpus.
+4. **Operational write hazard** — the content is correct but the write itself
+   corrupts the file (interrupted write, full disk leaving a truncated file).
+   Caught by the **atomic write**: write a temp file in the same directory,
+   `fsync`, carry over the original's mode, and `os.replace` it in. A reader sees
+   either the old file or the complete new one, never a mix.
+
+A failure at layer 1–3 is a fixer bug, not user error: `--apply` refuses the
+whole file, writes nothing, prints the diff for diagnosis, and exits 2.
+
+### Deferred
+
+- **Strong structural proof.** The interim structure check (layer 2) only
+  asserts *untouched* config is unchanged. The strong form has each fixer
+  declare its intended semantic delta (e.g. `+services.web.read_only`,
+  `-services.web.security_opt[seccomp:unconfined]`) and the engine verify the
+  actual parsed delta equals the declared one — catching a fixer that mutates
+  *its own* service in an unintended way, not just a neighbour. Needs a delta
+  declaration on the fixer interface; defer until a real divergence motivates it.
+- **CRLF / BOM read-path fidelity.** The atomic write emits the computed text
+  verbatim, but `load_compose` reads with newline normalization, so a
+  CRLF-authored file is rewritten with LF endings. Preserving the original line
+  ending (and a leading BOM) requires the *read* path to retain them, not just
+  the write path — a separate change.
+- **Concurrency (TOCTOU).** A fix bases its edits on the file as read; a
+  concurrent edit between read and `os.replace` is silently clobbered.
+  Re-checking the on-disk content is unchanged just before the swap would refuse
+  rather than overwrite. Cheap, but a distinct concern from durability.
+- **Context-aware gating for behavior-changing fixers.** Some caveats could
+  become refusals when the same file shows a clear breakage signal: CL-0005
+  under `network_mode: host` (the `127.0.0.1:` rewrite has different semantics
+  there), and CL-0007 when a service has no `tmpfs:` or writable mount (a
+  read-only rootfs is then very likely to break it — a candidate for a stronger,
+  context-specific caveat rather than an outright refusal).
+
 ## Out of scope for this ADR
 
 - **`fix --check`** (exit 1 if edits would be made, à la `black --check`) — a

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -18,6 +18,7 @@ from compose_lint.fix import (
     collect_edits,
     render_file_diff,
     reparse_or_error,
+    verify_apply,
 )
 from compose_lint.formatters.json import build_json_log
 from compose_lint.formatters.json import format_findings as format_json
@@ -444,14 +445,14 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
             sys.exit(2)
 
     only = set(args.only) if args.only else None
-    had_parse_error = False
+    had_error = False
 
     for filepath in args.files:
         try:
             data, lines = load_compose(filepath)
         except FileNotFoundError:
             print(f"Error: {filepath}: file not found", file=sys.stderr)
-            had_parse_error = True
+            had_error = True
             continue
         except ComposeNotApplicableError as e:
             # v1 / fragment file: skipped, not an error (ADR-013).
@@ -459,7 +460,7 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
             continue
         except ComposeError as e:
             print(f"Error: {filepath}: {e}", file=sys.stderr)
-            had_parse_error = True
+            had_error = True
             continue
 
         text = Path(filepath).read_text(encoding="utf-8")
@@ -501,7 +502,34 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
                 f"({guard_error}); no changes written",
                 file=sys.stderr,
             )
-            had_parse_error = True
+            had_error = True
+            continue
+
+        # Layer above the parse net (ADR-014): valid Compose is not enough — the
+        # patch must also leave untouched config intact, converge on a second
+        # pass, and raise no new finding. A failure here is a fixer bug too:
+        # refuse, write nothing, and surface the diff for diagnosis.
+        verify_error = verify_apply(
+            data,
+            findings,
+            result,
+            patched,
+            only=only,
+            disabled_rules=disabled_rules,
+            severity_overrides=severity_overrides,
+            excluded_services=excluded_services,
+        )
+        if verify_error is not None:
+            print(
+                render_file_diff(filepath, text, patched, result.caveats),
+                end="",
+                file=sys.stderr,
+            )
+            print(
+                f"Error: {filepath}: {verify_error}; no changes written",
+                file=sys.stderr,
+            )
+            had_error = True
             continue
 
         if args.apply:
@@ -523,4 +551,4 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
                 file=sys.stderr,
             )
 
-    sys.exit(2 if had_parse_error else 0)
+    sys.exit(2 if had_error else 0)

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import os
+import stat
 import sys
+import tempfile
 from pathlib import Path
 from typing import NoReturn
 
@@ -416,6 +419,35 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
     sys.exit(1 if has_errors else 0)
 
 
+def _atomic_write(path: Path, content: str) -> None:
+    """Write ``content`` to ``path`` atomically, preserving its mode.
+
+    A fix must never leave a half-written Compose file: an interrupted in-place
+    write (crash, full disk) would corrupt a file ``docker compose`` then
+    refuses to start. Write to a temp file in the same directory, flush it to
+    disk, and ``os.replace`` it into place — a reader sees either the old file or
+    the complete new one, never a truncated mix. The original file's permission
+    bits carry over so the fix neither relaxes nor tightens them. ``newline=""``
+    writes the computed text verbatim, with no newline translation.
+    """
+    fd, tmp_name = tempfile.mkstemp(
+        dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as tmp:
+            tmp.write(content)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+        # Best-effort mode carry-over; the swap below still lands the content.
+        with contextlib.suppress(OSError):
+            os.chmod(tmp_path, stat.S_IMODE(path.stat().st_mode))
+        os.replace(tmp_path, path)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
 def _run_fix(args: argparse.Namespace) -> NoReturn:
     """Run the experimental `fix` operation (ADR-014).
 
@@ -533,7 +565,7 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
             continue
 
         if args.apply:
-            Path(filepath).write_text(patched, encoding="utf-8")
+            _atomic_write(Path(filepath), patched)
             print(
                 f"{filepath}: applied {len(result.edits)} fix(es) across "
                 f"{len(result.fixed)} finding(s)",

--- a/src/compose_lint/fix.py
+++ b/src/compose_lint/fix.py
@@ -17,7 +17,7 @@ import difflib
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from compose_lint.models import Finding, TextEdit
+from compose_lint.models import Finding, Severity, TextEdit
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -693,4 +693,111 @@ def reparse_or_error(patched: str) -> str | None:
         loads(patched)
     except ComposeError as e:
         return str(e)
+    return None
+
+
+def _structural_drift(
+    original: dict[str, Any],
+    patched: dict[str, Any],
+    fixed_services: set[str],
+) -> str | None:
+    """Return a message if ``patched`` changed anything outside the fixed services.
+
+    Compares the two parsed trees, which carry plain Python types only (line
+    numbers live in a separate map), so deep equality is a faithful test of
+    "same configuration". Three things must hold for the patch to be confined to
+    what the fixers claimed: every top-level key other than ``services`` is
+    unchanged, the set of service names is unchanged, and every service the fix
+    did *not* touch is deep-equal before and after. Returns ``None`` when only
+    the fixed services differ, else the first violation found.
+    """
+    orig_top = {k: v for k, v in original.items() if k != "services"}
+    new_top = {k: v for k, v in patched.items() if k != "services"}
+    if orig_top != new_top:
+        return "computed fix changed configuration outside services"
+
+    orig_services = original.get("services") or {}
+    new_services = patched.get("services") or {}
+    if set(orig_services) != set(new_services):
+        return "computed fix added or removed a service"
+
+    for name, config in orig_services.items():
+        if name in fixed_services:
+            continue
+        if config != new_services.get(name):
+            return f"computed fix altered untouched service '{name}'"
+    return None
+
+
+def verify_apply(
+    original_data: dict[str, Any],
+    findings: list[Finding],
+    result: FixResult,
+    patched: str,
+    *,
+    only: set[str] | None = None,
+    disabled_rules: dict[str, str | None] | None = None,
+    severity_overrides: dict[str, Severity] | None = None,
+    excluded_services: dict[str, dict[str, str | None]] | None = None,
+) -> str | None:
+    """Verify a patched candidate beyond "it parses" before it is written.
+
+    The layer above :func:`reparse_or_error` (ADR-014). Re-parsing proves the
+    output is *valid* Compose; it does not prove it is the *intended* Compose. A
+    text splice with a miscomputed span can drop or mangle a neighbouring key and
+    still emit valid YAML, which :func:`reparse_or_error` waves through. This
+    re-runs the engine on the candidate and checks the three properties the
+    corpus gate enforces pre-release but a live ``--apply`` could not, returning a
+    diagnostic on the first failure (else ``None``):
+
+    1. **Structure preserved** — every service the fix did not touch, and every
+       top-level key outside ``services``, parses identically before and after
+       (:func:`_structural_drift`). This is the cheap form of the check: it
+       confirms untouched config is unchanged in the parsed tree, not that the
+       *touched* services changed in exactly the intended way (that would need
+       each fixer to declare its semantic delta — a heavier mechanism).
+    2. **Converges** — a second collection on the candidate is a no-op, so a
+       re-run of ``fix`` would not keep editing the file.
+    3. **No new finding** — the candidate raises nothing the original did not, so
+       a fix never trades one problem for another.
+
+    Assumes ``patched`` already parses (the caller runs :func:`reparse_or_error`
+    first); a parse failure here is reported as a verification failure all the
+    same rather than raising.
+    """
+    from compose_lint.engine import run_rules
+    from compose_lint.parser import ComposeError, loads
+
+    try:
+        re_data, re_lines = loads(patched)
+    except ComposeError as e:  # pragma: no cover - reparse guard runs first
+        return f"computed fix does not parse as Compose ({e})"
+
+    drift = _structural_drift(original_data, re_data, {f.service for f in result.fixed})
+    if drift is not None:
+        return drift
+
+    re_findings = run_rules(
+        re_data,
+        re_lines,
+        disabled_rules=disabled_rules,
+        severity_overrides=severity_overrides,
+        excluded_services=excluded_services,
+    )
+
+    if collect_edits(re_findings, re_data, re_lines, patched, only=only).edits:
+        return "computed fix does not converge: a second pass would still edit it"
+
+    before = {(f.rule_id, f.service, f.message) for f in findings}
+    new = sorted(
+        {
+            (f.rule_id, f.service)
+            for f in re_findings
+            if (f.rule_id, f.service, f.message) not in before
+        }
+    )
+    if new:
+        sample = ", ".join(f"{rule_id} on '{service}'" for rule_id, service in new[:2])
+        return f"computed fix introduces a new finding ({sample})"
+
     return None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -409,6 +410,17 @@ class TestFixSubcommand:
         patched = f.read_text()
         assert "read_only: true" in patched
         assert "no-new-privileges:true" in patched
+
+    def test_apply_preserves_file_mode(self, tmp_path: Path) -> None:
+        # --apply swaps the file in atomically; the new file must keep the
+        # original's permission bits, not inherit the temp file's 0600.
+        f = tmp_path / "docker-compose.yml"
+        f.write_text(_BARE_SERVICE)
+        f.chmod(0o640)
+        result = run_cli_env(_EXPERIMENTAL, "fix", "--apply", str(f))
+        assert result.returncode == 0
+        assert stat.S_IMODE(f.stat().st_mode) == 0o640
+        assert "read_only: true" in f.read_text()
 
     def test_only_restricts_to_named_rule(self, tmp_path: Path) -> None:
         f = tmp_path / "docker-compose.yml"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -465,3 +465,25 @@ class TestFixSubcommand:
         assert exc.value.code == 2
         assert "does not parse as Compose" in capsys.readouterr().err
         assert f.read_text() == _BARE_SERVICE  # nothing written
+
+    def test_apply_refuses_to_write_structural_drift(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # Beyond the parse net (ADR-014): a patch that is valid Compose but
+        # mutates a service no fixer touched must also be refused, untouched.
+        # Force such a patch (valid YAML, an extra service) to drive the guard.
+        from compose_lint import cli
+
+        f = tmp_path / "docker-compose.yml"
+        f.write_text(_BARE_SERVICE)
+        monkeypatch.setenv("COMPOSE_LINT_EXPERIMENTAL", "1")
+        drifted = _BARE_SERVICE + "  ghost:\n    image: scratch\n"
+        monkeypatch.setattr(cli, "apply_edits", lambda text, edits: drifted)
+        with pytest.raises(SystemExit) as exc:
+            cli.main(["fix", "--apply", str(f)])
+        assert exc.value.code == 2
+        assert "added or removed a service" in capsys.readouterr().err
+        assert f.read_text() == _BARE_SERVICE  # nothing written

--- a/tests/test_fix.py
+++ b/tests/test_fix.py
@@ -8,6 +8,7 @@ import pytest
 
 from compose_lint.engine import run_rules
 from compose_lint.fix import (
+    FixResult,
     OverlappingEditError,
     _spans_conflict,
     apply_edits,
@@ -23,8 +24,9 @@ from compose_lint.fix import (
     render_file_diff,
     reparse_or_error,
     replace_lines,
+    verify_apply,
 )
-from compose_lint.models import TextEdit
+from compose_lint.models import Finding, Severity, TextEdit
 from compose_lint.parser import load_compose
 
 if TYPE_CHECKING:
@@ -710,3 +712,82 @@ def test_reparse_or_error_flags_not_compose() -> None:
     msg = reparse_or_error("services:\n  web:\n")
     assert msg is not None
     assert "must be a mapping" in msg
+
+
+# --- verify_apply (post-parse safety net) ----------------------------------
+
+
+def test_verify_apply_passes_clean_fix(tmp_path: Path) -> None:
+    # The real fixers leave a converging, finding-free, structure-preserving
+    # result, so the verifier must accept their own output.
+    findings, data, lines, text = _findings_for(
+        tmp_path, "services:\n  web:\n    image: nginx:1.27\n"
+    )
+    result = collect_edits(findings, data, lines, text)
+    patched = apply_edits(text, result.edits)
+    assert verify_apply(data, findings, result, patched) is None
+
+
+def test_verify_apply_flags_structural_drift() -> None:
+    # A patch that parses but alters a service no fixer touched is collateral
+    # damage the parse net cannot see; the verifier names the wrong service.
+    original = {"services": {"web": {"image": "a"}, "db": {"image": "b"}}}
+    result = FixResult(
+        fixed=[
+            Finding(
+                rule_id="CL-0007",
+                severity=Severity.MEDIUM,
+                service="web",
+                message="x",
+            )
+        ]
+    )
+    patched = "services:\n  web:\n    image: a\n  db:\n    image: CHANGED\n"
+    msg = verify_apply(original, [], result, patched)
+    assert msg is not None
+    assert "untouched service 'db'" in msg
+
+
+def test_verify_apply_flags_added_service() -> None:
+    # A patch may not invent (or drop) a service the original never had.
+    original = {"services": {"web": {"image": "a"}}}
+    patched = "services:\n  web:\n    image: a\n  ghost:\n    image: b\n"
+    msg = verify_apply(original, [], FixResult(), patched)
+    assert msg is not None
+    assert "added or removed a service" in msg
+
+
+def test_verify_apply_flags_non_convergence(tmp_path: Path) -> None:
+    # A patch still carrying a fixable finding would make a second `fix` pass
+    # edit again — refuse it. Feeding the original text back as the "patch"
+    # (no edits applied) is exactly that shape.
+    findings, data, lines, text = _findings_for(
+        tmp_path, "services:\n  web:\n    image: nginx:1.27\n"
+    )
+    msg = verify_apply(data, findings, FixResult(), text)
+    assert msg is not None
+    assert "does not converge" in msg
+
+
+def test_verify_apply_flags_new_finding(tmp_path: Path) -> None:
+    # A patch that introduces a finding the original lacked must be refused.
+    # `only` is scoped to a report-only rule so the convergence check passes
+    # (nothing fixable left) and the new-finding check is what fires.
+    findings, data, lines, text = _findings_for(
+        tmp_path, "services:\n  web:\n    image: nginx:1.27\n"
+    )
+    result = FixResult(
+        fixed=[
+            Finding(
+                rule_id="CL-0007",
+                severity=Severity.MEDIUM,
+                service="web",
+                message="x",
+            )
+        ]
+    )
+    patched = "services:\n  web:\n    image: nginx:1.27\n    privileged: true\n"
+    msg = verify_apply(data, findings, result, patched, only={"CL-0002"})
+    assert msg is not None
+    assert "introduces a new finding" in msg
+    assert "CL-0002" in msg


### PR DESCRIPTION
## Why

`reparse_or_error` (#268) proves a patched file is *valid* Compose. It does not prove the patch is the *intended* Compose, nor that the write itself is safe. This adds the layers above it so `--apply` defends every way a fix can break a running service, not just the syntactic one.

A fix can break a service four ways; each is now defended at apply time (with the corpus gate behind them):

1. **Invalid file** → the parse net (`reparse_or_error`, already present).
2. **Collateral mutation** — a miscomputed splice span drops/mangles a key the fixer never meant to touch, but still emits valid YAML → **new** structure check.
3. **Self-inconsistent fix** — does not converge, or introduces a new finding → **new** converge + no-new-finding checks (the corpus gate's invariants, now enforced at apply time).
4. **Operational write hazard** — interrupted/partial write corrupts the file → **new** atomic write.

## What

- **`verify_apply`** (`fix.py`): re-runs the engine on the candidate and refuses unless (a) every untouched service and top-level key parses identically before/after, (b) a second collection is a no-op, (c) no new finding appears. Wired into `_run_fix` after the parse guard; a failure refuses the file, writes nothing, prints the diff, exits 2.
- **`_atomic_write`** (`cli.py`): temp file in the same dir → `fsync` → carry over mode → `os.replace`. Replaces the truncate-in-place `Path.write_text`.
- **ADR-014 addendum**: documents the four-way taxonomy and the deferred items (strong per-fixer declared-delta proof, CRLF/BOM read-path fidelity, TOCTOU concurrency guard, context-aware gating for CL-0005/CL-0007).

## Notes

- The structure check is the *cheap* form (untouched config unchanged), not the strong per-fixer delta proof — deferred in the ADR.
- Renames the `_run_fix` `had_parse_error` flag to `had_error` now that it covers non-parse refusals.
- New tests: `verify_apply` unit cases (clean pass, structural drift, added service, non-convergence, new finding), CLI refusal on forced drift, and mode-preservation on `--apply`.
- Gate green locally: `ruff check`, `ruff format --check`, `mypy src/` (strict), `pytest` (641 passed, 2 corpus-gated skips).

Refs ADR-014, #268.