### PR TITLE
Validate config: warn on unknown keys, reject non-bool enabled (#279 G1/G2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `redis://:password@host` is the standard Redis URL form. The
   password-is-a-`$VAR` skip is unchanged. (#279)
 
+- `.compose-lint.yml` no longer silently ignores misconfiguration that would
+  leave a security control at its default. An unknown rule id (a typo'd
+  `CL-001` or a retired `CL-9999`), an unrecognized top-level key (a misplaced
+  `fail_on:`), or an unknown per-rule key (`severty:`) now prints a stderr
+  warning instead of being dropped — mirroring the existing unknown-service
+  warning. And `enabled` must be a real boolean: a quoted `'false'` or a `0` is
+  now a hard error (exit 2) rather than a silent no-op that left the rule
+  running while the user believed it off. (YAML's bare `false`/`no`/`off` still
+  parse to a real boolean and work.) (#279)
+
 - Text output: the `SUPPRESSED` marker no longer pushes a suppressed finding's
   rule and message columns out of alignment — the severity column is padded to
   fit the marker so every row lines up. CL-0020 and CL-0021 (credential-shaped

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,6 +50,17 @@ Excluded services still produce **SUPPRESSED** findings, with the per-service re
 - **Global `enabled: false` wins** over per-service exclusions: if a rule is disabled globally, every service is suppressed regardless of `exclude_services`.
 - **No inline suppression syntax** — there is no `# compose-lint: disable` comment form. Suppressions are tracked in config so reviewers can audit them.
 
+## Validation
+
+A `.compose-lint.yml` that silently fails to take effect is a security risk — the user believes a rule is suppressed or re-tuned when it is not. compose-lint validates the file on load:
+
+- **Unknown rule IDs warn.** `rules:` keys are checked against the registered rule set. A typo (`CL-001`) or a retired ID (`CL-9999`) prints a stderr warning so the override isn't silently dropped.
+- **Unknown top-level keys warn.** Only `rules` is recognized at the top level. A misplaced CLI flag (e.g. a top-level `fail_on:`) or any other key warns instead of being ignored.
+- **Unknown per-rule keys warn.** Inside a rule block, only `enabled`, `reason`, `severity`, and `exclude_services` are recognized. A typo'd `severty:` warns.
+- **`enabled` must be a real boolean.** A quoted `'false'`, `0`, or any non-boolean is a **hard error** (exit 2), not a silent no-op that would leave the rule on. YAML's boolean keywords (`true`/`false`, `yes`/`no`, `on`/`off`) all parse to a real boolean and work as expected.
+
+Warnings never change the exit code; only the hard errors above do.
+
 ## Output formats
 
 `--format` selects the output (`text` default, `json`, `sarif`). Text writes a human banner, per-file summary, and verdict; `json` and `sarif` emit only the machine document on stdout so redirects stay clean.

--- a/src/compose_lint/config.py
+++ b/src/compose_lint/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -9,9 +10,36 @@ import yaml
 
 from compose_lint.models import Severity
 
+# The only top-level key the config schema defines today (docs/configuration.md).
+# Anything else is almost certainly a typo or a misplaced CLI flag (e.g. a
+# top-level `fail_on:`), so we warn rather than silently drop it (issue #279 G1).
+_KNOWN_TOP_LEVEL_KEYS = frozenset({"rules"})
+
+# Recognized keys inside a per-rule block. A key outside this set (a typo'd
+# `severty:` or a `reason:` with no `enabled: false`) is silently inert today;
+# warn so the user learns their override never took effect (issue #279 G1).
+_KNOWN_RULE_KEYS = frozenset({"enabled", "reason", "severity", "exclude_services"})
+
 
 class ConfigError(Exception):
     """Raised when a config file is invalid."""
+
+
+def _warn(message: str) -> None:
+    """Emit a non-fatal config diagnostic to stderr.
+
+    Mirrors the CLI's unknown-service warning (ADR-010): a misconfiguration that
+    silently weakens a security control should be visible, but config and
+    Compose files evolve independently, so it must not hard-fail the run.
+    """
+    print(f"Warning: {message}", file=sys.stderr)
+
+
+def _known_rule_ids() -> set[str]:
+    """Return the set of registered rule IDs for config validation."""
+    from compose_lint.rules import get_registered_rules
+
+    return {cls().metadata.id for cls in get_registered_rules()}
 
 
 def _parse_severity(value: str) -> Severity:
@@ -70,6 +98,13 @@ def load_config(
     if not isinstance(data, dict):
         raise ConfigError("Config file must be a YAML mapping")
 
+    for key in data:
+        if str(key) not in _KNOWN_TOP_LEVEL_KEYS:
+            _warn(
+                f"config: unknown top-level key '{key}' (recognized: "
+                f"{', '.join(sorted(_KNOWN_TOP_LEVEL_KEYS))}); it has no effect"
+            )
+
     return _parse_rules(data.get("rules", {}))
 
 
@@ -83,6 +118,7 @@ def _parse_rules(
     disabled: dict[str, str | None] = {}
     overrides: dict[str, Severity] = {}
     excluded: ExcludedServices = {}
+    known_ids = _known_rule_ids()
 
     for rule_id, rule_config in rules.items():
         rule_id = str(rule_id)
@@ -90,9 +126,30 @@ def _parse_rules(
         if not isinstance(rule_config, dict):
             raise ConfigError(f"Config for rule '{rule_id}' must be a mapping")
 
-        if rule_config.get("enabled") is False:
-            reason = rule_config.get("reason")
-            disabled[rule_id] = str(reason) if reason is not None else None
+        if rule_id not in known_ids:
+            _warn(
+                f"config: unknown rule id '{rule_id}'; the override has no effect "
+                "(check for a typo or a retired rule)"
+            )
+
+        for key in rule_config:
+            if str(key) not in _KNOWN_RULE_KEYS:
+                _warn(
+                    f"config: rule '{rule_id}' has unknown key '{key}' (recognized: "
+                    f"{', '.join(sorted(_KNOWN_RULE_KEYS))}); it has no effect"
+                )
+
+        if "enabled" in rule_config:
+            enabled = rule_config["enabled"]
+            if not isinstance(enabled, bool):
+                raise ConfigError(
+                    f"Config for rule '{rule_id}': 'enabled' must be true or false, "
+                    f"not {enabled!r} — a quoted 'false', 0, or no would otherwise "
+                    "silently leave the rule on"
+                )
+            if enabled is False:
+                reason = rule_config.get("reason")
+                disabled[rule_id] = str(reason) if reason is not None else None
 
         if "severity" in rule_config:
             overrides[rule_id] = _parse_severity(str(rule_config["severity"]))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -110,6 +110,80 @@ class TestLoadConfig:
             load_config(config)
 
 
+class TestConfigValidation:
+    """Validation of silent config misconfiguration (issue #279 G1/G2)."""
+
+    def test_unknown_rule_id_warns(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text("rules:\n  CL-9999:\n    enabled: false\n")
+        load_config(config)
+        err = capsys.readouterr().err
+        assert "unknown rule id 'CL-9999'" in err
+
+    def test_typoed_rule_id_warns(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # `CL-001` (missing a digit) is a common, silent typo.
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text("rules:\n  CL-001:\n    enabled: false\n")
+        load_config(config)
+        assert "unknown rule id 'CL-001'" in capsys.readouterr().err
+
+    def test_known_rule_id_does_not_warn(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text("rules:\n  CL-0001:\n    enabled: false\n")
+        load_config(config)
+        assert "unknown rule id" not in capsys.readouterr().err
+
+    def test_unknown_top_level_key_warns(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # A top-level `fail_on:` is a natural mistake (it's a CLI flag).
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text("fail_on: critical\nrules:\n  CL-0001:\n    enabled: false\n")
+        load_config(config)
+        assert "unknown top-level key 'fail_on'" in capsys.readouterr().err
+
+    def test_unknown_rule_key_warns(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text("rules:\n  CL-0001:\n    severty: high\n")
+        load_config(config)
+        assert "unknown key 'severty'" in capsys.readouterr().err
+
+    def test_enabled_quoted_false_raises(self, tmp_path: Path) -> None:
+        # A quoted 'false' is a string, not the YAML boolean — it must not be a
+        # silent no-op that leaves the rule on (issue #279 G2).
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text("rules:\n  CL-0001:\n    enabled: 'false'\n")
+        with pytest.raises(ConfigError, match="'enabled' must be true or false"):
+            load_config(config)
+
+    def test_enabled_zero_raises(self, tmp_path: Path) -> None:
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text("rules:\n  CL-0001:\n    enabled: 0\n")
+        with pytest.raises(ConfigError, match="'enabled' must be true or false"):
+            load_config(config)
+
+    def test_enabled_yaml_no_still_disables(self, tmp_path: Path) -> None:
+        # YAML 1.1 `no` parses to the boolean False, so it legitimately disables.
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text("rules:\n  CL-0001:\n    enabled: no\n")
+        disabled, _overrides, _excluded = load_config(config)
+        assert "CL-0001" in disabled
+
+    def test_enabled_true_keeps_rule_active(self, tmp_path: Path) -> None:
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text("rules:\n  CL-0001:\n    enabled: true\n")
+        disabled, _overrides, _excluded = load_config(config)
+        assert "CL-0001" not in disabled
+
+
 class TestExcludeServices:
     """Tests for per-service rule exclusions (ADR-010)."""
 


### PR DESCRIPTION
Part of the #279 second-wave umbrella. A `.compose-lint.yml` that silently fails to take effect is a security risk — the user believes a rule is suppressed or re-tuned when it is not.

## G1 — unknown/typo'd rule IDs and unknown keys are silently ignored

`_parse_rules` never validated rule IDs, and only `rules` was read from the top level, so `rules: {CL-9999: …}`, a typo'd `CL-001`, or a top-level `fail_on:` were accepted silently and the intended override never applied.

- Validate `rules:` keys against the registered rule set; warn on an unknown id.
- Warn on unrecognized **top-level** keys (only `rules` is defined).
- Warn on unknown **per-rule** keys (only `enabled`, `reason`, `severity`, `exclude_services` are recognized — a typo'd `severty:` now surfaces).

All three are stderr warnings that mirror the existing unknown-service warning (ADR-010); they never change the exit code.

## G2 — `enabled: 'false'` / `enabled: 0` did not disable a rule

`if rule_config.get("enabled") is False:` was an identity check matching only the YAML boolean `false`. A quoted `'false'`, `0`, or `no`-as-a-string was a silent no-op — the user believed the rule was off when it was on.

`enabled` must now be a real boolean; anything else is a hard `ConfigError` (exit 2). YAML's bare `false`/`no`/`off` parse to a real boolean and still work.

## Docs
- New "Validation" section in `docs/configuration.md`.

## Tests
- Unknown rule id / top-level key / per-rule key each warn; a known id does not.
- `enabled: 'false'` and `enabled: 0` raise; `enabled: no` still disables; `enabled: true` keeps the rule active.

## Quality
`ruff check`, `ruff format --check`, `mypy src/` (strict, py3.13), `pytest` (722 passed, 2 skipped) all green.