### PR TITLE
Make CL-0003 fixer extends-aware to avoid duplicate security_opt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The CL-0003 (`no-new-privileges`) fixer no longer adds `security_opt` to a
+  service that uses `extends:`. Docker concatenates list fields across an
+  `extends` merge, so fixing both a base and the service extending it produced a
+  duplicated `no-new-privileges:true` that `docker compose config` rejects. The
+  base is still fixed and the child inherits the entry.
+
 ## [0.9.0] - 2026-05-24
 
 ### Added

--- a/scripts/corpus/README.md
+++ b/scripts/corpus/README.md
@@ -42,6 +42,31 @@ LINT_WORKERS=4 python scripts/corpus/fix_gate.py
 
 Use it as the fast local loop while iterating on a fixer; the committed pytest gate stays authoritative (`COMPOSE_LINT_CORPUS=~/.cache/compose-lint-corpus pytest tests/test_corpus_fix.py`). It also prints findings-fixed counts per rule — a quick coverage signal to diff against the baseline after changing a fixer. Exits non-zero if any invariant fails.
 
+## Docker config gate (external validity)
+
+`docker_config_gate.py` answers a question `fix_gate.py` can't: does **Docker's own loader** still accept a file after `compose-lint fix --apply`? The fix gate checks our internal ADR-014 invariants (re-parse, idempotent, no new finding); this one runs `docker compose config -q` on the patched text.
+
+It is **differential** — many real files fail `docker compose config` on their own (missing `include:` targets, env-only required values), which isn't our regression. A file only counts as a REGRESSION when Docker accepted the *original* but rejects the *fixed* version. To stay cheap it validates the fixed file first and only re-checks the original when the fixed one fails.
+
+```bash
+python scripts/corpus/docker_config_gate.py            # all cores, full corpus (~9 min)
+python scripts/corpus/docker_config_gate.py --limit 300  # quick sample
+LINT_WORKERS=4 python scripts/corpus/docker_config_gate.py
+```
+
+Requires the Docker Compose CLI plugin. If `docker compose version` fails the gate SKIPs with exit 0, so a Docker-less leg never breaks on it. Install at user level (no root):
+
+```bash
+v=v5.1.4; asset="docker-compose-linux-$(uname -m)"
+base="https://github.com/docker/compose/releases/download/$v"
+cd "$(mktemp -d)"
+curl -fsSL -O "$base/$asset" -O "$base/$asset.sha256"
+sha256sum -c "$asset.sha256"                       # must print: OK
+mkdir -p ~/.docker/cli-plugins
+install -m 0755 "$asset" ~/.docker/cli-plugins/docker-compose
+docker compose version
+```
+
 ## Tiers
 
 - `canonical` — official upstream examples (what people copy from READMEs)

