### PR TITLE
Add CL-0022: flag unhardened tmpfs mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   status to stderr. Takes a single `FILE`. Bare `compose-lint <file>` and
   `compose-lint check` are unaffected.
 
+- CL-0022 flags `tmpfs:` mounts that omit `noexec`, `nosuid`, or `nodev`
+  (MEDIUM). A writable, executable in-memory mount is a payload-staging surface,
+  especially under `read_only: true` where tmpfs is often the only writable
+  path. Covers the short string/list `tmpfs:` form (the long `volumes:` form
+  can't express these flags through Compose); the message names the missing
+  flags. `compose-lint fix` appends them in place, preserving existing options
+  like `size=`, with a caveat that `noexec` is behavior-changing.
+
 ### Changed
 
 - CL-0011 now flags the `PERFMON` capability (HIGH), completing the pair split

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ If you need broad IaC coverage across Terraform, Kubernetes, and more, KICS cove
 | [CL-0019](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0019.md) | MEDIUM | Image tag without digest | [Rule #13](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-13-enhance-supply-chain-security) | — |
 | [CL-0020](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0020.md) | HIGH | Credential-shaped env key with literal value | [Rule #12](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-12-utilize-docker-secrets-for-sensitive-data-management) | — |
 | [CL-0021](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0021.md) | HIGH | Credential embedded in connection-string env value | [Rule #12](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-12-utilize-docker-secrets-for-sensitive-data-management) | — |
+| [CL-0022](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0022.md) | MEDIUM | tmpfs mount not hardened | [Rule #8](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-8-set-filesystem-and-volumes-to-read-only) | — |
 
 ## Severity Levels
 

--- a/docs/SECURITY-EXPECTATIONS.md
+++ b/docs/SECURITY-EXPECTATIONS.md
@@ -75,7 +75,7 @@ pipeline, this is the page to read.
    It cannot tell you what a running container is *actually* doing —
    only what its declared configuration *would* let it do.
 
-5. **It is not exhaustive.** The 21 rules cover the misconfigurations
+5. **It is not exhaustive.** The 22 rules cover the misconfigurations
    that the OWASP Docker Security Cheat Sheet, CIS Docker Benchmark,
    and Docker official documentation ground (see
    [README.md](../README.md#rules) for the full list). Misconfigurations

--- a/docs/rules/CL-0022.md
+++ b/docs/rules/CL-0022.md
@@ -1,0 +1,61 @@
+# CL-0022: tmpfs mount not hardened
+
+**Severity:** MEDIUM
+
+**References:**
+- [OWASP Docker Security Rule #8](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-8-set-filesystem-and-volumes-to-read-only)
+- [Docker docs — tmpfs mounts](https://docs.docker.com/engine/storage/tmpfs/)
+
+## What it detects
+
+Any service whose short-form `tmpfs:` entry — a single string or a list of strings — omits one or more of `noexec`, `nosuid`, or `nodev`:
+
+```yaml
+tmpfs:
+  - /tmp                                  # flagged: no hardening flags
+  - /run:size=64m                         # flagged: size set, but no noexec/nosuid/nodev
+  - /cache:noexec,nosuid,nodev            # clean
+tmpfs: /var/run                           # flagged (scalar form)
+```
+
+The message names the specific flags that are missing, so a partially-hardened mount (`/tmp:noexec`) is still flagged for the remaining two.
+
+The long-form mount syntax is **out of scope** — it cannot express these flags through Compose:
+
+```yaml
+volumes:
+  - type: tmpfs       # not flagged: Compose exposes only size/mode here, not noexec
+    target: /tmp
+```
+
+## Why it matters
+
+A tmpfs is an in-memory filesystem the container can always write to. Without mount options it is also **executable** and honors **setuid** bits and **device nodes**:
+
+- **`noexec`** stops a payload written to the tmpfs from being executed. This is the load-bearing flag: a writable, executable scratch space is a classic place for an attacker to stage and run a dropped binary.
+- **`nosuid`** stops a setuid binary placed on the mount from elevating privileges.
+- **`nodev`** stops device nodes on the mount from being treated as devices.
+
+The gap matters most alongside CL-0007 (`read_only: true`). The recommended way to keep a read-only-root container working is to mount writable scratch space as tmpfs — which then becomes the *only* writable path. Leaving it executable hands an attacker back exactly the foothold the read-only root was meant to remove.
+
+## Fix
+
+Add the flags to the tmpfs entry:
+
+```yaml
+# Before
+services:
+  web:
+    image: nginx:1.27-alpine
+    tmpfs:
+      - /tmp
+
+# After
+services:
+  web:
+    image: nginx:1.27-alpine
+    tmpfs:
+      - /tmp:noexec,nosuid,nodev
+```
+
+`compose-lint fix` performs this edit automatically, preserving any existing options (e.g. `size=64m`). The fix carries a caveat: keep `noexec` unless the workload legitimately executes files from the mount, in which case drop only `noexec` and keep `nosuid,nodev`.

--- a/src/compose_lint/rules/CL0022_tmpfs_hardening.py
+++ b/src/compose_lint/rules/CL0022_tmpfs_hardening.py
@@ -1,0 +1,201 @@
+"""CL-0022: tmpfs mount missing hardening flags."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from compose_lint.fix import is_anchored_or_merged
+from compose_lint.models import Finding, RuleMetadata, Severity, TextEdit
+from compose_lint.rules import BaseRule, register_rule
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+# Order is canonical: a fixer appends missing flags in this sequence.
+_HARDENING_FLAGS = ("noexec", "nosuid", "nodev")
+
+_CAVEAT = (
+    "noexec blocks executing files from the tmpfs; if the workload legitimately "
+    "runs binaries or scripts from this mount it will break — drop noexec there."
+)
+
+OWASP_REF = (
+    "https://cheatsheetseries.owasp.org/cheatsheets/"
+    "Docker_Security_Cheat_Sheet.html#rule-8-set-filesystem-and-volumes-to-read-only"
+)
+
+DOCKER_REF = "https://docs.docker.com/engine/storage/tmpfs/"
+
+
+def _missing_flags(entry: str) -> list[str]:
+    """Return the hardening flags absent from a ``path[:opt,opt]`` tmpfs entry."""
+    _, _, optstr = entry.partition(":")
+    opts = {o for o in optstr.split(",") if o}
+    return [flag for flag in _HARDENING_FLAGS if flag not in opts]
+
+
+@register_rule
+class TmpfsHardeningRule(BaseRule):
+    """Detects ``tmpfs`` mounts that omit ``noexec``/``nosuid``/``nodev``."""
+
+    @property
+    def metadata(self) -> RuleMetadata:
+        return RuleMetadata(
+            id="CL-0022",
+            name="tmpfs mount not hardened",
+            description=(
+                "A tmpfs mount without noexec, nosuid, and nodev leaves a "
+                "writable, executable in-memory filesystem — a staging ground "
+                "for dropped payloads, especially under a read-only root."
+            ),
+            severity=Severity.MEDIUM,
+            references=[OWASP_REF, DOCKER_REF],
+        )
+
+    def check(
+        self,
+        service_name: str,
+        service_config: dict[str, Any],
+        global_config: dict[str, Any],
+        lines: dict[str, int],
+    ) -> Iterator[Finding]:
+        tmpfs = service_config.get("tmpfs")
+        # Only the short `tmpfs:` form (string or list of strings) exposes mount
+        # flags through Compose; the long `volumes: [{type: tmpfs}]` form does
+        # not, so it is out of scope.
+        if isinstance(tmpfs, str):
+            entries = [(tmpfs, f"services.{service_name}.tmpfs")]
+        elif isinstance(tmpfs, list):
+            entries = [
+                (item, f"services.{service_name}.tmpfs[{i}]")
+                for i, item in enumerate(tmpfs)
+                if isinstance(item, str)
+            ]
+        else:
+            return
+
+        for entry, line_key in entries:
+            missing = _missing_flags(entry)
+            if not missing:
+                continue
+            path = entry.partition(":")[0]
+            yield Finding(
+                rule_id="CL-0022",
+                severity=Severity.MEDIUM,
+                service=service_name,
+                message=(
+                    f"tmpfs mount '{path}' is missing hardening option(s) "
+                    f"{', '.join(missing)}. A writable, executable in-memory "
+                    "mount is a staging ground for dropped payloads — especially "
+                    "under read_only: true where it may be the only writable path."
+                ),
+                line=lines.get(line_key) or lines.get(f"services.{service_name}.tmpfs"),
+                fix=(
+                    "Add mount flags to the tmpfs entry:\n"
+                    "  tmpfs:\n"
+                    f"    - {path}:{','.join(_HARDENING_FLAGS)}\n"
+                    "Keep noexec unless the workload must execute from the mount."
+                ),
+                references=[OWASP_REF, DOCKER_REF],
+            )
+
+    def fix(
+        self,
+        finding: Finding,
+        data: dict[str, Any],
+        lines: dict[str, int],
+        text: str,
+    ) -> list[TextEdit] | None:
+        """Append the missing ``noexec``/``nosuid``/``nodev`` flags in place.
+
+        Edits the tmpfs entry's scalar — ``- /tmp`` becomes
+        ``- /tmp:noexec,nosuid,nodev`` and ``- /run:size=64m`` keeps its existing
+        options. Handles both the list-item form and the single-string
+        ``tmpfs: /tmp`` form, inside surrounding quotes when present. The edit
+        carries a caveat because ``noexec`` changes runtime behavior (ADR-014).
+
+        Refuses (returns ``None``) for anchored/merged services, flow-style
+        (``tmpfs: [/tmp]``) or ``${VAR}`` entries, or a line that is not a plain
+        scalar tmpfs entry.
+        """
+        service = finding.service
+        services = data.get("services")
+        if not isinstance(services, dict):
+            return None
+        service_config = services.get(service)
+        if not isinstance(service_config, dict):
+            return None
+        if not isinstance(service_config.get("tmpfs"), (str, list)):
+            return None
+
+        item_line = finding.line
+        service_line = lines.get(f"services.{service}")
+        if item_line is None or service_line is None:
+            return None
+        source_lines = text.splitlines(keepends=True)
+        n = len(source_lines)
+        if not (1 <= item_line <= n and 1 <= service_line <= n):
+            return None
+        if is_anchored_or_merged(source_lines, service_line):
+            return None
+
+        span = _value_span(source_lines[item_line - 1])
+        if span is None:
+            return None
+        value, start_col, end_col = span
+        # Flow collection or interpolation: ambiguous to edit, leave manual.
+        if value[:1] in ("[", "{") or "$" in value:
+            return None
+
+        missing = _missing_flags(value)
+        if not missing:
+            return None
+        path, _, optstr = value.partition(":")
+        opts = [o for o in optstr.split(",") if o]
+        new_value = f"{path}:{','.join(opts + missing)}"
+
+        return [
+            TextEdit(
+                item_line, start_col, item_line, end_col, new_value, caveat=_CAVEAT
+            )
+        ]
+
+
+def _value_span(raw_line: str) -> tuple[str, int, int] | None:
+    """Return ``(value, start_col, end_col)`` for a tmpfs entry's scalar.
+
+    Handles a block-sequence item (``- /tmp``) and the single-string mapping
+    form (``tmpfs: /tmp``). Columns are 1-indexed and the span is half-open,
+    pointing inside a surrounding quote when the value is quoted. A trailing
+    ``# comment`` is excluded. Returns ``None`` when the line is neither shape.
+    """
+    line = raw_line.rstrip("\n")
+    idx = len(line) - len(line.lstrip(" "))
+    if idx < len(line) and line[idx] == "-":
+        idx += 1
+        if idx >= len(line) or line[idx] != " ":
+            return None
+    elif line[idx:].startswith("tmpfs:"):
+        idx += len("tmpfs:")
+    else:
+        return None
+    while idx < len(line) and line[idx] == " ":
+        idx += 1
+    if idx >= len(line):
+        return None
+
+    if line[idx] in ("'", '"'):
+        quote = line[idx]
+        close = line.find(quote, idx + 1)
+        if close == -1:
+            return None
+        return line[idx + 1 : close], idx + 2, close + 1
+
+    rest = line[idx:]
+    comment = rest.find(" #")
+    if comment != -1:
+        rest = rest[:comment]
+    value = rest.rstrip()
+    if not value:
+        return None
+    return value, idx + 1, idx + 1 + len(value)

--- a/tests/compose_files/valid_basic.yml
+++ b/tests/compose_files/valid_basic.yml
@@ -9,8 +9,8 @@ services:
       - ALL
     read_only: true
     tmpfs:
-      - /tmp
-      - /run
+      - /tmp:noexec,nosuid,nodev
+      - /run:noexec,nosuid,nodev
   db:
     image: postgres:16-alpine@sha256:b1234567890abcdef
     security_opt:
@@ -19,5 +19,5 @@ services:
       - ALL
     read_only: true
     tmpfs:
-      - /tmp
-      - /run
+      - /tmp:noexec,nosuid,nodev
+      - /run:noexec,nosuid,nodev

--- a/tests/test_CL0022.py
+++ b/tests/test_CL0022.py
@@ -1,0 +1,145 @@
+"""Tests for CL-0022: tmpfs mount not hardened."""
+
+from __future__ import annotations
+
+from compose_lint.fix import apply_edits
+from compose_lint.parser import loads
+from compose_lint.rules.CL0022_tmpfs_hardening import TmpfsHardeningRule
+
+
+class TestTmpfsHardeningRule:
+    """Detection of tmpfs mounts missing noexec/nosuid/nodev."""
+
+    def setup_method(self) -> None:
+        self.rule = TmpfsHardeningRule()
+
+    def _check(self, body: str) -> list:
+        content = f"services:\n  a:\n    image: nginx:1.27\n{body}"
+        data, lines = loads(content)
+        return list(self.rule.check("a", data["services"]["a"], data, lines))
+
+    def test_detects_bare_list_entry(self) -> None:
+        findings = self._check("    tmpfs:\n      - /tmp\n")
+        assert len(findings) == 1
+        assert findings[0].rule_id == "CL-0022"
+        assert findings[0].severity.value == "medium"
+        assert "/tmp" in findings[0].message
+        for flag in ("noexec", "nosuid", "nodev"):
+            assert flag in findings[0].message
+
+    def test_detects_scalar_form(self) -> None:
+        findings = self._check("    tmpfs: /run\n")
+        assert len(findings) == 1
+        assert "/run" in findings[0].message
+
+    def test_preserves_unrelated_options_but_still_flags(self) -> None:
+        findings = self._check("    tmpfs:\n      - /run:size=64m\n")
+        assert len(findings) == 1
+
+    def test_partial_flags_still_fires_for_the_rest(self) -> None:
+        findings = self._check("    tmpfs:\n      - /tmp:noexec\n")
+        assert len(findings) == 1
+        assert "nosuid" in findings[0].message
+        assert "nodev" in findings[0].message
+        assert "noexec" not in findings[0].message
+
+    def test_fully_hardened_is_clean(self) -> None:
+        findings = self._check("    tmpfs:\n      - /tmp:noexec,nosuid,nodev\n")
+        assert findings == []
+
+    def test_no_tmpfs_is_clean(self) -> None:
+        assert self._check("    read_only: true\n") == []
+
+    def test_long_form_volumes_tmpfs_out_of_scope(self) -> None:
+        # The `volumes: [{type: tmpfs}]` form cannot express noexec/nosuid/nodev
+        # through Compose, so it is intentionally not flagged.
+        findings = self._check(
+            "    volumes:\n      - type: tmpfs\n        target: /tmp\n"
+        )
+        assert findings == []
+
+    def test_multiple_entries_each_flag(self) -> None:
+        findings = self._check("    tmpfs:\n      - /tmp\n      - /run:nodev\n")
+        assert len(findings) == 2
+
+    def test_metadata_and_references(self) -> None:
+        meta = self.rule.metadata
+        assert meta.id == "CL-0022"
+        assert meta.severity.value == "medium"
+        assert any("owasp" in r.lower() for r in meta.references)
+
+
+class TestTmpfsHardeningFix:
+    """The CL-0022 auto-fix appends the missing flags (ADR-014)."""
+
+    def setup_method(self) -> None:
+        self.rule = TmpfsHardeningRule()
+
+    def _fix(self, content: str, want_path: str) -> list:
+        data, lines = loads(content)
+        findings = [
+            f
+            for f in self.rule.check("a", data["services"]["a"], data, lines)
+            if f"'{want_path}'" in f.message
+        ]
+        assert findings, f"expected CL-0022 to fire for {want_path}"
+        return self.rule.fix(findings[0], data, lines, content)
+
+    def test_appends_all_flags_to_bare_list_entry(self) -> None:
+        content = "services:\n  a:\n    image: nginx:1.27\n    tmpfs:\n      - /tmp\n"
+        edits = self._fix(content, "/tmp")
+        assert edits is not None
+        assert "- /tmp:noexec,nosuid,nodev\n" in apply_edits(content, edits)
+
+    def test_preserves_existing_options(self) -> None:
+        content = (
+            "services:\n  a:\n    image: nginx:1.27\n"
+            "    tmpfs:\n      - /run:size=64m\n"
+        )
+        edits = self._fix(content, "/run")
+        assert edits is not None
+        assert "- /run:size=64m,noexec,nosuid,nodev\n" in apply_edits(content, edits)
+
+    def test_fixes_scalar_form(self) -> None:
+        content = "services:\n  a:\n    image: nginx:1.27\n    tmpfs: /var/cache\n"
+        edits = self._fix(content, "/var/cache")
+        assert edits is not None
+        assert "tmpfs: /var/cache:noexec,nosuid,nodev\n" in apply_edits(content, edits)
+
+    def test_only_appends_missing_flag(self) -> None:
+        content = (
+            "services:\n  a:\n    image: nginx:1.27\n    tmpfs:\n      - /tmp:noexec\n"
+        )
+        edits = self._fix(content, "/tmp")
+        assert edits is not None
+        assert "- /tmp:noexec,nosuid,nodev\n" in apply_edits(content, edits)
+
+    def test_fix_is_idempotent(self) -> None:
+        content = "services:\n  a:\n    image: nginx:1.27\n    tmpfs:\n      - /tmp\n"
+        edits = self._fix(content, "/tmp")
+        assert edits is not None
+        fixed = apply_edits(content, edits)
+        data, lines = loads(fixed)
+        assert list(self.rule.check("a", data["services"]["a"], data, lines)) == []
+
+    def test_edit_carries_caveat(self) -> None:
+        content = "services:\n  a:\n    image: nginx:1.27\n    tmpfs:\n      - /tmp\n"
+        edits = self._fix(content, "/tmp")
+        assert edits is not None
+        assert edits[0].caveat is not None
+        assert "noexec" in edits[0].caveat
+
+    def test_handles_quoted_value(self) -> None:
+        content = 'services:\n  a:\n    image: nginx:1.27\n    tmpfs:\n      - "/tmp"\n'
+        edits = self._fix(content, "/tmp")
+        assert edits is not None
+        # The replacement lands inside the quotes, keeping them intact.
+        assert '"/tmp:noexec,nosuid,nodev"\n' in apply_edits(content, edits)
+
+    def test_refuses_flow_style(self) -> None:
+        content = "services:\n  a:\n    image: nginx:1.27\n    tmpfs: [/tmp]\n"
+        assert self._fix(content, "/tmp") is None
+
+    def test_refuses_interpolation(self) -> None:
+        content = "services:\n  a:\n    image: nginx:1.27\n    tmpfs: ${TMP}\n"
+        assert self._fix(content, "${TMP}") is None


### PR DESCRIPTION
A new rule from the CIS Docker Benchmark / #192 review, shipping with an auto-fixer.

## What it detects

A `tmpfs:` mount that omits `noexec`, `nosuid`, or `nodev` — a writable, **executable** in-memory filesystem. The risk is sharpest alongside CL-0007 (`read_only: true`): the recommended way to keep a read-only-root container working is a tmpfs scratch mount, which then becomes the *only* writable path — leaving it executable hands an attacker back the foothold read-only root was meant to remove.

- Covers the short string/list `tmpfs:` form. The long `volumes: [{type: tmpfs}]` form **cannot express these flags** through Compose, so it's out of scope.
- The message names the missing flags, so a partially-hardened entry (`/tmp:noexec`) still fires for `nosuid`/`nodev`.
- **MEDIUM**, grounded in OWASP rule 8 (filesystem hardening) + the Docker tmpfs docs.

## Fixer

Appends the missing flags in place, preserving existing options:

```
- /tmp            →  - /tmp:noexec,nosuid,nodev
- /run:size=64m   →  - /run:size=64m,noexec,nosuid,nodev
tmpfs: /var/cache →  tmpfs: /var/cache:noexec,nosuid,nodev
```

Carries a behavior-change caveat (`noexec`), and refuses anchored/merged services, flow-style (`tmpfs: [/tmp]`), and `${VAR}` entries — the same refusal discipline as the other fixers.

## Validation

- Unit tests: detection (list/scalar/partial/hardened/long-form-out-of-scope) + fixer (append/preserve/scalar/quoted/idempotent/caveat/refusals).
- **Full corpus fix-gate: 134 CL-0022 findings fixed, 0 reparse failures, 0 non-idempotent, 0 introduced findings.**
- `valid_basic.yml` (the clean baseline fixture) hardened so it stays clean and models the recommended config.
- Quality gate: `ruff check`, `ruff format --check`, `mypy src/` (strict, 38 files), `pytest` (776 passed, 2 pre-existing skips) — all pass.

Refs #192.