### PR TITLE
Isolate a crashing rule so it cannot abort the whole run (#279 E1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A rule that raises no longer aborts the entire run. Previously an uncaught
+  exception from any rule escaped as a traceback and exited 1 —
+  indistinguishable from a normal "findings at/above threshold" result, and in a
+  directory sweep every remaining file was lost. The engine now isolates each
+  rule per service: a failure is reported to stderr and the run continues, and
+  the CLI maps it to exit 2 ("compose-lint itself couldn't run", ADR-006) so a
+  crash is never mistaken for a clean lint failure. (#279)
+
 - Text output: the `SUPPRESSED` marker no longer pushes a suppressed finding's
   rule and message columns out of alignment — the severity column is padded to
   fit the marker so every row lines up. CL-0020 and CL-0021 (credential-shaped

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ CI log that renders ANSI.
 |------|---------|
 | 0 | No findings at or above the `--fail-on` threshold |
 | 1 | One or more findings at or above the `--fail-on` threshold |
-| 2 | Usage error (invalid args, file not found, invalid Compose file) |
+| 2 | compose-lint couldn't run (invalid args, file not found, invalid Compose file, or a rule crashed) |
 
 The default threshold is `high` — medium and low findings don't fail CI unless you opt in:
 

--- a/docs/adr/006-exit-codes.md
+++ b/docs/adr/006-exit-codes.md
@@ -10,3 +10,4 @@
 - Matches Hadolint's `--failure-threshold` and KICS's severity-mapped exit codes.
 - Default behavior is strict (fail on high/critical) but teams can relax with `--fail-on critical` or tighten with `--fail-on low`.
 - Exit 2 for file/config errors distinguishes "your compose file has issues" from "compose-lint itself couldn't run."
+- A rule that raises is isolated rather than aborting the run (the failure is reported to stderr and the sweep continues), and maps to exit 2 for the same reason: it means compose-lint itself couldn't complete the analysis, not that the file failed the lint. This keeps a crash from being silently truncated mid-sweep or mistaken for a clean exit-1 findings result.

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -339,6 +339,7 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
     all_sarif: list[dict[str, object]] = []
     all_file_findings: list[tuple[list[Finding], str]] = []
     parse_errors: list[tuple[str, str]] = []
+    rule_errors: list[tuple[str, str]] = []
     has_errors = False
     seen_services: set[str] = set()
 
@@ -362,12 +363,26 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
 
         seen_services.update(data.get("services", {}).keys())
 
+        def _record_rule_error(
+            rule_id: str,
+            service_name: str,
+            exc: Exception,
+            _filepath: str = filepath,
+        ) -> None:
+            msg = (
+                f"rule {rule_id} failed on service '{service_name}': "
+                f"{type(exc).__name__}: {exc}"
+            )
+            rule_errors.append((_filepath, msg))
+            print(f"Error: {_filepath}: {msg}", file=sys.stderr)
+
         findings = run_rules(
             data,
             lines,
             disabled_rules=disabled_rules,
             severity_overrides=severity_overrides,
             excluded_services=excluded_services,
+            on_error=_record_rule_error,
         )
 
         if args.skip_suppressed:
@@ -422,7 +437,7 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
         sarif_log = build_sarif_log(all_sarif, parse_errors)
         print(json.dumps(sarif_log, indent=2, allow_nan=False))
 
-    if parse_errors:
+    if parse_errors or rule_errors:
         sys.exit(2)
     sys.exit(1 if has_errors else 0)
 

--- a/src/compose_lint/engine.py
+++ b/src/compose_lint/engine.py
@@ -2,11 +2,24 @@
 
 from __future__ import annotations
 
+import sys
 from dataclasses import replace
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from compose_lint.models import Finding, Severity
 from compose_lint.rules import get_registered_rules
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def _default_rule_error(rule_id: str, service_name: str, exc: Exception) -> None:
+    """Report a crashed rule to stderr without aborting the run."""
+    print(
+        f"Error: rule {rule_id} failed on service '{service_name}': "
+        f"{type(exc).__name__}: {exc}",
+        file=sys.stderr,
+    )
 
 
 def run_rules(
@@ -15,6 +28,7 @@ def run_rules(
     disabled_rules: dict[str, str | None] | None = None,
     severity_overrides: dict[str, Severity] | None = None,
     excluded_services: dict[str, dict[str, str | None]] | None = None,
+    on_error: Callable[[str, str, Exception], None] | None = None,
 ) -> list[Finding]:
     """Run all registered rules against the parsed Compose data.
 
@@ -22,10 +36,18 @@ def run_rules(
     those findings are marked suppressed with an appropriate reason. A
     global disable takes precedence over per-service exclusions (see
     ADR-010). Returns findings sorted by line number (None-line last).
+
+    A rule that raises is isolated rather than allowed to abort the whole
+    run: the failure is reported via ``on_error`` (defaulting to a stderr
+    diagnostic) and the engine continues with the next service and rule. The
+    CLI maps such a failure to exit 2 ("compose-lint itself couldn't run",
+    ADR-006) so a directory sweep is never silently truncated and a crash is
+    never mistaken for a clean lint failure.
     """
     disabled = disabled_rules or {}
     overrides = severity_overrides or {}
     excluded = excluded_services or {}
+    report_error = on_error if on_error is not None else _default_rule_error
     findings: list[Finding] = []
 
     rule_classes = get_registered_rules()
@@ -39,7 +61,14 @@ def run_rules(
         rule_excluded = excluded.get(rule_id, {})
 
         for service_name, service_config in services.items():
-            for finding in rule.check(service_name, service_config, data, lines):
+            try:
+                rule_findings = list(
+                    rule.check(service_name, service_config, data, lines)
+                )
+            except Exception as exc:  # noqa: BLE001 - isolate a crashing rule
+                report_error(rule_id, service_name, exc)
+                continue
+            for finding in rule_findings:
                 if rule_id in overrides and not is_suppressed:
                     finding = replace(finding, severity=overrides[rule_id])
                 if is_suppressed:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,8 +7,14 @@ import stat
 import subprocess
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from compose_lint.models import Finding
 
 FIXTURES = Path(__file__).parent / "compose_files"
 
@@ -492,3 +498,50 @@ class TestFixSubcommand:
         assert exc.value.code == 2
         assert "added or removed a service" in capsys.readouterr().err
         assert f.read_text() == _BARE_SERVICE  # nothing written
+
+
+class TestRuleCrashExitCode:
+    """A rule that raises maps to exit 2, not a clean/findings exit (#279 E1)."""
+
+    def test_rule_crash_exits_2_with_diagnostic(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        from compose_lint import cli
+        from compose_lint.models import RuleMetadata, Severity
+        from compose_lint.rules import BaseRule, _registry
+
+        class _CrashingRule(BaseRule):
+            @property
+            def metadata(self) -> RuleMetadata:
+                return RuleMetadata(
+                    id="CL-CRASH",
+                    name="Crashing rule",
+                    description="Always raises",
+                    severity=Severity.HIGH,
+                )
+
+            def check(self, *_: object) -> Iterator[Finding]:
+                raise RuntimeError("boom")
+                yield  # pragma: no cover - makes this a generator
+
+        f = tmp_path / "docker-compose.yml"
+        f.write_text(_BARE_SERVICE)
+
+        saved = list(_registry)
+        _registry.clear()
+        _registry.append(_CrashingRule)
+        try:
+            with pytest.raises(SystemExit) as exc:
+                cli.main(["check", str(f)])
+        finally:
+            _registry.clear()
+            _registry.extend(saved)
+
+        # Exit 2: "compose-lint itself couldn't run" (ADR-006), distinguishable
+        # from a clean run (0) and from real findings (1).
+        assert exc.value.code == 2
+        err = capsys.readouterr().err
+        assert "CL-CRASH" in err
+        assert "RuntimeError" in err

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -210,6 +210,73 @@ class TestRunRules:
         assert findings[0].suppressed is False
 
 
+class _CrashingRule(BaseRule):
+    """A test rule that raises while checking any service."""
+
+    @property
+    def metadata(self) -> RuleMetadata:
+        return RuleMetadata(
+            id="CL-CRASH",
+            name="Crashing rule",
+            description="Always raises",
+            severity=Severity.HIGH,
+        )
+
+    def check(
+        self,
+        service_name: str,
+        service_config: dict[str, Any],
+        global_config: dict[str, Any],
+        lines: dict[str, int],
+    ) -> Iterator[Finding]:
+        raise RuntimeError("boom")
+        yield  # pragma: no cover - makes this a generator
+
+
+class TestRuleIsolation:
+    """A rule that raises must not abort the whole run (issue #279 E1)."""
+
+    def setup_method(self) -> None:
+        self._saved_registry = list(_registry)
+        _registry.clear()
+        _registry.append(_CrashingRule)
+        _registry.append(_DummyRule)
+
+    def teardown_method(self) -> None:
+        _registry.clear()
+        _registry.extend(self._saved_registry)
+
+    def test_other_rules_still_run_when_one_crashes(self) -> None:
+        data = {"services": {"web": {"test_flag": True}}}
+        findings = run_rules(data, {}, on_error=lambda *_: None)
+        # The good rule's finding survives; the crashing rule yields nothing.
+        assert [f.rule_id for f in findings] == ["CL-TEST"]
+
+    def test_default_reports_crash_to_stderr(self, capsys: Any) -> None:
+        data = {"services": {"web": {"test_flag": True}}}
+        run_rules(data, {})
+        err = capsys.readouterr().err
+        assert "CL-CRASH" in err
+        assert "web" in err
+        assert "RuntimeError" in err
+
+    def test_on_error_callback_receives_failure(self) -> None:
+        seen: list[tuple[str, str, str]] = []
+        data = {"services": {"web": {"image": "nginx"}}}
+        run_rules(
+            data,
+            {},
+            on_error=lambda rid, svc, exc: seen.append((rid, svc, type(exc).__name__)),
+        )
+        assert seen == [("CL-CRASH", "web", "RuntimeError")]
+
+    def test_crash_reported_per_service(self) -> None:
+        seen: list[str] = []
+        data = {"services": {"web": {}, "db": {}}}
+        run_rules(data, {}, on_error=lambda _rid, svc, _exc: seen.append(svc))
+        assert sorted(seen) == ["db", "web"]
+
+
 class TestFilterFindings:
     """Tests for filter_findings function."""
 


### PR DESCRIPTION
## E1 — a rule raising an exception aborts the entire run

Part of the #279 second-wave umbrella. Reported per-bug per the umbrella convention.

`run_rules` called `rule.check(...)` with no guard, and the only `try/except` in the CLI wraps `load_compose`, not the engine. Any rule that raises escaped as an uncaught traceback and the process **exited 1** — byte-for-byte indistinguishable from a normal "findings at/above threshold" result. In a directory sweep, every remaining file was lost and a CI consumer could not tell a crash from a lint failure.

### Change

- **Engine**: each rule's per-service `check(...)` is now wrapped. A rule that raises is isolated — the failure is reported via an `on_error` callback (defaulting to a stderr diagnostic) and the engine continues with the next service and rule. `KeyboardInterrupt`/`SystemExit` still propagate (`except Exception`, not `BaseException`).
- **CLI**: `check` records rule crashes and maps them to **exit 2** — "compose-lint itself couldn't run" per ADR-006 — so a crash is never mistaken for a clean exit-1 findings result, and the sweep is never silently truncated. Each crash also prints `Error: <file>: rule <id> failed on service '<svc>': <Type>: <msg>` to stderr.

This is the defense-in-depth companion to #277 F1 (resolver strip removes the typed-value source; this guard ensures a future edge case can't silently abort a CI sweep).

### Docs
- ADR-006 and the README exit-code table note the rule-crash → exit 2 mapping.

### Tests
- Engine: a crashing rule no longer aborts the run; good rules still produce findings; default stderr diagnostic; `on_error` callback receives the failure; crash reported per service.
- CLI: an injected crashing rule yields exit 2 with a stderr diagnostic.

### Quality
`ruff check`, `ruff format --check`, `mypy src/` (strict, py3.13), and `pytest` (710 passed, 2 skipped) all green.