### PR TITLE
Detect bare published ports (CL-0005) and password-only URLs (CL-0021) (#279 R1/R2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the CLI maps it to exit 2 ("compose-lint itself couldn't run", ADR-006) so a
   crash is never mistaken for a clean lint failure. (#279)
 
+- CL-0005 now flags a bare short-syntax port with no colon (`"3000"`, `3001`, a
+  `"3000-3005"` range). Docker still publishes it — `docker compose up` assigns a
+  random (ephemeral) host port bound to all interfaces (`0.0.0.0` and `[::]`) —
+  so it is the same exposure class the rule targets, and it is the most common
+  port form in real homelab files. The finding notes the host port is ephemeral
+  and the guidance binds it to localhost with `127.0.0.1::<port>`. The in-scalar
+  autofixer refuses this form (it can't synthesize the empty-host-port syntax).
+  (#279)
+
+- CL-0021 now flags a password-only userinfo (`scheme://:password@host`). The
+  regex required a non-empty username, but RFC 3986 §3.2.1 permits an empty one
+  and `redis://:password@host` is the standard Redis URL form. The
+  password-is-a-`$VAR` skip is unchanged. (#279)
+
 - Text output: the `SUPPRESSED` marker no longer pushes a suppressed finding's
   rule and message columns out of alignment — the severity column is padded to
   fit the marker so every row lines up. CL-0020 and CL-0021 (credential-shaped

--- a/docs/rules/CL-0005.md
+++ b/docs/rules/CL-0005.md
@@ -8,7 +8,7 @@
 
 ## What it detects
 
-Port mappings that don't specify a bind address or that bind to a wildcard, in both short syntax (`"8080:80"`, `"0.0.0.0:8080:80"`, `"[::]:8080:80"`) and long syntax (`published:` without `host_ip:`, or with `host_ip: "0.0.0.0"` / `host_ip: "::"`). Specific bind addresses including loopback (`127.0.0.1`, `[::1]`) are not flagged. Container-only ports (`"80"`) are not flagged since they are not published to the host.
+Port mappings that don't specify a bind address or that bind to a wildcard, in both short syntax (`"8080:80"`, `"0.0.0.0:8080:80"`, `"[::]:8080:80"`) and long syntax (`published:` without `host_ip:`, or with `host_ip: "0.0.0.0"` / `host_ip: "::"`). A bare short-syntax port with no colon (`"80"`, `3001`, a `"3000-3005"` range) is also flagged: Docker still publishes it, assigning a random (ephemeral) host port bound to all interfaces (`docker compose config` normalizes `- "80"` to a published `target`, and `docker compose up` binds it on `0.0.0.0`). Bind it with `127.0.0.1::80` to keep the ephemeral port on localhost. Specific bind addresses including loopback (`127.0.0.1`, `[::1]`) are not flagged.
 
 ## Why it matters
 

--- a/docs/rules/CL-0021.md
+++ b/docs/rules/CL-0021.md
@@ -20,11 +20,11 @@ services:
       AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow  # fires
 ```
 
-The value-side regex matches any URI scheme (`[a-zA-Z][a-zA-Z0-9+.\-]*`) followed by `://user:password@`, where neither userinfo half is empty and neither contains a `$` (variable substitution).
+The value-side regex matches any URI scheme (`[a-zA-Z][a-zA-Z0-9+.\-]*`) followed by `://user:password@`, where the password half is non-empty and contains no `$` (variable substitution). The username half may be empty: RFC 3986 §3.2.1 permits it, and `redis://:password@host` — the standard Redis URL form — still leaks the password, so it fires.
 
 Skipped:
 
-- Either userinfo half contains `${VAR}` or `$VAR` — the credential is parameterized.
+- Password half contains `${VAR}` or `$VAR` — the credential is parameterized. (A `$`-valued *username* with a literal password still fires: the password leaks regardless.)
 - Userinfo password is empty (`scheme://user:@host`) — no credential to leak.
 - No userinfo at all (`scheme://host/path`) — nothing to flag.
 - Empty or non-string value.

--- a/src/compose_lint/rules/CL0005_unbound_ports.py
+++ b/src/compose_lint/rules/CL0005_unbound_ports.py
@@ -40,6 +40,13 @@ _PORT_PATTERN = re.compile(
     rf"^(?:(?P<ip>[^:]+):)?(?P<host>{_PORT_PART}):(?P<container>{_PORT_PART})$"
 )
 
+# A bare short-syntax port with no colon (`"3000"`, `3001`, a `"3000-3005"`
+# range, optional `/proto`). Docker still publishes it — `docker compose
+# config` normalizes `- "3000"` to a `target` with an ephemeral host port
+# bound to all interfaces (0.0.0.0) — so it is the same exposure class this
+# rule targets (issue #279 R1). Anchored to reject non-port junk.
+_BARE_PORT_PATTERN = re.compile(rf"^{_PORT_PART}$")
+
 # Values that publish on all interfaces — equivalent to no bind address.
 # These are detection patterns, not actual bind addresses.
 _WILDCARD_IPS = frozenset({"0.0.0.0", "::", "[::]", "*"})  # nosec B104
@@ -95,8 +102,14 @@ class UnboundPortsRule(BaseRule):
         lines: dict[str, int],
         index: int,
     ) -> Iterator[Finding]:
-        # Container-only port (no host mapping) — not published, skip
+        # A bare port with no colon is still published: Docker assigns an
+        # ephemeral host port bound to all interfaces (issue #279 R1). Fire
+        # with an ephemeral-port message; reject non-port junk via the pattern.
         if ":" not in port_str:
+            if _BARE_PORT_PATTERN.match(port_str):
+                yield self._make_finding(
+                    port_str, service_name, lines, index, bare=True
+                )
             return
 
         # Extract bracketed IPv6 prefix (e.g. "[::]:8080:80") before the
@@ -147,22 +160,40 @@ class UnboundPortsRule(BaseRule):
         service_name: str,
         lines: dict[str, int],
         index: int,
+        bare: bool = False,
     ) -> Finding:
+        if bare:
+            message = (
+                f"Bare port '{port_str}' is published on all interfaces: Docker "
+                "assigns a random (ephemeral) host port bound to 0.0.0.0. It "
+                "bypasses host firewalls (UFW/firewalld), potentially exposing "
+                "this port to the public internet."
+            )
+            # `127.0.0.1::3000` keeps the ephemeral host port (empty middle
+            # field) while pinning the bind address to localhost.
+            fix = (
+                f"Bind to localhost, keeping an ephemeral host port: "
+                f"127.0.0.1::{port_str}\n"
+                "If public access is needed, use a reverse proxy with TLS."
+            )
+        else:
+            message = (
+                f"Port '{port_str}' is bound to all interfaces. Docker bypasses "
+                "host firewalls (UFW/firewalld), potentially exposing this port "
+                "to the public internet."
+            )
+            fix = (
+                f"Bind to localhost: 127.0.0.1:{port_str}\n"
+                "If public access is needed, use a reverse proxy with TLS."
+            )
         return Finding(
             rule_id="CL-0005",
             severity=Severity.HIGH,
             service=service_name,
-            message=(
-                f"Port '{port_str}' is bound to all interfaces. Docker bypasses "
-                "host firewalls (UFW/firewalld), potentially exposing this port "
-                "to the public internet."
-            ),
+            message=message,
             line=lines.get(f"services.{service_name}.ports[{index}]")
             or lines.get(f"services.{service_name}.ports"),
-            fix=(
-                f"Bind to localhost: 127.0.0.1:{port_str}\n"
-                "If public access is needed, use a reverse proxy with TLS."
-            ),
+            fix=fix,
             references=[OWASP_REF, CIS_REF],
         )
 

--- a/src/compose_lint/rules/CL0021_connection_string_credentials.py
+++ b/src/compose_lint/rules/CL0021_connection_string_credentials.py
@@ -22,11 +22,14 @@ RFC3986_REF = "https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.1"
 
 # Match `scheme://user:password@` in any env value. The scheme follows
 # RFC 3986 §3.1 (alpha + alnum/+/-/.); user and password halves stop at
-# the structural separators (':', '/', '@', whitespace). The '$' guard
-# below filters out variable substitutions in either half.
+# the structural separators (':', '/', '@', whitespace). The user half is
+# optional (`*`, not `+`): RFC 3986 §3.2.1 permits an empty username, and
+# `redis://:password@host` — the standard Redis URL form — must still fire
+# (issue #279 R2). The '$' guard below filters out variable substitutions in
+# the password half.
 _URI_USERINFO_RE = re.compile(
     r"(?P<scheme>[a-zA-Z][a-zA-Z0-9+.\-]*)://"
-    r"(?P<user>[^:/@\s]+):"
+    r"(?P<user>[^:/@\s]*):"
     r"(?P<password>[^@/\s]+)@"
 )
 

--- a/tests/compose_files/insecure_ports.yml
+++ b/tests/compose_files/insecure_ports.yml
@@ -19,7 +19,7 @@ services:
       - target: 80
         published: 8080
         host_ip: "127.0.0.1"
-  container_only:
+  bare_port:
     image: nginx:1.27-alpine
     ports:
       - "80"

--- a/tests/test_CL0005.py
+++ b/tests/test_CL0005.py
@@ -78,9 +78,15 @@ class TestUnboundPortsRule:
         findings = self._check("bound_long")
         assert len(findings) == 0
 
-    def test_container_only_port_no_findings(self) -> None:
-        findings = self._check("container_only")
-        assert len(findings) == 0
+    def test_bare_port_fires_as_ephemeral(self) -> None:
+        # A bare short-syntax port (`"80"`) is still published: Docker assigns
+        # an ephemeral host port bound to all interfaces (issue #279 R1).
+        findings = self._check("bare_port")
+        assert len(findings) == 1
+        assert findings[0].rule_id == "CL-0005"
+        assert "ephemeral" in findings[0].message
+        # Guidance keeps the ephemeral host port while binding to localhost.
+        assert "127.0.0.1::80" in (findings[0].fix or "")
 
     def test_port_range(self) -> None:
         findings = self._check("port_range")
@@ -249,6 +255,14 @@ class TestUnboundPortsFix:
             line=line,
         )
         assert self.rule.fix(finding, data, lines, content) is None
+
+    def test_refuses_bare_port(self, tmp_path: Path) -> None:
+        # A bare port fires (issue #279 R1), but the in-scalar fixer only
+        # rewrites a host:container scalar; it can't synthesize the
+        # ephemeral-localhost (`127.0.0.1::3000`) form, so it refuses (ADR-014).
+        content = 'services:\n  web:\n    ports:\n      - "3000"\n'
+        edits = self._fix(tmp_path, content)
+        assert edits is None
 
     def test_long_syntax_inserts_host_ip_when_absent(self, tmp_path: Path) -> None:
         content = (

--- a/tests/test_CL0021.py
+++ b/tests/test_CL0021.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from compose_lint.models import Finding, Severity
-from compose_lint.parser import load_compose
+from compose_lint.parser import load_compose, loads
 from compose_lint.rules.CL0021_connection_string_credentials import (
     ConnectionStringCredentialsRule,
 )
@@ -72,6 +72,29 @@ class TestConnectionStringCredentialsRule:
 
     def test_skip_user_literal_password_var(self) -> None:
         findings = self._check("skip_user_literal_password_var")
+        assert findings == []
+
+    def _check_inline(self, value: str) -> list[Finding]:
+        data, lines = loads(
+            "services:\n"
+            "  app:\n"
+            "    image: nginx\n"
+            "    environment:\n"
+            f"      URL: {value}\n"
+        )
+        return list(self.rule.check("app", data["services"]["app"], data, lines))
+
+    def test_detect_password_only_userinfo(self) -> None:
+        # RFC 3986 §3.2.1 permits an empty username, and `redis://:password@host`
+        # is the standard Redis URL form — it must fire (issue #279 R2).
+        findings = self._check_inline('"redis://:supersecret@redis:6379/0"')
+        assert len(findings) == 1
+        assert findings[0].rule_id == "CL-0021"
+        assert "redis" in findings[0].message
+
+    def test_skip_password_only_userinfo_var_password(self) -> None:
+        # The empty-username form still honors the password-is-a-var guard.
+        findings = self._check_inline('"redis://:${REDIS_PASSWORD}@redis:6379/0"')
         assert findings == []
 
     def test_detect_user_var_password_literal(self) -> None:


### PR DESCRIPTION
Part of the #279 second-wave umbrella. Two rule false-negatives, both live-reproduced.

## R1 — CL-0005: bare short-syntax port is never flagged

`_check_short_syntax` returned early on `":" not in port_str`, treating `"3000"` / `3001` as container-only. But a bare port **is published**: `docker compose up` assigns a random (ephemeral) host port bound to **all interfaces**. Verified live:

```
$ docker compose ... ports: ["3000"]   →   ps shows  0.0.0.0:32768->3000/tcp, [::]:32768->3000/tcp
```

This is the most common port form in real homelab files.

- Fire on a bare port (validated against a port-shaped pattern so non-port junk is rejected).
- The message notes the host port is ephemeral/random, not literally `3000`.
- Guidance binds to localhost while keeping the ephemeral port: `127.0.0.1::<port>` (verified valid via `docker compose config`).
- The in-scalar autofixer **refuses** the bare form (it only rewrites a host:container scalar; it can't synthesize the empty-host-port syntax) — a safe refusal per ADR-014.

## R2 — CL-0021: password-only userinfo (`scheme://:password@`) is missed

The regex required a non-empty username (`(?P<user>[^:/@\s]+):`), but RFC 3986 §3.2.1 permits an empty username and `redis://:password@host` is the standard Redis URL form. Changed the user group to `*`. The password-is-a-`$VAR` skip is unchanged.

## Docs
- CL-0005.md no longer claims bare ports are unpublished; documents the ephemeral-binding behavior and the `127.0.0.1::<port>` remedy.
- CL-0021.md reflects the now-optional username, and corrects a pre-existing drift (only the **password** being a `$VAR` skips — a var username with a literal password still fires, per #277 F6).

## Tests
- CL-0005: bare port fires as ephemeral (message + `127.0.0.1::80` guidance); fixer refuses the bare form; existing `container_only` fixture/test renamed to `bare_port`.
- CL-0021: `redis://:supersecret@host` fires; the empty-username + `${VAR}` password form is still skipped.

## Quality
`ruff check`, `ruff format --check`, `mypy src/` (strict, py3.13), `pytest` (713 passed, 2 skipped) all green.