### PR TITLE
Flag PERFMON capability in CL-0011

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   status to stderr. Takes a single `FILE`. Bare `compose-lint <file>` and
   `compose-lint check` are unaffected.
 
+### Changed
+
+- CL-0011 now flags the `PERFMON` capability (HIGH), completing the pair split
+  out of `SYS_ADMIN` in Linux 5.8 (`BPF` shipped in 0.10.0). A service with
+  `cap_add: [PERFMON]` that previously passed will now report a finding.
+
 ## [0.11.0] - 2026-05-25
 
 ### Added

--- a/docs/rules/CL-0011.md
+++ b/docs/rules/CL-0011.md
@@ -23,8 +23,9 @@ Services that add dangerous Linux capabilities via `cap_add`:
 | `DAC_READ_SEARCH` | HIGH | Bypass file read permission checks on the host |
 | `DAC_OVERRIDE` | HIGH | Bypass all file read, write, and execute permission checks |
 | `BPF` | HIGH | Load BPF programs — arbitrary kernel read/write on modern kernels |
+| `PERFMON` | HIGH | Performance-monitoring access (`perf_event_open`) — enables timing/side-channel attacks and kernel info disclosure |
 
-Safe capabilities like `NET_BIND_SERVICE` or `CHOWN` are not flagged. `PERFMON` is not yet on the dangerous list. `MKNOD` and `SYS_CHROOT` are intentionally not flagged here because the `cap_drop: [ALL]` baseline (CL-0006) already covers them; adding them back is not on its own a HIGH-severity escape path.
+Safe capabilities like `NET_BIND_SERVICE` or `CHOWN` are not flagged. `BPF` and `PERFMON` were split out of `SYS_ADMIN` in Linux 5.8 and are flagged in their own right. `MKNOD` and `SYS_CHROOT` are intentionally not flagged here because the `cap_drop: [ALL]` baseline (CL-0006) already covers them; adding them back is not on its own a HIGH-severity escape path.
 
 ## Why it matters
 

--- a/src/compose_lint/rules/CL0011_dangerous_cap_add.py
+++ b/src/compose_lint/rules/CL0011_dangerous_cap_add.py
@@ -36,6 +36,10 @@ DANGEROUS_CAPS: dict[str, str] = {
     "DAC_READ_SEARCH": "bypass file read permission checks on the host",
     "DAC_OVERRIDE": "bypass all file read, write, and execute permission checks",
     "BPF": "load BPF programs — arbitrary kernel read/write on modern kernels",
+    "PERFMON": (
+        "performance-monitoring access (perf_event_open) — enables timing and "
+        "side-channel attacks and kernel info disclosure"
+    ),
 }
 
 CRITICAL_CAPS: frozenset[str] = frozenset({"ALL"})

--- a/tests/test_CL0011.py
+++ b/tests/test_CL0011.py
@@ -52,6 +52,13 @@ class TestDangerousCapAddRule:
         assert len(findings) == 1
         assert "BPF" in findings[0].message
 
+    def test_detects_perfmon(self) -> None:
+        # Split out of SYS_ADMIN in Linux 5.8, like BPF (issue #192).
+        findings = self._check_cap("PERFMON")
+        assert len(findings) == 1
+        assert findings[0].severity == Severity.HIGH
+        assert "PERFMON" in findings[0].message
+
     def test_detects_cap_prefixed_capability(self) -> None:
         # Docker treats `CAP_SYS_ADMIN` == `SYS_ADMIN`; the rule keyed on the
         # bare name and missed the prefixed form, including `CAP_ALL` (#277 F2).


### PR DESCRIPTION
Completes the trivial item from the #192 rule-docs review.

`PERFMON` was split out of `SYS_ADMIN` in Linux 5.8 alongside `BPF` (which shipped in 0.10.0). It grants `perf_event_open()` access — usable for timing/side-channel attacks and kernel info disclosure — so it belongs on CL-0011's dangerous-capabilities list at **HIGH**, parallel to `BPF`.

## Change

- One entry in `DANGEROUS_CAPS` (CL0011_dangerous_cap_add.py). The existing `check()` already strips the optional `CAP_` prefix and uppercases, so `PERFMON`, `cap_perfmon`, and `CAP_PERFMON` all match for free.
- Doc table row in `docs/rules/CL-0011.md`; removed the "not yet on the dangerous list" note.
- Test mirroring `test_detects_bpf`.
- CHANGELOG `[Unreleased]` under Changed (a service with `cap_add: [PERFMON]` that previously passed now reports a finding — a tightened rule, MINOR per the compatibility policy).

Corpus hit rate is 0 (measured in #192); the value is completeness against the modern Linux capability set, not coverage.

## Quality gate

`ruff check`, `ruff format --check`, `mypy src/` (strict), `pytest` (759 passed, 2 pre-existing skips) — all pass.

Refs #192.