### PR TITLE
Harden ClusterFuzzLite checkout and fuzz image hygiene (#279 supply chain)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,6 +21,8 @@ mutants/
 .coverage
 htmlcov/
 .claude/
+CLAUDE.md
+AGENTS.md
 .vscode/
 .idea/
 .env

--- a/.github/workflows/cflite-batch.yml
+++ b/.github/workflows/cflite-batch.yml
@@ -21,6 +21,8 @@ jobs:
         sanitizer: [address, undefined]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Build fuzzers
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1

--- a/.github/workflows/cflite-pr.yml
+++ b/.github/workflows/cflite-pr.yml
@@ -20,6 +20,8 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Build fuzzers
         id: build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deliberately excludes the line number, so an alert survives unrelated line
   shifts. Additive to the SARIF contract (ADR-015). (#278)
 
+### Security
+
+- ClusterFuzzLite hygiene (issue #279). The `cflite-pr` and `cflite-batch`
+  workflow checkouts now set `persist-credentials: false` like every other
+  workflow, so the `GITHUB_TOKEN` is not left in `.git/config` while PR-author
+  code runs during fuzzing. The fuzz image's `COPY .` no longer ingests
+  `CLAUDE.md` / `AGENTS.md` — they are added to `.dockerignore`. (#279)
+
 ### Fixed
 
 - Documentation and grounding drift corrected (issue #279 D1–D6). OWASP


### PR DESCRIPTION
Final item of the #279 second-wave umbrella — the two supply-chain nits. The pipeline is otherwise fully compliant with the CLAUDE.md pinning/publishing rules.

- **`persist-credentials: false`** added to the `cflite-pr.yml` and `cflite-batch.yml` checkout steps. Every other workflow already sets it; on a fork `pull_request` the `GITHUB_TOKEN` would otherwise persist in `.git/config` while PR-author code runs during fuzzing.
- **`CLAUDE.md` / `AGENTS.md` added to `.dockerignore`** so the `.clusterfuzzlite/Dockerfile`'s `COPY .` no longer pulls agent files into the ephemeral, unpublished fuzz image. (`.claude/` was already excluded.)

No code or behavior change. Workflow YAML validated; CI's actionlint job covers the workflows.