### PR TITLE
Close five security-rule false negatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- CL-0011 now flags `CAP_`-prefixed capabilities (`CAP_SYS_ADMIN`, `CAP_ALL`,
+  ...). Docker treats the `CAP_` prefix as optional, but the rule keyed on the
+  bare name and missed the prefixed form entirely. (#277)
+- CL-0017 now flags `rshared` mount propagation in both short and long syntax,
+  not just `shared`. `rshared` is the recursive — and more common — form that
+  still propagates container mounts to the host. (#277)
+- CL-0005 now evaluates the bind-address slot when the host port is a `${VAR}`
+  substitution (`${HOSTPORT}:80`). Previously a var-valued host port failed the
+  port pattern and the whole entry was skipped, hiding a wildcard publish. (#277)
+- CL-0021 now flags an inline connection-string credential when the username is
+  a `${VAR}` but the password is a literal (`postgres://${DB_USER}:secret@db`).
+  Only a var-valued *password* means the secret is parameterized. (#277)
+- CL-0020 now flags an unquoted numeric credential value (`DB_PASSWORD:
+  12345678`). The value decodes to an int and was skipped; it is coerced to its
+  string form before the checks, while YAML boolean toggles stay exempt. (#277)
+
 - `security_opt` directives are now matched with their `=` separator treated as
   equivalent to `:`, the way Docker accepts them. CL-0009 was missing an
   `=`-form profile disable (`seccomp=unconfined`, `label=disable`) and CL-0003

--- a/src/compose_lint/rules/CL0005_unbound_ports.py
+++ b/src/compose_lint/rules/CL0005_unbound_ports.py
@@ -31,9 +31,13 @@ CIS_REF = (
 
 # Matches HOST:CONTAINER (with optional non-bracketed IPv4/hostname prefix)
 # or HOST:CONTAINER/proto. Bracketed IPv6 prefixes are stripped before this
-# pattern is applied — see _check_short_syntax.
+# pattern is applied — see _check_short_syntax. The host and container slots
+# also accept a `${VAR}` substitution so a var-valued host port (e.g.
+# `${HOSTPORT}:80`) still has its bind-address slot evaluated rather than
+# skipping the whole entry (issue #277 F5).
+_PORT_PART = r"(?:[\d\-]+(?:/\w+)?|\$\{[^}]+\}(?:/\w+)?)"
 _PORT_PATTERN = re.compile(
-    r"^(?:(?P<ip>[^:]+):)?(?P<host>[\d\-]+):(?P<container>[\d\-]+(?:/\w+)?)$"
+    rf"^(?:(?P<ip>[^:]+):)?(?P<host>{_PORT_PART}):(?P<container>{_PORT_PART})$"
 )
 
 # Values that publish on all interfaces — equivalent to no bind address.

--- a/src/compose_lint/rules/CL0011_dangerous_cap_add.py
+++ b/src/compose_lint/rules/CL0011_dangerous_cap_add.py
@@ -68,10 +68,15 @@ class DangerousCapAddRule(BaseRule):
             return
 
         for i, cap in enumerate(cap_add):
-            cap_upper = str(cap).upper()
-            if cap_upper in DANGEROUS_CAPS:
+            cap_upper = str(cap).strip().upper()
+            # Docker treats a `CAP_` prefix as optional: `CAP_SYS_ADMIN` and
+            # `SYS_ADMIN` name the same capability (so does `CAP_ALL`). The
+            # dict keys are the bare names, so strip the prefix before lookup
+            # (issue #277 F2).
+            cap_key = cap_upper.removeprefix("CAP_")
+            if cap_key in DANGEROUS_CAPS:
                 severity = (
-                    Severity.CRITICAL if cap_upper in CRITICAL_CAPS else Severity.HIGH
+                    Severity.CRITICAL if cap_key in CRITICAL_CAPS else Severity.HIGH
                 )
                 yield Finding(
                     rule_id="CL-0011",
@@ -79,7 +84,7 @@ class DangerousCapAddRule(BaseRule):
                     service=service_name,
                     message=(
                         f"Service adds dangerous capability {cap_upper}: "
-                        f"{DANGEROUS_CAPS[cap_upper]}."
+                        f"{DANGEROUS_CAPS[cap_key]}."
                     ),
                     line=lines.get(f"services.{service_name}.cap_add[{i}]")
                     or lines.get(f"services.{service_name}.cap_add"),

--- a/src/compose_lint/rules/CL0017_shared_mount.py
+++ b/src/compose_lint/rules/CL0017_shared_mount.py
@@ -14,6 +14,11 @@ CIS_REF = (
     "CIS Docker Benchmark 5.20 — Ensure mount propagation mode is not set to shared"
 )
 
+# Propagation modes that let a mount created in the container appear on the host.
+# `rshared` is the recursive form and the more common one in the wild; `slave`/
+# `rslave` propagate host -> container only, so they are not flagged (#277 F4).
+_SHARED_PROPAGATION = frozenset({"shared", "rshared"})
+
 
 @register_rule
 class SharedMountRule(BaseRule):
@@ -58,8 +63,8 @@ class SharedMountRule(BaseRule):
         # e.g., /host:/container:shared or /host:/container:ro,shared
         parts = volume.split(":")
         if len(parts) >= 3:
-            options = parts[-1].split(",")
-            return "shared" in options
+            options = {opt.strip().lower() for opt in parts[-1].split(",")}
+            return bool(options & _SHARED_PROPAGATION)
         return False
 
     def _is_shared_long_syntax(self, volume: Any) -> bool:
@@ -70,7 +75,10 @@ class SharedMountRule(BaseRule):
         if not isinstance(bind, dict):
             return False
         propagation = bind.get("propagation")
-        return isinstance(propagation, str) and propagation.lower() == "shared"
+        return (
+            isinstance(propagation, str)
+            and propagation.strip().lower() in _SHARED_PROPAGATION
+        )
 
     def _make_finding(
         self, service_name: str, lines: dict[str, int], volume_str: str, index: int

--- a/src/compose_lint/rules/CL0020_credential_env_keys.py
+++ b/src/compose_lint/rules/CL0020_credential_env_keys.py
@@ -80,12 +80,20 @@ def _is_literal_credential_value(raw: Any) -> bool:
     """Decide whether a value should be treated as a literal credential.
 
     Skips:
-    - Non-string and empty-string values (env unset, not a credential)
+    - Booleans (a YAML `yes`/`no`/`true`/`false` toggle, not a credential)
+    - Non-string, non-numeric, and empty-string values (env unset)
     - Boolean / numeric toggles like "yes", "true", "1"
     - Any value containing a ${VAR} substitution (parameterized)
 
-    Booleans and ints in YAML decode to Python bool/int and are skipped too.
+    An unquoted numeric value (`DB_PASSWORD: 12345678`) decodes to a Python
+    int/float; it is coerced to its string form so a numeric literal secret is
+    still flagged (issue #277 F7). Booleans subclass int, so they are checked
+    first to preserve the toggle exemption.
     """
+    if isinstance(raw, bool):
+        return False
+    if isinstance(raw, (int, float)):
+        raw = str(raw)
     if not isinstance(raw, str):
         return False
     if raw == "":

--- a/src/compose_lint/rules/CL0021_connection_string_credentials.py
+++ b/src/compose_lint/rules/CL0021_connection_string_credentials.py
@@ -58,14 +58,16 @@ def _iter_env(env_block: Any) -> Iterator[tuple[str, Any, int | None]]:
 def _find_inline_credential(value: str) -> tuple[str, str, str] | None:
     """Return (scheme, user, password) for an inline credential, else None.
 
-    Returns the first match where neither userinfo half is a variable
-    substitution. Substituted halves indicate the credential is
-    parameterized — the secure-ish pattern, not an inline literal.
+    Returns the first match whose *password* half is a literal. Only the
+    password being a `${VAR}` substitution means the secret is parameterized;
+    a substituted username with a literal password (e.g.
+    `postgres://${DB_USER}:secret@db`) still leaks the credential, so it must
+    not suppress the finding (issue #277 F6).
     """
     for m in _URI_USERINFO_RE.finditer(value):
         user = m.group("user")
         password = m.group("password")
-        if _is_var_ref(user) or _is_var_ref(password):
+        if _is_var_ref(password):
             continue
         return m.group("scheme"), user, password
     return None

--- a/tests/compose_files/insecure_connection_string_creds.yml
+++ b/tests/compose_files/insecure_connection_string_creds.yml
@@ -36,7 +36,7 @@ services:
     image: app:1.0
     environment:
       DATABASE_URL: postgres://app:${DB_PASSWORD}@db/app
-  skip_user_var_password_literal:
+  detect_user_var_password_literal:
     image: app:1.0
     environment:
       DATABASE_URL: postgres://${USER}:literalpw@db/app

--- a/tests/test_CL0005.py
+++ b/tests/test_CL0005.py
@@ -44,6 +44,28 @@ class TestUnboundPortsRule:
         assert len(findings) == 1
         assert findings[0].rule_id == "CL-0005"
 
+    def test_detects_var_host_port_unbound(self) -> None:
+        # A `${VAR}`-valued host port failed the port regex, so the whole entry
+        # was skipped and the missing bind address went undetected (#277 F5).
+        data, lines = loads(
+            "services:\n  a:\n    image: nginx\n    ports:\n      - ${HOSTPORT}:80\n"
+        )
+        findings = list(self.rule.check("a", data["services"]["a"], data, lines))
+        assert len(findings) == 1
+        assert findings[0].rule_id == "CL-0005"
+
+    def test_var_host_port_with_loopback_bind_no_findings(self) -> None:
+        # A real bind address still suppresses the finding even with a var port.
+        data, lines = loads(
+            "services:\n"
+            "  a:\n"
+            "    image: nginx\n"
+            "    ports:\n"
+            "      - 127.0.0.1:${HOSTPORT}:80\n"
+        )
+        findings = list(self.rule.check("a", data["services"]["a"], data, lines))
+        assert findings == []
+
     def test_bound_short_syntax_no_findings(self) -> None:
         findings = self._check("bound_short")
         assert len(findings) == 0

--- a/tests/test_CL0011.py
+++ b/tests/test_CL0011.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from compose_lint.models import Severity
-from compose_lint.parser import load_compose
+from compose_lint.parser import load_compose, loads
 from compose_lint.rules.CL0011_dangerous_cap_add import DangerousCapAddRule
 
 FIXTURES = Path(__file__).parent / "compose_files"
@@ -28,6 +28,25 @@ class TestDangerousCapAddRule:
         assert len(findings) == 1
         assert findings[0].rule_id == "CL-0011"
         assert "SYS_ADMIN" in findings[0].message
+
+    def test_detects_cap_prefixed_capability(self) -> None:
+        # Docker treats `CAP_SYS_ADMIN` == `SYS_ADMIN`; the rule keyed on the
+        # bare name and missed the prefixed form, including `CAP_ALL` (#277 F2).
+        data, lines = loads(
+            "services:\n  a:\n    image: nginx:1.27\n    cap_add: [CAP_SYS_ADMIN]\n"
+        )
+        findings = list(self.rule.check("a", data["services"]["a"], data, lines))
+        assert len(findings) == 1
+        assert findings[0].rule_id == "CL-0011"
+        assert "CAP_SYS_ADMIN" in findings[0].message
+
+    def test_detects_cap_all_prefixed(self) -> None:
+        data, lines = loads(
+            "services:\n  a:\n    image: nginx:1.27\n    cap_add: [CAP_ALL]\n"
+        )
+        findings = list(self.rule.check("a", data["services"]["a"], data, lines))
+        assert len(findings) == 1
+        assert findings[0].severity is Severity.CRITICAL
 
     def test_detects_sys_ptrace(self) -> None:
         findings = self._check("sys_ptrace")

--- a/tests/test_CL0017.py
+++ b/tests/test_CL0017.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from compose_lint.parser import load_compose
+from compose_lint.parser import load_compose, loads
 from compose_lint.rules.CL0017_shared_mount import SharedMountRule
 
 FIXTURES = Path(__file__).parent / "compose_files"
@@ -35,6 +35,39 @@ class TestSharedMountRule:
     def test_detects_shared_long_syntax(self) -> None:
         findings = self._check("shared_long")
         assert len(findings) == 1
+
+    def test_detects_rshared_short_syntax(self) -> None:
+        # `rshared` (recursive) propagates to the host like `shared` and is the
+        # more common dangerous form; `"shared" in ["rshared"]` was False (#277 F4).
+        data, lines = loads(
+            "services:\n  a:\n    image: nginx:1.27\n    volumes: ['/h:/c:rshared']\n"
+        )
+        findings = list(self.rule.check("a", data["services"]["a"], data, lines))
+        assert len(findings) == 1
+        assert findings[0].rule_id == "CL-0017"
+
+    def test_detects_rshared_long_syntax(self) -> None:
+        data, lines = loads(
+            "services:\n"
+            "  a:\n"
+            "    image: nginx:1.27\n"
+            "    volumes:\n"
+            "      - type: bind\n"
+            "        source: /h\n"
+            "        target: /c\n"
+            "        bind:\n"
+            "          propagation: rshared\n"
+        )
+        findings = list(self.rule.check("a", data["services"]["a"], data, lines))
+        assert len(findings) == 1
+
+    def test_rslave_no_findings(self) -> None:
+        # rslave/slave propagate host -> container only; not flagged.
+        data, lines = loads(
+            "services:\n  a:\n    image: nginx:1.27\n    volumes: ['/h:/c:rslave']\n"
+        )
+        findings = list(self.rule.check("a", data["services"]["a"], data, lines))
+        assert findings == []
 
     def test_rprivate_no_findings(self) -> None:
         findings = self._check("rprivate_long")

--- a/tests/test_CL0020.py
+++ b/tests/test_CL0020.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from compose_lint.models import Finding, Severity
-from compose_lint.parser import load_compose
+from compose_lint.parser import load_compose, loads
 from compose_lint.rules.CL0020_credential_env_keys import CredentialEnvKeysRule
 
 FIXTURES = Path(__file__).parent / "compose_files"
@@ -31,6 +31,32 @@ class TestCredentialEnvKeysRule:
         assert findings[0].rule_id == "CL-0020"
         assert findings[0].severity == Severity.HIGH
         assert "POSTGRES_PASSWORD" in findings[0].message
+
+    def test_detects_numeric_password(self) -> None:
+        # An unquoted numeric value decodes to int and was skipped (#277 F7).
+        data, lines = loads(
+            "services:\n"
+            "  a:\n"
+            "    image: nginx:1.27\n"
+            "    environment:\n"
+            "      DB_PASSWORD: 12345678\n"
+        )
+        findings = list(self.rule.check("a", data["services"]["a"], data, lines))
+        assert len(findings) == 1
+        assert findings[0].rule_id == "CL-0020"
+
+    def test_boolean_value_not_flagged(self) -> None:
+        # A credential-shaped key whose value is a YAML boolean (decodes to a
+        # Python bool) is a toggle, not a literal secret — keep it exempt (#277 F7).
+        data, lines = loads(
+            "services:\n"
+            "  a:\n"
+            "    image: nginx:1.27\n"
+            "    environment:\n"
+            "      DB_PASSWORD: no\n"
+        )
+        findings = list(self.rule.check("a", data["services"]["a"], data, lines))
+        assert findings == []
 
     def test_detects_decoy_value(self) -> None:
         # Placeholder values still fire — same leak path, same fix.

--- a/tests/test_CL0021.py
+++ b/tests/test_CL0021.py
@@ -74,11 +74,13 @@ class TestConnectionStringCredentialsRule:
         findings = self._check("skip_user_literal_password_var")
         assert findings == []
 
-    def test_skip_user_var_password_literal(self) -> None:
-        # Either half being a var disqualifies — credential is parameterized
-        # at least in part.
-        findings = self._check("skip_user_var_password_literal")
-        assert findings == []
+    def test_detect_user_var_password_literal(self) -> None:
+        # Only the password being a var means the secret is parameterized. A var
+        # username with a literal password still leaks the password, so it must
+        # fire (issue #277 F6).
+        findings = self._check("detect_user_var_password_literal")
+        assert len(findings) == 1
+        assert findings[0].rule_id == "CL-0021"
 
     def test_skip_pure_var_value(self) -> None:
         findings = self._check("skip_pure_var_value")


### PR DESCRIPTION
Batches the five remaining false-negative findings from #277 (one rule each, all independent — grouped like #261's lows batch).

| # | Rule | Was missed | Fix |
|---|------|-----------|-----|
| **F2** | CL-0011 | `CAP_SYS_ADMIN`, `CAP_ALL` (any `CAP_` prefix) | Strip a leading `CAP_` before the `DANGEROUS_CAPS` lookup |
| **F4** | CL-0017 | `rshared` propagation (short + long) | Match `{shared, rshared}`; `slave`/`rslave` stay excluded |
| **F5** | CL-0005 | `${HOSTPORT}:80` (var host port) | Accept a `${...}` token in the host/container slots so the bind slot is still evaluated |
| **F6** | CL-0021 | `postgres://${DB_USER}:secret@db` (var user, literal pw) | Skip only when the **password** half is a var |
| **F7** | CL-0020 | `DB_PASSWORD: 12345678` (numeric) | Coerce int/float to str; booleans stay exempt as toggles |

Each fix ships with a detection test and a matching negative case (non-dangerous caps, `rslave`, a loopback-bound var port, a var password, a boolean toggle value). The CL-0021 var-user/literal-password fixture flips from "skip" to "detect" to match F6.

All four gates pass locally (669 passed, 2 skipped).

> Same note as #282: real-corpus output shifts (more findings), so the CI-skipped `tests/corpus_snapshot.json.gz` is regenerated once after this batch lands.

Part of #277 (F2, F4, F5, F6, F7).