### PR TITLE
Emit conformant repo-relative URIs in SARIF output (#278 S1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- SARIF `artifactLocation.uri` is now a conformant, GitHub-resolvable URI
+  reference. Paths were emitted verbatim, so an absolute path would not resolve
+  on GitHub Code Scanning and a space or non-ASCII byte
+  (`/tmp/my dir/café.yml`) was not a legal RFC-3986 URI reference at all. Files
+  under the working directory are now emitted as percent-encoded repo-relative
+  paths tagged with a `SRCROOT` `uriBaseId`, declared once per run in
+  `originalUriBaseIds` alongside `invocations[].workingDirectory`; out-of-tree
+  paths fall back to an absolute, percent-encoded `file:` URI. (#278)
+
 - JSON output now emits `service` as a string and never emits bare `NaN`/
   `Infinity`. A service name is a YAML mapping key, so a key like `true`, a bare
   number, or `.nan` resolved to a non-string scalar: `.nan` produced invalid

--- a/src/compose_lint/formatters/sarif.py
+++ b/src/compose_lint/formatters/sarif.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import os
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
 
 from compose_lint import __version__
 from compose_lint.models import Severity
@@ -17,6 +20,43 @@ SARIF_SCHEMA = (
     "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/"
     "main/sarif-2.1/schema/sarif-schema-2.1.0.json"
 )
+
+# Symbolic base for relativized artifact URIs. Declared once per run in
+# ``originalUriBaseIds`` (pointed at the working directory) and referenced from
+# each in-tree ``artifactLocation`` via ``uriBaseId``; GitHub Code Scanning
+# resolves the pair to a repo-relative path.
+_URI_BASE_ID = "SRCROOT"
+
+
+def _working_dir_uri() -> str:
+    """The current working directory as a ``file:`` URI with a trailing slash.
+
+    A base URI for relative-reference resolution must end in ``/`` (RFC 3986
+    §5.3); ``Path.as_uri`` percent-encodes any spaces/Unicode in the path.
+    """
+    return Path.cwd().as_uri() + "/"
+
+
+def _artifact_location(filepath: str) -> dict[str, Any]:
+    """Build a SARIF ``artifactLocation`` with a conformant URI reference.
+
+    SARIF §3.4.1 requires ``uri`` to be a valid RFC-3986 URI reference, and
+    GitHub Code Scanning resolves it against the repository root — so emitting a
+    raw OS path verbatim is wrong twice over: an absolute path won't resolve on
+    GitHub, and a space or non-ASCII byte (``/tmp/my dir/café.yml``) is not a
+    legal URI reference. When the file lives under the working directory, emit a
+    percent-encoded repo-relative path tagged with the ``SRCROOT`` base id;
+    otherwise fall back to an absolute, percent-encoded ``file:`` URI.
+    """
+    try:
+        rel = os.path.relpath(filepath, os.getcwd())
+    except ValueError:
+        # No common base (e.g. different drive on Windows).
+        rel = ".."
+    if not rel.startswith(".."):
+        return {"uri": quote(rel.replace(os.sep, "/")), "uriBaseId": _URI_BASE_ID}
+    return {"uri": Path(filepath).resolve().as_uri()}
+
 
 # GitHub Code Scanning security-severity mapping (numeric).
 # Over 9.0 = critical, 7.0-8.9 = high, 4.0-6.9 = medium, 0.1-3.9 = low.
@@ -103,7 +143,7 @@ def _build_fix(edits: list[TextEdit], filepath: str) -> dict[str, Any]:
     fix: dict[str, Any] = {
         "artifactChanges": [
             {
-                "artifactLocation": {"uri": filepath},
+                "artifactLocation": _artifact_location(filepath),
                 "replacements": replacements,
             },
         ],
@@ -141,7 +181,7 @@ def format_findings(
             "locations": [
                 {
                     "physicalLocation": {
-                        "artifactLocation": {"uri": filepath},
+                        "artifactLocation": _artifact_location(filepath),
                         "region": {"startLine": f.line or 1},
                     },
                 },
@@ -181,8 +221,10 @@ def build_sarif_log(
     """
     rules, _ = _build_rules()
 
+    working_dir_uri = _working_dir_uri()
     invocation: dict[str, Any] = {
         "executionSuccessful": not parse_errors,
+        "workingDirectory": {"uri": working_dir_uri},
     }
     if parse_errors:
         invocation["toolExecutionNotifications"] = [
@@ -192,7 +234,7 @@ def build_sarif_log(
                 "locations": [
                     {
                         "physicalLocation": {
-                            "artifactLocation": {"uri": filepath},
+                            "artifactLocation": _artifact_location(filepath),
                         },
                     },
                 ],
@@ -213,6 +255,7 @@ def build_sarif_log(
                         "rules": rules,
                     },
                 },
+                "originalUriBaseIds": {_URI_BASE_ID: {"uri": working_dir_uri}},
                 "invocations": [invocation],
                 "results": all_results,
             },

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -341,7 +341,9 @@ class TestCLI:
         uri = notifications[0]["locations"][0]["physicalLocation"]["artifactLocation"][
             "uri"
         ]
-        assert uri == str(bad)
+        # `bad` lives outside the repo working directory, so it is emitted as an
+        # absolute, percent-encoded file: URI rather than the raw OS path (S1).
+        assert uri == bad.resolve().as_uri()
 
     def test_sarif_clean_run_marks_execution_successful(self) -> None:
         result = run_cli(

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -375,3 +375,93 @@ class TestSarifSchemaCompliance:
             format_findings([f], "test.yml", fixes=[(f, edits)]),
         )
         self._validate(log, tmp_path)
+
+
+class TestArtifactUri:
+    """`artifactLocation.uri` is a conformant, GitHub-resolvable URI (S1)."""
+
+    def test_in_tree_path_is_relative_with_base_id(self, tmp_path: Path) -> None:
+        # A file under the working directory becomes a repo-relative path tagged
+        # with the SRCROOT base id rather than a non-resolvable absolute path.
+        sub = tmp_path / "stack"
+        sub.mkdir()
+        target = sub / "docker-compose.yml"
+        target.touch()
+        cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            loc = format_findings([_sample_finding()], str(target))[0]
+            art = loc["locations"][0]["physicalLocation"]["artifactLocation"]
+        finally:
+            os.chdir(cwd)
+        assert art["uri"] == "stack/docker-compose.yml"
+        assert art["uriBaseId"] == "SRCROOT"
+
+    def test_relative_input_stays_relative(self) -> None:
+        loc = format_findings([_sample_finding()], "docker-compose.yml")[0]
+        art = loc["locations"][0]["physicalLocation"]["artifactLocation"]
+        assert art["uri"] == "docker-compose.yml"
+        assert art["uriBaseId"] == "SRCROOT"
+
+    def test_spaces_and_unicode_are_percent_encoded(self, tmp_path: Path) -> None:
+        d = tmp_path / "my dir"
+        d.mkdir()
+        target = d / "café.yml"
+        target.touch()
+        cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            art = format_findings([_sample_finding()], str(target))[0]["locations"][0][
+                "physicalLocation"
+            ]["artifactLocation"]
+        finally:
+            os.chdir(cwd)
+        assert art["uri"] == "my%20dir/caf%C3%A9.yml"
+        assert " " not in art["uri"]
+
+    def test_out_of_tree_path_is_absolute_file_uri(self, tmp_path: Path) -> None:
+        # A path that does not live under the working directory cannot be made
+        # repo-relative without a `..`, so it falls back to an absolute file: URI
+        # (percent-encoded, no base id).
+        outside = tmp_path / "outside space.yml"
+        outside.touch()
+        work = tmp_path / "work"
+        work.mkdir()
+        cwd = os.getcwd()
+        os.chdir(work)
+        try:
+            art = format_findings([_sample_finding()], str(outside))[0]["locations"][0][
+                "physicalLocation"
+            ]["artifactLocation"]
+        finally:
+            os.chdir(cwd)
+        assert art["uri"].startswith("file://")
+        assert "outside%20space.yml" in art["uri"]
+        assert "uriBaseId" not in art
+
+    def test_log_declares_src_root_and_working_directory(self) -> None:
+        run = build_sarif_log(format_findings([_sample_finding()], "x.yml"))["runs"][0]
+        base = run["originalUriBaseIds"]["SRCROOT"]["uri"]
+        assert base.startswith("file://")
+        assert base.endswith("/")
+        assert run["invocations"][0]["workingDirectory"]["uri"] == base
+
+    def test_fix_and_notification_uris_are_normalized(self, tmp_path: Path) -> None:
+        f = _sample_finding()
+        edit = TextEdit(3, 1, 3, 1, "x\n")
+        sub = tmp_path / "stack"
+        sub.mkdir()
+        target = sub / "compose.yml"
+        target.touch()
+        cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            results = format_findings([f], str(target), fixes=[(f, [edit])])
+            fix_uri = results[0]["fixes"][0]["artifactChanges"][0]["artifactLocation"]
+            log = build_sarif_log(results, parse_errors=[(str(target), "broken")])
+        finally:
+            os.chdir(cwd)
+        assert fix_uri == {"uri": "stack/compose.yml", "uriBaseId": "SRCROOT"}
+        notif = log["runs"][0]["invocations"][0]["toolExecutionNotifications"][0]
+        notif_art = notif["locations"][0]["physicalLocation"]["artifactLocation"]
+        assert notif_art == {"uri": "stack/compose.yml", "uriBaseId": "SRCROOT"}


### PR DESCRIPTION
Part of the output-format conformance umbrella #278 — SARIF finding **S1**.

## Problem
`artifactLocation.uri` was the raw OS path (`sarif.py` result locations, structured-fix `artifactChanges`, and parse-error notifications). The emitted SARIF passes the OASIS 2.1.0 *schema* (its `format` assertions don't enforce this), but the URI is wrong for real consumers two ways:

- **Absolute paths don't resolve on GitHub.** Code Scanning resolves `uri` against the repository root; `/home/runner/work/.../docker-compose.yml` points nowhere in the repo.
- **Spaces and non-ASCII bytes are not legal URI references** (SARIF §3.4.1 / RFC 3986). `/tmp/my dir/café.yml` emitted `"uri": "/tmp/my dir/café.yml"` — a raw space and `é`.

## Fix
New `_artifact_location(filepath)`:
- File **under** the working directory → percent-encoded **repo-relative** path + `"uriBaseId": "SRCROOT"`.
- File **outside** it → absolute, percent-encoded `file:` URI (no base id).

The run now declares the base once in `originalUriBaseIds.SRCROOT` and mirrors it in `invocations[].workingDirectory`, so GitHub resolves the `uriBaseId` to a repo-relative path. Applied uniformly to result locations, fix `artifactChanges`, and notifications.

| Input (cwd = repo root) | Before | After |
|---|---|---|
| `docker-compose.yml` | `docker-compose.yml` | `docker-compose.yml` + `uriBaseId` |
| `/repo/stack/c.yml` | `/repo/stack/c.yml` | `stack/c.yml` + `uriBaseId` |
| `my dir/café.yml` | `my dir/café.yml` | `my%20dir/caf%C3%A9.yml` + `uriBaseId` |
| `/elsewhere/x.yml` | `/elsewhere/x.yml` | `file:///elsewhere/x.yml` |

## Tests
New `TestArtifactUri` covers relativization, space/Unicode encoding, the out-of-tree `file:` fallback, the run-level base declaration, and fix/notification URIs. The existing schema-compliance suite still validates the new shape against the canonical OASIS 2.1.0 schema. One CLI test that asserted the old raw absolute path was updated to the conformant `file:` URI.

## Checks
`ruff check`, `ruff format --check`, `mypy src/` (strict), full `pytest` (incl. `check-jsonschema` SARIF validation) green.