### PR TITLE
Close rule coverage gaps: runtime sockets, secret keys, caps, devices (#279 R3/R4/R5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Rule coverage gaps closed (issue #279 R3/R4/R5). CL-0001 now flags any
+  container-runtime control socket — `containerd.sock`, `crio.sock`, and
+  `podman.sock` in addition to `docker.sock` (podman/crio were caught by no
+  rule before); the rule is retitled "Container runtime socket mounted" and its
+  message names the runtime. CL-0020 adds `PASSPHRASE` and `ENCRYPTION_KEY` to
+  the credential-key list (a generic `_KEY` suffix is deliberately not matched
+  — it false-positives on `LICENSE_KEY` etc.). CL-0011 adds the `SYS_BOOT`,
+  `DAC_OVERRIDE`, and `BPF` capabilities; CL-0016 adds the `/dev/fuse` and
+  `/dev/kmsg` devices. (#279)
+
 - SARIF rule descriptors are now correct in three ways. `helpUri` is set only
   to a reference that is actually a URI — rules grounded in a CIS benchmark
   (CL-0012, CL-0015, CL-0016, CL-0017) emitted the benchmark *prose* as

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ docker-compose.yml
 
   service: traefik  (line 9)
     line  severity  rule     message
-       9  SUPPRESSED  CL-0001  Docker socket mounted via '/var/run/docker.sock:/var/run/docker.sock'. This gives the container full control over the Docker daemon.
+       9  SUPPRESSED  CL-0001  Docker runtime socket mounted via '/var/run/docker.sock:/var/run/docker.sock'. This gives the container full control over the Docker runtime — equivalent to root on the host.
           reason: SEC-1234 approved — socket proxy planned for 2026-Q3
        9  HIGH      CL-0013  Service mounts sensitive host path '/var/run/docker.sock' (under /var/run). This exposes host system files to the container.
           9 │       - /var/run/docker.sock:/var/run/docker.sock
@@ -153,7 +153,7 @@ If you need broad IaC coverage across Terraform, Kubernetes, and more, KICS cove
 
 | ID | Severity | Description | OWASP | CIS |
 |----|----------|-------------|-------|-----|
-| [CL-0001](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0001.md) | CRITICAL | Docker socket mounted | [Rule #1](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1---do-not-expose-the-docker-daemon-socket-even-to-the-containers) | 5.32 |
+| [CL-0001](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0001.md) | CRITICAL | Container runtime socket mounted | [Rule #1](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1---do-not-expose-the-docker-daemon-socket-even-to-the-containers) | 5.32 |
 | [CL-0002](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0002.md) | CRITICAL | Privileged mode enabled | [Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3---do-not-run-containers-with-the---privileged-flag) | 5.5 |
 | [CL-0003](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0003.md) | MEDIUM | Privilege escalation not blocked | [Rule #4](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-4---add-no-new-privileges-flag) | 5.26 |
 | [CL-0004](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0004.md) | MEDIUM | Image not pinned to version | [Rule #13](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-13---enhance-supply-chain-security) | 5.28 |

--- a/docs/rules/CL-0001.md
+++ b/docs/rules/CL-0001.md
@@ -1,4 +1,4 @@
-# CL-0001: Docker Socket Mounted
+# CL-0001: Container Runtime Socket Mounted
 
 **Severity:** CRITICAL
 
@@ -8,7 +8,7 @@
 
 ## What it detects
 
-Any service whose `volumes:` list contains a path with `docker.sock` in it — including read-only mounts (`:ro`) and rootless / Podman socket variants (`$XDG_RUNTIME_DIR/docker.sock`, `podman.sock`). Detection is substring-based, so atypical paths (e.g. a named volume literally called `docker.sock`) can produce false positives; suppress with a `reason:` if so.
+Any service whose `volumes:` list contains a container-runtime control socket — `docker.sock`, `containerd.sock`, `crio.sock`, or `podman.sock` — including read-only mounts (`:ro`) and rootless variants (`$XDG_RUNTIME_DIR/docker.sock`). Detection is substring-based, so atypical paths (e.g. a named volume literally called `docker.sock`) can produce false positives; suppress with a `reason:` if so.
 
 ## Why it matters
 

--- a/docs/rules/CL-0011.md
+++ b/docs/rules/CL-0011.md
@@ -19,9 +19,12 @@ Services that add dangerous Linux capabilities via `cap_add`:
 | `SYS_MODULE` | HIGH | Load/unload kernel modules |
 | `SYS_RAWIO` | HIGH | Raw I/O port access (iopl/ioperm) |
 | `SYS_TIME` | HIGH | Change system clock, affecting all containers and the host |
+| `SYS_BOOT` | HIGH | Reboot the host or load a new kernel via kexec |
 | `DAC_READ_SEARCH` | HIGH | Bypass file read permission checks on the host |
+| `DAC_OVERRIDE` | HIGH | Bypass all file read, write, and execute permission checks |
+| `BPF` | HIGH | Load BPF programs — arbitrary kernel read/write on modern kernels |
 
-Safe capabilities like `NET_BIND_SERVICE` or `CHOWN` are not flagged. `BPF` (split out of `SYS_ADMIN` in Linux 5.8+) and `PERFMON` are not yet on the dangerous list. `MKNOD` and `SYS_CHROOT` are intentionally not flagged here because the `cap_drop: [ALL]` baseline (CL-0006) already covers them; adding them back is not on its own a HIGH-severity escape path.
+Safe capabilities like `NET_BIND_SERVICE` or `CHOWN` are not flagged. `PERFMON` is not yet on the dangerous list. `MKNOD` and `SYS_CHROOT` are intentionally not flagged here because the `cap_drop: [ALL]` baseline (CL-0006) already covers them; adding them back is not on its own a HIGH-severity escape path.
 
 ## Why it matters
 

--- a/docs/rules/CL-0016.md
+++ b/docs/rules/CL-0016.md
@@ -22,8 +22,10 @@ Services that expose dangerous host devices via `devices:`:
 | `/dev/zfs` | ZFS pool control — create/destroy/import any pool the host can see |
 | `/dev/rbd*` | Ceph RBD — remote block device access |
 | `/dev/raw*` | Raw character devices |
+| `/dev/fuse` | Userspace filesystem mounts — enables mount-based container escapes |
+| `/dev/kmsg` | Kernel log buffer — read or inject kernel messages |
 
-Safe devices like `/dev/net/tun` or `/dev/fuse` are not flagged.
+Safe devices like `/dev/net/tun` are not flagged.
 
 ## Why it matters
 

--- a/docs/rules/CL-0020.md
+++ b/docs/rules/CL-0020.md
@@ -17,7 +17,7 @@ Matched key patterns:
 
 | Match type | Pattern | Notes |
 |---|---|---|
-| substring | `PASSWORD`, `TOKEN`, `SECRET`, `API_KEY`, `APIKEY`, `PRIVATE_KEY`, `ACCESS_KEY`, `SECRET_KEY`, `CREDENTIAL` | case-insensitive |
+| substring | `PASSWORD`, `PASSPHRASE`, `TOKEN`, `SECRET`, `API_KEY`, `APIKEY`, `PRIVATE_KEY`, `ACCESS_KEY`, `SECRET_KEY`, `ENCRYPTION_KEY`, `CREDENTIAL` | case-insensitive |
 | suffix    | `_PASS`, `_PWD`, `PASSWD`, `_SALT`, `_DSN` | suffix-anchored to avoid noisy substring hits (raw `PASS` would match Passport.js naming) |
 
 Exemptions (key matches a credential pattern but the rule does **not** fire):

--- a/docs/severity.md
+++ b/docs/severity.md
@@ -44,7 +44,7 @@ CIS reference numbers in rule docs are pinned to **CIS Docker Benchmark v1.7.0**
 
 | Rule | Exploitability | Impact | Severity |
 |------|---------------|--------|----------|
-| CL-0001 (Docker socket) | Direct | Host | CRITICAL |
+| CL-0001 (runtime socket) | Direct | Host | CRITICAL |
 | CL-0002 (Privileged mode) | Direct | Host | CRITICAL |
 | CL-0005 (Unbound ports) | Exposed | Single container | HIGH |
 | CL-0008 (Host network) | Exposed | Host | HIGH |
@@ -84,7 +84,7 @@ These rules trigger when a service does not declare a recommended hardening dire
 - **CL-0007** — `read_only: true` not set
 - **CL-0019** — `image:` not pinned to a digest
 
-CL-0001 (Docker socket) and CL-0002 (privileged) are technically presence-based, but the underlying patterns (mounting the socket, running privileged) are common enough that, in practice, they cluster with absence rules in frequency.
+CL-0001 (runtime socket) and CL-0002 (privileged) are technically presence-based, but the underlying patterns (mounting the socket, running privileged) are common enough that, in practice, they cluster with absence rules in frequency.
 
 ### Explicit-disable rules — fire only when a service opts into a dangerous configuration
 

--- a/src/compose_lint/rules/CL0001_docker_socket.py
+++ b/src/compose_lint/rules/CL0001_docker_socket.py
@@ -21,21 +21,36 @@ CIS_REF = (
     "mounted inside any containers"
 )
 
+# Control sockets for container runtimes. Mounting any of them grants the
+# container root-equivalent control of the host's runtime; podman.sock and
+# crio.sock are caught by neither CL-0001 (until now) nor CL-0013, and
+# containerd.sock was only salvaged incidentally by CL-0013 (issue #279 R4).
+# Matched as a substring so both short- and long-syntax mounts are covered.
+_RUNTIME_SOCKETS: dict[str, str] = {
+    "docker.sock": "Docker",
+    "containerd.sock": "containerd",
+    "crio.sock": "CRI-O",
+    "podman.sock": "Podman",
+}
+
 
 @register_rule
 class DockerSocketRule(BaseRule):
-    """Detects Docker socket mounts in service volumes."""
+    """Detects container-runtime control-socket mounts in service volumes."""
 
     @property
     def metadata(self) -> RuleMetadata:
         return RuleMetadata(
             id="CL-0001",
-            name="Docker socket mounted",
+            name="Container runtime socket mounted",
             description=(
-                "Mounting the Docker socket gives a container full root-level "
-                "access to the host's Docker daemon. A compromised container can "
-                "create privileged containers, access all other containers, and "
-                "escape to the host."
+                "Mounting a container runtime's control socket (Docker, "
+                "containerd, CRI-O, or Podman) gives a container full root-level "
+                "access to the host's runtime. A compromised container can create "
+                "privileged containers, access all other containers, and escape "
+                "to the host. The OWASP/CIS grounding is written for the Docker "
+                "socket; the exposure is identical for any runtime that exposes "
+                "an unauthenticated control socket."
             ),
             severity=Severity.CRITICAL,
             references=[OWASP_REF, CIS_REF],
@@ -54,21 +69,33 @@ class DockerSocketRule(BaseRule):
 
         for i, volume in enumerate(volumes):
             volume_str = str(volume)
-            if "docker.sock" in volume_str:
-                yield Finding(
-                    rule_id="CL-0001",
-                    severity=Severity.CRITICAL,
-                    service=service_name,
-                    message=(
-                        f"Docker socket mounted via '{volume_str}'. "
-                        "This gives the container full control over the Docker daemon."
-                    ),
-                    line=lines.get(f"services.{service_name}.volumes[{i}]")
-                    or lines.get(f"services.{service_name}.volumes"),
-                    fix=(
-                        "Use a Docker socket proxy (e.g., "
-                        "tecnativa/docker-socket-proxy) to expose only "
-                        "the API endpoints your service needs."
-                    ),
-                    references=[OWASP_REF, CIS_REF],
-                )
+            runtime = next(
+                (
+                    name
+                    for marker, name in _RUNTIME_SOCKETS.items()
+                    if marker in volume_str
+                ),
+                None,
+            )
+            if runtime is None:
+                continue
+            yield Finding(
+                rule_id="CL-0001",
+                severity=Severity.CRITICAL,
+                service=service_name,
+                message=(
+                    f"{runtime} runtime socket mounted via '{volume_str}'. "
+                    f"This gives the container full control over the {runtime} "
+                    "runtime — equivalent to root on the host."
+                ),
+                line=lines.get(f"services.{service_name}.volumes[{i}]")
+                or lines.get(f"services.{service_name}.volumes"),
+                fix=(
+                    "Don't mount the runtime socket. If a service genuinely "
+                    "needs Docker API access, put a socket proxy (e.g. "
+                    "tecnativa/docker-socket-proxy) in front of it, restricted "
+                    "to the minimum endpoints; other runtimes have equivalent "
+                    "rootless or proxied integrations."
+                ),
+                references=[OWASP_REF, CIS_REF],
+            )

--- a/src/compose_lint/rules/CL0011_dangerous_cap_add.py
+++ b/src/compose_lint/rules/CL0011_dangerous_cap_add.py
@@ -32,7 +32,10 @@ DANGEROUS_CAPS: dict[str, str] = {
     "SYS_MODULE": "load/unload kernel modules",
     "SYS_RAWIO": "raw I/O port access (iopl/ioperm)",
     "SYS_TIME": "change system clock, affecting all containers and the host",
+    "SYS_BOOT": "reboot the host or load a new kernel via kexec",
     "DAC_READ_SEARCH": "bypass file read permission checks on the host",
+    "DAC_OVERRIDE": "bypass all file read, write, and execute permission checks",
+    "BPF": "load BPF programs — arbitrary kernel read/write on modern kernels",
 }
 
 CRITICAL_CAPS: frozenset[str] = frozenset({"ALL"})

--- a/src/compose_lint/rules/CL0016_dangerous_devices.py
+++ b/src/compose_lint/rules/CL0016_dangerous_devices.py
@@ -32,6 +32,11 @@ _DANGEROUS_DEVICE_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"^/dev/zfs$"), "/dev/zfs — ZFS pool control device"),
     (re.compile(r"^/dev/rbd"), "/dev/rbd* — Ceph RBD block device"),
     (re.compile(r"^/dev/raw"), "/dev/raw* — raw character device"),
+    (
+        re.compile(r"^/dev/fuse$"),
+        "/dev/fuse — userspace filesystem mounts (enables mount-based escapes)",
+    ),
+    (re.compile(r"^/dev/kmsg$"), "/dev/kmsg — kernel log buffer read/inject"),
 ]
 
 

--- a/src/compose_lint/rules/CL0020_credential_env_keys.py
+++ b/src/compose_lint/rules/CL0020_credential_env_keys.py
@@ -19,8 +19,14 @@ OWASP_REF = (
 COMPOSE_SECRETS_REF = "https://docs.docker.com/reference/compose-file/secrets/"
 
 # Substring matches (case-insensitive on the upper-cased key).
+# PASSPHRASE and ENCRYPTION_KEY are unambiguously secret material (issue #279
+# R3). A *generic* `_KEY` suffix is deliberately not added: it false-positives on
+# non-secret names like LICENSE_KEY / PUBLIC_KEY / IDEMPOTENCY_KEY, against this
+# project's "no unactionable findings" principle. GPG_KEY is likewise omitted —
+# it commonly names a key *id*/fingerprint (public), not key material.
 _SUBSTRING_PATTERNS = (
     "PASSWORD",
+    "PASSPHRASE",
     "TOKEN",
     "SECRET",
     "API_KEY",
@@ -28,6 +34,7 @@ _SUBSTRING_PATTERNS = (
     "PRIVATE_KEY",
     "ACCESS_KEY",
     "SECRET_KEY",
+    "ENCRYPTION_KEY",
     "CREDENTIAL",
 )
 
@@ -134,9 +141,10 @@ class CredentialEnvKeysRule(BaseRule):
             name="Credential-shaped env key with literal value",
             description=(
                 "Environment variables whose key name matches a credential "
-                "convention (PASSWORD, TOKEN, SECRET, API_KEY, ACCESS_KEY, "
-                "PRIVATE_KEY, CREDENTIAL, *_PASS, *_PWD, PASSWD, *_SALT, "
-                "*_DSN) and whose value is a non-empty literal string. The "
+                "convention (PASSWORD, PASSPHRASE, TOKEN, SECRET, API_KEY, "
+                "ACCESS_KEY, PRIVATE_KEY, ENCRYPTION_KEY, CREDENTIAL, *_PASS, "
+                "*_PWD, PASSWD, *_SALT, *_DSN) and whose value is a non-empty "
+                "literal string. The "
                 "credential is exposed via `docker inspect`, "
                 "`/proc/<pid>/environ`, `docker compose config`, process "
                 "listings, and CI logs. Compose's `secrets:` primitive "

--- a/tests/compose_files/insecure_devices.yml
+++ b/tests/compose_files/insecure_devices.yml
@@ -32,10 +32,17 @@ services:
     devices:
       - /dev/mem:/dev/mem
       - /dev/sda:/dev/sda
+  dev_fuse:
+    image: nginx:1.27-alpine
+    devices:
+      - /dev/fuse:/dev/fuse
+  dev_kmsg:
+    image: nginx:1.27-alpine
+    devices:
+      - /dev/kmsg:/dev/kmsg
   safe_device:
     image: nginx:1.27-alpine
     devices:
       - /dev/net/tun:/dev/net/tun
-      - /dev/fuse:/dev/fuse
   no_devices:
     image: nginx:1.27-alpine

--- a/tests/test_CL0001.py
+++ b/tests/test_CL0001.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from compose_lint.parser import load_compose
+from compose_lint.parser import load_compose, loads
 from compose_lint.rules.CL0001_docker_socket import DockerSocketRule
 
 FIXTURES = Path(__file__).parent / "compose_files"
@@ -33,6 +33,30 @@ class TestDockerSocketRule:
         )
         assert len(findings) == 1
         assert "docker.sock" in findings[0].message
+
+    def _check_socket(self, mount: str) -> list:
+        data, lines = loads(
+            f"services:\n  svc:\n    image: nginx\n    volumes:\n      - {mount}\n"
+        )
+        return list(self.rule.check("svc", data["services"]["svc"], data, lines))
+
+    def test_detects_podman_socket(self) -> None:
+        # podman.sock was caught by neither CL-0001 nor CL-0013 (issue #279 R4).
+        findings = self._check_socket("/run/podman/podman.sock:/run/podman/podman.sock")
+        assert len(findings) == 1
+        assert "Podman" in findings[0].message
+
+    def test_detects_containerd_socket(self) -> None:
+        findings = self._check_socket(
+            "/run/containerd/containerd.sock:/run/containerd/containerd.sock"
+        )
+        assert len(findings) == 1
+        assert "containerd" in findings[0].message
+
+    def test_detects_crio_socket(self) -> None:
+        findings = self._check_socket("/var/run/crio/crio.sock:/var/run/crio/crio.sock")
+        assert len(findings) == 1
+        assert "CRI-O" in findings[0].message
 
     def test_clean_service_no_findings(self) -> None:
         data, lines = load_compose(FIXTURES / "valid_basic.yml")

--- a/tests/test_CL0011.py
+++ b/tests/test_CL0011.py
@@ -29,6 +29,29 @@ class TestDangerousCapAddRule:
         assert findings[0].rule_id == "CL-0011"
         assert "SYS_ADMIN" in findings[0].message
 
+    def _check_cap(self, cap: str) -> list:
+        data, lines = loads(
+            f"services:\n  a:\n    image: nginx:1.27\n    cap_add: [{cap}]\n"
+        )
+        return list(self.rule.check("a", data["services"]["a"], data, lines))
+
+    def test_detects_sys_boot(self) -> None:
+        # Curated-list additions (issue #279 R5).
+        findings = self._check_cap("SYS_BOOT")
+        assert len(findings) == 1
+        assert findings[0].severity == Severity.HIGH
+        assert "SYS_BOOT" in findings[0].message
+
+    def test_detects_dac_override(self) -> None:
+        findings = self._check_cap("DAC_OVERRIDE")
+        assert len(findings) == 1
+        assert "DAC_OVERRIDE" in findings[0].message
+
+    def test_detects_bpf(self) -> None:
+        findings = self._check_cap("BPF")
+        assert len(findings) == 1
+        assert "BPF" in findings[0].message
+
     def test_detects_cap_prefixed_capability(self) -> None:
         # Docker treats `CAP_SYS_ADMIN` == `SYS_ADMIN`; the rule keyed on the
         # bare name and missed the prefixed form, including `CAP_ALL` (#277 F2).

--- a/tests/test_CL0016.py
+++ b/tests/test_CL0016.py
@@ -58,6 +58,17 @@ class TestDangerousDevicesRule:
         assert len(findings) == 1
         assert "/dev/disk/" in findings[0].message
 
+    def test_detects_dev_fuse(self) -> None:
+        # /dev/fuse enables mount-based container escapes (issue #279 R5).
+        findings = self._check("dev_fuse")
+        assert len(findings) == 1
+        assert "/dev/fuse" in findings[0].message
+
+    def test_detects_dev_kmsg(self) -> None:
+        findings = self._check("dev_kmsg")
+        assert len(findings) == 1
+        assert "/dev/kmsg" in findings[0].message
+
     def test_detects_multiple(self) -> None:
         findings = self._check("multiple")
         assert len(findings) == 2

--- a/tests/test_CL0020.py
+++ b/tests/test_CL0020.py
@@ -45,6 +45,30 @@ class TestCredentialEnvKeysRule:
         assert len(findings) == 1
         assert findings[0].rule_id == "CL-0020"
 
+    def _check_key(self, key: str, value: str = "hunter2") -> list[Finding]:
+        data, lines = loads(
+            "services:\n"
+            "  a:\n"
+            "    image: nginx:1.27\n"
+            "    environment:\n"
+            f"      {key}: {value}\n"
+        )
+        return list(self.rule.check("a", data["services"]["a"], data, lines))
+
+    def test_detects_passphrase(self) -> None:
+        # PASSPHRASE is unambiguously a secret and was missed (issue #279 R3).
+        findings = self._check_key("GPG_PASSPHRASE")
+        assert len(findings) == 1
+        assert "GPG_PASSPHRASE" in findings[0].message
+
+    def test_detects_encryption_key(self) -> None:
+        findings = self._check_key("ENCRYPTION_KEY")
+        assert len(findings) == 1
+
+    def test_license_key_not_flagged(self) -> None:
+        # A generic `_KEY` suffix is deliberately not matched (issue #279 R3).
+        assert self._check_key("LICENSE_KEY") == []
+
     def test_boolean_value_not_flagged(self) -> None:
         # A credential-shaped key whose value is a YAML boolean (decodes to a
         # Python bool) is a toggle, not a literal secret — keep it exempt (#277 F7).


### PR DESCRIPTION
Part of the #279 second-wave umbrella. Curated-list / detection gaps across four rules.

## R4 — CL-0001: non-Docker runtime sockets missed
Detection keyed solely on the `docker.sock` substring, so mounting `podman.sock` (caught by **neither** CL-0001 nor CL-0013) or `crio.sock` slipped through, and `containerd.sock` was only salvaged incidentally by CL-0013. CL-0001 now matches `docker.sock`, `containerd.sock`, `crio.sock`, and `podman.sock`; it is retitled **"Container runtime socket mounted"** and the finding names the runtime. The OWASP/CIS grounding stays Docker-written (the exposure is identical for any unauthenticated control socket) — the description says so.

## R3 — CL-0020: common secret key names missed
Added `PASSPHRASE` and `ENCRYPTION_KEY` (unambiguous secret material). A **generic `_KEY` suffix is deliberately not added** — it false-positives on `LICENSE_KEY` / `PUBLIC_KEY` / `IDEMPOTENCY_KEY`, against the project's no-unactionable-findings principle. `GPG_KEY` is omitted for the same reason (commonly a public key id/fingerprint, not key material).

## R5 — curated-list additions
- **CL-0011**: `SYS_BOOT` (reboot host / kexec), `DAC_OVERRIDE` (bypass all file perms), `BPF` (arbitrary kernel read/write on modern kernels).
- **CL-0016**: `/dev/fuse` (mount-based escapes) and `/dev/kmsg` (kernel log read/inject). The CL-0016 doc previously listed `/dev/fuse` as *safe* — corrected.

## Docs
Rule docs (CL-0001/0011/0016/0020), the README rule table + example output, and `docs/severity.md` updated to match.

## Tests
New detection tests for each added socket / key / cap / device; the `safe_device` fixture no longer carries `/dev/fuse`, and a `LICENSE_KEY`-is-not-flagged test guards the deliberate `_KEY` non-match.

## Quality
`ruff check`, `ruff format --check`, `mypy src/` (strict, py3.13), `pytest` (739 passed, 2 skipped) all green.