### PR TITLE
Treat = and : as equivalent security_opt separators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `security_opt` directives are now matched with their `=` separator treated as
+  equivalent to `:`, the way Docker accepts them. CL-0009 was missing an
+  `=`-form profile disable (`seccomp=unconfined`, `label=disable`) and CL-0003
+  was firing on a service already hardened with `no-new-privileges=true`. A
+  shared `normalize_security_opt` helper canonicalizes the separator (and case)
+  before every membership/prefix check across the rules and the fix engine.
+  (#277)
 - CL-0005 no longer misses short-syntax ports whose host and container sides are
   both `<= 59` (`22:22`, `25:25`, `53:53`, ...). PyYAML's YAML 1.1 resolvers
   parsed these as a single base-60 integer (`22:22` → `1342`), so the rule's

--- a/src/compose_lint/fix.py
+++ b/src/compose_lint/fix.py
@@ -27,10 +27,25 @@ if TYPE_CHECKING:
 # territory. Shared here so CL-0003 can decline to append into a block whose
 # entries are *all* profile-disables: CL-0009 will act on those, and appending a
 # survivor first would let a second `fix` pass delete them (breaking idempotency,
-# ADR-014). Values are matched against `str(opt).strip().lower()`.
+# ADR-014). Values are matched against `normalize_security_opt(opt)`.
 DISABLED_SECURITY_PROFILES = frozenset(
     {"seccomp:unconfined", "apparmor:unconfined", "label:disable"}
 )
+
+
+def normalize_security_opt(opt: Any) -> str:
+    """Canonicalize a ``security_opt`` entry for comparison.
+
+    Docker accepts both separators for a ``security_opt`` directive —
+    ``seccomp=unconfined`` ≡ ``seccomp:unconfined``, ``no-new-privileges=true`` ≡
+    ``no-new-privileges:true`` (verified with ``docker compose config``, which
+    accepts and preserves both). Rules and fixers compare against the colon form,
+    so without normalizing the separator CL-0009 misses an ``=``-form disable
+    (issue #277 F3) and CL-0003 fires on an already-hardened ``=``-form
+    ``no-new-privileges`` (#277 P1). Lower-cases and rewrites only the first
+    ``=`` (the key/value separator), leaving any ``=`` inside a value untouched.
+    """
+    return str(opt).strip().lower().replace("=", ":", 1)
 
 
 def extends_targets(data: dict[str, Any]) -> set[str]:
@@ -512,7 +527,8 @@ def _coordinate_security_opt(
     if not isinstance(security_opt, list) or not security_opt:
         return None
     if not any(
-        str(opt).strip().lower() in DISABLED_SECURITY_PROFILES for opt in security_opt
+        normalize_security_opt(opt) in DISABLED_SECURITY_PROFILES
+        for opt in security_opt
     ):
         return None  # no profile-disable to remove: nothing to coordinate
 
@@ -547,7 +563,7 @@ def _coordinate_security_opt(
         return None
     kept: list[str] = []
     for idx, opt in zip(item_lines, security_opt, strict=True):
-        value = str(opt).strip().lower()
+        value = normalize_security_opt(opt)
         if value in DISABLED_SECURITY_PROFILES:
             continue  # a disable CL-0009 removes
         if value.startswith("no-new-privileges"):

--- a/src/compose_lint/rules/CL0003_no_new_privileges.py
+++ b/src/compose_lint/rules/CL0003_no_new_privileges.py
@@ -11,6 +11,7 @@ from compose_lint.fix import (
     first_child_indent,
     is_anchored_or_merged,
     line_indent,
+    normalize_security_opt,
     opens_block_body,
 )
 from compose_lint.models import Finding, RuleMetadata, Severity, TextEdit
@@ -60,7 +61,8 @@ class NoNewPrivilegesRule(BaseRule):
             security_opt = []
 
         has_no_new_privs = any(
-            str(opt).strip() in ("no-new-privileges:true", "no-new-privileges")
+            normalize_security_opt(opt)
+            in ("no-new-privileges:true", "no-new-privileges")
             for opt in security_opt
         )
 
@@ -153,13 +155,14 @@ class NoNewPrivilegesRule(BaseRule):
         if not isinstance(security_opt, list):
             return None
         if any(
-            str(opt).strip().startswith("no-new-privileges") for opt in security_opt
+            normalize_security_opt(opt).startswith("no-new-privileges")
+            for opt in security_opt
         ):
             # Already named (e.g. `no-new-privileges:false`): appending the true
             # form would duplicate the key. Leave it for the human.
             return None
         if security_opt and all(
-            str(opt).strip().lower() in DISABLED_SECURITY_PROFILES
+            normalize_security_opt(opt) in DISABLED_SECURITY_PROFILES
             for opt in security_opt
         ):
             # Every entry is a profile-disable CL-0009 will remove. If we append

--- a/src/compose_lint/rules/CL0009_security_profile.py
+++ b/src/compose_lint/rules/CL0009_security_profile.py
@@ -8,6 +8,7 @@ from compose_lint.fix import (
     DISABLED_SECURITY_PROFILES,
     delete_lines,
     is_anchored_or_merged,
+    normalize_security_opt,
     opens_block_body,
 )
 from compose_lint.models import Finding, RuleMetadata, Severity
@@ -86,7 +87,7 @@ class SecurityProfileRule(BaseRule):
             return
 
         for i, opt in enumerate(security_opt):
-            opt_str = str(opt).strip().lower()
+            opt_str = normalize_security_opt(opt)
             if opt_str not in DISABLED_SECURITY_PROFILES:
                 continue
             profile_key = opt_str.split(":", 1)[0]
@@ -166,7 +167,7 @@ class SecurityProfileRule(BaseRule):
         disabled = sum(
             1
             for opt in security_opt
-            if str(opt).strip().lower() in DISABLED_SECURITY_PROFILES
+            if normalize_security_opt(opt) in DISABLED_SECURITY_PROFILES
         )
         legit_remaining = len(security_opt) - disabled
 

--- a/tests/test_CL0003.py
+++ b/tests/test_CL0003.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from compose_lint.fix import apply_edits
-from compose_lint.parser import load_compose
+from compose_lint.parser import load_compose, loads
 from compose_lint.rules.CL0003_no_new_privileges import NoNewPrivilegesRule
 
 if TYPE_CHECKING:
@@ -64,6 +64,19 @@ class TestNoNewPrivilegesRule:
             self.rule.check("short_form", data["services"]["short_form"], data, lines)
         )
         assert len(findings) == 0
+
+    def test_equals_separator_counts_as_hardened(self) -> None:
+        # Docker accepts `no-new-privileges=true` as well as the colon form, so a
+        # service hardened with the `=` form must not be flagged (#277 P1).
+        data, lines = loads(
+            "services:\n"
+            "  a:\n"
+            "    image: nginx:1.27\n"
+            "    security_opt:\n"
+            "      - no-new-privileges=true\n"
+        )
+        findings = list(self.rule.check("a", data["services"]["a"], data, lines))
+        assert findings == []
 
     def test_safe_short_form_with_others_no_findings(self) -> None:
         data, lines = load_compose(FIXTURES / "safe_no_new_priv_short.yml")

--- a/tests/test_CL0009.py
+++ b/tests/test_CL0009.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from compose_lint.fix import apply_edits
-from compose_lint.parser import load_compose
+from compose_lint.parser import load_compose, loads
 from compose_lint.rules.CL0009_security_profile import SecurityProfileRule
 
 if TYPE_CHECKING:
@@ -34,6 +34,21 @@ class TestSecurityProfileRule:
         assert len(findings) == 1
         assert findings[0].rule_id == "CL-0009"
         assert "seccomp" in findings[0].message
+
+    def test_detects_equals_separator_disable(self) -> None:
+        # Docker accepts `seccomp=unconfined` as well as `seccomp:unconfined`;
+        # the rule compared only the colon form and missed it (#277 F3).
+        data, lines = loads(
+            "services:\n"
+            "  a:\n"
+            "    image: nginx:1.27\n"
+            "    security_opt:\n"
+            "      - seccomp=unconfined\n"
+            "      - label=disable\n"
+        )
+        findings = list(self.rule.check("a", data["services"]["a"], data, lines))
+        assert {f.rule_id for f in findings} == {"CL-0009"}
+        assert len(findings) == 2
 
     def test_detects_apparmor_unconfined(self) -> None:
         data, lines = load_compose(FIXTURES / "insecure_security_profile.yml")

--- a/tests/test_fix.py
+++ b/tests/test_fix.py
@@ -21,6 +21,7 @@ from compose_lint.fix import (
     has_merge_key_child,
     is_anchored_or_merged,
     line_indent,
+    normalize_security_opt,
     opens_block_body,
     render_file_diff,
     reparse_or_error,
@@ -516,6 +517,17 @@ def test_coordination_refuses_anchored_service(tmp_path: Path) -> None:
     result = collect_edits(findings, data, lines, text, only={"CL-0003", "CL-0009"})
     assert result.edits == []
     assert {"CL-0003", "CL-0009"} <= {f.rule_id for f in result.manual}
+
+
+def test_normalize_security_opt() -> None:
+    # `=` and `:` separators are equivalent in Docker; normalize to the colon
+    # form, lower-case, and leave a value's own `=` (after the first) intact.
+    assert normalize_security_opt("seccomp=unconfined") == "seccomp:unconfined"
+    assert normalize_security_opt("  SECCOMP:Unconfined  ") == "seccomp:unconfined"
+    assert normalize_security_opt("no-new-privileges=true") == "no-new-privileges:true"
+    assert normalize_security_opt("label=disable") == "label:disable"
+    # Only the first separator is rewritten; a later `=` in the value survives.
+    assert normalize_security_opt("label=user:a=b") == "label:user:a=b"
 
 
 def test_extends_targets_recognises_both_forms() -> None:


### PR DESCRIPTION
Fixes #277 **F3** (false negative) and **P1** (false positive) — the same root cause, the cross-cutting separator fix the issue called out.

### The bug
Docker accepts both separators for a `security_opt` directive. Verified with installed Docker (`docker compose config` accepts and preserves both):

```
- seccomp=unconfined        ≡  - seccomp:unconfined
- no-new-privileges=true    ≡  - no-new-privileges:true
- label=disable             ≡  - label:disable
```

compose-lint only compared the colon form, so:
- **F3** — CL-0009 missed an `=`-form profile disable (`seccomp=unconfined`, `apparmor=unconfined`, `label=disable`).
- **P1** — CL-0003 fired on a service already hardened with `no-new-privileges=true`.

### The fix
A shared `normalize_security_opt(opt)` helper in `fix.py` lower-cases and rewrites **only the first** `=` (the key/value separator — a later `=` inside a value, e.g. `label=user:a=b`, is left intact). Every `security_opt` membership/prefix check now routes through it:
- CL-0009 check + fixer,
- CL-0003 check + fixer,
- the CL-0003/CL-0009 coordination pass.

### Tests
- `test_CL0009::test_detects_equals_separator_disable` — `=`-form disables fire.
- `test_CL0003::test_equals_separator_counts_as_hardened` — `no-new-privileges=true` is not flagged.
- `test_fix::test_normalize_security_opt` — helper unit coverage including the value-`=` edge.

All four gates pass locally (660 passed, 2 skipped).

Part of #277 (F3, P1).