### PR TITLE
Add CL-0023: flag dangerous network sysctls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   flags. `compose-lint fix` appends them in place, preserving existing options
   like `size=`, with a caveat that `noexec` is behavior-changing.
 
+- CL-0023 flags services that enable an escape-adjacent `net.*` sysctl —
+  `ip_forward`, IPv6 `forwarding`, `accept_source_route`, and ICMP
+  `accept_redirects`/`send_redirects` (MEDIUM). Enabling these turns the
+  container into a network pivot, most acutely with host networking (CL-0008)
+  or multiple networks. Handles the map and list `sysctls:` forms; a value of
+  `0` and unlisted sysctls are not flagged. No auto-fix — the parameter is set
+  deliberately when present, so removal is left to manual review.
+
 ### Changed
 
 - CL-0011 now flags the `PERFMON` capability (HIGH), completing the pair split

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ If you need broad IaC coverage across Terraform, Kubernetes, and more, KICS cove
 | [CL-0020](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0020.md) | HIGH | Credential-shaped env key with literal value | [Rule #12](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-12-utilize-docker-secrets-for-sensitive-data-management) | — |
 | [CL-0021](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0021.md) | HIGH | Credential embedded in connection-string env value | [Rule #12](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-12-utilize-docker-secrets-for-sensitive-data-management) | — |
 | [CL-0022](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0022.md) | MEDIUM | tmpfs mount not hardened | [Rule #8](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-8-set-filesystem-and-volumes-to-read-only) | — |
+| [CL-0023](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0023.md) | MEDIUM | Dangerous network sysctl enabled | — | — |
 
 ## Severity Levels
 

--- a/docs/SECURITY-EXPECTATIONS.md
+++ b/docs/SECURITY-EXPECTATIONS.md
@@ -75,7 +75,7 @@ pipeline, this is the page to read.
    It cannot tell you what a running container is *actually* doing —
    only what its declared configuration *would* let it do.
 
-5. **It is not exhaustive.** The 22 rules cover the misconfigurations
+5. **It is not exhaustive.** The 23 rules cover the misconfigurations
    that the OWASP Docker Security Cheat Sheet, CIS Docker Benchmark,
    and Docker official documentation ground (see
    [README.md](../README.md#rules) for the full list). Misconfigurations

--- a/docs/rules/CL-0023.md
+++ b/docs/rules/CL-0023.md
@@ -1,0 +1,59 @@
+# CL-0023: Dangerous network sysctl enabled
+
+**Severity:** MEDIUM
+
+**References:**
+- [Docker Compose — `sysctls`](https://docs.docker.com/reference/compose-file/services/#sysctls)
+- CIS Distribution Independent Linux Benchmark §3.3 — Network Parameters (Host and Router)
+
+## What it detects
+
+A service whose `sysctls:` (map or list form) **enables** a forwarding or redirect `net.*` parameter the kernel disables by default:
+
+```yaml
+sysctls:
+  net.ipv4.ip_forward: 1                       # flagged
+  net.ipv6.conf.all.forwarding: 1              # flagged
+  net.ipv4.conf.all.accept_source_route: 1     # flagged
+  net.ipv4.conf.all.accept_redirects: 1        # flagged
+  net.ipv4.conf.all.send_redirects: 1          # flagged
+```
+
+The list form is equivalent:
+
+```yaml
+sysctls:
+  - net.ipv4.ip_forward=1
+```
+
+A value of `0` is not flagged, and sysctls outside this set (e.g. a `net.core.somaxconn` tuning) are left alone. Docker only permits *namespaced* sysctls, so these apply to the container's network namespace.
+
+## Why it matters
+
+These parameters control whether the network stack **routes or redirects** traffic — behavior the kernel default (`0`) deliberately disables:
+
+- **`ip_forward` / `…forwarding`** turn the container into a router: it can forward packets between the networks it is attached to. Combined with multiple Docker networks, or with `network_mode: host` (CL-0008), that makes the container a pivot between network segments.
+- **`accept_source_route`** lets a remote attacker dictate the path a reply takes, bypassing routing-based controls.
+- **`accept_redirects` / `send_redirects`** let ICMP redirects rewrite routing tables — a classic man-in-the-middle and traffic-reroute primitive.
+
+The risk is sharpest when the container shares the host network namespace or bridges multiple networks; in an isolated single-network container the blast radius is that namespace, but enabling these is still a deliberate weakening of the default posture and is rarely necessary.
+
+## Fix
+
+Remove the parameter, or set it to `0`:
+
+```yaml
+# Before
+services:
+  gateway:
+    image: example:1.0
+    sysctls:
+      net.ipv4.ip_forward: 1
+
+# After — drop it unless the workload must route
+services:
+  gateway:
+    image: example:1.0
+```
+
+If forwarding is genuinely required (e.g. a deliberate gateway container), keep the container off the host network and restrict it to the networks it must serve. This finding has no auto-fix: the parameter is set on purpose when present, so removal is left to manual review.

--- a/src/compose_lint/rules/CL0023_dangerous_sysctls.py
+++ b/src/compose_lint/rules/CL0023_dangerous_sysctls.py
@@ -1,0 +1,120 @@
+"""CL-0023: Dangerous network sysctl enabled."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from compose_lint.models import Finding, RuleMetadata, Severity
+from compose_lint.rules import BaseRule, register_rule
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+DOCKER_REF = "https://docs.docker.com/reference/compose-file/services/#sysctls"
+
+CIS_REF = (
+    "CIS Distribution Independent Linux Benchmark §3.3 — Network Parameters "
+    "(Host and Router)"
+)
+
+# Namespaced net.* sysctls whose secure posture is "off" (kernel default 0).
+# Enabling one inside a container re-enables routing/redirect behavior that turns
+# the container into a network pivot — most acutely when it also shares the host
+# network namespace (CL-0008) or bridges multiple Docker networks.
+_DANGEROUS_SYSCTLS: dict[str, str] = {
+    "net.ipv4.ip_forward": (
+        "enables IPv4 forwarding — the container can route traffic between "
+        "networks, a pivot primitive"
+    ),
+    "net.ipv6.conf.all.forwarding": (
+        "enables IPv6 forwarding — the container can route traffic between "
+        "networks, a pivot primitive"
+    ),
+    "net.ipv4.conf.all.accept_source_route": (
+        "accepts source-routed packets — lets an attacker dictate the return "
+        "path and bypass routing controls"
+    ),
+    "net.ipv4.conf.all.accept_redirects": (
+        "accepts ICMP redirects — an attacker can rewrite the container's routing table"
+    ),
+    "net.ipv4.conf.all.send_redirects": (
+        "sends ICMP redirects — can be abused to reroute other hosts' traffic"
+    ),
+}
+
+
+def _enabled(value: Any) -> bool:
+    """Return whether a sysctl value turns the parameter on (``1``/``true``)."""
+    if isinstance(value, bool):
+        return value
+    return str(value).strip() == "1"
+
+
+def _entries(sysctls: Any) -> list[tuple[str, Any, str]]:
+    """Normalize the map and list ``sysctls`` forms to ``(key, value, suffix)``.
+
+    ``suffix`` is the line-map marker for the entry: ``.<key>`` for the map form
+    and ``[i]`` for the list form. Both are looked up against the block line as a
+    fallback, so a miss (e.g. a flow-style block) still yields a usable line.
+    """
+    if isinstance(sysctls, dict):
+        return [(str(key), value, f".{key}") for key, value in sysctls.items()]
+    if isinstance(sysctls, list):
+        out: list[tuple[str, Any, str]] = []
+        for i, entry in enumerate(sysctls):
+            if isinstance(entry, str) and "=" in entry:
+                key, _, value = entry.partition("=")
+                out.append((key.strip(), value.strip(), f"[{i}]"))
+        return out
+    return []
+
+
+@register_rule
+class DangerousSysctlsRule(BaseRule):
+    """Detects services enabling escape-adjacent network sysctls."""
+
+    @property
+    def metadata(self) -> RuleMetadata:
+        return RuleMetadata(
+            id="CL-0023",
+            name="Dangerous network sysctl enabled",
+            description=(
+                "Enabling a forwarding or redirect net.* sysctl inside a "
+                "container re-enables routing behavior the kernel disables by "
+                "default, turning the container into a network pivot."
+            ),
+            severity=Severity.MEDIUM,
+            references=[DOCKER_REF, CIS_REF],
+        )
+
+    def check(
+        self,
+        service_name: str,
+        service_config: dict[str, Any],
+        global_config: dict[str, Any],
+        lines: dict[str, int],
+    ) -> Iterator[Finding]:
+        for key, value, suffix in _entries(service_config.get("sysctls")):
+            if key not in _DANGEROUS_SYSCTLS or not _enabled(value):
+                continue
+            line = lines.get(f"services.{service_name}.sysctls{suffix}") or lines.get(
+                f"services.{service_name}.sysctls"
+            )
+            yield Finding(
+                rule_id="CL-0023",
+                severity=Severity.MEDIUM,
+                service=service_name,
+                message=(
+                    f"Service enables sysctl '{key}': "
+                    f"{_DANGEROUS_SYSCTLS[key]}. The risk is acute when the "
+                    "container shares the host network (CL-0008) or bridges "
+                    "multiple networks."
+                ),
+                line=line,
+                fix=(
+                    f"Remove '{key}' or set it to 0 unless the workload must "
+                    "route traffic. If routing is required, keep the container "
+                    "off the host network and limit it to the networks it serves."
+                ),
+                references=[DOCKER_REF, CIS_REF],
+            )

--- a/tests/test_CL0023.py
+++ b/tests/test_CL0023.py
@@ -1,0 +1,72 @@
+"""Tests for CL-0023: Dangerous network sysctl enabled."""
+
+from __future__ import annotations
+
+from compose_lint.parser import loads
+from compose_lint.rules.CL0023_dangerous_sysctls import (
+    DOCKER_REF,
+    DangerousSysctlsRule,
+)
+
+
+class TestDangerousSysctlsRule:
+    """Detection of escape-adjacent net.* sysctls."""
+
+    def setup_method(self) -> None:
+        self.rule = DangerousSysctlsRule()
+
+    def _check(self, body: str) -> list:
+        content = f"services:\n  a:\n    image: nginx:1.27\n{body}"
+        data, lines = loads(content)
+        return list(self.rule.check("a", data["services"]["a"], data, lines))
+
+    def test_detects_ip_forward_map_form(self) -> None:
+        findings = self._check("    sysctls:\n      net.ipv4.ip_forward: 1\n")
+        assert len(findings) == 1
+        assert findings[0].rule_id == "CL-0023"
+        assert findings[0].severity.value == "medium"
+        assert "net.ipv4.ip_forward" in findings[0].message
+
+    def test_detects_ip_forward_quoted_value(self) -> None:
+        findings = self._check('    sysctls:\n      net.ipv4.ip_forward: "1"\n')
+        assert len(findings) == 1
+
+    def test_detects_list_form(self) -> None:
+        findings = self._check("    sysctls:\n      - net.ipv6.conf.all.forwarding=1\n")
+        assert len(findings) == 1
+        assert "forwarding" in findings[0].message
+
+    def test_detects_redirects_and_source_route(self) -> None:
+        findings = self._check(
+            "    sysctls:\n"
+            "      net.ipv4.conf.all.accept_source_route: 1\n"
+            "      net.ipv4.conf.all.accept_redirects: 1\n"
+            "      net.ipv4.conf.all.send_redirects: 1\n"
+        )
+        assert len(findings) == 3
+
+    def test_value_zero_is_clean(self) -> None:
+        assert self._check("    sysctls:\n      net.ipv4.ip_forward: 0\n") == []
+
+    def test_unlisted_sysctl_is_clean(self) -> None:
+        # A benign tuning sysctl is not in the dangerous set.
+        assert self._check("    sysctls:\n      net.core.somaxconn: 1024\n") == []
+
+    def test_no_sysctls_is_clean(self) -> None:
+        assert self._check("    read_only: true\n") == []
+
+    def test_points_at_the_offending_line(self) -> None:
+        findings = self._check("    sysctls:\n      net.ipv4.ip_forward: 1\n")
+        # Line 5: services(1) a(2) image(3) sysctls(4) ip_forward(5).
+        assert findings[0].line == 5
+
+    def test_metadata_and_references(self) -> None:
+        meta = self.rule.metadata
+        assert meta.id == "CL-0023"
+        assert meta.severity.value == "medium"
+        assert DOCKER_REF in meta.references
+
+    def test_has_fix_guidance(self) -> None:
+        findings = self._check("    sysctls:\n      net.ipv4.ip_forward: 1\n")
+        assert findings[0].fix is not None
+        assert "0" in findings[0].fix


### PR DESCRIPTION
The last build item from the #192 rule-docs review.

## What it detects

A service that **enables** an escape-adjacent `net.*` sysctl (value `1`) in either the map or list `sysctls:` form:

- `net.ipv4.ip_forward`, `net.ipv6.conf.all.forwarding` — make the container a router/pivot between networks.
- `net.ipv4.conf.all.accept_source_route` — lets an attacker dictate the return path.
- `net.ipv4.conf.all.accept_redirects` / `send_redirects` — ICMP-redirect MITM / reroute primitives.

A value of `0` and any sysctl outside this curated set are not flagged. Docker only permits namespaced sysctls, so these apply to the container's netns.

## Severity & grounding

**MEDIUM**, deliberately — the threat is namespace-scoped unless combined with `network_mode: host` (CL-0008) or a multi-network container. Grounded in the [Docker Compose `sysctls` reference](https://docs.docker.com/reference/compose-file/services/#sysctls) (verified live, incl. the namespaced-only note) and the CIS Linux network-parameters benchmark (§3.3). There is no CIS *Docker* item for this, hence the honest MEDIUM rather than HIGH.

## No auto-fix

When present, these are set on purpose, so auto-removal would be wrong-by-default — removal is left to manual review (the finding's guidance explains how).

## Validation

- Unit tests: map form, quoted value, list form, all five sysctls, value-`0` clean, unlisted-sysctl clean, line pointer, metadata/fix.
- Quality gate: `ruff check`, `ruff format --check`, `mypy src/` (strict, 39 files), `pytest` (787 passed, 2 pre-existing skips). 0% corpus hit rate (expected — set only deliberately), so no snapshot drift.

Refs #192. With this merged, the remaining #192 candidates are all dismissals (see the issue) and it can be closed.