### PR TITLE
Maintain CHANGELOG compare-link footer (backfill 0.9.0 + automate)

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -3,8 +3,8 @@ name: Release prep
 # Maintainer-triggered. Opens the "Prepare X.Y.Z release" PR for you:
 # bumps pyproject.toml + src/compose_lint/__init__.py, renames the
 # CHANGELOG [Unreleased] section to [X.Y.Z] - <today>, inserts a fresh
-# empty [Unreleased] above it, commits on a release/X.Y.Z branch, and
-# opens a PR against main.
+# empty [Unreleased] above it, updates the CHANGELOG compare-link footer,
+# commits on a release/X.Y.Z branch, and opens a PR against main.
 #
 # The signed annotated tag is NOT created here. After the PR merges,
 # run `git tag -s vX.Y.Z -m "compose-lint X.Y.Z" && git push origin vX.Y.Z`
@@ -89,6 +89,38 @@ jobs:
             exit 1
           fi
           mv CHANGELOG.md.new CHANGELOG.md
+
+      - name: Update CHANGELOG compare links
+        env:
+          VERSION: ${{ inputs.version }}
+          REPO: ${{ github.repository }}
+        run: |
+          # The [Unreleased] footer link encodes the previous release as
+          # vPREV...HEAD. Point [Unreleased] at the new version and insert a
+          # [X.Y.Z] link comparing vPREV...vX.Y.Z. This is cosmetic, so warn
+          # (don't fail the release) if the footer link is missing or unparseable.
+          url="https://github.com/${REPO}/compare"
+          unreleased=$(grep -E '^\[Unreleased\]: ' CHANGELOG.md || true)
+          if [ -z "${unreleased}" ]; then
+            echo "::warning::No [Unreleased] compare link in CHANGELOG.md; skipping footer update"
+            exit 0
+          fi
+          prev=$(printf '%s\n' "${unreleased}" \
+            | sed -nE 's#^.*/compare/v([0-9]+\.[0-9]+\.[0-9]+)\.\.\.HEAD$#\1#p')
+          if [ -z "${prev}" ]; then
+            echo "::warning::Could not parse previous version from '${unreleased}'; skipping footer update"
+            exit 0
+          fi
+          awk -v v="${VERSION}" -v prev="${prev}" -v url="${url}" '
+            /^\[Unreleased\]: / {
+              print "[Unreleased]: " url "/v" v "...HEAD"
+              print "[" v "]: " url "/v" prev "...v" v
+              next
+            }
+            { print }
+          ' CHANGELOG.md > CHANGELOG.md.new
+          mv CHANGELOG.md.new CHANGELOG.md
+          grep -E "^\[Unreleased\]: |^\[${VERSION}\]: " CHANGELOG.md
 
       - name: Verify versions match
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -698,7 +698,8 @@ First public release.
   inputs through `env:` rather than direct `${{ }}` interpolation to prevent
   shell injection.
 
-[Unreleased]: https://github.com/tmatens/compose-lint/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/tmatens/compose-lint/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/tmatens/compose-lint/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/tmatens/compose-lint/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/tmatens/compose-lint/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/tmatens/compose-lint/compare/v0.6.0...v0.7.0


### PR DESCRIPTION
Follow-up to the 0.9.0 release: the CHANGELOG compare-link footer wasn't being maintained, so each release left it stale (0.9.0 shipped with `[Unreleased]` still at `v0.8.0...HEAD` and no `[0.9.0]` link; 0.5.x needed the same hand-fix).

## Commits

1. **Backfill 0.9.0** — point `[Unreleased]` at `v0.9.0...HEAD` and add `[0.9.0]: …compare/v0.8.0...v0.9.0`. One-time data fix for the release that already shipped.
2. **Automate in release-prep** — a new step (after the `[Unreleased]`→`[X.Y.Z]` rename) parses the previous version from the existing `[Unreleased]` link (`vPREV...HEAD`), repoints `[Unreleased]` at `vX.Y.Z...HEAD`, and inserts `[X.Y.Z]: …compare/vPREV...vX.Y.Z`. No new input needed. The footer is cosmetic, so a missing/unparseable link **warns rather than failing** the release.

## Verification

Dry-ran the transform on the current CHANGELOG simulating a `1.0.0` release:
```
[Unreleased]: …/compare/v1.0.0...HEAD
[1.0.0]:      …/compare/v0.9.0...v1.0.0
[0.9.0]:      …/compare/v0.8.0...v0.9.0   (preserved)
```
`prev` parsed correctly as `0.9.0`; prior links untouched. Workflow YAML validated.

Docs/workflow only.