--- a/scripts/corpus/docker_config_gate.py
+++ b/scripts/corpus/docker_config_gate.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""External-validity gate — does Docker still accept a file after we fix it?
+
+The fix_gate (and the committed ``tests/test_corpus_fix.py``) prove the
+*internal* ADR-014 invariants: patched text re-parses with our own parser, is
+idempotent, and adds no new finding. This gate proves the *external* one: that
+``docker compose config`` — Docker's own loader/interpolator — still accepts the
+file after ``compose-lint fix --apply``.
+
+It is differential. Many real corpus files fail ``docker compose config`` on
+their own (missing ``include:`` targets, env-only required values, etc.), and
+that is not our fault. So a file is only a REGRESSION when Docker accepted the
+*original* but rejects the *fixed* version. To keep the run cheap we validate the
+fixed file first and only fall back to validating the original when the fixed one
+fails — the common case (fix is fine) costs a single ``config`` invocation.
+
+Requires the Docker Compose CLI plugin (``docker compose version``). If it is
+absent the gate SKIPs with exit 0 so it never breaks a Docker-less CI leg.
+
+    python scripts/corpus/docker_config_gate.py            # all cores, full corpus
+    python scripts/corpus/docker_config_gate.py --limit 300  # quick sample
+    LINT_WORKERS=4 python scripts/corpus/docker_config_gate.py
+
+Corpus lives outside the repo at ~/.cache/compose-lint-corpus/files/ (see
+README.md). Exits non-zero if any fix regresses Docker acceptance.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from multiprocessing import Pool
+from pathlib import Path
+
+from compose_lint.engine import run_rules
+from compose_lint.fix import apply_edits, collect_edits
+from compose_lint.parser import (
+    ComposeError,
+    ComposeNotApplicableError,
+    load_compose,
+)
+
+CACHE = Path.home() / ".cache" / "compose-lint-corpus"
+FILES = CACHE / "files"
+WORKERS = int(os.environ.get("LINT_WORKERS", str(os.cpu_count() or 4)))
+# config is pure parse + interpolation, but guard against a pathological hang.
+CONFIG_TIMEOUT = 30
+
+
+def _docker_config_ok(text: str) -> tuple[bool, str]:
+    """Write ``text`` to an isolated project dir and run ``docker compose config``.
+
+    Returns ``(accepted, stderr)``. Each file gets its own temp dir so Docker's
+    env-file / project-name resolution can't leak between files or pick up a
+    stray ``.env`` from the shared cwd.
+    """
+    with tempfile.TemporaryDirectory() as project:
+        compose = Path(project) / "compose.yaml"
+        compose.write_text(text, encoding="utf-8")
+        try:
+            proc = subprocess.run(
+                ["docker", "compose", "-f", str(compose), "config", "-q"],
+                capture_output=True,
+                text=True,
+                timeout=CONFIG_TIMEOUT,
+            )
+        except subprocess.TimeoutExpired:
+            return False, f"timeout after {CONFIG_TIMEOUT}s"
+        return proc.returncode == 0, proc.stderr.strip()
+
+
+def check_file(path: Path) -> dict:
+    """Validate one file's fix against ``docker compose config``."""
+    result: dict = {
+        "fixed": 0,
+        "fixed_ok": 0,
+        "regression": None,
+        "preexisting": 0,
+    }
+    try:
+        data, lines = load_compose(path)
+    except (ComposeError, ComposeNotApplicableError, FileNotFoundError):
+        return result
+    text = path.read_text(encoding="utf-8")
+    findings = run_rules(data, lines)
+    collected = collect_edits(findings, data, lines, text)
+    if not collected.edits:
+        return result
+    result["fixed"] = 1
+    patched = apply_edits(text, collected.edits)
+
+    fixed_ok, fixed_err = _docker_config_ok(patched)
+    if fixed_ok:
+        result["fixed_ok"] = 1
+        return result
+
+    # Fixed text was rejected — was the original accepted? If so, we broke it.
+    orig_ok, _ = _docker_config_ok(text)
+    if orig_ok:
+        reason = fixed_err.splitlines()[-1] if fixed_err else "rejected"
+        result["regression"] = f"{path.name}: {reason}"
+    else:
+        result["preexisting"] = 1
+    return result
+
+
+def _plugin_available() -> bool:
+    try:
+        proc = subprocess.run(
+            ["docker", "compose", "version"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+    return proc.returncode == 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="validate only the first N corpus files (0 = all)",
+    )
+    args = parser.parse_args()
+
+    if not _plugin_available():
+        print(
+            "SKIP: 'docker compose' plugin not available; "
+            "install it to run the external-validity gate.",
+            file=sys.stderr,
+        )
+        return 0
+
+    files = sorted(FILES.glob("*.yml"))
+    if not files:
+        print(f"no corpus files under {FILES}", file=sys.stderr)
+        return 2
+    if args.limit:
+        files = files[: args.limit]
+    print(f"corpus files: {len(files)} · workers: {WORKERS}", file=sys.stderr)
+
+    fixed = fixed_ok = preexisting = 0
+    regressions: list[str] = []
+
+    started = time.monotonic()
+    with Pool(processes=WORKERS) as pool:
+        for record in pool.imap_unordered(check_file, files, chunksize=8):
+            fixed += record["fixed"]
+            fixed_ok += record["fixed_ok"]
+            preexisting += record["preexisting"]
+            if record["regression"]:
+                regressions.append(record["regression"])
+    elapsed = time.monotonic() - started
+
+    print(f"files with fixes: {fixed}  ({elapsed:.0f}s)")
+    print(f"  docker accepts fixed file:        {fixed_ok}")
+    print(f"  docker rejected orig AND fixed:   {preexisting}  (pre-existing)")
+    print(f"  REGRESSIONS (orig ok, fixed bad): {len(regressions)}")
+    for item in regressions[:25]:
+        print(f"    {item}")
+
+    if regressions:
+        print("RESULT: FAIL")
+        return 1
+    print("RESULT: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/compose_lint/rules/CL0003_no_new_privileges.py
+++ b/src/compose_lint/rules/CL0003_no_new_privileges.py
@@ -97,10 +97,11 @@ class NoNewPrivilegesRule(BaseRule):
         the only hardening-only fixer (ADR-014) — blocking setuid/setgid
         escalation has near-zero breakage — so the edit carries no caveat.
 
-        Refuses (returns ``None``) for anchored/merged services, a flow-style or
-        non-list ``security_opt``, a service whose child indentation cannot be
-        determined, or a ``security_opt`` that already names ``no-new-privileges``
-        with a different value (appending the true form would duplicate the key).
+        Refuses (returns ``None``) for anchored/merged services, services that
+        use ``extends:``, a flow-style or non-list ``security_opt``, a service
+        whose child indentation cannot be determined, or a ``security_opt`` that
+        already names ``no-new-privileges`` with a different value (appending the
+        true form would duplicate the key).
         """
         service = finding.service
         services = data.get("services")
@@ -108,6 +109,15 @@ class NoNewPrivilegesRule(BaseRule):
             return None
         service_config = services.get(service)
         if not isinstance(service_config, dict):
+            return None
+
+        if "extends" in service_config:
+            # Docker concatenates list fields like ``security_opt`` across an
+            # ``extends`` merge. If we add the entry here and the base also gets
+            # it (the rule fires on both, since the parser doesn't resolve
+            # ``extends``), Docker sees two equal items and rejects the file.
+            # The base — or any non-extending service — still gets fixed, and the
+            # child inherits it. Refuse; leave extends chains for the human.
             return None
 
         key_line = lines.get(f"services.{service}")

--- a/tests/test_CL0003.py
+++ b/tests/test_CL0003.py
@@ -235,3 +235,19 @@ class TestNoNewPrivilegesFix:
             "    image: nginx\n"
         )
         assert self._fix(tmp_path, content) is None
+
+    def test_refuses_service_using_extends(self, tmp_path: Path) -> None:
+        # Docker concatenates security_opt across an extends merge, so fixing both
+        # the base and the child yields a duplicate item Docker rejects. The base
+        # still gets fixed and the child inherits it; refuse on the child.
+        content = (
+            "services:\n"
+            "  base:\n"
+            "    image: nginx\n"
+            "  child:\n"
+            "    extends: base\n"
+            "    image: nginx\n"
+        )
+        assert self._fix(tmp_path, content, service="child") is None
+        # The base, which does not extend, is still fixed.
+        assert self._fix(tmp_path, content, service="base") is not None


### PR DESCRIPTION
## What

The CL-0003 (`no-new-privileges`) fixer refuses to add `security_opt` to a service that uses `extends:`. It also adds `scripts/corpus/docker_config_gate.py`, the external-validity corpus gate that surfaced the bug.

## The bug

Docker **concatenates list fields** like `security_opt` across an `extends` merge. The CL-0003 rule fires on both a base service and a service that `extends` it (the parser deliberately doesn't resolve `extends`), so the fixer added `no-new-privileges:true` to each. After Docker's merge the child had two equal items, which `docker compose config` rejects:

```
services.<svc>.security_opt items at 0 and 1 are equal
```

Our internal `fix_gate` couldn't catch this — PyYAML collapses the merge to a single item, so the re-parse looks clean. Only Docker's stricter loader sees the collision.

## The fix

Refuse the fix when a service uses `extends:`. The base (or any non-extending service) is still fixed, and the child **inherits** the entry through the merge — so it stays protected with a single item. Confirmed against `docker compose config`:

- base-only `no-new-privileges` + `extends` child → child resolves to one entry, **accepted**
- base + child both set → duplicate, **rejected**

## Evidence (full corpus, 6,444 real GitHub compose files)

| `docker compose config` on fixed files | before | after |
|---|---|---|
| accepts fixed file | 4414 | 4423 |
| rejected orig AND fixed (pre-existing) | 1246 | 1246 |
| **regressions (orig ok, fixed bad)** | **9** | **0** |

All 9 regressions used `extends:`. Internal fix-gate still PASS (CL-0003 fix count 12675→12490; the 185 extending children are now correctly refused but inherit protection).

## New tooling

`scripts/corpus/docker_config_gate.py` runs `docker compose config` over the corpus **differentially** — a file only counts as a regression when Docker accepted the original but rejects the fixed version, so pre-existing Docker-invalid files don't count. SKIPs (exit 0) when the compose plugin is absent. Complements `fix_gate.py` (internal ADR-014 invariants) with external validity.

## Checks

- 642 pytest pass, 2 skipped · mypy clean · ruff check/format clean on `src/ tests/`
- internal `fix_gate.py`: PASS · external `docker_config_gate.py`: 0 regressions corpus-wide