### PR TITLE
Backfill the Unreleased changelog ahead of 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Experimental `fix` subcommand** (ADR-014) that auto-remediates the
+  mechanically-safe findings — CL-0003, CL-0005, CL-0007, CL-0009,
+  CL-0014, and CL-0015. Dry-run by default (prints a unified diff and
+  flags behavior-changing edits); `--apply` writes fixes in place;
+  `--only` restricts to named rules; `.compose-lint.yml` suppressions are
+  honored; and SARIF output can carry the edits as `fixes[]`. It is
+  reachable without `COMPOSE_LINT_EXPERIMENTAL` but stays hidden from
+  `--help`, prints an experimental warning on every run, is dry-run by
+  default, and is excluded from the SemVer contract until promoted.
+  (#246, #247, #250, #251, #253, #255, #260, #263, #264, #265, #266,
+  #267, #268, #269, #270)
+- `check` as an explicit subcommand, with the CLI routed through argparse
+  subcommands; bare `compose-lint <file>` still works as an implicit
+  `check`, and `--explain CL-XXXX` prints a rule's documentation
+  (ADR-011). (#248)
+- `skip-suppressed`, `quiet`, and `verbose` inputs on the GitHub Action,
+  mirroring the CLI flags. (#258)
+- A published compatibility and stability policy
+  (`docs/compatibility.md`) documenting what SemVer does and does not
+  cover, including the JSON `version` field. (#254)
+
 ### Changed
 
-- The experimental `fix` subcommand is now reachable without setting
-  `COMPOSE_LINT_EXPERIMENTAL=1` (ADR-014 Phase 2). It remains hidden from
-  `--help`, prints an experimental warning on every run, is dry-run by
-  default, and stays excluded from the SemVer contract until promoted.
-  Structured SARIF `fixes[]` from the engine remain behind
-  `COMPOSE_LINT_EXPERIMENTAL=1` until full promotion.
+- JSON output is wrapped in a versioned envelope: the findings array now
+  sits under a top-level object carrying a `version` field, so consumers
+  can detect the schema (ADR-015). (#252)
+- `--explain` is rejected when combined with `--format json` or
+  `--format sarif`, which produced meaningless output. (#257)
+- CIS Docker Benchmark citations re-grounded to v1.7.0. (#256)
 
 ## [0.8.0] - 2026-05-23
 


### PR DESCRIPTION
## Why

`release-prep.yml` promotes the `[Unreleased]` section **verbatim** into the new version, so anything missing there ships undocumented (the trap that hit 0.5.2 — four PRs with no entries). Every user-facing PR merged since `v0.8.0` (`94c3389`, #241) was missing except the Phase 2 entry. This fills the gap before we cut 0.9.0.

**No version bump here** — `release-prep.yml` owns the `0.8.0 → 0.9.0` bump and the `[Unreleased]` → `[0.9.0]` promotion.

## Coverage audit (PRs since v0.8.0)

**Included (user-facing):**
| PR(s) | Entry |
|---|---|
| #246, #247, #250, #251, #253, #255, #260, #263–#270 | Experimental `fix` subcommand (one umbrella `Added` entry) |
| #248 | `check` subcommand + argparse routing + `--explain` |
| #258 | Action `skip-suppressed` / `quiet` / `verbose` inputs |
| #254 | Compatibility & stability policy doc |
| #252 | JSON versioned envelope |
| #257 | `--explain` rejected with `--format json`/`sarif` |
| #256 | CIS Docker Benchmark citations → v1.7.0 |

**Omitted (not user-facing):** #242 (release pin bump), #243 (demo regen), #244 (README positioning copy), #245 (test import style), #249 (internal docs/citations), #259 (version-bump tooling docs), #262 (Renovate base-image digest bump).

## Judgment calls for your review

1. **Experimental `fix` is folded into one `Added` entry** rather than enumerating its ~14 hardening PRs as separate Fixed/Changed items — no released user could reach the feature before this cycle, so its internal evolution isn't separately notable. All PR numbers are still cited for traceability.
2. **The fix feature is announced at all** — it's experimental and hidden, but now reachable, and the previously-approved Phase 2 entry already referenced it (incoherently, since it was never introduced). Announcing it makes that coherent.
3. **#256 (CIS citations)** included as a minor `Changed` because the rule reference text users see shifts; tell me if you'd rather drop it.

Adjust any of these in review and I'll amend.