### PR TITLE
Tolerate override tags and non-UTF-8 files in the parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Compose override-file tags `!reset` and `!override` no longer make a valid
+  file fail to parse (exit 2). `LineLoader` (a `SafeLoader` subclass) had no
+  constructor for them, so it raised a `ConstructorError`; it now constructs the
+  underlying value and ignores the merge directive, which is all the linter
+  needs. (#277)
+- A non-UTF-8 (e.g. latin-1) file now raises a per-file `ComposeError` instead
+  of an uncaught `UnicodeDecodeError`. Previously one bad-encoding file aborted
+  an entire directory sweep. (#277)
 - The `fix` engine no longer adds `no-new-privileges:true` to either side of an
   `extends` relationship. Docker concatenates list fields like `security_opt`
   across an `extends` merge, so adding the entry to a service that `extends:`

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -169,6 +169,33 @@ def _construct_sequence(loader: LineLoader, node: yaml.SequenceNode) -> list[Any
     return items
 
 
+def _construct_override_tag(loader: LineLoader, node: yaml.Node) -> Any:
+    """Construct a node carrying a Compose override tag (``!reset``/``!override``).
+
+    These are first-class Compose override-file syntax, not arbitrary YAML object
+    tags: ``!override`` replaces a value instead of merging it, and ``!reset``
+    drops an inherited value. A ``SafeLoader`` has no constructor for them, so it
+    raises ``ConstructorError`` and a valid override file is reported broken
+    (issue #277 B1). compose-lint only needs the underlying value to lint, so we
+    construct the node as if the tag were absent — delegating to the
+    line-capturing map/seq constructors so line tracking still works inside an
+    overridden block, and re-resolving a scalar's implicit type so
+    ``!override 8080`` stays an int and ``!reset null`` stays None.
+    """
+    if isinstance(node, yaml.MappingNode):
+        return _construct_mapping(loader, node)
+    if isinstance(node, yaml.SequenceNode):
+        return _construct_sequence(loader, node)
+    # Only a scalar node remains. Re-resolve its implicit type as if the tag were
+    # absent so `!override 8080` stays an int and `!reset null` stays None.
+    assert isinstance(node, yaml.ScalarNode)  # noqa: S101
+    resolved_tag = loader.resolve(yaml.ScalarNode, node.value, (True, False))  # type: ignore[no-untyped-call]
+    plain = yaml.ScalarNode(
+        resolved_tag, node.value, node.start_mark, node.end_mark, node.style
+    )
+    return loader.construct_object(plain)  # type: ignore[no-untyped-call]
+
+
 LineLoader.add_constructor(
     yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
     _construct_mapping,
@@ -177,6 +204,9 @@ LineLoader.add_constructor(
     yaml.resolver.BaseResolver.DEFAULT_SEQUENCE_TAG,
     _construct_sequence,
 )
+# Compose override-file tags: parse the value, ignore the merge directive.
+LineLoader.add_constructor("!reset", _construct_override_tag)
+LineLoader.add_constructor("!override", _construct_override_tag)
 
 
 def _strip_lines(data: Any) -> Any:
@@ -319,6 +349,12 @@ def load_compose(
         content = filepath.read_text(encoding="utf-8")
     except FileNotFoundError:
         raise
+    except UnicodeDecodeError as e:
+        # A non-UTF-8 file (e.g. latin-1) raises UnicodeDecodeError, a ValueError
+        # subclass that the OSError handler below does not catch. Left uncaught it
+        # would abort a whole directory sweep on one bad file; surface it as a
+        # per-file ComposeError instead (issue #277 B2).
+        raise ComposeError(f"Invalid encoding: file is not valid UTF-8 ({e})") from e
     except OSError as e:
         raise ComposeError(f"Cannot read file: {e}") from e
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -43,6 +43,41 @@ class TestLoads:
             loads("")
 
 
+class TestOverrideTags:
+    """Compose override-file tags (`!reset` / `!override`) parse, not crash."""
+
+    def test_override_sequence(self) -> None:
+        # Issue #277 B1: !override is valid Compose syntax; the value is the list.
+        data, _lines = loads(
+            'services:\n  app:\n    image: nginx\n    ports: !override ["8443:443"]\n'
+        )
+        assert data["services"]["app"]["ports"] == ["8443:443"]
+
+    def test_reset_scalar_is_none(self) -> None:
+        data, _lines = loads(
+            "services:\n  app:\n    image: nginx\n    ports: !reset null\n"
+        )
+        assert data["services"]["app"]["ports"] is None
+
+    def test_override_scalar_keeps_implicit_type(self) -> None:
+        # The override tag is stripped, so the scalar resolves to its plain type.
+        data, _lines = loads(
+            "services:\n  app:\n    image: nginx\n    shm_size: !override 8080\n"
+        )
+        assert data["services"]["app"]["shm_size"] == 8080
+
+    def test_override_mapping_keeps_line_tracking(self) -> None:
+        data, lines = loads(
+            "services:\n"
+            "  app:\n"
+            "    image: nginx\n"
+            "    environment: !override\n"
+            "      FOO: bar\n"
+        )
+        assert data["services"]["app"]["environment"] == {"FOO": "bar"}
+        assert lines["services.app.environment.FOO"] == 5
+
+
 class TestLoadCompose:
     """Tests for load_compose function."""
 
@@ -110,6 +145,15 @@ class TestLoadCompose:
     def test_file_not_found(self) -> None:
         with pytest.raises(FileNotFoundError):
             load_compose(FIXTURES / "nonexistent.yml")
+
+    def test_non_utf8_file_raises_compose_error(self, tmp_path: Path) -> None:
+        # Issue #277 B2: a latin-1 file raises UnicodeDecodeError (a ValueError),
+        # which the OSError handler does not catch. Left uncaught it aborts a whole
+        # directory sweep; it must surface as a per-file ComposeError instead.
+        path = tmp_path / "latin1.yml"
+        path.write_bytes("services:\n  app:\n    image: caf\xe9\n".encode("latin-1"))
+        with pytest.raises(ComposeError, match="Invalid encoding"):
+            load_compose(path)
 
     def test_empty_file(self) -> None:
         with pytest.raises(ComposeError, match="file is empty"):


### PR DESCRIPTION
Fixes the two 🔴 Breakage findings from #277.

### B1 — `!reset` / `!override` rejected as invalid YAML (exit 2)
These are first-class Compose override-file syntax (`!override` replaces instead of merging; `!reset` drops an inherited value). `LineLoader` (a `SafeLoader` subclass) registered constructors only for the default map/seq tags, so any other tag raised a `ConstructorError` → `ComposeError` → exit 2. A **valid** override file was reported broken.

Now a single constructor handles both tags by building the underlying value and ignoring the merge directive:
- mapping/sequence → delegate to the existing line-capturing constructors, so line tracking still works inside an overridden block;
- scalar → re-resolve the implicit type as if the tag were absent, so `!override 8080` stays an `int` and `!reset null` stays `None`.

### B2 — non-UTF-8 file crashes the whole run
`load_compose` read with `encoding="utf-8"` but caught only `FileNotFoundError`/`OSError`. A latin-1 file raises `UnicodeDecodeError` (a `ValueError`), which slipped through — and in a directory sweep aborted *every other file*. Now caught and re-raised as a per-file `ComposeError("Invalid encoding: ...")`, so the sweep continues.

### Tests
`tests/test_parser.py`: a new `TestOverrideTags` class (override sequence, `!reset` → `None`, scalar type preservation, mapping line tracking) and a non-UTF-8 `load_compose` case.

All four gates pass locally (`ruff check`, `ruff format --check`, `mypy src/`, full `pytest` — 652 passed, 2 skipped).

Part of #277 (B1, B2). Next up: F1 (the resolver strip, also closing #278 J1).