### PR TITLE
Promote fix subcommand to the documented SemVer surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The `fix` subcommand is promoted out of experimental and onto the documented,
+  SemVer-covered surface (ADR-014, Phase 3). It now lists in `compose-lint
+  --help` and has a README section. Behavior is unchanged: dry-run by default
+  (prints a unified diff, writes nothing), `--apply` writes fixes in place via
+  an atomic swap, `--only CL-XXXX` scopes to named rules, suppressed findings
+  are never touched, and every apply is guarded by a re-parse plus a
+  verify-apply pass that refuses to write anything that wouldn't re-lint clean.
+  Promotion follows a full-corpus soak over ~6.4k real Compose files with zero
+  re-parse failures, zero non-idempotent fixes, and zero new findings
+  introduced.
+
+### Changed
+
+- Structured SARIF `fixes[]` (machine-applicable `artifactChanges`, which GitHub
+  Code Scanning renders as suggested changes) now ship unconditionally in
+  `check --format sarif`. They were previously gated behind
+  `COMPOSE_LINT_EXPERIMENTAL=1`; that environment variable is now a no-op.
+- `fix` no longer prints a per-invocation "experimental" warning to stderr — it
+  is part of the stability contract from this release.
+
 ## [0.10.0] - 2026-05-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -215,6 +215,40 @@ compose-lint [OPTIONS] [FILE ...]
   --version                    Show version and exit
 ```
 
+## Fixing findings
+
+`compose-lint fix` auto-remediates the findings that have a safe, unambiguous
+edit — adding `read_only: true`, `no-new-privileges:true`, dropping a bare
+`latest` tag, binding a published port to `127.0.0.1`, and similar. It is
+**dry-run by default**: it prints a unified diff and writes nothing.
+
+```bash
+compose-lint fix docker-compose.yml            # preview the diff, write nothing
+compose-lint fix --apply docker-compose.yml    # write the fixes in place
+compose-lint fix --only CL-0007 --apply .      # restrict to one rule
+```
+
+- **Dry-run by default; `--apply` writes in place** via an atomic swap that
+  preserves the file's permission bits — an interrupted write never corrupts the
+  Compose file.
+- **Only safe, mechanical fixes are applied.** Findings whose remediation is
+  context-dependent (e.g. CL-0006 capability lists, CL-0001 socket mounts) are
+  reported as needing manual review, never auto-edited.
+- **Suppressed findings are never touched** — `.compose-lint.yml` disables and
+  per-service excludes are honored.
+- **Refuses unsafe edits.** Files using YAML anchors, merge keys, or `${VAR}`
+  interpolation in the affected region are skipped rather than risk a wrong
+  rewrite, and every apply is re-parsed and re-linted before it is written —
+  anything that wouldn't round-trip clean is refused with the diff surfaced for
+  diagnosis.
+- **Diff is data, status is human.** The diff goes to stdout; progress and
+  warnings go to stderr, so `compose-lint fix file.yml > changes.diff` captures
+  exactly the patch.
+
+Structured fixes also ride in SARIF output: `compose-lint check --format sarif`
+populates `fixes[].artifactChanges`, which GitHub Code Scanning renders as an
+inline suggested change on the pull request.
+
 ## Versioning & stability
 
 compose-lint follows [Semantic Versioning](https://semver.org/). From 1.0, the CLI, exit codes, config schema, and JSON/SARIF output are stable. New and tightened rules ship in MINOR releases, so pin a version or use `--fail-on` if you need deterministic CI. See [docs/compatibility.md](https://github.com/tmatens/compose-lint/blob/main/docs/compatibility.md) for the full stability promise and deprecation policy.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -51,14 +51,13 @@ Turn findings into fixes. This is where the product's differentiation grows the 
 
 **`--explain CL-XXXX`** _(shipped in v0.4.x)_ — prints the full prose from `docs/rules/CL-XXXX.md` in the terminal, reducing context-switching to the browser during triage. Rule-doc markdown is force-included into the wheel at build time. No new deps; pulled forward out of Milestone 3 because it's strictly additive and unblocks the `--fix` UX work.
 
-**`--fix` mode** — auto-fix for safe, unambiguous rules:
-- CL-0003: inject `no-new-privileges:true` into `security_opt:`
-- CL-0005: prepend `127.0.0.1:` to unbound port mappings
-- CL-0007: add `read_only: true`
-- Dry run by default; `--fix --apply` writes in-place.
-- Out of scope for auto-fix: CL-0001 (socket proxy replacement is non-trivial), CL-0016 (correct secret management is context-dependent).
+**`fix` subcommand** _(shipped; promoted to the documented, SemVer-covered surface in 0.11.0 — [ADR-014](adr/014-fix-remediation.md))_ — auto-fix for safe, unambiguous rules:
+- Six fixers: CL-0003 (`no-new-privileges:true`), CL-0005 (bind published ports to `127.0.0.1`), CL-0007 (`read_only: true`), CL-0009, CL-0014, CL-0015.
+- Dry run by default; `fix --apply` writes in-place via an atomic swap; `--only CL-XXXX` scopes to named rules.
+- Refuses anchors/merge keys/`${VAR}` regions and guards every apply with a re-parse + verify-apply pass.
+- Out of scope for auto-fix: CL-0001 (socket proxy replacement is non-trivial), CL-0006 (capability lists are image-specific), CL-0016 (correct secret management is context-dependent).
 
-**Remediation snippets in SARIF** — populate `fix.changes[]` objects so GitHub Code Scanning can display a suggested-change diff inline on pull requests.
+**Remediation snippets in SARIF** _(shipped in 0.11.0)_ — `check --format sarif` populates `fixes[].artifactChanges` so GitHub Code Scanning displays a suggested-change diff inline on pull requests.
 
 **Shellcheck integration** _(pending decision — [ADR-007](adr/007-shellcheck-integration.md))_
 - Lint shell commands inside `command` and `entrypoint` (string form) and `healthcheck.test` with `CMD-SHELL`.
@@ -73,7 +72,7 @@ v1.0 is the **stability commitment**: the CLI surface, exit codes, configuration
 
 **GA criteria:**
 - **Stable, documented contract** — CLI flags, exit codes ([ADR-006](adr/006-exit-codes.md)), the `.compose-lint.yml` schema, and the JSON + SARIF output shapes are frozen and documented as the 1.0 surface. The JSON output gains a versioned envelope before the freeze, so run-level metadata (tool version, parse errors) can be added later without breaking consumers.
-- **`fix` resolved** — shipped as GA, or explicitly carved out as experimental with its own stability exemption, so the rest of the surface can stabilize independently ([ADR-014](adr/014-fix-remediation.md)).
+- **`fix` resolved** — _done._ Shipped as GA and brought under the SemVer contract in 0.11.0 ([ADR-014](adr/014-fix-remediation.md)), independently of the 1.0 cut.
 - **Grounding + severity audit complete** — every rule cites OWASP/CIS/Docker, and no severity change is pending that would alter a CI gate after the freeze.
 - **Documented upgrade/deprecation policy** — the SemVer stability promise (rule additions, severity changes, config and output-shape changes) and the deprecation lifecycle, in [compatibility.md](compatibility.md).
 
@@ -128,6 +127,6 @@ Python 3.10 is scheduled to age out of the matrix when it reaches upstream EOL i
 | Rule Coverage (19 rules) | v0.3 | complete |
 | Per-service rule overrides | v0.4 | complete |
 | CL-0006 profiles + real-world examples + Homebrew tap | v0.4.x | in progress |
-| Remediation (`--explain`, `--fix`, SARIF fixes, shellcheck) | v0.5–0.8 | in progress |
+| Remediation (`--explain`, `fix`, SARIF fixes, shellcheck) | v0.5–0.11 | `fix` GA in 0.11.0; shellcheck pending |
 | GA / 1.0 — stable contract + `fix` + upgrade policy | v1.0 | next |
 | Ecosystem integrations (VS Code, custom rules) | v1.x | |

--- a/docs/adr/014-fix-remediation.md
+++ b/docs/adr/014-fix-remediation.md
@@ -1,6 +1,11 @@
 # ADR-014: `fix` — Automated Remediation of Auto-Fixable Findings
 
-**Status:** Proposed
+**Status:** Accepted — Phase 3 reached in 0.11.0. `fix` is promoted to the
+documented, SemVer-covered surface: it lists in `--help`, structured SARIF
+`fixes[]` ship unconditionally, and the per-invocation experimental warning and
+`COMPOSE_LINT_EXPERIMENTAL` gate are removed. All five promotion criteria in
+Part 5 are met, including the full-corpus soak (~6.4k files: zero re-parse
+failures, zero non-idempotent fixes, zero new findings introduced).
 
 **Context:** compose-lint tells a user what is wrong and how to fix it, but
 today the fix is prose the user applies by hand. Milestone 3 of the roadmap

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -26,11 +26,6 @@ These may change in any release, including PATCH, without a major bump:
 - **Human text output** — the exact wording, layout, colour, and ordering of
   `--format text`. It is for humans; parse JSON or SARIF if you need a stable
   shape. (The JSON `version` field exists precisely so you can.)
-- **The experimental `fix` subcommand** — reachable but hidden from `--help`,
-  prints a stderr warning on every run, and is excluded from the SemVer contract
-  until promoted ([ADR-014](adr/014-fix-remediation.md)). Its flags, output, and
-  behavior may change in any release. (Structured SARIF `fixes[]` from the engine
-  stay behind `COMPOSE_LINT_EXPERIMENTAL=1` until that promotion.)
 - **Internal Python API** — anything beyond `compose_lint.__version__` and the
   documented CLI. compose-lint is a CLI / GitHub Action, not an importable
   library; rule classes, the engine, parser, and formatters are implementation

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -75,24 +75,6 @@ def _effective_config_path(explicit: str | None) -> Path | None:
 # top-level parser sees it; any other flag-only invocation routes to `check`.
 _GLOBAL_FLAGS = frozenset({"-h", "--help", "--version"})
 
-# Stderr banner printed on every `fix` invocation (ADR-014, Part 5).
-_FIX_EXPERIMENTAL_WARNING = (
-    "warning: 'fix' is experimental; its flags, output, and behavior may change "
-    "in any release. Dry-run by default — review the diff before --apply."
-)
-
-
-def _experimental_enabled() -> bool:
-    """Return whether experimental fix-engine *output* is gated on.
-
-    Post-Phase-2 (ADR-014) the `fix` subcommand itself is always available but
-    hidden; this gate now only controls the one piece still held back for
-    Phase 3 — structured SARIF ``fixes[]`` in ``check --format sarif`` — which
-    stays behind ``COMPOSE_LINT_EXPERIMENTAL=1`` until the engine is promoted
-    into the SemVer contract.
-    """
-    return os.environ.get("COMPOSE_LINT_EXPERIMENTAL") == "1"
-
 
 def _subcommands() -> set[str]:
     """Return the subcommand names the argv shim should recognize.
@@ -100,8 +82,7 @@ def _subcommands() -> set[str]:
     Bare ``compose-lint <file>`` is kept working as an implicit ``check``
     (ADR-011): when the first non-flag token is not one of these, the shim
     prepends ``check``. ``fix`` is recognized so ``compose-lint fix ...`` routes
-    to it; the command is still hidden from ``--help`` (Phase 2), just no longer
-    gated behind an env var.
+    to it.
     """
     return {"check", "fix"}
 
@@ -186,17 +167,20 @@ def _add_check_subparser(
 def _add_fix_subparser(
     subparsers: argparse._SubParsersAction,  # type: ignore[type-arg]
 ) -> None:
-    """Register the hidden, experimental `fix` subcommand (ADR-014).
+    """Register the `fix` subcommand (ADR-014).
 
-    Omitting ``help=`` keeps it out of ``compose-lint --help``: argparse only
-    lists subparsers that were given a help string (passing
-    ``help=argparse.SUPPRESS`` instead renders a literal ``==SUPPRESS==`` row).
-    Post-Phase-2 the command is always registered; hiding it is now this
-    omission's job alone, not an env gate's.
+    Promoted to the documented, SemVer-covered surface in 0.11.0: it carries a
+    ``help=`` string so it lists in ``compose-lint --help`` like ``check``.
     """
     fix = subparsers.add_parser(
         "fix",
-        description="Auto-remediate auto-fixable findings (experimental).",
+        help="auto-remediate auto-fixable findings (dry-run; --apply to write)",
+        description=(
+            "Auto-remediate auto-fixable findings. Dry-run by default: prints a "
+            "unified diff and writes nothing. Pass --apply to write fixes in "
+            "place. Findings with no safe automatic fix are left for manual "
+            "review; suppressed findings are never touched."
+        ),
     )
     fix.add_argument(
         "files",
@@ -237,8 +221,6 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     subparsers = parser.add_subparsers(dest="command", metavar="COMMAND")
     _add_check_subparser(subparsers)
-    # `fix` is always registered (Phase 2) but stays hidden from --help; see
-    # _add_fix_subparser for how (it omits help=).
     _add_fix_subparser(subparsers)
     return parser
 
@@ -397,13 +379,12 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
             print(format_summary(findings, filepath), flush=True)
             all_file_findings.append((findings, filepath))
         elif args.output_format == "sarif":
-            # Structured SARIF fixes ride on the experimental fix engine, so they
-            # stay gated until the feature is promoted (ADR-014). Without the gate
-            # the output keeps the prose `properties.fix` only.
-            fixes = None
-            if _experimental_enabled():
-                text = Path(filepath).read_text(encoding="utf-8")
-                fixes = collect_edits(findings, data, lines, text).fixed_edits
+            # Structured SARIF fixes (ADR-014, promoted in 0.11.0): every
+            # auto-fixable finding carries its machine-applicable edit so GitHub
+            # Code Scanning can render a suggested change. Findings with no safe
+            # fixer keep the prose `properties.fix` only.
+            text = Path(filepath).read_text(encoding="utf-8")
+            fixes = collect_edits(findings, data, lines, text).fixed_edits
             all_sarif.extend(format_sarif(findings, filepath, fixes=fixes))
         else:
             all_json.extend(format_json(findings, filepath))
@@ -474,7 +455,7 @@ def _atomic_write(path: Path, content: str) -> None:
 
 
 def _run_fix(args: argparse.Namespace) -> NoReturn:
-    """Run the experimental `fix` operation (ADR-014).
+    """Run the `fix` operation (ADR-014).
 
     Dry-run by default: a unified diff of proposed edits goes to stdout and
     status goes to stderr; nothing is written. ``--apply`` writes edits in
@@ -482,8 +463,6 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
     Exit 0 on success, 2 on usage/parse error — findings are the input, not the
     failure signal, so residual manual-only findings do not change the code.
     """
-    print(_FIX_EXPERIMENTAL_WARNING, file=sys.stderr)
-
     try:
         disabled_rules, severity_overrides, excluded_services = load_config(args.config)
     except ConfigError as e:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -381,22 +381,16 @@ _BARE_SERVICE = "services:\n  web:\n    image: nginx:1.27\n"
 
 
 class TestFixSubcommand:
-    """Tests for the hidden, experimental `fix` subcommand (ADR-014).
-
-    Post-Phase-2 `fix` is reachable without ``COMPOSE_LINT_EXPERIMENTAL``, so
-    these invoke it with a plain ``run_cli``; the env var now only gates SARIF
-    fixes (see ``test_sarif``).
-    """
+    """Tests for the `fix` subcommand (ADR-014, promoted in 0.11.0)."""
 
     def test_dry_run_prints_diff_to_stdout(self, tmp_path: Path) -> None:
         f = tmp_path / "docker-compose.yml"
         f.write_text(_BARE_SERVICE)
         result = run_cli("fix", str(f))
         assert result.returncode == 0
-        # Diff (data) on stdout; warning + status (human) on stderr.
+        # Diff (data) on stdout; status (human) on stderr.
         assert "+    read_only: true" in result.stdout
         assert "⚠ behavior-changing · CL-0007" in result.stdout
-        assert "experimental" in result.stderr.lower()
         # Dry-run writes nothing.
         assert f.read_text() == _BARE_SERVICE
 
@@ -440,20 +434,24 @@ class TestFixSubcommand:
         assert "read_only: true" not in patched
         assert "no-new-privileges:true" in patched
 
-    def test_hidden_from_help(self) -> None:
-        # Always registered post-Phase-2, but still omitted from --help.
+    def test_listed_in_help(self) -> None:
+        # Promoted in 0.11.0: `fix` carries a help string, so it appears in
+        # the top-level command list alongside `check`.
         result = run_cli("--help")
         assert result.returncode == 0
-        assert "fix" not in result.stdout
+        assert "fix" in result.stdout
+        assert "auto-remediate" in result.stdout.lower()
 
-    def test_available_without_env_gate(self, tmp_path: Path) -> None:
+    def test_no_experimental_warning(self, tmp_path: Path) -> None:
+        # Promoted to the SemVer contract: no per-invocation experimental
+        # warning is printed (it was the carve-out's mitigation).
         f = tmp_path / "docker-compose.yml"
         f.write_text(_BARE_SERVICE)
-        # Phase 2: `fix` runs without COMPOSE_LINT_EXPERIMENTAL — still hidden,
-        # still warned-on, dry-run by default (writes nothing).
         result = run_cli("fix", str(f))
         assert result.returncode == 0
-        assert "experimental" in result.stderr.lower()
+        # Match the old warning's phrase, not the bare word — the temp path can
+        # contain "experimental" (it is derived from this test's name).
+        assert "is experimental" not in result.stderr.lower()
         assert "+    read_only: true" in result.stdout
         assert f.read_text() == _BARE_SERVICE
 

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -370,12 +370,7 @@ class TestSarifCLI:
         }
         assert len(files) >= 2
 
-    def _run_sarif(self, *, experimental: bool) -> dict:
-        env = dict(os.environ)
-        if experimental:
-            env["COMPOSE_LINT_EXPERIMENTAL"] = "1"
-        else:
-            env.pop("COMPOSE_LINT_EXPERIMENTAL", None)
+    def _run_sarif(self) -> dict:
         result = subprocess.run(
             [
                 sys.executable,
@@ -387,23 +382,19 @@ class TestSarifCLI:
             ],
             capture_output=True,
             text=True,
-            env=env,
         )
         return json.loads(result.stdout)
 
-    def test_structured_fixes_emitted_under_experimental(self) -> None:
-        data = self._run_sarif(experimental=True)
+    def test_structured_fixes_emitted_by_default(self) -> None:
+        # Promoted in 0.11.0: structured SARIF fixes ship unconditionally, with
+        # no COMPOSE_LINT_EXPERIMENTAL gate.
+        data = self._run_sarif()
         results = data["runs"][0]["results"]
         with_fixes = [r for r in results if "fixes" in r]
-        assert with_fixes, "expected structured fixes when experimental is enabled"
+        assert with_fixes, "expected structured fixes in SARIF output"
         change = with_fixes[0]["fixes"][0]["artifactChanges"][0]
         assert change["replacements"]
-
-    def test_structured_fixes_gated_off_by_default(self) -> None:
-        data = self._run_sarif(experimental=False)
-        results = data["runs"][0]["results"]
-        assert all("fixes" not in r for r in results)
-        # the prose guidance is still present
+        # the prose guidance is still present alongside the structured fix
         assert any("properties" in r for r in results)
 
 


### PR DESCRIPTION
## What

ADR-014 **Phase 3**: the `fix` subcommand graduates from experimental to the documented, SemVer-covered surface.

## Why now

All five ADR-014 promotion criteria hold. The gating one — the full-corpus soak — passed this run:

```
corpus files: 6,444 · workers: 8
fixed files:  5,666
reparse failures:        0
non-idempotent:          0
introduced new finding:  0
RESULT: PASS
```

## Changes

- **Unhide** — `fix` now lists in `compose-lint --help` (its subparser carries a help string).
- **SARIF fixes by default** — structured `fixes[].artifactChanges` ship unconditionally in `check --format sarif`; the `COMPOSE_LINT_EXPERIMENTAL` env var is now a no-op.
- **Drop the experimental warning** — no per-invocation stderr warning; `fix` is part of the stability contract from this release.
- **Docs** — README `Fixing findings` section; `fix` removed from the "not covered" list in `compatibility.md`; ADR-014 status → Accepted; ROADMAP updated; CHANGELOG `[Unreleased]` entry.

Behavior is otherwise **unchanged**: dry-run by default, `--apply` writes via an atomic swap, `--only` scopes to named rules, suppressed findings are never touched, and every apply is guarded by a re-parse + verify-apply pass.

Ships in **0.11.0** (version bump happens at release time via release-prep, per RELEASING.md).

## Verification

- `ruff check src/ tests/`, `ruff format --check src/ tests/`, `mypy src/` (strict) — clean
- `pytest` — 742 passed, 2 skipped
- Manual smoke: `fix` in `--help`, no experimental warning on stderr, SARIF `artifactChanges` present without the env var