### PR TITLE
Refuse extends-merged security_opt fixes on both sides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- The CL-0003 (`no-new-privileges`) fixer no longer adds `security_opt` to a
-  service that uses `extends:`. Docker concatenates list fields across an
-  `extends` merge, so fixing both a base and the service extending it produced a
-  duplicated `no-new-privileges:true` that `docker compose config` rejects. The
-  base is still fixed and the child inherits the entry.
+- The `fix` engine no longer adds `no-new-privileges:true` to either side of an
+  `extends` relationship. Docker concatenates list fields like `security_opt`
+  across an `extends` merge, so adding the entry to a service that `extends:`
+  another — or to a base another service extends — could produce a duplicated
+  item that `docker compose config` rejects. The duplicate only exists after
+  Docker's merge (our parser does not resolve `extends`), so the post-apply
+  reparse guard could not catch it. Both the per-finding CL-0003 fixer and the
+  CL-0003/CL-0009 coordination pass now refuse both sides and leave the chain
+  for manual review. (#276, #277)
 
 ## [0.9.0] - 2026-05-24
 

--- a/src/compose_lint/fix.py
+++ b/src/compose_lint/fix.py
@@ -33,6 +33,41 @@ DISABLED_SECURITY_PROFILES = frozenset(
 )
 
 
+def extends_targets(data: dict[str, Any]) -> set[str]:
+    """Return the names of services another in-file service ``extends``.
+
+    A base service must not have list-valued fields (``security_opt``,
+    ``cap_add``, ...) auto-appended or created by a fixer: Docker append-merges
+    the base's list into every service that ``extends`` it, so an item we add to
+    the base can collide with one the child already declares — or one a fixer
+    adds to a sibling — yielding a duplicate item Docker rejects. Our parser
+    never resolves ``extends``, so that duplicate exists only post-merge, where
+    neither the reparse guard nor ``verify_apply`` can see it. This mirrors the
+    child-side ``"extends" in service_config`` refusal the per-finding fixers
+    already carry (issue #277 C1).
+
+    Only same-file targets count: an ``extends`` carrying a ``file:`` key points
+    at a base in another file, so a like-named local service is not its target.
+    Both the mapping form (``extends: {service: base}``) and the string short
+    form (``extends: base``) are recognised.
+    """
+    services = data.get("services")
+    if not isinstance(services, dict):
+        return set()
+    targets: set[str] = set()
+    for name, config in services.items():
+        if name == "__lines__" or not isinstance(config, dict):
+            continue
+        ext = config.get("extends")
+        if isinstance(ext, str):
+            targets.add(ext)
+        elif isinstance(ext, dict) and not ext.get("file"):
+            service = ext.get("service")
+            if isinstance(service, str):
+                targets.add(service)
+    return targets
+
+
 class OverlappingEditError(ValueError):
     """Raised when two edits target overlapping regions of the same file."""
 
@@ -466,6 +501,12 @@ def _coordinate_security_opt(
         return None
     service_config = services.get(service)
     if not isinstance(service_config, dict):
+        return None
+    if "extends" in service_config or service in extends_targets(data):
+        # Either side of an extends merge: rewriting this security_opt would
+        # collide with the append-merged list on the other side (issue #277 C1).
+        # The per-finding fixers already refuse the child side; refuse the base
+        # side too, since the coordinator re-implements the security_opt add.
         return None
     security_opt = service_config.get("security_opt")
     if not isinstance(security_opt, list) or not security_opt:

--- a/src/compose_lint/rules/CL0003_no_new_privileges.py
+++ b/src/compose_lint/rules/CL0003_no_new_privileges.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 from compose_lint.fix import (
     DISABLED_SECURITY_PROFILES,
     block_span,
+    extends_targets,
     first_child_indent,
     is_anchored_or_merged,
     line_indent,
@@ -97,8 +98,9 @@ class NoNewPrivilegesRule(BaseRule):
         the only hardening-only fixer (ADR-014) — blocking setuid/setgid
         escalation has near-zero breakage — so the edit carries no caveat.
 
-        Refuses (returns ``None``) for anchored/merged services, services that
-        use ``extends:``, a flow-style or non-list ``security_opt``, a service
+        Refuses (returns ``None``) for anchored/merged services, either side of
+        an ``extends`` merge (the service uses ``extends:``, or a sibling
+        ``extends`` it), a flow-style or non-list ``security_opt``, a service
         whose child indentation cannot be determined, or a ``security_opt`` that
         already names ``no-new-privileges`` with a different value (appending the
         true form would duplicate the key).
@@ -111,13 +113,15 @@ class NoNewPrivilegesRule(BaseRule):
         if not isinstance(service_config, dict):
             return None
 
-        if "extends" in service_config:
+        if "extends" in service_config or service in extends_targets(data):
             # Docker concatenates list fields like ``security_opt`` across an
-            # ``extends`` merge. If we add the entry here and the base also gets
-            # it (the rule fires on both, since the parser doesn't resolve
-            # ``extends``), Docker sees two equal items and rejects the file.
-            # The base — or any non-extending service — still gets fixed, and the
-            # child inherits it. Refuse; leave extends chains for the human.
+            # ``extends`` merge. Adding the entry to either side risks a duplicate
+            # post-merge: a child that adds it collides with the inherited copy,
+            # and a base that adds it collides with one the child already declares
+            # or that a sibling fixer adds. The rule fires on every unmerged
+            # service (the parser doesn't resolve ``extends``), and the duplicate
+            # exists only inside Docker, so the reparse guard can't catch it.
+            # Refuse both sides; leave extends chains for the human (issue #277 C1).
             return None
 
         key_line = lines.get(f"services.{service}")

--- a/tests/test_CL0003.py
+++ b/tests/test_CL0003.py
@@ -236,10 +236,12 @@ class TestNoNewPrivilegesFix:
         )
         assert self._fix(tmp_path, content) is None
 
-    def test_refuses_service_using_extends(self, tmp_path: Path) -> None:
-        # Docker concatenates security_opt across an extends merge, so fixing both
-        # the base and the child yields a duplicate item Docker rejects. The base
-        # still gets fixed and the child inherits it; refuse on the child.
+    def test_refuses_both_sides_of_extends(self, tmp_path: Path) -> None:
+        # Docker concatenates security_opt across an extends merge, so adding the
+        # entry to either side can duplicate it post-merge (issue #277 C1): a base
+        # that adds it collides with one the child already carries (or that a
+        # sibling fixer adds), and the child collides with the inherited copy.
+        # Both sides refuse; the human resolves the chain.
         content = (
             "services:\n"
             "  base:\n"
@@ -249,5 +251,20 @@ class TestNoNewPrivilegesFix:
             "    image: nginx\n"
         )
         assert self._fix(tmp_path, content, service="child") is None
-        # The base, which does not extend, is still fixed.
-        assert self._fix(tmp_path, content, service="base") is not None
+        # The base is an extends target, so it is no longer auto-fixed either.
+        assert self._fix(tmp_path, content, service="base") is None
+
+    def test_fixes_service_with_no_extends_relation(self, tmp_path: Path) -> None:
+        # A plain service in a file that happens to use extends elsewhere is still
+        # fixed: only the base and the extending child step aside.
+        content = (
+            "services:\n"
+            "  base:\n"
+            "    image: nginx\n"
+            "  child:\n"
+            "    extends: base\n"
+            "    image: nginx\n"
+            "  standalone:\n"
+            "    image: nginx\n"
+        )
+        assert self._fix(tmp_path, content, service="standalone") is not None

--- a/tests/test_fix.py
+++ b/tests/test_fix.py
@@ -15,6 +15,7 @@ from compose_lint.fix import (
     block_span,
     collect_edits,
     delete_lines,
+    extends_targets,
     first_child_indent,
     has_anchor_child,
     has_merge_key_child,
@@ -515,6 +516,78 @@ def test_coordination_refuses_anchored_service(tmp_path: Path) -> None:
     result = collect_edits(findings, data, lines, text, only={"CL-0003", "CL-0009"})
     assert result.edits == []
     assert {"CL-0003", "CL-0009"} <= {f.rule_id for f in result.manual}
+
+
+def test_extends_targets_recognises_both_forms() -> None:
+    data = {
+        "services": {
+            "base": {"image": "nginx"},
+            "other_base": {"image": "nginx"},
+            "remote_base": {"image": "nginx"},
+            "shortform": {"extends": "base"},
+            "longform": {"extends": {"service": "other_base"}},
+            # An extends pointing at another file does not target a local service.
+            "crossfile": {"extends": {"file": "common.yml", "service": "remote_base"}},
+            "plain": {"image": "nginx"},
+        }
+    }
+    assert extends_targets(data) == {"base", "other_base"}
+
+
+def test_extends_targets_empty_without_services() -> None:
+    assert extends_targets({}) == set()
+    assert extends_targets({"services": []}) == set()
+
+
+def test_coordination_refuses_extends_child(tmp_path: Path) -> None:
+    # Issue #277 C1: the child goes through the coordination pass (it has a
+    # disable + no no-new-privileges), but it `extends` a base whose security_opt
+    # is append-merged into it. Rewriting the child here, while the base's
+    # per-finding fixer appends to the base, duplicates the entry post-merge —
+    # invisible to the reparse guard. Both sides must refuse: the file is left
+    # untouched so Docker (which accepted the original) still accepts it.
+    findings, data, lines, text = _findings_for(
+        tmp_path,
+        "services:\n"
+        "  base:\n"
+        "    image: nginx:1.27\n"
+        "    security_opt:\n"
+        "      - label:user:foo\n"
+        "  child:\n"
+        "    extends:\n"
+        "      service: base\n"
+        "    image: nginx:1.27\n"
+        "    security_opt:\n"
+        "      - seccomp:unconfined\n",
+    )
+    result = collect_edits(findings, data, lines, text, only={"CL-0003", "CL-0009"})
+    assert result.edits == []
+    manual_rules = {f.rule_id for f in result.manual}
+    assert {"CL-0003", "CL-0009"} <= manual_rules
+
+
+def test_extends_base_not_appended_when_child_declares_entry(tmp_path: Path) -> None:
+    # Issue #277 C1, base side: the child already declares no-new-privileges, so
+    # nothing fires on it, but the base lacks it and CL-0003 fires. Appending to
+    # the base would collide with the child's inherited-then-own copy post-merge.
+    # The base is an extends target, so its per-finding fixer must refuse.
+    findings, data, lines, text = _findings_for(
+        tmp_path,
+        "services:\n"
+        "  base:\n"
+        "    image: nginx:1.27\n"
+        "    security_opt:\n"
+        "      - label:user:foo\n"
+        "  child:\n"
+        "    extends:\n"
+        "      service: base\n"
+        "    image: nginx:1.27\n"
+        "    security_opt:\n"
+        "      - no-new-privileges:true\n",
+    )
+    result = collect_edits(findings, data, lines, text, only={"CL-0003", "CL-0009"})
+    assert result.edits == []
+    assert "CL-0003" in {f.rule_id for f in result.manual}
 
 
 def test_collect_edits_removes_one_item_keeps_others(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes the C1 corruption from #277 (sharpened in #279).

## The bug

Docker append-merges list fields like `security_opt` across an `extends` merge. The fix engine never resolves `extends`, so it lints and fixes each *unmerged* service in isolation. Adding `no-new-privileges:true` to a service that `extends:` another — **or** to a base another service extends — can leave a duplicate item `docker compose config` rejects. The duplicate exists only after Docker's merge, so the post-apply reparse guard and `verify_apply` can't see it.

PR #276 fixed the **child** side of the per-finding CL-0003 fixer. This PR closes the two gaps #277/#279 identified:

1. The CL-0003/CL-0009 **coordination pass** (`_coordinate_security_opt`) re-implements the `security_opt` add with no `extends` check.
2. A **base** that a sibling `extends` can still collect an append that collides with the child's own (or inherited) entry — so the per-finding fixer must refuse extends *targets*, not just services that use `extends`.

## The fix

- New `extends_targets(data)` helper: returns the in-file services another service `extends` (mapping `{service: …}` and string short forms; cross-file `extends` carrying a `file:` key excluded).
- Both the per-finding CL-0003 fixer and the coordination pass now refuse a service that uses `extends` **or** is an extends target. The chain is left for manual review.

## Verification

Against installed Docker (`v5.1.4`), the minimal repro from the issue:

```
OLD code: → services.child.security_opt items at 1 and 2 are equal  (REJECTED)
NEW code: → file left untouched; docker compose config ACCEPTS it
```

New tests:
- `test_coordination_refuses_extends_child` — the issue's exact `(disable child + non-disable base)` shape produces no edits.
- `test_extends_base_not_appended_when_child_declares_entry` — base side, where the child already declares `no-new-privileges`.
- `test_extends_targets_*` — helper unit coverage (both forms, cross-file exclusion).
- Updated `test_CL0003.py` to reflect both-sided refusal, plus a standalone-service case proving unrelated services are still fixed.

All four gates pass locally (`ruff check`, `ruff format --check`, `mypy src/`, full `pytest` — 647 passed, 2 skipped).

Per the umbrella convention I'll keep reporting #277 status per-bug.