### PR TITLE
Fix OWASP grounding drift and rule doc/message mismatches (#279 D1-D6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Documentation and grounding drift corrected (issue #279 D1–D6). OWASP
+  renumbered the Docker Security Cheat Sheet and switched its anchors to a
+  single-dash slug, so every citation was either pointing at the wrong rule or
+  landing at page top. All OWASP deep links (rule docs, the README table, and
+  the embedded `references=` URLs in code) now use the live single-dash anchors,
+  and four drifted citations are corrected: CL-0002 and CL-0011 → Rule #3 (Limit
+  capabilities, where `--privileged` is discussed), CL-0003 → Rule #4 (Prevent
+  in-container privilege escalation), CL-0018 → Rule #2 (Set a user), CL-0020 and
+  CL-0021 → Rule #12 (Utilize Docker Secrets). CL-0002's finding message no
+  longer overclaims "functionally equivalent to host root" — it now matches the
+  doc's "trivially escapable to host root." The CL-0018 doc now reflects that
+  the rule fires on any root *user portion* regardless of group (`root:1000`),
+  and the CL-0015 doc now documents the `test: ["NONE"]` branch the code already
+  implements. (#279)
+
 - Rule coverage gaps closed (issue #279 R3/R4/R5). CL-0001 now flags any
   container-runtime control socket — `containerd.sock`, `crio.sock`, and
   `podman.sock` in addition to `docker.sock` (podman/crio were caught by no

--- a/README.md
+++ b/README.md
@@ -120,13 +120,13 @@ docker-compose.yml
           9 │       - /var/run/docker.sock:/var/run/docker.sock
             │         ────────────────────
           fix: Remove the bind mount for /var/run/docker.sock. If the container needs specific files, copy them into the image at build time or use a named volume with only the required data.
-          ref: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-8---set-filesystem-and-volumes-to-read-only
+          ref: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-8-set-filesystem-and-volumes-to-read-only
       11  HIGH      CL-0005  Port '8080:80' is bound to all interfaces. Docker bypasses host firewalls (UFW/firewalld), potentially exposing this port to the public internet.
           11 │       - "8080:80"
              │          ───────
           fix: Bind to localhost: 127.0.0.1:8080:80
                If public access is needed, use a reverse proxy with TLS.
-          ref: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-5a---be-careful-when-mapping-container-ports-to-the-host-with-firewalls-like-ufw
+          ref: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-5a-be-careful-when-mapping-container-ports-to-the-host-with-firewalls-like-ufw
 
 docker-compose.yml: 2 high  ·  1 suppressed (not counted)
 ✗ FAIL  ·  2 findings at or above high
@@ -153,27 +153,27 @@ If you need broad IaC coverage across Terraform, Kubernetes, and more, KICS cove
 
 | ID | Severity | Description | OWASP | CIS |
 |----|----------|-------------|-------|-----|
-| [CL-0001](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0001.md) | CRITICAL | Container runtime socket mounted | [Rule #1](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1---do-not-expose-the-docker-daemon-socket-even-to-the-containers) | 5.32 |
-| [CL-0002](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0002.md) | CRITICAL | Privileged mode enabled | [Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3---do-not-run-containers-with-the---privileged-flag) | 5.5 |
-| [CL-0003](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0003.md) | MEDIUM | Privilege escalation not blocked | [Rule #4](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-4---add-no-new-privileges-flag) | 5.26 |
-| [CL-0004](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0004.md) | MEDIUM | Image not pinned to version | [Rule #13](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-13---enhance-supply-chain-security) | 5.28 |
-| [CL-0005](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0005.md) | HIGH | Ports bound to all interfaces | [Rule #5a](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-5a---be-careful-when-mapping-container-ports-to-the-host-with-firewalls-like-ufw) | 5.14 |
-| [CL-0006](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0006.md) | MEDIUM | No capability restrictions | [Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3---limit-capabilities-grant-only-specific-capabilities-needed-by-a-container) | 5.4 |
-| [CL-0007](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0007.md) | MEDIUM | Filesystem not read-only | [Rule #8](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-8---set-filesystem-and-volumes-to-read-only) | 5.13 |
-| [CL-0008](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0008.md) | HIGH | Host network mode | [Rule #5](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-5---be-mindful-of-inter-container-connectivity) | 5.10 |
-| [CL-0009](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0009.md) | HIGH | Security profile disabled | [Rule #6](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-6---use-linux-security-module-seccomp-apparmor-or-selinux) | 5.2, 5.3, 5.22 |
-| [CL-0010](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0010.md) | HIGH | Host namespace sharing | [Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3---limit-capabilities-grant-only-specific-capabilities-needed-by-a-container) | 5.16, 5.17, 5.21, 5.31 |
-| [CL-0011](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0011.md) | HIGH | Dangerous capabilities added | [Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3---limit-capabilities-grant-only-specific-capabilities-needed-by-a-container) | 5.4 |
+| [CL-0001](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0001.md) | CRITICAL | Container runtime socket mounted | [Rule #1](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1-do-not-expose-the-docker-daemon-socket-even-to-the-containers) | 5.32 |
+| [CL-0002](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0002.md) | CRITICAL | Privileged mode enabled | [Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-specific-capabilities-needed-by-a-container) | 5.5 |
+| [CL-0003](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0003.md) | MEDIUM | Privilege escalation not blocked | [Rule #4](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-4-prevent-in-container-privilege-escalation) | 5.26 |
+| [CL-0004](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0004.md) | MEDIUM | Image not pinned to version | [Rule #13](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-13-enhance-supply-chain-security) | 5.28 |
+| [CL-0005](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0005.md) | HIGH | Ports bound to all interfaces | [Rule #5a](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-5a-be-careful-when-mapping-container-ports-to-the-host-with-firewalls-like-ufw) | 5.14 |
+| [CL-0006](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0006.md) | MEDIUM | No capability restrictions | [Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-specific-capabilities-needed-by-a-container) | 5.4 |
+| [CL-0007](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0007.md) | MEDIUM | Filesystem not read-only | [Rule #8](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-8-set-filesystem-and-volumes-to-read-only) | 5.13 |
+| [CL-0008](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0008.md) | HIGH | Host network mode | [Rule #5](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-5-be-mindful-of-inter-container-connectivity) | 5.10 |
+| [CL-0009](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0009.md) | HIGH | Security profile disabled | [Rule #6](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-6-use-linux-security-module-seccomp-apparmor-or-selinux-for-runtime-security) | 5.2, 5.3, 5.22 |
+| [CL-0010](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0010.md) | HIGH | Host namespace sharing | [Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-specific-capabilities-needed-by-a-container) | 5.16, 5.17, 5.21, 5.31 |
+| [CL-0011](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0011.md) | HIGH | Dangerous capabilities added | [Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-specific-capabilities-needed-by-a-container) | 5.4 |
 | [CL-0012](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0012.md) | MEDIUM | PIDs cgroup limit disabled | — | 5.29 |
-| [CL-0013](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0013.md) | HIGH | Sensitive host path mounted | [Rule #8](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-8---set-filesystem-and-volumes-to-read-only) | 5.6 |
+| [CL-0013](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0013.md) | HIGH | Sensitive host path mounted | [Rule #8](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-8-set-filesystem-and-volumes-to-read-only) | 5.6 |
 | [CL-0014](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0014.md) | MEDIUM | Logging driver disabled | — | — |
 | [CL-0015](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0015.md) | LOW | Healthcheck disabled | — | 4.6, 5.27 |
 | [CL-0016](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0016.md) | HIGH | Dangerous host device exposed | — | 5.18 |
 | [CL-0017](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0017.md) | MEDIUM | Shared mount propagation | — | 5.20 |
-| [CL-0018](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0018.md) | MEDIUM | Explicit root user | [Rule #7](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-7---do-not-run-containers-with-a-root-user) | — |
-| [CL-0019](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0019.md) | MEDIUM | Image tag without digest | [Rule #13](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-13---enhance-supply-chain-security) | — |
-| [CL-0020](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0020.md) | HIGH | Credential-shaped env key with literal value | [Rule #11](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-11---use-secret-management-tools) | — |
-| [CL-0021](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0021.md) | HIGH | Credential embedded in connection-string env value | [Rule #11](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-11---use-secret-management-tools) | — |
+| [CL-0018](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0018.md) | MEDIUM | Explicit root user | [Rule #2](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-2-set-a-user) | — |
+| [CL-0019](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0019.md) | MEDIUM | Image tag without digest | [Rule #13](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-13-enhance-supply-chain-security) | — |
+| [CL-0020](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0020.md) | HIGH | Credential-shaped env key with literal value | [Rule #12](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-12-utilize-docker-secrets-for-sensitive-data-management) | — |
+| [CL-0021](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0021.md) | HIGH | Credential embedded in connection-string env value | [Rule #12](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-12-utilize-docker-secrets-for-sensitive-data-management) | — |
 
 ## Severity Levels
 

--- a/docs/rules/CL-0001.md
+++ b/docs/rules/CL-0001.md
@@ -3,7 +3,7 @@
 **Severity:** CRITICAL
 
 **References:**
-- [OWASP Docker Security Rule #1](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1---do-not-expose-the-docker-daemon-socket-even-to-the-containers)
+- [OWASP Docker Security Rule #1](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1-do-not-expose-the-docker-daemon-socket-even-to-the-containers)
 - CIS Docker Benchmark 5.32 — Ensure that the Docker socket is not mounted inside any containers
 
 ## What it detects

--- a/docs/rules/CL-0002.md
+++ b/docs/rules/CL-0002.md
@@ -3,7 +3,7 @@
 **Severity:** CRITICAL
 
 **References:**
-- [OWASP Docker Security Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3---do-not-run-containers-with-the---privileged-flag)
+- [OWASP Docker Security Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-specific-capabilities-needed-by-a-container)
 - CIS Docker Benchmark 5.5 — Ensure that privileged containers are not used
 
 ## What it detects

--- a/docs/rules/CL-0003.md
+++ b/docs/rules/CL-0003.md
@@ -3,7 +3,7 @@
 **Severity:** MEDIUM
 
 **References:**
-- [OWASP Docker Security Rule #4](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-4---add-no-new-privileges-flag)
+- [OWASP Docker Security Rule #4](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-4-prevent-in-container-privilege-escalation)
 - CIS Docker Benchmark 5.26 — Ensure that the container is restricted from acquiring additional privileges
 
 ## What it detects

--- a/docs/rules/CL-0004.md
+++ b/docs/rules/CL-0004.md
@@ -3,7 +3,7 @@
 **Severity:** MEDIUM
 
 **References:**
-- [OWASP Docker Security Rule #13](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-13---enhance-supply-chain-security)
+- [OWASP Docker Security Rule #13](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-13-enhance-supply-chain-security)
 - CIS Docker Benchmark 5.28 — Ensure that Docker commands always make use of the latest version of their image
 
 ## What it detects

--- a/docs/rules/CL-0005.md
+++ b/docs/rules/CL-0005.md
@@ -3,7 +3,7 @@
 **Severity:** HIGH
 
 **References:**
-- [OWASP Docker Security Rule #5a](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-5a---be-careful-when-mapping-container-ports-to-the-host-with-firewalls-like-ufw)
+- [OWASP Docker Security Rule #5a](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-5a-be-careful-when-mapping-container-ports-to-the-host-with-firewalls-like-ufw)
 - CIS Docker Benchmark 5.14 — Ensure that incoming container traffic is bound to a specific host interface
 
 ## What it detects

--- a/docs/rules/CL-0006.md
+++ b/docs/rules/CL-0006.md
@@ -3,7 +3,7 @@
 **Severity:** MEDIUM
 
 **References:**
-- [OWASP Docker Security Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3---limit-capabilities-grant-only-specific-capabilities-needed-by-a-container)
+- [OWASP Docker Security Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-specific-capabilities-needed-by-a-container)
 - CIS Docker Benchmark 5.4 — Ensure that Linux kernel capabilities are restricted within containers
 
 ## What it detects

--- a/docs/rules/CL-0007.md
+++ b/docs/rules/CL-0007.md
@@ -3,7 +3,7 @@
 **Severity:** MEDIUM
 
 **References:**
-- [OWASP Docker Security Rule #8](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-8---set-filesystem-and-volumes-to-read-only)
+- [OWASP Docker Security Rule #8](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-8-set-filesystem-and-volumes-to-read-only)
 - CIS Docker Benchmark 5.13 — Ensure that the container's root filesystem is mounted as read only
 
 ## What it detects

--- a/docs/rules/CL-0008.md
+++ b/docs/rules/CL-0008.md
@@ -3,7 +3,7 @@
 **Severity:** HIGH
 
 **References:**
-- [OWASP Docker Security Rule #5](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-5---be-mindful-of-inter-container-connectivity)
+- [OWASP Docker Security Rule #5](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-5-be-mindful-of-inter-container-connectivity)
 - CIS Docker Benchmark 5.10 — Ensure that the host's network namespace is not shared
 
 ## What it detects

--- a/docs/rules/CL-0009.md
+++ b/docs/rules/CL-0009.md
@@ -3,7 +3,7 @@
 **Severity:** HIGH
 
 **References:**
-- [OWASP Docker Security Rule #6](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-6---use-linux-security-module-seccomp-apparmor-or-selinux)
+- [OWASP Docker Security Rule #6](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-6-use-linux-security-module-seccomp-apparmor-or-selinux-for-runtime-security)
 - CIS Docker Benchmark 5.22 — Ensure that the default seccomp profile is not Disabled
 - CIS Docker Benchmark 5.2 — Ensure that, if applicable, an AppArmor Profile is enabled
 - CIS Docker Benchmark 5.3 — Ensure that, if applicable, SELinux security options are set

--- a/docs/rules/CL-0010.md
+++ b/docs/rules/CL-0010.md
@@ -3,7 +3,7 @@
 **Severity:** HIGH
 
 **References:**
-- [OWASP Docker Security Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3---limit-capabilities-grant-only-specific-capabilities-needed-by-a-container)
+- [OWASP Docker Security Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-specific-capabilities-needed-by-a-container)
 - CIS Docker Benchmark 5.16 — Ensure that the host's process namespace is not shared
 - CIS Docker Benchmark 5.17 — Ensure that the host's IPC namespace is not shared
 - CIS Docker Benchmark 5.31 — Ensure that the host's user namespaces are not shared

--- a/docs/rules/CL-0011.md
+++ b/docs/rules/CL-0011.md
@@ -3,7 +3,7 @@
 **Severity:** HIGH (CRITICAL when `cap_add: ALL` is used)
 
 **References:**
-- [OWASP Docker Security Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3---limit-capabilities-grant-only-specific-capabilities-needed-by-a-container)
+- [OWASP Docker Security Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-specific-capabilities-needed-by-a-container)
 - CIS Docker Benchmark 5.4 — Ensure that Linux kernel capabilities are restricted within containers
 
 ## What it detects

--- a/docs/rules/CL-0013.md
+++ b/docs/rules/CL-0013.md
@@ -3,7 +3,7 @@
 **Severity:** HIGH (CRITICAL when the entire host root filesystem is mounted)
 
 **References:**
-- [OWASP Docker Security Rule #8](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-8---set-filesystem-and-volumes-to-read-only)
+- [OWASP Docker Security Rule #8](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-8-set-filesystem-and-volumes-to-read-only)
 - CIS Docker Benchmark 5.6 — Ensure sensitive host system directories are not mounted on containers
 
 ## What it detects

--- a/docs/rules/CL-0015.md
+++ b/docs/rules/CL-0015.md
@@ -8,7 +8,7 @@
 
 ## What it detects
 
-Services with `healthcheck.disable: true`. Services without a healthcheck configuration or with `disable: false` are not flagged — this rule targets explicit opt-outs only.
+Services that explicitly disable their healthcheck, in either form: `healthcheck.disable: true`, or a `healthcheck.test` of `["NONE"]` / `"NONE"` (the Compose spec's way of clearing an image's inherited healthcheck). Services without a healthcheck configuration, or with `disable: false`, are not flagged — this rule targets explicit opt-outs only.
 
 ## Why it matters
 

--- a/docs/rules/CL-0018.md
+++ b/docs/rules/CL-0018.md
@@ -3,12 +3,12 @@
 **Severity:** MEDIUM
 
 **References:**
-- [OWASP Docker Security Rule #7](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-7---do-not-use-root-user)
+- [OWASP Docker Security Rule #2](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-2-set-a-user)
 - [Docker security: rootless mode and userns-remap](https://docs.docker.com/engine/security/userns-remap/)
 
 ## What it detects
 
-Services that explicitly set the user to root: `user: root`, `user: "0"`, `user: "root:root"`, or `user: "0:0"`. Services without a `user:` directive are not flagged — the absence of `user:` does not imply root, as the image's `USER` instruction determines the UID.
+Any service whose `user:` value has a root user portion — `root` or `0` — regardless of the group. This covers `user: root`, `user: "0"`, `user: "root:root"`, and `user: "0:0"`, but also `user: "root:1000"`, `user: "0:staff"`, and any other `root:<group>` / `0:<gid>` form (only the part before the `:` is checked). Services without a `user:` directive are not flagged — the absence of `user:` does not imply root, as the image's `USER` instruction determines the UID.
 
 ## Why it matters
 

--- a/docs/rules/CL-0019.md
+++ b/docs/rules/CL-0019.md
@@ -3,7 +3,7 @@
 **Severity:** MEDIUM
 
 **References:**
-- [OWASP Docker Security Rule #13](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-13---enhance-supply-chain-security)
+- [OWASP Docker Security Rule #13](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-13-enhance-supply-chain-security)
 
 ## What it detects
 

--- a/docs/rules/CL-0020.md
+++ b/docs/rules/CL-0020.md
@@ -3,7 +3,7 @@
 **Severity:** HIGH
 
 **References:**
-- [OWASP Docker Security Cheat Sheet — Rule #11: Use secret management tools](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-11---use-secret-management-tools)
+- [OWASP Docker Security Cheat Sheet — Rule #12: Utilize Docker Secrets for Sensitive Data Management](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-12-utilize-docker-secrets-for-sensitive-data-management)
 - [Compose `secrets:` top-level element](https://docs.docker.com/reference/compose-file/secrets/)
 
 ## What it detects

--- a/docs/rules/CL-0021.md
+++ b/docs/rules/CL-0021.md
@@ -3,7 +3,7 @@
 **Severity:** HIGH
 
 **References:**
-- [OWASP Docker Security Cheat Sheet — Rule #11: Use secret management tools](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-11---use-secret-management-tools)
+- [OWASP Docker Security Cheat Sheet — Rule #12: Utilize Docker Secrets for Sensitive Data Management](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-12-utilize-docker-secrets-for-sensitive-data-management)
 - [Compose `secrets:` top-level element](https://docs.docker.com/reference/compose-file/secrets/)
 - [RFC 3986 §3.2.1 — userinfo deprecation for passwords](https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.1)
 

--- a/src/compose_lint/rules/CL0001_docker_socket.py
+++ b/src/compose_lint/rules/CL0001_docker_socket.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 OWASP_REF = (
     "https://cheatsheetseries.owasp.org/cheatsheets/"
-    "Docker_Security_Cheat_Sheet.html#rule-1---do-not-expose-the-docker-daemon-socket-"
+    "Docker_Security_Cheat_Sheet.html#rule-1-do-not-expose-the-docker-daemon-socket-"
     "even-to-the-containers"
 )
 

--- a/src/compose_lint/rules/CL0002_privileged_mode.py
+++ b/src/compose_lint/rules/CL0002_privileged_mode.py
@@ -12,8 +12,8 @@ if TYPE_CHECKING:
 
 OWASP_REF = (
     "https://cheatsheetseries.owasp.org/cheatsheets/"
-    "Docker_Security_Cheat_Sheet.html#rule-3---do-not-run-containers-with-the---"
-    "privileged-flag"
+    "Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-"
+    "specific-capabilities-needed-by-a-container"
 )
 
 CIS_REF = "CIS Docker Benchmark 5.5 — Ensure that privileged containers are not used"
@@ -50,9 +50,10 @@ class PrivilegedModeRule(BaseRule):
                 severity=Severity.CRITICAL,
                 service=service_name,
                 message=(
-                    "Service runs in privileged mode. This disables container "
-                    "isolation and is functionally equivalent to running on the "
-                    "host as root."
+                    "Service runs in privileged mode. This disables nearly all "
+                    "container isolation — the container gets all Linux "
+                    "capabilities and host device access, and is trivially "
+                    "escapable to host root."
                 ),
                 line=lines.get(f"services.{service_name}.privileged"),
                 fix=(

--- a/src/compose_lint/rules/CL0003_no_new_privileges.py
+++ b/src/compose_lint/rules/CL0003_no_new_privileges.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 OWASP_REF = (
     "https://cheatsheetseries.owasp.org/cheatsheets/"
-    "Docker_Security_Cheat_Sheet.html#rule-4---add-no-new-privileges-flag"
+    "Docker_Security_Cheat_Sheet.html#rule-4-prevent-in-container-privilege-escalation"
 )
 
 CIS_REF = (

--- a/src/compose_lint/rules/CL0004_image_not_pinned.py
+++ b/src/compose_lint/rules/CL0004_image_not_pinned.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 OWASP_REF = (
     "https://cheatsheetseries.owasp.org/cheatsheets/"
-    "Docker_Security_Cheat_Sheet.html#rule-13---enhance-supply-chain-security"
+    "Docker_Security_Cheat_Sheet.html#rule-13-enhance-supply-chain-security"
 )
 
 CIS_REF = (

--- a/src/compose_lint/rules/CL0005_unbound_ports.py
+++ b/src/compose_lint/rules/CL0005_unbound_ports.py
@@ -20,7 +20,7 @@ _CAVEAT = (
 
 OWASP_REF = (
     "https://cheatsheetseries.owasp.org/cheatsheets/"
-    "Docker_Security_Cheat_Sheet.html#rule-5a---be-careful-when-mapping-container-"
+    "Docker_Security_Cheat_Sheet.html#rule-5a-be-careful-when-mapping-container-"
     "ports-to-the-host-with-firewalls-like-ufw"
 )
 

--- a/src/compose_lint/rules/CL0006_cap_drop.py
+++ b/src/compose_lint/rules/CL0006_cap_drop.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 OWASP_REF = (
     "https://cheatsheetseries.owasp.org/cheatsheets/"
-    "Docker_Security_Cheat_Sheet.html#rule-3---limit-capabilities-grant-only-"
+    "Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-"
     "specific-capabilities-needed-by-a-container"
 )
 

--- a/src/compose_lint/rules/CL0007_read_only.py
+++ b/src/compose_lint/rules/CL0007_read_only.py
@@ -21,7 +21,7 @@ _CAVEAT = (
 
 OWASP_REF = (
     "https://cheatsheetseries.owasp.org/cheatsheets/"
-    "Docker_Security_Cheat_Sheet.html#rule-8---set-filesystem-and-volumes-to-read-only"
+    "Docker_Security_Cheat_Sheet.html#rule-8-set-filesystem-and-volumes-to-read-only"
 )
 
 CIS_REF = (

--- a/src/compose_lint/rules/CL0008_host_network.py
+++ b/src/compose_lint/rules/CL0008_host_network.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 OWASP_REF = (
     "https://cheatsheetseries.owasp.org/cheatsheets/"
-    "Docker_Security_Cheat_Sheet.html#rule-5---be-mindful-of-inter-container-connectivity"
+    "Docker_Security_Cheat_Sheet.html#rule-5-be-mindful-of-inter-container-connectivity"
 )
 
 CIS_REF = (

--- a/src/compose_lint/rules/CL0009_security_profile.py
+++ b/src/compose_lint/rules/CL0009_security_profile.py
@@ -27,8 +27,8 @@ _CAVEAT = (
 
 OWASP_REF = (
     "https://cheatsheetseries.owasp.org/cheatsheets/"
-    "Docker_Security_Cheat_Sheet.html#rule-6---use-linux-security-module-"
-    "seccomp-apparmor-or-selinux"
+    "Docker_Security_Cheat_Sheet.html#rule-6-use-linux-security-module-"
+    "seccomp-apparmor-or-selinux-for-runtime-security"
 )
 
 CIS_SECCOMP_REF = (

--- a/src/compose_lint/rules/CL0010_host_namespace.py
+++ b/src/compose_lint/rules/CL0010_host_namespace.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 OWASP_REF = (
     "https://cheatsheetseries.owasp.org/cheatsheets/"
-    "Docker_Security_Cheat_Sheet.html#rule-3---limit-capabilities-grant-only-"
+    "Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-"
     "specific-capabilities-needed-by-a-container"
 )
 

--- a/src/compose_lint/rules/CL0011_dangerous_cap_add.py
+++ b/src/compose_lint/rules/CL0011_dangerous_cap_add.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 OWASP_REF = (
     "https://cheatsheetseries.owasp.org/cheatsheets/"
-    "Docker_Security_Cheat_Sheet.html#rule-3---limit-capabilities-grant-only-"
+    "Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-"
     "specific-capabilities-needed-by-a-container"
 )
 

--- a/src/compose_lint/rules/CL0013_sensitive_mount.py
+++ b/src/compose_lint/rules/CL0013_sensitive_mount.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 OWASP_REF = (
     "https://cheatsheetseries.owasp.org/cheatsheets/"
-    "Docker_Security_Cheat_Sheet.html#rule-8---set-filesystem-and-volumes-to-read-only"
+    "Docker_Security_Cheat_Sheet.html#rule-8-set-filesystem-and-volumes-to-read-only"
 )
 
 CIS_REF = (

--- a/src/compose_lint/rules/CL0018_explicit_root.py
+++ b/src/compose_lint/rules/CL0018_explicit_root.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 OWASP_REF = (
     "https://cheatsheetseries.owasp.org/cheatsheets/"
-    "Docker_Security_Cheat_Sheet.html#rule-7---do-not-use-root-user"
+    "Docker_Security_Cheat_Sheet.html#rule-2-set-a-user"
 )
 
 DOCKER_REF = "https://docs.docker.com/engine/security/userns-remap/"

--- a/src/compose_lint/rules/CL0019_image_no_digest.py
+++ b/src/compose_lint/rules/CL0019_image_no_digest.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 OWASP_REF = (
     "https://cheatsheetseries.owasp.org/cheatsheets/"
-    "Docker_Security_Cheat_Sheet.html#rule-13---enhance-supply-chain-security"
+    "Docker_Security_Cheat_Sheet.html#rule-13-enhance-supply-chain-security"
 )
 
 # Tags that CL-0004 already handles — we skip them to avoid overlap

--- a/src/compose_lint/rules/CL0020_credential_env_keys.py
+++ b/src/compose_lint/rules/CL0020_credential_env_keys.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 OWASP_REF = (
     "https://cheatsheetseries.owasp.org/cheatsheets/"
-    "Docker_Security_Cheat_Sheet.html#rule-11---use-secret-management-tools"
+    "Docker_Security_Cheat_Sheet.html#rule-12-utilize-docker-secrets-for-sensitive-data-management"
 )
 
 COMPOSE_SECRETS_REF = "https://docs.docker.com/reference/compose-file/secrets/"

--- a/src/compose_lint/rules/CL0021_connection_string_credentials.py
+++ b/src/compose_lint/rules/CL0021_connection_string_credentials.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 OWASP_REF = (
     "https://cheatsheetseries.owasp.org/cheatsheets/"
-    "Docker_Security_Cheat_Sheet.html#rule-11---use-secret-management-tools"
+    "Docker_Security_Cheat_Sheet.html#rule-12-utilize-docker-secrets-for-sensitive-data-management"
 )
 
 COMPOSE_SECRETS_REF = "https://docs.docker.com/reference/compose-file/secrets/"

--- a/tests/test_CL0002.py
+++ b/tests/test_CL0002.py
@@ -23,6 +23,15 @@ class TestPrivilegedModeRule:
         assert findings[0].rule_id == "CL-0002"
         assert findings[0].severity.value == "critical"
 
+    def test_message_matches_doc_wording(self) -> None:
+        # The message must not overclaim "functionally equivalent to host root";
+        # the doc/metadata say "trivially escapable" instead (issue #279 D5).
+        data, lines = load_compose(FIXTURES / "insecure_privileged.yml")
+        findings = list(self.rule.check("app", data["services"]["app"], data, lines))
+        msg = findings[0].message
+        assert "trivially escapable to host root" in msg
+        assert "functionally equivalent" not in msg
+
     def test_clean_service_no_findings(self) -> None:
         data, lines = load_compose(FIXTURES / "insecure_privileged.yml")
         findings = list(

--- a/tests/test_rule_loader.py
+++ b/tests/test_rule_loader.py
@@ -41,6 +41,20 @@ def test_each_rule_id_is_unique() -> None:
     assert len(rule_ids) == len(set(rule_ids)), f"duplicate rule IDs: {rule_ids}"
 
 
+def test_owasp_references_use_single_dash_anchors() -> None:
+    """OWASP cheat-sheet anchors must use the live single-dash slug form.
+
+    The page's mkdocs build collapses `[-\\s]+` to one separator, so the old
+    GitHub-style triple-dash anchors (`#rule-1---do-not-...`) land at page top.
+    Guards against reintroducing them (issue #279 D1).
+    """
+    for cls in get_registered_rules():
+        for ref in cls().metadata.references:
+            if "Docker_Security_Cheat_Sheet.html#" in ref:
+                anchor = ref.split("#", 1)[1]
+                assert "--" not in anchor, f"{cls().metadata.id}: stale anchor {anchor}"
+
+
 def test_register_rule_appends_to_registry() -> None:
     from compose_lint.rules import BaseRule, register_rule
 


### PR DESCRIPTION
Part of the #279 second-wave umbrella. Docs / grounding drift — the highest-mislead section.

## D1 — OWASP grounding has drifted (anchors + four citations)
OWASP renumbered the Docker Security Cheat Sheet and its mkdocs build now collapses `[-\s]+` to a single separator, so:
- **Every** OWASP deep link used the old GitHub triple-dash anchor (`#rule-1---do-not-…`) and landed at page top. All of them — rule docs, the README table, and the embedded `references=` URLs in code — now use the live single-dash slugs (verified against the live page).
- Four citations pointed at the wrong (renumbered) rule and are corrected:
  - **CL-0002**, **CL-0011** → Rule #3 *Limit capabilities* (the live page discusses `--privileged` under Rule #3).
  - **CL-0003** → Rule #4 *Prevent in-container privilege escalation* (was "add no-new-privileges flag").
  - **CL-0018** → Rule #2 *Set a user* (root-user guidance moved off the old Rule #7, now *Limit resources*).
  - **CL-0020**, **CL-0021** → Rule #12 *Utilize Docker Secrets* (secrets moved off the old Rule #11, now *rootless mode*).

## D2 — CL-0018 doc narrower than the code
The doc listed only `user: root` / `"0"` / `"root:root"` / `"0:0"`, but the code checks only the part before `:`, so it also fires on `user: "root:1000"`, `"0:staff"`, etc. Doc updated.

## D3 — CL-0015 doc omits the `test: ["NONE"]` branch
The code (and `severity.md`) already cover `test: ["NONE"]` / `"NONE"`; the rule doc was the outlier. Added.

## D5 — CL-0002 message contradicts its own doc
The message said "functionally equivalent to running on the host as root"; the doc and metadata deliberately say "trivially escapable to host root, *not literally equivalent*." Message aligned.

## D6 / D4
- **D6** is subsumed by D1: the README and rule-doc CL-0018 anchors both now point at `#rule-2-set-a-user`.
- **D4** was already satisfied by **#277 F4** — `CL-0017` matches `rshared` (`_SHARED_PROPAGATION = {"shared", "rshared"}`), so `severity.md`'s `:rshared` claim is already true. No change needed; verified.

## Tests
- A registry-wide guard asserts no OWASP reference contains a `--` (stale triple-dash anchor).
- CL-0002 message asserts the "trivially escapable" wording and rejects "functionally equivalent."

## Quality
`ruff check`, `ruff format --check`, `mypy src/` (strict, py3.13), `pytest` (741 passed, 2 skipped) all green.