### PR TITLE
Reject duplicate mapping keys to match Docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Duplicate mapping keys are now rejected with a parse error, matching Docker
+  (which refuses them). Previously PyYAML silently let the last value win, so a
+  service with `privileged: true` followed by `privileged: false` — a file
+  Docker will not load — reported clean, and the line map pointed at the wrong
+  occurrence. Detection runs before merge-key (`<<`) flattening, so an
+  `extends`/anchor merge that overrides an inherited key is not misreported as a
+  duplicate. (#277)
+
 - CL-0011 now flags `CAP_`-prefixed capabilities (`CAP_SYS_ADMIN`, `CAP_ALL`,
   ...). Docker treats the `CAP_` prefix as optional, but the rule keyed on the
   bare name and missed the prefixed form entirely. (#277)

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -129,7 +129,41 @@ class LineLoader(yaml.SafeLoader):
         self._seq_lines: dict[int, dict[int, int]] = {}
 
 
+def _reject_duplicate_keys(loader: LineLoader, node: yaml.MappingNode) -> None:
+    """Raise if a mapping declares the same key twice (issue #277 P2).
+
+    Docker's loader rejects duplicate mapping keys; PyYAML silently lets the last
+    value win, so ``privileged: true`` followed by ``privileged: false`` parsed
+    clean and the line map pointed at the wrong occurrence. Matching Docker, this
+    is a hard error.
+
+    Runs *before* ``flatten_mapping`` so a merge key (``<<``) that legitimately
+    reintroduces an overridden key is not mistaken for a duplicate — merge
+    overrides only appear in ``node.value`` after flattening, and they are
+    resolved by precedence, not rejected. Unhashable (complex ``? ...``) keys are
+    skipped here; the construction loop surfaces them as their own error.
+    """
+    seen: set[Any] = set()
+    for key_node, _value_node in node.value:
+        if key_node.tag == "tag:yaml.org,2002:merge":
+            continue  # the `<<` merge directive, not a data key
+        key = loader.construct_object(key_node)  # type: ignore[no-untyped-call]
+        try:
+            duplicate = key in seen
+        except TypeError:
+            continue  # unhashable key — the construction loop reports it
+        if duplicate:
+            raise yaml.constructor.ConstructorError(
+                None,
+                None,
+                f"found duplicate key {key!r}; Docker rejects duplicate mapping keys",
+                key_node.start_mark,
+            )
+        seen.add(key)
+
+
 def _construct_mapping(loader: LineLoader, node: yaml.MappingNode) -> dict[str, Any]:
+    _reject_duplicate_keys(loader, node)
     loader.flatten_mapping(node)
     mapping: dict[str, Any] = {}
     line_map: dict[str, int] = {}

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -43,6 +43,40 @@ class TestLoads:
             loads("")
 
 
+class TestDuplicateKeys:
+    """Duplicate mapping keys are rejected, matching Docker (#277 P2)."""
+
+    def test_duplicate_key_in_service_rejected(self) -> None:
+        # PyYAML let the last value win; Docker rejects the file outright.
+        with pytest.raises(ComposeError, match="duplicate key 'privileged'"):
+            loads(
+                "services:\n"
+                "  web:\n"
+                "    image: nginx\n"
+                "    privileged: false\n"
+                "    privileged: true\n"
+            )
+
+    def test_duplicate_service_name_rejected(self) -> None:
+        with pytest.raises(ComposeError, match="duplicate key 'web'"):
+            loads("services:\n  web:\n    image: a\n  web:\n    image: b\n")
+
+    def test_merge_key_override_is_not_a_duplicate(self) -> None:
+        # A merge key legitimately reintroduces an overridden key; the explicit
+        # value wins and the file stays valid.
+        data, _lines = loads(
+            "x-base: &base\n"
+            "  image: nginx\n"
+            '  restart: "no"\n'
+            "services:\n"
+            "  web:\n"
+            "    <<: *base\n"
+            "    restart: always\n"
+        )
+        assert data["services"]["web"]["restart"] == "always"
+        assert data["services"]["web"]["image"] == "nginx"
+
+
 class TestOverrideTags:
     """Compose override-file tags (`!reset` / `!override`) parse, not crash."""
 


### PR DESCRIPTION
Fixes #277 **P2**.

### The bug
Docker's loader refuses a duplicate mapping key — verified:

```
$ docker compose -f dup.yml config
failed to parse dup.yml: yaml: construct errors:
  line 5: mapping key "privileged" already defined at line 4
```

PyYAML silently lets the last value win, so `privileged: true` then `privileged: false` — a file Docker won't load — parsed clean, and the line map pointed at the wrong occurrence.

### The fix
`_reject_duplicate_keys` raises a `ConstructorError` (surfaced as `ComposeError` → exit 2) on a repeated key. The subtlety is **merge keys**: it runs *before* `flatten_mapping`, so an `extends`/anchor merge that overrides an inherited key (`<<: *base` then `restart: always`) is **not** misreported — merge overrides only appear in `node.value` after flattening and are resolved by precedence. Unhashable complex keys are left to the construction loop's existing error.

### Tests
- duplicate key in a service → rejected,
- duplicate service name → rejected,
- merge-key override → stays valid (`restart: always` wins, `image` inherited).

Verified merge/anchor handling against installed Docker. All four gates pass locally (full suite 669 passed, 2 skipped; parser suite 39 passed).

Part of #277 (P2) — the last actionable finding. The ⚪ by-design / ADR-deferred items in the issue remain noted.