### PR TITLE
Expose the fix subcommand without the experimental env gate (Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The experimental `fix` subcommand is now reachable without setting
+  `COMPOSE_LINT_EXPERIMENTAL=1` (ADR-014 Phase 2). It remains hidden from
+  `--help`, prints an experimental warning on every run, is dry-run by
+  default, and stays excluded from the SemVer contract until promoted.
+  Structured SARIF `fixes[]` from the engine remain behind
+  `COMPOSE_LINT_EXPERIMENTAL=1` until full promotion.
+
 ## [0.8.0] - 2026-05-23
 
 ### Added

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -26,10 +26,11 @@ These may change in any release, including PATCH, without a major bump:
 - **Human text output** — the exact wording, layout, colour, and ordering of
   `--format text`. It is for humans; parse JSON or SARIF if you need a stable
   shape. (The JSON `version` field exists precisely so you can.)
-- **The experimental `fix` subcommand** — gated behind
-  `COMPOSE_LINT_EXPERIMENTAL`, prints a stderr warning, and is excluded from the
-  SemVer contract until promoted ([ADR-014](adr/014-fix-remediation.md)). Its
-  flags, output, and existence may change without notice.
+- **The experimental `fix` subcommand** — reachable but hidden from `--help`,
+  prints a stderr warning on every run, and is excluded from the SemVer contract
+  until promoted ([ADR-014](adr/014-fix-remediation.md)). Its flags, output, and
+  behavior may change in any release. (Structured SARIF `fixes[]` from the engine
+  stay behind `COMPOSE_LINT_EXPERIMENTAL=1` until that promotion.)
 - **Internal Python API** — anything beyond `compose_lint.__version__` and the
   documented CLI. compose-lint is a CLI / GitHub Action, not an importable
   library; rule classes, the engine, parser, and formatters are implementation

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -77,16 +77,19 @@ _GLOBAL_FLAGS = frozenset({"-h", "--help", "--version"})
 
 # Stderr banner printed on every `fix` invocation (ADR-014, Part 5).
 _FIX_EXPERIMENTAL_WARNING = (
-    "warning: 'fix' is experimental and unstable; output and flags may change "
-    "without notice. Review the diff before --apply."
+    "warning: 'fix' is experimental; its flags, output, and behavior may change "
+    "in any release. Dry-run by default — review the diff before --apply."
 )
 
 
 def _experimental_enabled() -> bool:
-    """Return whether the experimental `fix` subcommand is gated on.
+    """Return whether experimental fix-engine *output* is gated on.
 
-    Phase 1 of ADR-014 hides `fix` entirely unless ``COMPOSE_LINT_EXPERIMENTAL``
-    is set to ``1``, so it cannot be discovered or invoked by accident.
+    Post-Phase-2 (ADR-014) the `fix` subcommand itself is always available but
+    hidden; this gate now only controls the one piece still held back for
+    Phase 3 — structured SARIF ``fixes[]`` in ``check --format sarif`` — which
+    stays behind ``COMPOSE_LINT_EXPERIMENTAL=1`` until the engine is promoted
+    into the SemVer contract.
     """
     return os.environ.get("COMPOSE_LINT_EXPERIMENTAL") == "1"
 
@@ -96,14 +99,11 @@ def _subcommands() -> set[str]:
 
     Bare ``compose-lint <file>`` is kept working as an implicit ``check``
     (ADR-011): when the first non-flag token is not one of these, the shim
-    prepends ``check``. ``fix`` is only recognized when experimental mode is on,
-    so without the env gate ``compose-lint fix ...`` falls through to ``check``
-    and fails as a missing file rather than exposing the hidden command.
+    prepends ``check``. ``fix`` is recognized so ``compose-lint fix ...`` routes
+    to it; the command is still hidden from ``--help`` (Phase 2), just no longer
+    gated behind an env var.
     """
-    commands = {"check"}
-    if _experimental_enabled():
-        commands.add("fix")
-    return commands
+    return {"check", "fix"}
 
 
 def _add_check_subparser(
@@ -191,7 +191,8 @@ def _add_fix_subparser(
     Omitting ``help=`` keeps it out of ``compose-lint --help``: argparse only
     lists subparsers that were given a help string (passing
     ``help=argparse.SUPPRESS`` instead renders a literal ``==SUPPRESS==`` row).
-    The caller also only registers it at all when experimental mode is enabled.
+    Post-Phase-2 the command is always registered; hiding it is now this
+    omission's job alone, not an env gate's.
     """
     fix = subparsers.add_parser(
         "fix",
@@ -236,8 +237,9 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     subparsers = parser.add_subparsers(dest="command", metavar="COMMAND")
     _add_check_subparser(subparsers)
-    if _experimental_enabled():
-        _add_fix_subparser(subparsers)
+    # `fix` is always registered (Phase 2) but stays hidden from --help; see
+    # _add_fix_subparser for how (it omits help=).
+    _add_fix_subparser(subparsers)
     return parser
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 import stat
 import subprocess
 import sys
@@ -20,18 +19,6 @@ def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
         [sys.executable, "-m", "compose_lint", *args],
         capture_output=True,
         text=True,
-    )
-
-
-def run_cli_env(
-    env_extra: dict[str, str], *args: str
-) -> subprocess.CompletedProcess[str]:
-    """Run the CLI with extra environment variables (e.g. the experimental gate)."""
-    return subprocess.run(
-        [sys.executable, "-m", "compose_lint", *args],
-        capture_output=True,
-        text=True,
-        env={**os.environ, **env_extra},
     )
 
 
@@ -382,17 +369,21 @@ class TestCLI:
         assert "CL-0003" in result.stderr
 
 
-_EXPERIMENTAL = {"COMPOSE_LINT_EXPERIMENTAL": "1"}
 _BARE_SERVICE = "services:\n  web:\n    image: nginx:1.27\n"
 
 
 class TestFixSubcommand:
-    """Tests for the hidden, experimental `fix` subcommand (ADR-014)."""
+    """Tests for the hidden, experimental `fix` subcommand (ADR-014).
+
+    Post-Phase-2 `fix` is reachable without ``COMPOSE_LINT_EXPERIMENTAL``, so
+    these invoke it with a plain ``run_cli``; the env var now only gates SARIF
+    fixes (see ``test_sarif``).
+    """
 
     def test_dry_run_prints_diff_to_stdout(self, tmp_path: Path) -> None:
         f = tmp_path / "docker-compose.yml"
         f.write_text(_BARE_SERVICE)
-        result = run_cli_env(_EXPERIMENTAL, "fix", str(f))
+        result = run_cli("fix", str(f))
         assert result.returncode == 0
         # Diff (data) on stdout; warning + status (human) on stderr.
         assert "+    read_only: true" in result.stdout
@@ -404,7 +395,7 @@ class TestFixSubcommand:
     def test_apply_writes_file_and_emits_no_diff(self, tmp_path: Path) -> None:
         f = tmp_path / "docker-compose.yml"
         f.write_text(_BARE_SERVICE)
-        result = run_cli_env(_EXPERIMENTAL, "fix", "--apply", str(f))
+        result = run_cli("fix", "--apply", str(f))
         assert result.returncode == 0
         assert result.stdout == ""
         patched = f.read_text()
@@ -417,7 +408,7 @@ class TestFixSubcommand:
         f = tmp_path / "docker-compose.yml"
         f.write_text(_BARE_SERVICE)
         f.chmod(0o640)
-        result = run_cli_env(_EXPERIMENTAL, "fix", "--apply", str(f))
+        result = run_cli("fix", "--apply", str(f))
         assert result.returncode == 0
         assert stat.S_IMODE(f.stat().st_mode) == 0o640
         assert "read_only: true" in f.read_text()
@@ -425,7 +416,7 @@ class TestFixSubcommand:
     def test_only_restricts_to_named_rule(self, tmp_path: Path) -> None:
         f = tmp_path / "docker-compose.yml"
         f.write_text(_BARE_SERVICE)
-        run_cli_env(_EXPERIMENTAL, "fix", "--apply", "--only", "CL-0007", str(f))
+        run_cli("fix", "--apply", "--only", "CL-0007", str(f))
         patched = f.read_text()
         assert "read_only: true" in patched
         assert "no-new-privileges" not in patched
@@ -435,25 +426,27 @@ class TestFixSubcommand:
         f.write_text(_BARE_SERVICE)
         config = tmp_path / ".compose-lint.yml"
         config.write_text("rules:\n  CL-0007:\n    enabled: false\n")
-        run_cli_env(_EXPERIMENTAL, "fix", "--apply", "--config", str(config), str(f))
+        run_cli("fix", "--apply", "--config", str(config), str(f))
         patched = f.read_text()
         # CL-0007 suppressed => not fixed; CL-0003 still applied.
         assert "read_only: true" not in patched
         assert "no-new-privileges:true" in patched
 
-    def test_hidden_from_help_even_when_enabled(self) -> None:
-        result = run_cli_env(_EXPERIMENTAL, "--help")
+    def test_hidden_from_help(self) -> None:
+        # Always registered post-Phase-2, but still omitted from --help.
+        result = run_cli("--help")
         assert result.returncode == 0
         assert "fix" not in result.stdout
 
-    def test_unavailable_without_env_gate(self, tmp_path: Path) -> None:
+    def test_available_without_env_gate(self, tmp_path: Path) -> None:
         f = tmp_path / "docker-compose.yml"
         f.write_text(_BARE_SERVICE)
-        # Without the gate, `fix` is not a subcommand: the shim routes it to
-        # `check` as a (missing) file, so no fix runs and no warning prints.
+        # Phase 2: `fix` runs without COMPOSE_LINT_EXPERIMENTAL — still hidden,
+        # still warned-on, dry-run by default (writes nothing).
         result = run_cli("fix", str(f))
-        assert result.returncode == 2
-        assert "experimental" not in result.stderr.lower()
+        assert result.returncode == 0
+        assert "experimental" in result.stderr.lower()
+        assert "+    read_only: true" in result.stdout
         assert f.read_text() == _BARE_SERVICE
 
     def test_apply_refuses_to_write_invalid_compose(
@@ -470,7 +463,6 @@ class TestFixSubcommand:
 
         f = tmp_path / "docker-compose.yml"
         f.write_text(_BARE_SERVICE)
-        monkeypatch.setenv("COMPOSE_LINT_EXPERIMENTAL", "1")
         monkeypatch.setattr(cli, "apply_edits", lambda text, edits: "services: [\n")
         with pytest.raises(SystemExit) as exc:
             cli.main(["fix", "--apply", str(f)])
@@ -491,7 +483,6 @@ class TestFixSubcommand:
 
         f = tmp_path / "docker-compose.yml"
         f.write_text(_BARE_SERVICE)
-        monkeypatch.setenv("COMPOSE_LINT_EXPERIMENTAL", "1")
         drifted = _BARE_SERVICE + "  ghost:\n    image: scratch\n"
         monkeypatch.setattr(cli, "apply_edits", lambda text, edits: drifted)
         with pytest.raises(SystemExit) as exc:


### PR DESCRIPTION
## Why

ADR-014 Part 5 stages `fix`'s exposure. Phase 1 hid it behind `COMPOSE_LINT_EXPERIMENTAL=1`. This is **Phase 2**: make `fix` reachable without the env var, while keeping it hidden, warned-on, dry-run-by-default, and out of the SemVer contract. (Phase 3, ~1.0, will unhide it and bring it under contract.)

## What

- **Drop the env gate** in two places (`cli.py`): the argv shim (`_subcommands`) and subparser registration (`_build_parser`). `compose-lint fix ...` now routes and runs without the env var.
- **Still hidden** from `--help` — the `fix` subparser still omits `help=`; that omission is now the only thing hiding it.
- **Keep the third gate**: structured SARIF `fixes[]` in `check --format sarif` stay behind `COMPOSE_LINT_EXPERIMENTAL=1` until Phase 3. `_experimental_enabled()` now only controls that, and its docstring says so.
- **Warning reworded** to the agreed Phase 2 text: *"'fix' is experimental; its flags, output, and behavior may change in any release. Dry-run by default — review the diff before --apply."*
- **Tests**: fix-command tests now invoke `fix` without the env (its whole point); the old `test_unavailable_without_env_gate` inverts to `test_available_without_env_gate`; `test_hidden_from_help` stays; dropped the now-dead `run_cli_env` helper and the orphaned `os` import. SARIF-fix gating test keeps the env (still gated).
- **Docs**: `docs/compatibility.md` reworded (reachable-but-hidden, not env-gated; SARIF note retained) and an `[Unreleased]` CHANGELOG entry.

## Not in this PR

- **Version bump (0.8.0 → 0.9.0)** — done by `release-prep.yml` when the release is cut, not here (per `docs/RELEASING.md`). The CHANGELOG `[Unreleased]` entry is staged for it to promote.

## Verification

- Full gate green locally: `ruff check`, `ruff format --check`, `mypy src/` (strict), `pytest` (641 passed, 2 corpus-gated skips).
- Smoke: `compose-lint fix <file>` with **no env var** → exit 0, new warning, dry-run diff on stdout, file untouched; `--help` does not list `fix`.

Refs ADR-014 (Part 5, Phase 2).