### PR TITLE
Fix SARIF rule descriptors: helpUri, severity overrides, fix matching (#279 S-a/S-b/S-c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- SARIF rule descriptors are now correct in three ways. `helpUri` is set only
+  to a reference that is actually a URI — rules grounded in a CIS benchmark
+  (CL-0012, CL-0015, CL-0016, CL-0017) emitted the benchmark *prose* as
+  `helpUri`, which SARIF 2.1.0 declares `"format": "uri"` and strict validators
+  / GitHub Code Scanning reject; the prose still appears in `help.text`. A
+  config `severity:` override now reaches `defaultConfiguration.level` and
+  `properties.security-severity` on the rule descriptor, not just the per-result
+  `level` — GitHub derives an alert's severity column from the rule, so an
+  override to e.g. `critical` no longer showed Medium while JSON and SARIF
+  disagreed. And a finding's structured `fixes[]` are matched to the finding by
+  logical identity (rule, line, service, message) rather than `id()`, so a
+  future refactor that copies findings can't silently drop every fix. (#279)
+
 - A rule that raises no longer aborts the entire run. Previously an uncaught
   exception from any rule escaped as a traceback and exited 1 —
   indistinguishable from a normal "findings at/above threshold" result, and in a

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -434,7 +434,9 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
         json_log = build_json_log(all_json, parse_errors)
         print(json.dumps(json_log, indent=2, allow_nan=False))
     elif args.output_format == "sarif":
-        sarif_log = build_sarif_log(all_sarif, parse_errors)
+        sarif_log = build_sarif_log(
+            all_sarif, parse_errors, severity_overrides=severity_overrides
+        )
         print(json.dumps(sarif_log, indent=2, allow_nan=False))
 
     if parse_errors or rule_errors:

--- a/src/compose_lint/formatters/sarif.py
+++ b/src/compose_lint/formatters/sarif.py
@@ -78,6 +78,17 @@ def _physical_location(filepath: str, line: int | None) -> dict[str, Any]:
     return location
 
 
+def _finding_key(finding: Finding) -> tuple[str, int | None, str, str]:
+    """A stable logical identity for matching a finding to its edits.
+
+    Covers rule, line, service, and message — the message carries the specific
+    offending value, so it distinguishes multiple hits of one rule on one
+    service. Unlike ``id(finding)`` this survives a finding being copied or
+    reconstructed between the ``fixes`` and ``findings`` arguments.
+    """
+    return (finding.rule_id, finding.line, str(finding.service), finding.message)
+
+
 # Fingerprint scheme version. Bump if the inputs below change, so a consumer can
 # tell an algorithm change from a genuine new finding.
 _FINGERPRINT_KEY = "composeLintFinding/v1"
@@ -120,11 +131,22 @@ _SARIF_LEVEL: dict[Severity, str] = {
 }
 
 
-def _build_rules() -> tuple[list[dict[str, Any]], dict[str, int]]:
+def _build_rules(
+    severity_overrides: dict[str, Severity] | None = None,
+) -> tuple[list[dict[str, Any]], dict[str, int]]:
     """Build SARIF rule definitions from the rule registry.
 
     Returns the rules array and a mapping of rule ID to index.
+
+    ``severity_overrides`` (from ``.compose-lint.yml``) is resolved into each
+    descriptor's ``defaultConfiguration.level`` and ``properties.security-severity``
+    so the rule's advertised severity matches the per-result ``level`` the engine
+    already overrides. GitHub Code Scanning derives an alert's severity column
+    from the *rule's* ``security-severity``, so without this an override to e.g.
+    ``critical`` still showed Medium in GitHub and the JSON/SARIF disagreed on the
+    same finding (issue #279 S-b).
     """
+    overrides = severity_overrides or {}
     rules: list[dict[str, Any]] = []
     index_map: dict[str, int] = {}
 
@@ -132,6 +154,7 @@ def _build_rules() -> tuple[list[dict[str, Any]], dict[str, int]]:
         rule = cls()
         meta = rule.metadata
         index_map[meta.id] = len(rules)
+        severity = overrides.get(meta.id, meta.severity)
 
         rule_obj: dict[str, Any] = {
             "id": meta.id,
@@ -139,15 +162,25 @@ def _build_rules() -> tuple[list[dict[str, Any]], dict[str, int]]:
             "shortDescription": {"text": meta.name},
             "fullDescription": {"text": meta.description},
             "defaultConfiguration": {
-                "level": _SARIF_LEVEL[meta.severity],
+                "level": _SARIF_LEVEL[severity],
             },
             "properties": {
-                "security-severity": _SECURITY_SEVERITY[meta.severity],
+                "security-severity": _SECURITY_SEVERITY[severity],
             },
         }
 
         if meta.references:
-            rule_obj["helpUri"] = meta.references[0]
+            # SARIF 2.1.0 declares helpUri with "format": "uri"; a CIS benchmark
+            # reference is free-text prose, not a URI, and strict validators /
+            # GitHub Code Scanning reject or ignore a non-URI helpUri. Use the
+            # first reference that looks like a URL; otherwise omit helpUri (the
+            # prose still appears in help.text). (issue #279 S-a)
+            help_uri = next(
+                (r for r in meta.references if r.startswith(("http://", "https://"))),
+                None,
+            )
+            if help_uri is not None:
+                rule_obj["helpUri"] = help_uri
             help_lines = [meta.description, "", "References:"]
             help_lines.extend(f"- {ref}" for ref in meta.references)
             rule_obj["help"] = {"text": "\n".join(help_lines)}
@@ -215,7 +248,14 @@ def format_findings(
     """
     rules, index_map = _build_rules()
     results: list[dict[str, Any]] = []
-    edits_by_finding = {id(finding): edits for finding, edits in (fixes or [])}
+    # Match edits to findings on a stable logical key rather than id(): the CLI
+    # happens to pass the same list objects to both calls today, but any future
+    # refactor that copies or reconstructs findings would silently drop every
+    # fix. Genuinely-identical findings would share edits, which is correct.
+    # (issue #279 S-c)
+    edits_by_finding = {
+        _finding_key(finding): edits for finding, edits in (fixes or [])
+    }
 
     for f in findings:
         physical_location = _physical_location(filepath, f.line)
@@ -239,7 +279,7 @@ def format_findings(
         if f.fix:
             result["properties"] = {"fix": f.fix}
 
-        edits = edits_by_finding.get(id(f))
+        edits = edits_by_finding.get(_finding_key(f))
         if edits:
             result["fixes"] = [_build_fix(edits, filepath)]
 
@@ -260,14 +300,19 @@ def format_findings(
 def build_sarif_log(
     all_results: list[dict[str, Any]],
     parse_errors: list[tuple[str, str]] | None = None,
+    severity_overrides: dict[str, Severity] | None = None,
 ) -> dict[str, Any]:
     """Build a complete SARIF log object.
 
     parse_errors entries (filepath, message) become invocation
     toolExecutionNotifications so SARIF consumers (GitHub code scanning)
     can report files that were skipped during the run.
+
+    ``severity_overrides`` (from ``.compose-lint.yml``) are resolved into the
+    rule descriptors so their advertised severity matches the per-result level
+    (issue #279 S-b).
     """
-    rules, _ = _build_rules()
+    rules, _ = _build_rules(severity_overrides)
 
     working_dir_uri = _working_dir_uri()
     invocation: dict[str, Any] = {

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -250,6 +250,66 @@ class TestBuildSarifLog:
         assert parsed["version"] == "2.1.0"
 
 
+class TestSarifDescriptorFixes:
+    """Descriptor-level SARIF fixes from issue #279 (S-a / S-b / S-c)."""
+
+    @staticmethod
+    def _rule(log: dict, rule_id: str) -> dict:
+        rules = log["runs"][0]["tool"]["driver"]["rules"]
+        return next(r for r in rules if r["id"] == rule_id)
+
+    def test_helpuri_omitted_for_cis_only_rule(self) -> None:
+        # CL-0012's only reference is CIS prose, not a URI (issue #279 S-a).
+        rule = self._rule(build_sarif_log([]), "CL-0012")
+        assert "helpUri" not in rule
+        # The prose still appears in help.text.
+        assert "CIS" in rule["help"]["text"]
+
+    def test_helpuri_is_a_uri_when_available(self) -> None:
+        # CL-0001's first reference is an OWASP URL.
+        rule = self._rule(build_sarif_log([]), "CL-0001")
+        assert rule["helpUri"].startswith(("http://", "https://"))
+
+    def test_no_rule_emits_a_non_uri_helpuri(self) -> None:
+        for rule in build_sarif_log([])["runs"][0]["tool"]["driver"]["rules"]:
+            if "helpUri" in rule:
+                assert rule["helpUri"].startswith(("http://", "https://"))
+
+    def test_severity_override_reaches_descriptor(self) -> None:
+        # GitHub derives the alert severity from the rule descriptor, not the
+        # result, so an override must reach both (issue #279 S-b).
+        log = build_sarif_log([], severity_overrides={"CL-0007": Severity.CRITICAL})
+        rule = self._rule(log, "CL-0007")
+        assert rule["properties"]["security-severity"] == "9.5"
+        assert rule["defaultConfiguration"]["level"] == "error"
+
+    def test_descriptor_uses_default_without_override(self) -> None:
+        rule = self._rule(build_sarif_log([]), "CL-0007")
+        assert rule["properties"]["security-severity"] == "5.5"
+        assert rule["defaultConfiguration"]["level"] == "warning"
+
+    def test_edits_match_by_logical_identity_not_object_id(self) -> None:
+        # The fix list and the findings list may hold distinct objects with the
+        # same logical identity; the match must survive that (issue #279 S-c).
+        original = _sample_finding()
+        edit = TextEdit(3, 1, 3, 1, "    read_only: true\n")
+        twin = Finding(
+            rule_id=original.rule_id,
+            severity=original.severity,
+            service=original.service,
+            message=original.message,
+            line=original.line,
+            fix=original.fix,
+            references=original.references,
+        )
+        assert twin is not original
+        results = format_findings(
+            [twin], "docker-compose.yml", fixes=[(original, [edit])]
+        )
+        assert "fixes" in results[0]
+        assert results[0]["fixes"][0]["artifactChanges"][0]["replacements"]
+
+
 class TestSarifCLI:
     """CLI integration tests for SARIF output."""
 


### PR DESCRIPTION
Part of the #279 second-wave umbrella. Three SARIF-descriptor correctness bugs.

## S-a — `helpUri` set to CIS prose, not a URI
`rule_obj["helpUri"] = meta.references[0]` was unconditional, so rules whose first reference is a CIS benchmark string (CL-0012, CL-0015, CL-0016, CL-0017) emitted free-text prose as `helpUri`. SARIF 2.1.0 declares `reportingDescriptor.helpUri` with `"format": "uri"`; GitHub Code Scanning / strict validators reject or ignore it. Now `helpUri` is set only to the first reference that looks like a URL (`http://`/`https://`); otherwise it's omitted — the prose still appears in `help.text`.

## S-b — config severity overrides don't reach the rule descriptor
The per-result `level` followed a `.compose-lint.yml` `severity:` override, but `_build_rules` read `meta.severity` directly, so `defaultConfiguration.level` and `properties.security-severity` kept the registry default. GitHub derives the alert's severity column from the **rule's** `security-severity`, so overriding e.g. CL-0007 to `critical` still showed **Medium**, and JSON↔SARIF disagreed on the same finding. `severity_overrides` is now threaded into `build_sarif_log` → `_build_rules` and resolved per rule.

## S-c — fix↔finding matching by `id()` is fragile (low)
`edits_by_finding = {id(finding): …}` worked only because the CLI passes the same list objects to both calls; any future refactor that copies/reconstructs findings would silently drop all `fixes[]`. Now matched on a stable composite key (`rule_id`, `line`, `service`, `message`).

## Tests
- S-a: CIS-only rule omits `helpUri` (prose stays in `help.text`); a URL-ref rule sets it; no rule emits a non-URI `helpUri`.
- S-b: an override reaches the descriptor's `security-severity`/`level`; the default is used without one.
- S-c: edits match a logically-identical but distinct finding object.

## Quality
`ruff check`, `ruff format --check`, `mypy src/` (strict, py3.13), `pytest` (728 passed, 2 skipped) all green.