### PR TITLE
Tighten SARIF ruleIndex, region, and schema reference (#278 S2/S6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- SARIF no longer emits a misleading `ruleIndex` for an unregistered rule.
+  `ruleIndex` defaulted to `0`, so a result whose rule was absent from the
+  registry pointed at the first rule (CL-0001) while `ruleId` named the real one
+  — a SARIF §3.52.5 contradiction. It is now emitted only when the rule is in
+  the registry. A result with an unknown or non-positive line likewise omits its
+  `region` instead of fabricating `startLine: 1`, which had mislocated the alert
+  at the top of the file. (#278)
+- SARIF `$schema` now points at the canonical, immutable OASIS errata01 URL
+  (`docs.oasis-open.org/.../sarif-schema-2.1.0.json`) instead of a
+  `raw.githubusercontent.com` `main`-branch link — the schema's own `$id`, and
+  no longer a mutable ref. (#278)
+
 - SARIF `artifactLocation.uri` is now a conformant, GitHub-resolvable URI
   reference. Paths were emitted verbatim, so an absolute path would not resolve
   on GitHub Code Scanning and a space or non-ASCII byte

--- a/src/compose_lint/formatters/sarif.py
+++ b/src/compose_lint/formatters/sarif.py
@@ -16,9 +16,13 @@ if TYPE_CHECKING:
 
     from compose_lint.models import Finding, TextEdit
 
+# The schema's canonical `$id`, served from the OASIS errata01 OS publication.
+# It is an immutable, versioned URL — unlike the previous raw.githubusercontent
+# `main`-branch link, which was a mutable ref (and so conflicted with this
+# repo's no-mutable-refs principle as well as not being the schema's own `$id`).
 SARIF_SCHEMA = (
-    "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/"
-    "main/sarif-2.1/schema/sarif-schema-2.1.0.json"
+    "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/"
+    "sarif-schema-2.1.0.json"
 )
 
 # Symbolic base for relativized artifact URIs. Declared once per run in
@@ -56,6 +60,21 @@ def _artifact_location(filepath: str) -> dict[str, Any]:
     if not rel.startswith(".."):
         return {"uri": quote(rel.replace(os.sep, "/")), "uriBaseId": _URI_BASE_ID}
     return {"uri": Path(filepath).resolve().as_uri()}
+
+
+def _physical_location(filepath: str, line: int | None) -> dict[str, Any]:
+    """Build a SARIF ``physicalLocation``, including ``region`` only when known.
+
+    SARIF requires ``region.startLine`` to be >= 1, so a missing or non-positive
+    line cannot be expressed as a region. Rather than fabricate ``startLine: 1``
+    (which mislocates the result at the top of the file), omit the region
+    entirely — a location with only an ``artifactLocation`` is valid and lets a
+    consumer attribute the result to the file as a whole.
+    """
+    location: dict[str, Any] = {"artifactLocation": _artifact_location(filepath)}
+    if line is not None and line >= 1:
+        location["region"] = {"startLine": line}
+    return location
 
 
 # GitHub Code Scanning security-severity mapping (numeric).
@@ -175,18 +194,19 @@ def format_findings(
     for f in findings:
         result: dict[str, Any] = {
             "ruleId": f.rule_id,
-            "ruleIndex": index_map.get(f.rule_id, 0),
             "level": _SARIF_LEVEL.get(f.severity, "warning"),
             "message": {"text": f.message},
             "locations": [
-                {
-                    "physicalLocation": {
-                        "artifactLocation": _artifact_location(filepath),
-                        "region": {"startLine": f.line or 1},
-                    },
-                },
+                {"physicalLocation": _physical_location(filepath, f.line)},
             ],
         }
+
+        # ruleIndex must identify the descriptor the result refers to (SARIF
+        # §3.52.5). Emit it only when the rule is actually in the registry;
+        # defaulting to 0 would point an unregistered rule at CL-0001 while
+        # ruleId named the real one — a self-contradiction.
+        if f.rule_id in index_map:
+            result["ruleIndex"] = index_map[f.rule_id]
 
         if f.fix:
             result["properties"] = {"fix": f.fix}

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -67,7 +67,9 @@ class TestFormatFindings:
         assert "fixes" not in results[0]
         assert "properties" not in results[0]
 
-    def test_line_defaults_to_1_when_none(self) -> None:
+    def test_region_omitted_when_line_unknown(self) -> None:
+        # A missing line cannot be a valid region (startLine must be >= 1), so the
+        # location carries only artifactLocation rather than a fabricated line 1.
         finding = Finding(
             rule_id="CL-0001",
             severity=Severity.CRITICAL,
@@ -77,7 +79,29 @@ class TestFormatFindings:
         )
         results = format_findings([finding], "test.yml")
         loc = results[0]["locations"][0]["physicalLocation"]
-        assert loc["region"]["startLine"] == 1
+        assert "region" not in loc
+        assert loc["artifactLocation"]["uri"] == "test.yml"
+
+    def test_registered_rule_has_matching_index(self) -> None:
+        results = format_findings([_sample_finding()], "test.yml")
+        log = build_sarif_log(results)
+        rules = log["runs"][0]["tool"]["driver"]["rules"]
+        idx = results[0]["ruleIndex"]
+        assert rules[idx]["id"] == results[0]["ruleId"]
+
+    def test_unregistered_rule_omits_index(self) -> None:
+        # An index would have to point somewhere; defaulting to 0 falsely
+        # attributes the result to the first registered rule. Omit it instead.
+        finding = Finding(
+            rule_id="CL-9999",
+            severity=Severity.HIGH,
+            service="web",
+            message="phantom rule",
+            line=3,
+        )
+        results = format_findings([finding], "test.yml")
+        assert results[0]["ruleId"] == "CL-9999"
+        assert "ruleIndex" not in results[0]
 
     def test_empty_findings(self) -> None:
         results = format_findings([], "docker-compose.yml")
@@ -181,8 +205,11 @@ class TestBuildSarifLog:
     def test_schema_and_version(self) -> None:
         log = build_sarif_log([])
         assert log["version"] == "2.1.0"
-        assert "$schema" in log
-        assert "sarif-schema-2.1.0" in log["$schema"]
+        # The canonical, immutable OASIS errata01 URL — not a mutable branch ref.
+        assert log["$schema"] == (
+            "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/"
+            "sarif-schema-2.1.0.json"
+        )
 
     def test_has_single_run(self) -> None:
         log = build_sarif_log([])


### PR DESCRIPTION
Part of the output-format conformance umbrella #278 — SARIF findings **S2** and **S6** (plus the related `region` line-0 minor). Three cheap correctness fixes to make before the SARIF shape is frozen at 1.0.

## S2 — `ruleIndex` no longer points an unregistered rule at CL-0001
`index_map.get(f.rule_id, 0)` defaulted a missing rule to index `0`, so `ruleIndex` named the *first* registered rule while `ruleId` named the real one — a §3.52.5 contradiction (the index must identify the descriptor the result refers to). Latent today (all findings come from registered rules) but a silent landmine. Now `ruleIndex` is emitted only when the rule is in the registry.

## Region — omit instead of fabricating `startLine: 1`
`{"startLine": f.line or 1}` collapsed an unknown/non-positive line to line 1, mislocating the alert at the top of the file. `startLine` must be >= 1, so a missing line can't be a region at all — the location now carries only `artifactLocation`, which is valid and lets a consumer attribute the result to the file as a whole.

## S6 — canonical, immutable `$schema`
Was `raw.githubusercontent.com/oasis-tcs/sarif-spec/main/...` — a **mutable** `main`-branch ref (conflicting with this repo's own no-mutable-refs principle) and not the schema's canonical `$id`. Now the OASIS errata01 OS URL: `https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json`.

## Tests
Registered rule → `ruleIndex` resolves to the matching descriptor; unregistered rule → no `ruleIndex`; unknown line → no `region`; `$schema` is the canonical URL. Existing OASIS-schema validation still passes.

## Checks
`ruff check`, `ruff format --check`, `mypy src/` (strict), full `pytest` (691 passed, 2 skipped) green.