### PR TITLE
Make the parser line map collision-proof and per-path (#279 E2/E3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Parser line-map robustness (issue #279 E2/E3). A service (or any key) named
+  `__lines__` is no longer silently dropped: the loader's line map now hangs off
+  a private non-string sentinel key instead of the literal string `"__lines__"`,
+  so it can't collide with user data — a security linter must not skip a service.
+  And a service that both defines a YAML anchor and is aliased elsewhere now
+  resolves its own line: previously the alias and the anchor-definer shared one
+  dict, and only whichever the traversal reached first got its keys recorded, so
+  the other (often the definer — the most obvious location) reported `line=None`.
+  Line numbers are now recorded per reachable path while the subtree is still
+  walked once, so the chained-alias DoS guard (issue #154) is preserved. (#279)
+
 - Documentation and grounding drift corrected (issue #279 D1–D6). OWASP
   renumbered the Docker Security Cheat Sheet and switched its anchors to a
   single-dash slug, so every citation was either pointing at the wrong rule or

--- a/src/compose_lint/fix.py
+++ b/src/compose_lint/fix.py
@@ -70,8 +70,8 @@ def extends_targets(data: dict[str, Any]) -> set[str]:
     if not isinstance(services, dict):
         return set()
     targets: set[str] = set()
-    for name, config in services.items():
-        if name == "__lines__" or not isinstance(config, dict):
+    for _name, config in services.items():
+        if not isinstance(config, dict):
             continue
         ext = config.get("extends")
         if isinstance(ext, str):

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -9,6 +9,25 @@ from typing import Any
 import yaml
 
 
+class _LinesKey:
+    """Sentinel dict key under which a mapping's line map is stashed.
+
+    A unique, non-string object so it can never collide with a YAML scalar key.
+    Keying on the literal string ``"__lines__"`` silently dropped a service (or
+    any key) genuinely named ``__lines__`` — a security linter skipping a
+    service (issue #279 E2).
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid only
+        return "<__lines__>"
+
+
+# The single shared sentinel instance used as the line-map key on every mapping.
+_LINES = _LinesKey()
+
+
 class ComposeError(Exception):
     """Raised when a file is not a valid Docker Compose file."""
 
@@ -76,7 +95,7 @@ def _classify_missing_services(data: dict[str, Any]) -> ComposeError:
     """
 
     def _is_meta(k: Any) -> bool:
-        if k == "__lines__":
+        if k is _LINES:
             return True
         if not isinstance(k, str):
             return False
@@ -113,8 +132,9 @@ class LineLoader(yaml.SafeLoader):
     only overrides here are the mapping and sequence constructors, both of
     which record line numbers and otherwise delegate to the safe loader.
 
-    Mapping line numbers are stored in a ``__lines__`` key on the dict
-    itself (stripped before returning to callers). Sequence line numbers
+    Mapping line numbers are stored under a private non-string sentinel key
+    (``_LINES``) on the dict itself (stripped before returning to callers), so
+    they can't collide with a YAML key named ``__lines__``. Sequence line numbers
     can't live on the list (lists don't carry attributes and adding a
     sentinel item would change semantics), so they're stashed on the
     loader instance under ``_seq_lines``, keyed by ``id(list)``. The id
@@ -162,10 +182,10 @@ def _reject_duplicate_keys(loader: LineLoader, node: yaml.MappingNode) -> None:
         seen.add(key)
 
 
-def _construct_mapping(loader: LineLoader, node: yaml.MappingNode) -> dict[str, Any]:
+def _construct_mapping(loader: LineLoader, node: yaml.MappingNode) -> dict[Any, Any]:
     _reject_duplicate_keys(loader, node)
     loader.flatten_mapping(node)
-    mapping: dict[str, Any] = {}
+    mapping: dict[Any, Any] = {}
     line_map: dict[str, int] = {}
     for key_node, value_node in node.value:
         key = loader.construct_object(key_node)  # type: ignore[no-untyped-call]
@@ -189,7 +209,7 @@ def _construct_mapping(loader: LineLoader, node: yaml.MappingNode) -> dict[str, 
         if isinstance(key, str):
             line_map[key] = key_node.start_mark.line + 1
         mapping[key] = value
-    mapping["__lines__"] = line_map
+    mapping[_LINES] = line_map
     return mapping
 
 
@@ -328,7 +348,7 @@ _install_scalar_resolvers()
 
 
 def _strip_lines(data: Any) -> Any:
-    """Remove __lines__ metadata from parsed data at every depth.
+    """Remove line-map metadata (the ``_LINES`` sentinel key) at every depth.
 
     Iterative post-order traversal with an explicit work stack so
     pathologically-nested YAML can't exhaust the interpreter's recursion
@@ -364,7 +384,7 @@ def _strip_lines(data: Any) -> Any:
                 memo[id(node)] = {
                     k: memo[id(v)] if isinstance(v, (dict, list)) else v
                     for k, v in node.items()
-                    if k != "__lines__"
+                    if k is not _LINES
                 }
             else:
                 memo[id(node)] = [
@@ -383,44 +403,56 @@ def _collect_lines(
     """Collect line numbers into a flat dot-notation map.
 
     Iterative traversal with an explicit work stack so pathologically-
-    nested YAML can't exhaust the interpreter's recursion limit. The
-    visited set keyed by id() collapses YAML anchor-shared subtrees so
-    chained aliases can't fan out into O(branching^depth) work — each
-    unique container is walked once under the first prefix that reaches
-    it. Recorded line numbers come from the container's own __lines__
-    map (mappings) or the loader's seq_lines sidecar (sequences), which
-    are identical no matter which alias path arrived first, so rule
-    lookups against any reachable path still resolve correctly for keys
-    directly on that container.
+    nested YAML can't exhaust the interpreter's recursion limit.
+
+    A container's own direct keys/items are recorded under *every* path that
+    reaches it, but its children are pushed (its subtree walked) only the first
+    time it is reached. This is the fix for issue #279 E3: when a service both
+    defines an anchor and is aliased elsewhere, the alias and the
+    anchor-definer reach the same shared dict, and the previous "skip the whole
+    container on revisit" logic recorded the shared keys under only one of the
+    two paths — so the other service's findings reported ``line=None`` (often
+    the anchor-definer's, the most obvious location to a reader).
+
+    Recording-per-path stays linear, not O(branching^depth): children are
+    pushed once per unique container, so the number of (container, path) pops is
+    bounded by the edge count of the unique-node DAG, not the number of
+    root-to-node paths. The ``expanded`` set keyed by id() preserves the
+    chained-alias DoS guard from issue #154. A shared subtree's *deeper* lines
+    are still recorded under only its first-reached path; rule lookups are
+    shallow (``services.<svc>.<key>``, with a list index falling back to the
+    list's own line), so the direct-key recording covers them.
     """
     seq_lines = seq_lines or {}
     lines: dict[str, int] = {}
-    visited: set[int] = set()
+    expanded: set[int] = set()
     stack: list[tuple[Any, str]] = [(data, prefix)]
     while stack:
         current, current_prefix = stack.pop()
         if isinstance(current, dict):
-            if id(current) in visited:
-                continue
-            visited.add(id(current))
-            line_map = current.get("__lines__", {})
+            first = id(current) not in expanded
+            if first:
+                expanded.add(id(current))
+            line_map = current.get(_LINES, {})
             for key, value in current.items():
-                if key == "__lines__":
+                if key is _LINES:
                     continue
                 full_key = f"{current_prefix}.{key}" if current_prefix else key
                 if key in line_map:
                     lines[full_key] = line_map[key]
-                stack.append((value, full_key))
+                if first:
+                    stack.append((value, full_key))
         elif isinstance(current, list):
-            if id(current) in visited:
-                continue
-            visited.add(id(current))
+            first = id(current) not in expanded
+            if first:
+                expanded.add(id(current))
             item_lines = seq_lines.get(id(current), {})
             for i, item in enumerate(current):
                 full_key = f"{current_prefix}[{i}]"
                 if i in item_lines:
                     lines[full_key] = item_lines[i]
-                stack.append((item, full_key))
+                if first:
+                    stack.append((item, full_key))
     return lines
 
 
@@ -439,7 +471,7 @@ def _validate_compose(data: Any) -> dict[str, Any]:
         raise ComposeError("Not a valid Compose file: 'services' must be a mapping")
 
     for name, config in services.items():
-        if name == "__lines__":
+        if name is _LINES:
             continue
         if not isinstance(config, dict):
             raise ComposeError(
@@ -455,7 +487,7 @@ def load_compose(
     """Load and validate a Docker Compose file.
 
     Returns a tuple of (data, lines) where data is the parsed Compose
-    file as plain Python dicts with __lines__ metadata stripped, and
+    file as plain Python dicts with the line-map metadata stripped, and
     lines is a flat dict mapping dot-notation paths to line numbers.
 
     Raises:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -9,6 +9,7 @@ from typing import Any
 import pytest
 
 from compose_lint.parser import (
+    _LINES,
     ComposeError,
     ComposeNotApplicableError,
     _collect_lines,
@@ -185,9 +186,9 @@ class TestLoadCompose:
 
     def test_no_lines_metadata_in_data(self) -> None:
         data, _lines = load_compose(FIXTURES / "valid_basic.yml")
-        assert "__lines__" not in data
-        assert "__lines__" not in data["services"]
-        assert "__lines__" not in data["services"]["web"]
+        for container in (data, data["services"], data["services"]["web"]):
+            assert _LINES not in container
+            assert "__lines__" not in container
 
     def test_line_numbers_present(self) -> None:
         _data, lines = load_compose(FIXTURES / "valid_basic.yml")
@@ -217,6 +218,34 @@ class TestLoadCompose:
         assert web["security_opt"] == ["no-new-privileges:true"]
         assert web["image"] == "nginx:1.27-alpine"
         assert lines["services.web"] > lines["services"]
+
+    def test_service_named_lines_is_not_dropped(self) -> None:
+        # The line-map sentinel must not collide with a service literally
+        # named __lines__ — it used to be silently overwritten and skipped, a
+        # security linter dropping a service (issue #279 E2).
+        data, lines = loads(
+            "services:\n  __lines__:\n    image: nginx\n    privileged: true\n"
+        )
+        assert "__lines__" in data["services"]
+        assert data["services"]["__lines__"]["privileged"] is True
+        assert lines["services.__lines__.privileged"] == 4
+
+    def test_anchor_definer_and_alias_both_resolve_lines(self) -> None:
+        # An anchor-defining service and its alias reach the same shared dict.
+        # Both must resolve the shared key's line, not just whichever the
+        # traversal reached first — the definer used to report line=None
+        # (issue #279 E3).
+        data, lines = loads(
+            "services:\n"
+            "  one: &base\n"
+            "    image: nginx\n"
+            "    privileged: true\n"
+            "  two: *base\n"
+        )
+        assert data["services"]["one"]["privileged"] is True
+        assert data["services"]["two"]["privileged"] is True
+        assert lines["services.one.privileged"] == 4
+        assert lines["services.two.privileged"] == 4
 
     def test_v2_with_version_key(self) -> None:
         data, _lines = load_compose(FIXTURES / "valid_v2.yml")
@@ -321,7 +350,7 @@ class TestDeepNestingTraversal:
     def _build_deep_chain(depth: int) -> dict[str, Any]:
         node: Any = "leaf"
         for i in range(depth):
-            node = {"a": node, "__lines__": {"a": i + 1}}
+            node = {"a": node, _LINES: {"a": i + 1}}
         return node
 
     def test_collect_lines_handles_depth_above_recursion_limit(self) -> None:
@@ -339,7 +368,7 @@ class TestDeepNestingTraversal:
         walk: Any = result
         for _ in range(depth):
             assert isinstance(walk, dict)
-            assert "__lines__" not in walk
+            assert _LINES not in walk
             walk = walk["a"]
         assert walk == "leaf"
 
@@ -347,19 +376,19 @@ class TestDeepNestingTraversal:
         # YAML anchors produce the same Python dict reachable from multiple
         # parents. The iterative impl memoizes by id() so shared subtrees
         # are processed once, keeping work linear in the underlying graph.
-        shared = {"image": "nginx", "__lines__": {"image": 3}}
+        shared = {"image": "nginx", _LINES: {"image": 3}}
         root = {
             "services": {
                 "web": shared,
                 "api": shared,
-                "__lines__": {"web": 2, "api": 4},
+                _LINES: {"web": 2, "api": 4},
             },
-            "__lines__": {"services": 1},
+            _LINES: {"services": 1},
         }
         stripped = _strip_lines(root)
         # Same stripped dict returned for both aliases.
         assert stripped["services"]["web"] is stripped["services"]["api"]
-        assert "__lines__" not in stripped["services"]["web"]
+        assert _LINES not in stripped["services"]["web"]
 
     def test_collect_lines_bounds_chained_alias_blowup(self) -> None:
         # Regression for issue #154: ClusterFuzzLite found a sub-1KB Compose


### PR DESCRIPTION
Part of the #279 second-wave umbrella — the parser line-map robustness items, taken last because they touch the chained-alias DoS guard (#154).

## E2 — a service named `__lines__` is silently dropped
`LineLoader` stashed each mapping's line map under the literal string key `"__lines__"`, and `_strip_lines` removed that key everywhere. A service (or any key) genuinely named `__lines__` collided with the sentinel and vanished from `data["services"]` with no error — a security linter silently skipping a service:

```yaml
services:
  __lines__:
    image: nginx
    privileged: true   # never evaluated
```

The line map now hangs off a private **non-string sentinel** (`_LINES`, a unique object), which can't collide with any YAML scalar key. The parser, `_strip_lines`, `_collect_lines`, `_validate_compose`, and `_classify_missing_services` all key on it; the dead `name == "__lines__"` guard in `fix.py` (which would now wrongly skip a real service) is removed.

## E3 — anchor-defining service loses its line; alias inherits it
`_collect_lines` walked a LIFO stack and claimed a shared dict by `id()` on first visit, then `continue`d on every later visit. When a service both defines an anchor and is aliased, the alias (popped first) marked the shared node visited, so the anchor-definer's keys were never recorded under its path — the definer reported `line=None` and the alias reported the anchor's line:

```yaml
services:
  one: &base
    image: nginx
    privileged: true   # line 4
  two: *base
```

Now a container's **own direct keys/items are recorded under every path that reaches it**, while its children are pushed (subtree walked) only the first time. Both `services.one.privileged` and `services.two.privileged` resolve to line 4.

### DoS guard preserved
Because children are still pushed once per unique container, the number of `(container, path)` pops is bounded by the **edge count of the unique-node DAG**, not the number of root-to-node paths — so the chained-alias fan-out from **#154** can't recur. Its regression test (`test_collect_lines_bounds_chained_alias_blowup`) still passes (<1s, <1000 entries). Deeper lines of a shared subtree are recorded under its first-reached path only; rule lookups are shallow (`services.<svc>.<key>`, with a list index falling back to the list's own line), so direct-key recording covers them.

## Tests
- E2: a `__lines__` service is preserved and its `privileged` line tracked.
- E3: anchor-definer and alias both resolve their `privileged` line (4).
- The synthetic `_strip_lines`/`_collect_lines` traversal tests now build metadata with the `_LINES` sentinel; the #154 bound test is unchanged and green.

## Quality
`ruff check`, `ruff format --check`, `mypy src/` (strict, py3.13), `pytest` (743 passed, 2 skipped) all green.