### PR TITLE
Fix text-formatter alignment, presence rules, and color env (#278 T1-T4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Text output: the `SUPPRESSED` marker no longer pushes a suppressed finding's
+  rule and message columns out of alignment — the severity column is padded to
+  fit the marker so every row lines up. CL-0020 and CL-0021 (credential-shaped
+  env keys and inline connection-string credentials) now render the source
+  excerpt and underline like the other value-naming rules; they had been left
+  out of the presence-rule set. `FORCE_COLOR=0`/`false` (case-insensitive) now
+  disables color and any other set value — including the empty string — enables
+  it, matching the chalk/supports-color convention (previously `FORCE_COLOR=false`
+  turned color *on*). The excerpt underline now matches the value at a token
+  boundary and measures display width (East-Asian wide and combining characters),
+  so it no longer mis-points on a value that is a substring of a longer token or
+  contains CJK/accented characters. (#278)
+
 - SARIF no longer emits a misleading `ruleIndex` for an unregistered rule.
   `ruleIndex` defaulted to `0`, so a result whose rule was absent from the
   registry pointed at the first rule (CL-0001) while `ruleId` named the real one

--- a/src/compose_lint/formatters/text.py
+++ b/src/compose_lint/formatters/text.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import re
 import sys
+import unicodedata
 from pathlib import Path
 
 from compose_lint.models import Finding, Severity
@@ -22,8 +23,16 @@ _RESET = "\033[0m"
 _BOLD = "\033[1m"
 _DIM = "\033[2m"
 
-# All active severity labels are padded to this width so finding columns align.
+# The marker shown in the severity column for a suppressed finding.
+_SUPPRESSED_LABEL = "SUPPRESSED"
+
+# All severity-column cells — severity labels and the SUPPRESSED marker — are
+# padded to this width so the rule/message columns line up across every row,
+# suppressed or not. "SUPPRESSED" (10) is wider than the longest severity
+# ("critical", 8), so the column widens to it rather than letting suppressed
+# rows push the later columns out of alignment.
 _SEV_WIDTH = max(len(s.value) for s in Severity)  # len("critical") == 8
+_LABEL_WIDTH = max(_SEV_WIDTH, len(_SUPPRESSED_LABEL))
 
 # Rule ids are always CL-XXXX; pad the column header to match the finding rows.
 _RULE_WIDTH = len("CL-XXXX")
@@ -61,6 +70,8 @@ _PRESENCE_RULES = frozenset(
         "CL-0017",
         "CL-0018",
         "CL-0019",
+        "CL-0020",
+        "CL-0021",
     }
 )
 
@@ -71,15 +82,17 @@ def _color_enabled() -> bool:
     """Decide whether to emit ANSI color, honoring the de-facto env standards.
 
     ``NO_COLOR`` (set to any non-empty value) disables color even on a TTY and
-    wins over everything, per https://no-color.org. ``FORCE_COLOR`` (set and
-    not ``0``) forces color even through a pipe — useful for pagers and CI logs
-    that render ANSI. Otherwise color follows whether stdout is a terminal.
+    wins over everything, per https://no-color.org. ``FORCE_COLOR``, when set,
+    overrides TTY detection: ``0`` or ``false`` (case-insensitive) disables
+    color, any other value — including the empty string — enables it, matching
+    the chalk/supports-color convention. Otherwise color follows whether stdout
+    is a terminal.
     """
     if os.environ.get("NO_COLOR"):
         return False
     force = os.environ.get("FORCE_COLOR")
-    if force and force != "0":
-        return True
+    if force is not None:
+        return force.lower() not in ("0", "false")
     return sys.stdout.isatty()
 
 
@@ -88,6 +101,50 @@ def _colorize(text: str, code: str) -> str:
     if not _color_enabled():
         return text
     return f"{code}{text}{_RESET}"
+
+
+def _display_width(text: str) -> int:
+    """Terminal column width of ``text``.
+
+    East-Asian wide/fullwidth code points count as 2 columns and zero-width
+    combining marks as 0, so an underline lines up under CJK or accented text
+    instead of drifting by the code-point/column mismatch. Uses the stdlib
+    ``unicodedata`` rather than ``wcwidth`` to keep the runtime dependency
+    surface at PyYAML only.
+    """
+    width = 0
+    for ch in text:
+        if unicodedata.combining(ch):
+            continue
+        width += 2 if unicodedata.east_asian_width(ch) in ("W", "F") else 1
+    return width
+
+
+def _find_token(haystack: str, needle: str) -> int:
+    """Index of ``needle`` in ``haystack`` at a token boundary, else first match.
+
+    Plain ``str.find`` underlines the first substring hit, which mis-points when
+    the value also appears inside a longer token (``80`` inside ``8080``) or as
+    an earlier substring. Prefer an occurrence whose neighbors are not
+    alphanumerics; fall back to the first match so a value that is only ever a
+    substring still gets underlined rather than skipped.
+    """
+
+    def _word(c: str) -> bool:
+        return c.isalnum() or c == "_"
+
+    first = haystack.find(needle)
+    start = 0
+    while True:
+        idx = haystack.find(needle, start)
+        if idx < 0:
+            return first
+        end = idx + len(needle)
+        before = haystack[idx - 1] if idx > 0 else ""
+        after = haystack[end] if end < len(haystack) else ""
+        if not _word(before) and not _word(after):
+            return idx
+        start = idx + 1
 
 
 def format_header(
@@ -141,9 +198,10 @@ def _excerpt(
     match = _QUOTED.search(message)
     if match:
         needle = match.group(1)
-        col = raw.find(needle)
+        col = _find_token(raw, needle)
         if col >= 0:
-            underline = " " * col + "─" * len(needle)
+            indent = _display_width(raw[:col])
+            underline = " " * indent + "─" * _display_width(needle)
             color = _COLORS.get(severity, "")
             out.append(f"{pad} {bar} {_colorize(underline, color)}")
     return out
@@ -196,7 +254,7 @@ def format_findings(
         out.append(
             _colorize(
                 f"    {'line'.rjust(4)}  "
-                f"{'severity'.ljust(_SEV_WIDTH)}  "
+                f"{'severity'.ljust(_LABEL_WIDTH)}  "
                 f"{'rule'.ljust(_RULE_WIDTH)}  message",
                 _DIM,
             )
@@ -206,9 +264,12 @@ def format_findings(
             if f.suppressed:
                 reason = f.suppression_reason or "disabled in .compose-lint.yml"
                 line_label = str(f.line) if f.line else "?"
+                marker = _colorize(
+                    _SUPPRESSED_LABEL.ljust(_LABEL_WIDTH), _SUPPRESSED_COLOR
+                )
                 out.append(
                     f"    {line_label.rjust(4)}  "
-                    f"{_colorize('SUPPRESSED', _SUPPRESSED_COLOR)}  "
+                    f"{marker}  "
                     f"{_colorize(f.rule_id, _DIM)}  "
                     f"{_colorize(f.message, _SUPPRESSED_COLOR)}"
                 )
@@ -216,7 +277,7 @@ def format_findings(
                     out.append(f"          {_colorize('reason:', _DIM)} {reason}")
                 continue
 
-            severity_label = f.severity.value.upper().ljust(_SEV_WIDTH)
+            severity_label = f.severity.value.upper().ljust(_LABEL_WIDTH)
             color = _COLORS.get(f.severity, "")
             line_label = str(f.line) if f.line else "?"
 

--- a/tests/test_text_formatter.py
+++ b/tests/test_text_formatter.py
@@ -14,8 +14,12 @@ import pytest
 
 from compose_lint.formatters.text import (
     _COLORS,
+    _LABEL_WIDTH,
+    _PRESENCE_RULES,
     _RESET,
     _colorize,
+    _display_width,
+    _find_token,
     format_aggregate_summary,
     format_findings,
     format_verdict,
@@ -266,3 +270,119 @@ def test_aggregate_summary_singular_file() -> None:
 def test_aggregate_summary_plural_files() -> None:
     out = format_aggregate_summary([([], "a.yml"), ([], "b.yml")])
     assert "2 files scanned" in out
+
+
+# --- T1: suppressed-row column alignment ----------------------------------
+
+
+def test_suppressed_row_aligns_with_finding_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _no_tty(monkeypatch)  # plain output, no ANSI to skew column indexing
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    findings = [
+        Finding("CL-0001", Severity.CRITICAL, "web", "active finding", line=2),
+        Finding(
+            "CL-0002", Severity.HIGH, "web", "muted finding", line=3, suppressed=True
+        ),
+    ]
+    out = format_findings(findings, "compose.yml")
+    rule_cols = [ln.index("CL-000") for ln in out.splitlines() if "CL-000" in ln]
+    assert len(rule_cols) == 2
+    assert rule_cols[0] == rule_cols[1]  # SUPPRESSED no longer shifts its row
+
+
+def test_suppressed_marker_padded_to_label_width(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _no_tty(monkeypatch)
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    finding = Finding("CL-0001", Severity.CRITICAL, "web", "x", line=1, suppressed=True)
+    out = format_findings([finding], "compose.yml")
+    assert f"SUPPRESSED{' ' * (_LABEL_WIDTH - len('SUPPRESSED'))}" in out
+
+
+# --- T2: CL-0020 / CL-0021 are presence rules -----------------------------
+
+
+def test_new_credential_rules_are_presence_rules() -> None:
+    assert {"CL-0020", "CL-0021"} <= _PRESENCE_RULES
+
+
+def test_cl0020_renders_source_excerpt(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    path = tmp_path / "compose.yml"
+    path.write_text(
+        "services:\n  web:\n    environment:\n"
+        "      AWS_SECRET_ACCESS_KEY: literalvalue\n",
+        encoding="utf-8",
+    )
+    finding = Finding(
+        "CL-0020",
+        Severity.HIGH,
+        "web",
+        "Service has credential-shaped env key 'AWS_SECRET_ACCESS_KEY' "
+        "with a literal value.",
+        line=4,
+    )
+    out = format_findings([finding], str(path))
+    assert "│" in out  # source gutter rendered
+    assert "─" * len("AWS_SECRET_ACCESS_KEY") in out  # underline under the key
+
+
+# --- T3: FORCE_COLOR truthiness -------------------------------------------
+
+
+def test_force_color_false_disables(monkeypatch: pytest.MonkeyPatch) -> None:
+    _force_color(monkeypatch)  # stdout looks like a tty (would colorize)
+    monkeypatch.setenv("FORCE_COLOR", "false")
+    assert _colorize("x", _RED) == "x"
+
+
+def test_force_color_false_is_case_insensitive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _force_color(monkeypatch)
+    monkeypatch.setenv("FORCE_COLOR", "FALSE")
+    assert _colorize("x", _RED) == "x"
+
+
+def test_force_color_empty_string_enables(monkeypatch: pytest.MonkeyPatch) -> None:
+    _no_tty(monkeypatch)  # pipe: default would be no color
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("FORCE_COLOR", "")
+    assert _colorize("x", _RED) == f"{_RED}x{_RESET}"
+
+
+# --- T4: excerpt underline alignment --------------------------------------
+
+
+def test_display_width_counts_wide_and_combining() -> None:
+    assert _display_width("abc") == 3
+    assert _display_width("你好") == 4  # two fullwidth code points
+    assert _display_width("é") == 1  # 'e' + combining acute = one column
+
+
+def test_find_token_prefers_boundary_over_substring() -> None:
+    # The standalone "80" (after the colon), not the "80" inside "8080".
+    assert _find_token("8080:80", "80") == 5
+    # Falls back to the first match when the value is only ever a substring.
+    assert _find_token("only-substr", "subst") == 5
+
+
+def test_underline_targets_standalone_token(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    path = tmp_path / "compose.yml"
+    path.write_text(
+        "services:\n  web:\n    ports:\n      - 8080:80\n", encoding="utf-8"
+    )
+    finding = Finding(
+        "CL-0005", Severity.HIGH, "web", "Host port '80' is published.", line=4
+    )
+    out = format_findings([finding], str(path))
+    raw = "      - 8080:80"
+    # The underline sits under the standalone 80 (after the colon, col 13), not
+    # the "80" inside 8080 (col 8); a col-8 underline would be " " * 8 + "──".
+    expected_col = raw.index(":80") + 1
+    assert expected_col == 13
+    assert (" " * expected_col + "──") in out


### PR DESCRIPTION
Final part of the output-format conformance umbrella #278 — the **text** findings T1–T4. Text isn't under the SemVer machine-output contract, so these are correctness/consistency fixes.

## T1 — `SUPPRESSED` row breaks column alignment
The `SUPPRESSED` marker (10 chars) wasn't padded to the severity-column width (8), so every suppressed row pushed the rule/message columns two chars right of all other rows. The severity column now widens to fit the marker, so rows line up whether suppressed or not.

## T2 — CL-0020 / CL-0021 missing from the presence-rule set
Both name a specific value on the source line (a credential-shaped env key / an inline connection-string credential), so they should render the source excerpt + underline like CL-0005 — but they were never added to `_PRESENCE_RULES`. Added.

## T3 — `FORCE_COLOR=false` forced color *on*
The check was `if force and force != "0"`, so `FORCE_COLOR=false` is truthy → color on (opposite of the chalk/supports-color convention), and `FORCE_COLOR=''` failed to enable. Now `0`/`false` (case-insensitive) disables, any other set value — including the empty string — enables. (`NO_COLOR` still wins, unchanged.)

## T4 — excerpt underline misaligns
`raw.find(needle)` (first/substring match) + `len(needle)` (code points) mis-pointed when a value appears as a substring of a longer token (`80` inside `8080`) or contains CJK/accented characters. Now matched at a token boundary and measured by display width.

**Dependency note:** the issue suggested `wcwidth`, but CLAUDE.md keeps the runtime dependency surface at PyYAML only — so display width is computed with the stdlib `unicodedata` (East-Asian wide/fullwidth → 2 columns, combining marks → 0) instead.

## Tests
New cases for each: suppressed-row alignment + marker padding (T1); CL-0020/0021 in the presence set + an excerpt rendering (T2); `FORCE_COLOR=false`/`FALSE`/`''` (T3); `_display_width`/`_find_token` units + a standalone-token underline (T4).

## Checks
`ruff check`, `ruff format --check`, `mypy src/` (strict), full `pytest` (705 passed, 2 skipped) green.