### PR TITLE
Add stable partialFingerprints to SARIF results (#278 S3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- SARIF results now carry a stable `partialFingerprints` value
+  (`composeLintFinding/v1`). GitHub Code Scanning uses it to deduplicate
+  uploads and track an alert across commits; without it, direct SARIF uploads
+  produced duplicate alerts and lost continuity when code moved. The digest is
+  derived from the finding's logical identity (file, rule, service, message) and
+  deliberately excludes the line number, so an alert survives unrelated line
+  shifts. Additive to the SARIF contract (ADR-015). (#278)
+
 ### Fixed
 
 - SARIF no longer emits a misleading `ruleIndex` for an unregistered rule.

--- a/src/compose_lint/formatters/sarif.py
+++ b/src/compose_lint/formatters/sarif.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -75,6 +76,31 @@ def _physical_location(filepath: str, line: int | None) -> dict[str, Any]:
     if line is not None and line >= 1:
         location["region"] = {"startLine": line}
     return location
+
+
+# Fingerprint scheme version. Bump if the inputs below change, so a consumer can
+# tell an algorithm change from a genuine new finding.
+_FINGERPRINT_KEY = "composeLintFinding/v1"
+
+
+def _partial_fingerprints(uri: str, finding: Finding) -> dict[str, str]:
+    """A stable per-finding fingerprint for GitHub alert dedup/tracking.
+
+    GitHub uses ``partialFingerprints`` to match the *same* alert across commits
+    and to deduplicate uploads; without them, repeated SARIF uploads create
+    duplicate alerts and lose continuity when code moves. The digest covers the
+    finding's logical identity — file, rule, service, and message (the message
+    carries the specific offending value, which distinguishes multiple hits of
+    one rule on one service) — but deliberately **not** the line number, so an
+    alert survives unrelated line shifts. Optional in base SARIF; emitting it is
+    additive to the contract (ADR-015).
+    """
+    # repr() of the component list is an unambiguous, collision-safe
+    # serialization (it escapes embedded quotes), so distinct findings
+    # cannot alias by component-boundary coincidence.
+    parts = [uri, finding.rule_id, str(finding.service), finding.message]
+    digest = hashlib.sha256(repr(parts).encode("utf-8")).hexdigest()
+    return {_FINGERPRINT_KEY: digest}
 
 
 # GitHub Code Scanning security-severity mapping (numeric).
@@ -192,13 +218,15 @@ def format_findings(
     edits_by_finding = {id(finding): edits for finding, edits in (fixes or [])}
 
     for f in findings:
+        physical_location = _physical_location(filepath, f.line)
         result: dict[str, Any] = {
             "ruleId": f.rule_id,
             "level": _SARIF_LEVEL.get(f.severity, "warning"),
             "message": {"text": f.message},
-            "locations": [
-                {"physicalLocation": _physical_location(filepath, f.line)},
-            ],
+            "locations": [{"physicalLocation": physical_location}],
+            "partialFingerprints": _partial_fingerprints(
+                physical_location["artifactLocation"]["uri"], f
+            ),
         }
 
         # ruleIndex must identify the descriptor the result refers to (SARIF

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -404,6 +404,48 @@ class TestSarifSchemaCompliance:
         self._validate(log, tmp_path)
 
 
+class TestPartialFingerprints:
+    """Each result carries a stable fingerprint for GitHub dedup/tracking (S3)."""
+
+    def test_present_on_every_result(self) -> None:
+        results = format_findings([_sample_finding()], "x.yml")
+        fp = results[0]["partialFingerprints"]
+        assert isinstance(fp["composeLintFinding/v1"], str)
+        assert len(fp["composeLintFinding/v1"]) == 64  # sha256 hex
+
+    def test_stable_across_runs(self) -> None:
+        a = format_findings([_sample_finding()], "x.yml")[0]
+        b = format_findings([_sample_finding()], "x.yml")[0]
+        assert a["partialFingerprints"] == b["partialFingerprints"]
+
+    def test_independent_of_line_number(self) -> None:
+        # An alert should survive an unrelated line shift, so the fingerprint
+        # must not change when only the line moves.
+        base = _sample_finding()
+        moved = Finding(
+            rule_id=base.rule_id,
+            severity=base.severity,
+            service=base.service,
+            message=base.message,
+            line=base.line + 100,
+        )
+        fa = format_findings([base], "x.yml")[0]["partialFingerprints"]
+        fb = format_findings([moved], "x.yml")[0]["partialFingerprints"]
+        assert fa == fb
+
+    def test_differs_by_rule_service_and_message(self) -> None:
+        base = _sample_finding()
+        variants = [
+            Finding("CL-0002", base.severity, base.service, base.message, base.line),
+            Finding(base.rule_id, base.severity, "other", base.message, base.line),
+            Finding(base.rule_id, base.severity, base.service, "other msg", base.line),
+        ]
+        baseline = format_findings([base], "x.yml")[0]["partialFingerprints"]
+        for v in variants:
+            other = format_findings([v], "x.yml")[0]["partialFingerprints"]
+            assert other != baseline
+
+
 class TestArtifactUri:
     """`artifactLocation.uri` is a conformant, GitHub-resolvable URI (S1)."""
 


### PR DESCRIPTION
Part of the output-format conformance umbrella #278 — SARIF finding **S3** (a GAP, not a non-conformance). Decided **now**, before the SARIF shape freezes at 1.0, because adding it later is the only thing that's hard about it.

## Why
SARIF results carried no `partialFingerprints`. GitHub Code Scanning uses these to deduplicate uploads and to track an alert as the "same" across commits. Without them, direct SARIF uploads produce **duplicate alerts** and **lose alert continuity** whenever code moves.

## What
Each result now carries `partialFingerprints["composeLintFinding/v1"]`, a sha256 over the finding's **logical identity** — file URI, rule id, service, and message (the message carries the specific offending value, so multiple hits of one rule on one service stay distinct). The **line number is deliberately excluded** so an alert survives an unrelated line shift. The digest hashes `repr(parts)` — an unambiguous, collision-safe serialization — and the key is versioned (`/v1`) so a future scheme change is distinguishable from a genuine new finding.

Additive to the SARIF contract per ADR-015 (post-1.0 SARIF changes must be additive; this lands pre-1.0 as a deliberate shaping decision).

## Tests
Present on every result (64-hex), stable across runs, **invariant under line shifts**, and distinct across rule/service/message. The OASIS-schema validation suite still passes with the new field.

## Checks
`ruff check`, `ruff format --check`, `mypy src/` (strict), full `pytest` green.