### PR TITLE
Drop sexagesimal and timestamp scalar resolvers in the parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- CL-0005 no longer misses short-syntax ports whose host and container sides are
+  both `<= 59` (`22:22`, `25:25`, `53:53`, ...). PyYAML's YAML 1.1 resolvers
+  parsed these as a single base-60 integer (`22:22` → `1342`), so the rule's
+  `str(port)` saw no colon and reported the file clean. `LineLoader` now drops
+  the sexagesimal `int`/`float` resolver alternatives and the `timestamp`
+  resolver (a bare date like `2024-01-01` was becoming a non-JSON-serializable
+  `datetime.date`), while keeping YAML 1.1 booleans — Docker coerces
+  `yes`/`no`/`on`/`off` to booleans for boolean-typed fields, so keeping them
+  preserves CL-0002/CL-0007 parity with `docker compose config`. (#277)
 - Compose override-file tags `!reset` and `!override` no longer make a valid
   file fail to parse (exit 2). `LineLoader` (a `SafeLoader` subclass) had no
   constructor for them, so it raised a `ConstructorError`; it now constructs the

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 
@@ -207,6 +208,89 @@ LineLoader.add_constructor(
 # Compose override-file tags: parse the value, ignore the merge directive.
 LineLoader.add_constructor("!reset", _construct_override_tag)
 LineLoader.add_constructor("!override", _construct_override_tag)
+
+
+def _install_scalar_resolvers() -> None:
+    """Rebuild LineLoader's implicit scalar resolvers without two YAML 1.1 traps.
+
+    PyYAML's ``SafeLoader`` resolves plain scalars with YAML 1.1 rules, which
+    mis-type two kinds of Compose value in security-relevant ways:
+
+    * **Sexagesimal integers/floats.** ``22:22`` (and any ``H:C`` port whose
+      sides are both <= 59) parses as the base-60 integer ``1342``, so CL-0005's
+      ``str(port)`` finds no ``:`` and the published port escapes detection
+      (issue #277 F1). The same alternative turns ``5:5``/``25:25``/``53:53``
+      into integers.
+    * **Timestamps.** A bare ``2024-01-01`` becomes a ``datetime.date``, which is
+      not JSON-serializable (latent crash in the JSON/SARIF formatters) and
+      breaks string-oriented rules.
+
+    This rebuilds the resolver table from PyYAML's own patterns with the
+    sexagesimal ``int``/``float`` alternatives removed and the ``timestamp``
+    resolver dropped, leaving every other resolver byte-identical. Booleans keep
+    their YAML 1.1 spelling (``yes``/``no``/``on``/``off`` as well as
+    ``true``/``false``) deliberately: Docker's loader coerces those words to
+    booleans for boolean-typed fields — ``docker compose config`` renders
+    ``privileged: yes`` as ``privileged: true`` — so dropping them would make
+    CL-0002/CL-0007 miss a hardening bypass Docker honors. Only ``LineLoader`` is
+    re-tabled; the global ``yaml.SafeLoader`` is untouched.
+    """
+    LineLoader.yaml_implicit_resolvers = {}
+    LineLoader.add_implicit_resolver(  # type: ignore[no-untyped-call]
+        "tag:yaml.org,2002:bool",
+        re.compile(
+            r"""^(?:yes|Yes|YES|no|No|NO
+                |true|True|TRUE|false|False|FALSE
+                |on|On|ON|off|Off|OFF)$""",
+            re.X,
+        ),
+        list("yYnNtTfFoO"),
+    )
+    LineLoader.add_implicit_resolver(  # type: ignore[no-untyped-call]
+        "tag:yaml.org,2002:float",
+        re.compile(
+            r"""^(?:[-+]?(?:[0-9][0-9_]*)\.[0-9_]*(?:[eE][-+][0-9]+)?
+                |\.[0-9][0-9_]*(?:[eE][-+][0-9]+)?
+                |[-+]?\.(?:inf|Inf|INF)
+                |\.(?:nan|NaN|NAN))$""",
+            re.X,
+        ),
+        list("-+0123456789."),
+    )
+    LineLoader.add_implicit_resolver(  # type: ignore[no-untyped-call]
+        "tag:yaml.org,2002:int",
+        re.compile(
+            r"""^(?:[-+]?0b[0-1_]+
+                |[-+]?0[0-7_]+
+                |[-+]?(?:0|[1-9][0-9_]*)
+                |[-+]?0x[0-9a-fA-F_]+)$""",
+            re.X,
+        ),
+        list("-+0123456789"),
+    )
+    LineLoader.add_implicit_resolver(  # type: ignore[no-untyped-call]
+        "tag:yaml.org,2002:merge",
+        re.compile(r"^(?:<<)$"),
+        ["<"],
+    )
+    LineLoader.add_implicit_resolver(  # type: ignore[no-untyped-call]
+        "tag:yaml.org,2002:null",
+        re.compile(
+            r"""^(?: ~
+                |null|Null|NULL
+                | )$""",
+            re.X,
+        ),
+        ["~", "n", "N", ""],
+    )
+    LineLoader.add_implicit_resolver(  # type: ignore[no-untyped-call]
+        "tag:yaml.org,2002:value",
+        re.compile(r"^(?:=)$"),
+        ["="],
+    )
+
+
+_install_scalar_resolvers()
 
 
 def _strip_lines(data: Any) -> Any:

--- a/tests/test_CL0005.py
+++ b/tests/test_CL0005.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 from compose_lint.fix import apply_edits
 from compose_lint.models import Finding, Severity
-from compose_lint.parser import load_compose
+from compose_lint.parser import load_compose, loads
 from compose_lint.rules.CL0005_unbound_ports import UnboundPortsRule
 
 if TYPE_CHECKING:
@@ -32,6 +32,17 @@ class TestUnboundPortsRule:
         findings = self._check("unbound_short")
         assert len(findings) == 2
         assert all(f.rule_id == "CL-0005" for f in findings)
+
+    def test_detects_sexagesimal_port(self) -> None:
+        # `22:22` parsed as the base-60 int 1342 under YAML 1.1, so the colon
+        # vanished and the rule found no host mapping (#277 F1). With the parser
+        # fixed the port is a string again and the unbound mapping is detected.
+        data, lines = loads(
+            "services:\n  ssh:\n    image: nginx\n    ports:\n      - 22:22\n"
+        )
+        findings = list(self.rule.check("ssh", data["services"]["ssh"], data, lines))
+        assert len(findings) == 1
+        assert findings[0].rule_id == "CL-0005"
 
     def test_bound_short_syntax_no_findings(self) -> None:
         findings = self._check("bound_short")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -78,6 +78,58 @@ class TestOverrideTags:
         assert lines["services.app.environment.FOO"] == 5
 
 
+class TestScalarResolvers:
+    """LineLoader avoids the YAML 1.1 sexagesimal and timestamp traps (#277 F1)."""
+
+    def test_sexagesimal_ports_stay_strings(self) -> None:
+        # `22:22` parsed as the base-60 int 1342 under YAML 1.1, hiding the colon
+        # from CL-0005. Both sides <= 59 must now stay a string.
+        data, _lines = loads(
+            "services:\n"
+            "  a:\n"
+            "    image: nginx\n"
+            "    ports:\n"
+            "      - 22:22\n"
+            "      - 25:25\n"
+            "      - 53:53\n"
+        )
+        ports = data["services"]["a"]["ports"]
+        assert ports == ["22:22", "25:25", "53:53"]
+        assert all(isinstance(p, str) for p in ports)
+
+    def test_plain_ints_and_floats_still_typed(self) -> None:
+        data, _lines = loads(
+            "services:\n  a:\n    image: nginx\n    cpu_count: 8080\n    ratio: 3.14\n"
+        )
+        svc = data["services"]["a"]
+        assert svc["cpu_count"] == 8080
+        assert svc["ratio"] == 3.14
+
+    def test_booleans_keep_yaml_1_1_spelling(self) -> None:
+        # Docker coerces yes/no/on/off to booleans for boolean-typed fields, so
+        # these must stay bool or CL-0002/CL-0007 would miss `privileged: yes`.
+        data, _lines = loads(
+            "services:\n"
+            "  a:\n"
+            "    image: nginx\n"
+            "    privileged: yes\n"
+            "    read_only: off\n"
+        )
+        svc = data["services"]["a"]
+        assert svc["privileged"] is True
+        assert svc["read_only"] is False
+
+    def test_bare_timestamp_stays_string(self) -> None:
+        # A bare date became a datetime.date under YAML 1.1, which is not
+        # JSON-serializable and breaks string-oriented rules.
+        data, _lines = loads(
+            "services:\n  a:\n    image: nginx\n    labels:\n      built: 2024-01-01\n"
+        )
+        built = data["services"]["a"]["labels"]["built"]
+        assert built == "2024-01-01"
+        assert isinstance(built, str)
+
+
 class TestLoadCompose:
     """Tests for load_compose function."""
 


### PR DESCRIPTION
Fixes #277 **F1** (and the datetime/bytes leak noted alongside it). Also closes the parser half of #278 J1 — the implicit-resolver strip both umbrellas pointed at.

### The bug
PyYAML's `SafeLoader` uses YAML 1.1 implicit resolvers. Two mis-type Compose values:

- **Sexagesimal ints** — `22:22` (any `H:C` short-syntax port with both sides ≤ 59: `5:5`, `25:25`, `53:53`) parses as the base-60 integer `1342`. CL-0005's `str(port)` then sees no colon and reports the file clean. `8080:80` only survived because `80 > 59`.
- **Timestamps** — a bare `2024-01-01` becomes a `datetime.date`: not JSON-serializable (latent crash in JSON/SARIF) and opaque to string-oriented rules.

### The fix
Rebuild `LineLoader`'s implicit resolver table from PyYAML's own patterns, with the sexagesimal `int`/`float` alternatives removed and the `timestamp` resolver dropped. Every other resolver is byte-identical, and only `LineLoader` is re-tabled — the global `yaml.SafeLoader` is untouched.

**Booleans keep their YAML 1.1 spelling on purpose.** I verified against installed Docker:

```
$ printf 'services:\n  a:\n    image: nginx\n    privileged: %s\n' yes | docker compose -f - config
    privileged: true      # yes/on -> true; no/off/false -> false
```

Docker coerces `yes`/`no`/`on`/`off` to booleans for boolean-typed fields, so stripping the 1.1 bool resolver would make CL-0002/CL-0007 **miss** a `privileged: yes` that Docker honors — a security false negative. So this is *not* a blanket YAML 1.2 switch; it's a targeted removal of the two traps.

### Tests
- `tests/test_parser.py::TestScalarResolvers` — sexagesimal ports stay strings; plain ints/floats stay typed; `yes`/`off` stay bool; bare timestamp stays a string.
- `tests/test_CL0005.py::test_detects_sexagesimal_port` — `22:22` is now detected as an unbound port.

All four gates pass locally (`ruff`, `ruff format`, `mypy src/`, full `pytest` — 657 passed, 2 skipped).

> Note: the committed `tests/corpus_snapshot.json.gz` (CI-skipped; needs a local corpus) will shift once real-corpus sexagesimal ports start firing CL-0005. I'm batching one snapshot regeneration after the remaining #277 fixes land rather than regenerating per-PR.

Part of #277 (F1).