### PR TITLE
Emit JSON service as string and forbid NaN/Infinity (#278 J1/J2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- JSON output now emits `service` as a string and never emits bare `NaN`/
+  `Infinity`. A service name is a YAML mapping key, so a key like `true`, a bare
+  number, or `.nan` resolved to a non-string scalar: `.nan` produced invalid
+  JSON (`"service": NaN`, which RFC 8259 forbids) while `true`/`123` produced a
+  wrongly-typed `service` field (ADR-015 contracts it as a string). The formatter
+  now coerces `service` to `str`, and both the JSON and SARIF dumps use
+  `allow_nan=False` so a stray non-finite float raises instead of writing invalid
+  JSON. (#278)
+
 - Duplicate mapping keys are now rejected with a parse error, matching Docker
   (which refuses them). Previously PyYAML silently let the last value win, so a
   service with `privileged: true` followed by `privileged: false` — a file

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -412,9 +412,15 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
             print(format_aggregate_summary(all_file_findings, len(parse_errors)))
         print(format_verdict(all_file_findings, args.fail_on, len(parse_errors)))
     elif args.output_format == "json":
-        print(json.dumps(build_json_log(all_json, parse_errors), indent=2))
+        # allow_nan=False makes a stray float NaN/Infinity raise rather than emit
+        # bare `NaN`/`Infinity` tokens, which RFC 8259 forbids and strict parsers
+        # reject. The formatter already coerces `service` to str, so this guards
+        # any future numeric field; the same applies to the SARIF dump below.
+        json_log = build_json_log(all_json, parse_errors)
+        print(json.dumps(json_log, indent=2, allow_nan=False))
     elif args.output_format == "sarif":
-        print(json.dumps(build_sarif_log(all_sarif, parse_errors), indent=2))
+        sarif_log = build_sarif_log(all_sarif, parse_errors)
+        print(json.dumps(sarif_log, indent=2, allow_nan=False))
 
     if parse_errors:
         sys.exit(2)

--- a/src/compose_lint/formatters/json.py
+++ b/src/compose_lint/formatters/json.py
@@ -23,7 +23,12 @@ def format_findings(findings: list[Finding], filepath: str) -> list[dict[str, ob
             "line": f.line,
             "rule_id": f.rule_id,
             "severity": f.severity.value,
-            "service": f.service,
+            # A service name is a YAML mapping key, which the loader may resolve
+            # into a non-string scalar (a bool from `true:`, an int from a bare
+            # number, a float from `.nan`). ADR-015 contracts `service` as a
+            # string, and a float NaN/Inf would also serialize as invalid JSON,
+            # so coerce here regardless of what the key resolved to.
+            "service": str(f.service),
             "message": f.message,
             "fix": f.fix,
             "references": list(f.references),

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,0 +1,124 @@
+"""Tests for the JSON formatter and its ADR-015 / RFC 8259 conformance.
+
+These guard the J1 failure modes from #278: a YAML service-name key can resolve
+to a non-string scalar (a bool from ``true:``, an int from a bare number, a
+float from ``.nan``), which broke the JSON contract three ways — a ``TypeError``
+crash, invalid ``NaN``/``Infinity`` tokens, and a wrong-typed ``service`` field.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+from compose_lint.formatters.json import build_json_log, format_findings
+from compose_lint.models import Finding, Severity
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _raise_constant(token: str) -> object:
+    """``json.loads`` callback that rejects bare NaN/Infinity tokens.
+
+    RFC 8259 §6 forbids them; a strict consumer would reject the document. Using
+    this as ``parse_constant`` turns the issue's "valid JSON, exit 0" NaN case
+    into a test failure instead of a silent pass.
+    """
+    raise AssertionError(f"non-JSON constant token in output: {token!r}")
+
+
+def _make(service: object) -> Finding:
+    # The dataclass annotates ``service`` as ``str``, but the parser feeds it
+    # whatever the YAML key resolved to; reproduce that here.
+    return Finding(
+        rule_id="CL-0004",
+        severity=Severity.MEDIUM,
+        service=service,  # type: ignore[arg-type]
+        message="Image 'nginx:latest' uses mutable tag.",
+        line=2,
+    )
+
+
+class TestServiceCoercion:
+    """`service` is always emitted as a string regardless of the key's type."""
+
+    @pytest.mark.parametrize(
+        ("service", "expected"),
+        [
+            (True, "True"),
+            (False, "False"),
+            (123, "123"),
+            (float("nan"), "nan"),
+            (float("inf"), "inf"),
+            ("web", "web"),
+        ],
+    )
+    def test_service_is_stringified(self, service: object, expected: str) -> None:
+        results = format_findings([_make(service)], "x.yml")
+        assert results[0]["service"] == expected
+        assert isinstance(results[0]["service"], str)
+
+
+class TestStrictSerialization:
+    """The serialized envelope is strict, parseable JSON (no NaN/Infinity)."""
+
+    def test_nan_service_does_not_emit_bare_nan(self) -> None:
+        log = build_json_log(format_findings([_make(float("nan"))], "x.yml"))
+        dumped = json.dumps(log, allow_nan=False)
+        # round-trips under a parser that rejects NaN/Infinity
+        parsed = json.loads(dumped, parse_constant=_raise_constant)
+        assert parsed["findings"][0]["service"] == "nan"
+
+    def test_allow_nan_false_would_catch_a_stray_float(self) -> None:
+        # Belt-and-suspenders: even if a numeric field ever carried a raw NaN,
+        # the CLI's allow_nan=False dump raises rather than emitting invalid JSON.
+        with pytest.raises(ValueError, match="Out of range float"):
+            json.dumps({"x": float("nan")}, allow_nan=False)
+
+
+class TestJsonCLI:
+    """End-to-end: typed service keys produce valid, contract-shaped JSON."""
+
+    def _run(self, tmp_path: Path, body: str) -> dict:
+        f = tmp_path / "compose.yml"
+        f.write_text(body)
+        result = subprocess.run(
+            [sys.executable, "-m", "compose_lint", "--format", "json", str(f)],
+            capture_output=True,
+            text=True,
+        )
+        # The pre-fix failures were a crash (exit 1, zero bytes to stdout) and
+        # invalid JSON (a bare NaN token); both are caught here. Findings on
+        # these fixtures are below the HIGH default threshold, so a healthy run
+        # exits 0 — never 2, and always with parseable JSON on stdout.
+        assert result.returncode in (0, 1), result.stderr
+        assert result.stdout, "expected JSON on stdout, got nothing (crash?)"
+        return json.loads(result.stdout, parse_constant=_raise_constant)
+
+    def test_date_service_key(self, tmp_path: Path) -> None:
+        data = self._run(
+            tmp_path,
+            "services:\n  2024-01-01:\n    image: nginx:latest\n",
+        )
+        services = {f["service"] for f in data["findings"]}
+        assert "2024-01-01" in services
+        assert all(isinstance(s, str) for s in services)
+
+    def test_nan_service_key(self, tmp_path: Path) -> None:
+        data = self._run(
+            tmp_path,
+            "services:\n  .nan:\n    image: nginx:latest\n",
+        )
+        assert all(isinstance(f["service"], str) for f in data["findings"])
+
+    def test_bool_service_key(self, tmp_path: Path) -> None:
+        data = self._run(
+            tmp_path,
+            "services:\n  true:\n    image: nginx:latest\n",
+        )
+        assert all(isinstance(f["service"], str) for f in data["findings"])


### PR DESCRIPTION
Part of the output-format conformance umbrella #278 — the **JSON** findings J1 and J2.

## Problem (J1)
A service name is a YAML mapping key, so `SafeLoader` resolves it into a typed Python object. That broke the JSON contract three ways on a *valid* Compose file:

| Service key | Before | Issue |
|---|---|---|
| `.nan` / `.inf` | `"service": NaN` | invalid JSON (RFC 8259 §6 forbids `NaN`/`Infinity`), exit 0 — looks successful |
| `true` / `123` | `"service": true` / `123` | valid JSON but wrong-typed `service` (ADR-015 contracts it as a string) |
| `2024-01-01` | `TypeError`, exit 1, 0 bytes | already fixed by the resolver strip in #282 |

```
$ compose-lint check x.yml --format json   # service key ".nan"
  "service": NaN,        # <- rejected by every strict parser
```

## Fix
- `formatters/json.py`: coerce `"service": str(f.service)` so the field is always a string regardless of how the key resolved.
- `cli.py`: pass `allow_nan=False` to **both** the JSON and SARIF `json.dumps` so any stray non-finite float raises instead of writing invalid JSON (defence for any future numeric field; SARIF never serializes `service` but gets the same guard).

## Tests (J2)
New `tests/test_json.py` — the JSON formatter had no strict-conformance test, which is why J1 shipped green. Covers date/`.nan`/`.inf`/bool/numeric service keys, parsed under a raising `parse_constant` so a bare `NaN`/`Infinity` token fails the suite. Unit + end-to-end CLI cases.

## Checks
`ruff check`, `ruff format --check`, `mypy src/` (strict), and the full `pytest` suite (683 passed, 2 skipped) all green.