### PR TITLE
Add live-container rule-premise validation suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -520,6 +520,27 @@ jobs:
           echo "::error::Expected action to fail on insecure fixture, got '${{ steps.insecure.outcome }}'"
           exit 1
 
+  # Runtime arm of the rule-grounding bar: every rule that describes container
+  # runtime state must demonstrate its premise against a live container (the
+  # insecure state is the Docker default, or the flagged config produces the
+  # insecure behavior). Catches the CL-0022/CL-0023 failure mode — a rule that
+  # flags a Docker default — before it ships. Runners have Docker preinstalled.
+  rule-premises:
+    name: Validate rule premises (live container)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Validate each runtime rule's premise against a live container
+        run: python scripts/validate_rule_premises.py
+
   # Single rollup job for branch protection. Required-status-checks should
   # point at this job name instead of the individual ci.yml job names, so
   # adding/renaming/removing jobs doesn't require a protection-rule edit.
@@ -546,6 +567,7 @@ jobs:
       - dockerfile-digests
       - docker-smoke
       - action-smoke
+      - rule-premises
     if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ Disables still produce suppressed findings. `reason` flows to `suppression_reaso
 
 ## Adding a rule
 
-See CONTRIBUTING.md for the full checklist. Every rule must cite OWASP, CIS, or Docker docs. Every finding must be actionable with specific fix guidance.
+See CONTRIBUTING.md for the full checklist. Every rule must cite OWASP, CIS, or Docker docs **that demonstrate the need in a container context** — generic host/Linux hardening a container's defaults already neutralize is not enough (see CL-0022/CL-0023). If a container-context source is thin, the rule's premise must be **validated at runtime**: a rule that describes container runtime state gets a check in `scripts/validate_rule_premises.py`, which proves the insecure state is Docker's *default* (for absence rules) or that the flagged config produces the insecure behavior (for presence rules). That suite runs in CI (`rule-premises` job). Every finding must be actionable with specific fix guidance.
 
 ## Contributor workflow
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is no longer flagged; `tmpfs: [/tmp:exec]` is. The auto-fix is dropped — the
   option is set deliberately, so reverting is left to manual review.
 
+- CL-0012's message no longer asserts a container can "create unlimited
+  processes" and fork-bomb the host. A container's `pids.max` is bounded by the
+  cgroup hierarchy (often a high parent cap, occasionally unbounded), so the
+  finding now says the limit is left to whatever that hierarchy allows. The rule
+  is unchanged — it still flags an explicit `pids_limit` of 0 or negative.
+
 ### Removed
 
 - CL-0023 (dangerous network sysctls), shipped in 0.12.0, is removed. Verified

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,15 +90,25 @@ pytest --cov=compose_lint --cov-report=term-missing --cov-fail-under=80
 7. Add rule documentation in `docs/rules/CL-{NNNN}.md`
 8. Fix guidance must be specific and actionable — show the exact YAML change
 9. Include a direct link to the supporting OWASP/CIS/Docker docs section
+10. If the rule describes container *runtime* state, add a premise check to
+    `scripts/validate_rule_premises.py` proving the insecure state is Docker's
+    default (absence rules) or that the flagged config produces the insecure
+    behavior (presence rules). It runs in CI (`rule-premises`) and guards
+    against flagging a Docker default — the CL-0022/CL-0023 failure mode
 
 ### Rule requirements
 
-- **Grounded in an authoritative source.** No opinion-only rules.
+- **Grounded in an authoritative source that demonstrates the need in a
+  container context** (CIS Docker, OWASP Docker Cheat Sheet, Docker docs) — not
+  generic host/Linux hardening a container's defaults already neutralize. If
+  container-context grounding is thin, validate the premise at runtime
+  (`scripts/validate_rule_premises.py`). No opinion-only rules.
 - **Every finding must be actionable.** If you can't tell the user exactly what
   to change, the finding isn't ready.
 - **Severity reflects real-world exploitability**, not subjective importance.
   See [docs/severity.md](docs/severity.md) for the scoring matrix.
-- **Rule IDs are permanent.** Never reuse or retire a `CL-XXXX` ID.
+- **Rule IDs are permanent from 1.0.** Never reuse or retire a `CL-XXXX` ID once
+  1.0 ships; pre-1.0, a mis-grounded rule may be removed and its ID reclaimed.
 
 ## Commit conventions
 

--- a/scripts/validate_rule_premises.py
+++ b/scripts/validate_rule_premises.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Validate each rule's premise against a live container (see AGENTS.md).
+
+compose-lint flags *runtime* misconfigurations, so a rule is only sound if the
+behavior it warns about is real in an actual container — and, for an
+"absence" rule (one that fires when a hardening directive is missing), if the
+insecure state is genuinely Docker's *default*. CL-0022 and CL-0023 shipped
+without that check and both flagged Docker defaults (tmpfs is mounted
+``noexec,nosuid,nodev`` by default; ``net.ipv4.ip_forward`` is ``1`` by
+default), so they were corrected/removed.
+
+This gate runs a short ``docker run`` per runtime-testable rule and asserts the
+premise holds. It is the runtime arm of the rule-grounding bar: a new rule must
+either cite a container-context source or pass a check here.
+
+Usage: ``python scripts/validate_rule_premises.py`` (needs a working Docker).
+Exits 0 if every premise holds (or Docker is unavailable → skipped), 1 on any
+failure. Rules that describe image/supply-chain or config-only concerns
+(CL-0004, CL-0014, CL-0015, CL-0019, CL-0020, CL-0021) have no runtime state to
+observe and are listed as intentionally out of scope.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# Pinned by manifest-list (OCI index) digest so CI uses no mutable ref.
+IMAGE = (
+    "busybox@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d"
+)
+# Rules with nothing to observe in a live container — grounded by source only.
+_NON_RUNTIME = ["CL-0004", "CL-0014", "CL-0015", "CL-0019", "CL-0020", "CL-0021"]
+
+
+def _run(args: list[str], cmd: list[str]) -> tuple[int, str]:
+    """``docker run --rm <args> IMAGE <cmd>`` → (returncode, stdout).
+
+    Returns *stdout only*: the container echoes the value each check inspects,
+    and ``docker`` itself writes warnings to stderr — folding stderr in here
+    corrupted exact/suffix matches (e.g. a stderr warning after ``SOCKET``).
+    """
+    proc = subprocess.run(
+        ["docker", "run", "--rm", *args, IMAGE, *cmd],
+        capture_output=True,
+        text=True,
+        timeout=90,
+    )
+    return proc.returncode, proc.stdout.strip()
+
+
+# --- per-rule premise checks: each returns (ok, detail) ---------------------
+
+
+def _cl0001() -> tuple[bool, str]:
+    """Mounting the docker socket exposes a root-equivalent control channel."""
+    rc, out = _run(
+        ["-v", "/var/run/docker.sock:/var/run/docker.sock"],
+        ["sh", "-c", "test -S /var/run/docker.sock && echo SOCKET || echo NONE"],
+    )
+    return ("SOCKET" in out), f"socket in container: {out!r}"
+
+
+def _cl0002() -> tuple[bool, str]:
+    """--privileged grants the full capability set."""
+    _, base = _run([], ["grep", "CapEff", "/proc/self/status"])
+    _, priv = _run(["--privileged"], ["grep", "CapEff", "/proc/self/status"])
+    return ("ffffffffff" in priv and priv != base), f"default={base} priv={priv}"
+
+
+def _cl0003() -> tuple[bool, str]:
+    """no-new-privileges is OFF by default (the insecure state is the default)."""
+    _, base = _run([], ["grep", "NoNewPrivs", "/proc/self/status"])
+    _, miti = _run(
+        ["--security-opt", "no-new-privileges"],
+        ["grep", "NoNewPrivs", "/proc/self/status"],
+    )
+    return ("0" in base and "1" in miti), f"default={base!r} mitigated={miti!r}"
+
+
+def _cl0005() -> tuple[bool, str]:
+    """A bare published port binds all interfaces (empty/0.0.0.0 host IP)."""
+    cid = subprocess.run(
+        ["docker", "create", "-p", "18080:80", IMAGE, "true"],
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    try:
+        out = subprocess.run(
+            ["docker", "inspect", "-f", "{{json .HostConfig.PortBindings}}", cid],
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    finally:
+        subprocess.run(["docker", "rm", "-f", cid], capture_output=True)
+    # Unspecified host IP serializes as "" — Docker then binds 0.0.0.0/::.
+    return ('"HostIp":""' in out), f"port bindings: {out}"
+
+
+def _cl0006() -> tuple[bool, str]:
+    """A container keeps ~14 default capabilities unless they are dropped."""
+    _, base = _run([], ["grep", "CapEff", "/proc/self/status"])
+    _, miti = _run(["--cap-drop", "ALL"], ["grep", "CapEff", "/proc/self/status"])
+    base_zero = base.split()[-1].strip("0") == ""
+    miti_zero = miti.split()[-1].strip("0") == ""
+    return (not base_zero and miti_zero), f"default={base} dropped={miti}"
+
+
+def _cl0007() -> tuple[bool, str]:
+    """The root filesystem is writable by default."""
+    _, base = _run([], ["sh", "-c", "touch /x 2>/dev/null && echo RW || echo RO"])
+    _, miti = _run(
+        ["--read-only"], ["sh", "-c", "touch /x 2>/dev/null && echo RW || echo RO"]
+    )
+    return (base.endswith("RW") and miti.endswith("RO")), f"default={base} ro={miti}"
+
+
+def _cl0008() -> tuple[bool, str]:
+    """--network host exposes the host's network interfaces."""
+    _, base = _run([], ["sh", "-c", "ls /sys/class/net | tr '\\n' ' '"])
+    _, host = _run(
+        ["--network", "host"], ["sh", "-c", "ls /sys/class/net | tr '\\n' ' '"]
+    )
+    return ("docker0" in host and host != base), f"default=[{base}] host=[{host}]"
+
+
+def _cl0009() -> tuple[bool, str]:
+    """A seccomp filter is active by default; unconfined removes it."""
+    _, base = _run([], ["grep", "Seccomp:", "/proc/self/status"])
+    _, unconf = _run(
+        ["--security-opt", "seccomp=unconfined"],
+        ["grep", "Seccomp:", "/proc/self/status"],
+    )
+    return ("2" in base and "0" in unconf), f"default={base!r} unconfined={unconf!r}"
+
+
+def _cl0010() -> tuple[bool, str]:
+    """--pid host makes every host process visible."""
+    _, base = _run([], ["sh", "-c", "ls -d /proc/[0-9]* | wc -l"])
+    _, host = _run(["--pid", "host"], ["sh", "-c", "ls -d /proc/[0-9]* | wc -l"])
+    return (int(host) > int(base) + 10), f"default={base} host={host}"
+
+
+def _cl0011() -> tuple[bool, str]:
+    """--cap-add adds the named capability to the effective set."""
+    _, base = _run([], ["grep", "CapEff", "/proc/self/status"])
+    _, added = _run(["--cap-add", "SYS_ADMIN"], ["grep", "CapEff", "/proc/self/status"])
+    return (added != base), f"default={base} +SYS_ADMIN={added}"
+
+
+def _cl0012() -> tuple[bool, str]:
+    """pids_limit: -1 (the rule's trigger) leaves a high/unbounded cap.
+
+    A positive limit is enforced; ``-1`` leaves whatever the cgroup hierarchy
+    allows (``max`` on an unconstrained host, or a high parent cap), which is far
+    looser than a sane explicit limit — the insecure choice the rule flags.
+    """
+    _, unlim = _run(["--pids-limit", "-1"], ["cat", "/sys/fs/cgroup/pids.max"])
+    _, limited = _run(["--pids-limit", "100"], ["cat", "/sys/fs/cgroup/pids.max"])
+    u = unlim.strip()
+    high = u == "max" or (u.isdigit() and int(u) > 1000)
+    return (high and limited.strip() == "100"), f"-1={u} 100={limited.strip()}"
+
+
+def _cl0013() -> tuple[bool, str]:
+    """A host bind mount exposes the host path inside the container."""
+    rc, out = _run(
+        ["-v", "/etc/os-release:/hostfile:ro"],
+        ["sh", "-c", "test -r /hostfile && echo READABLE || echo NONE"],
+    )
+    return out.endswith("READABLE"), f"host file in container: {out}"
+
+
+def _cl0016() -> tuple[bool, str]:
+    """--device exposes a host device that is absent by default."""
+    _, base = _run([], ["sh", "-c", "test -e /dev/kmsg && echo YES || echo NO"])
+    _, dev = _run(
+        ["--device", "/dev/kmsg"],
+        ["sh", "-c", "test -e /dev/kmsg && echo YES || echo NO"],
+    )
+    return (base.endswith("NO") and dev.endswith("YES")), f"default={base} device={dev}"
+
+
+def _cl0017() -> tuple[bool, str]:
+    """A shared bind propagation is observable as 'shared' in mountinfo."""
+    _, out = _run(
+        ["--mount", "type=bind,source=/tmp,target=/x,bind-propagation=shared"],
+        ["sh", "-c", "grep ' /x ' /proc/self/mountinfo"],
+    )
+    return ("shared:" in out), f"/x mountinfo: {out}"
+
+
+def _cl0018() -> tuple[bool, str]:
+    """An explicit user maps to that uid (root => 0)."""
+    _, root = _run(["--user", "root"], ["id", "-u"])
+    _, nonroot = _run(["--user", "1000"], ["id", "-u"])
+    return (
+        root.strip() == "0" and nonroot.strip() == "1000"
+    ), f"root={root} 1000={nonroot}"
+
+
+def _cl0022() -> tuple[bool, str]:
+    """tmpfs is noexec by default; :exec removes it (the inverted rule's premise)."""
+    _, base = _run(["--tmpfs", "/d"], ["sh", "-c", "grep ' /d ' /proc/self/mountinfo"])
+    _, ex = _run(
+        ["--tmpfs", "/d:exec"], ["sh", "-c", "grep ' /d ' /proc/self/mountinfo"]
+    )
+    return (
+        "noexec" in base and "noexec" not in ex
+    ), f"default has noexec={'noexec' in base}, :exec has noexec={'noexec' in ex}"
+
+
+CHECKS: list[tuple[str, str, Callable[[], tuple[bool, str]]]] = [
+    ("CL-0001", "docker socket mount is root-equivalent", _cl0001),
+    ("CL-0002", "privileged grants full caps", _cl0002),
+    ("CL-0003", "no-new-privileges off by default", _cl0003),
+    ("CL-0005", "bare published port binds all interfaces", _cl0005),
+    ("CL-0006", "default caps present unless dropped", _cl0006),
+    ("CL-0007", "rootfs writable by default", _cl0007),
+    ("CL-0008", "host network exposes host interfaces", _cl0008),
+    ("CL-0009", "seccomp filter active by default", _cl0009),
+    ("CL-0010", "pid host exposes host processes", _cl0010),
+    ("CL-0011", "cap_add adds the capability", _cl0011),
+    ("CL-0012", "explicit pids limit takes effect", _cl0012),
+    ("CL-0013", "host bind mount exposes host path", _cl0013),
+    ("CL-0016", "device exposes a host device", _cl0016),
+    ("CL-0017", "shared propagation is observable", _cl0017),
+    ("CL-0018", "explicit user maps to that uid", _cl0018),
+    ("CL-0022", "tmpfs noexec by default; :exec removes it", _cl0022),
+]
+
+
+def main() -> int:
+    if subprocess.run(["docker", "version"], capture_output=True).returncode != 0:
+        print("SKIP: Docker not available", file=sys.stderr)
+        return 0
+
+    failures = []
+    for rule_id, label, check in CHECKS:
+        try:
+            ok, detail = check()
+        except Exception as exc:  # noqa: BLE001 - a crashed check is a failure
+            ok, detail = False, f"{type(exc).__name__}: {exc}"
+        mark = "PASS" if ok else "FAIL"
+        print(f"  [{mark}] {rule_id}  {label}\n          {detail}")
+        if not ok:
+            failures.append(rule_id)
+
+    print()
+    print(f"not runtime-testable (grounded by source): {', '.join(_NON_RUNTIME)}")
+    if failures:
+        print(f"RESULT: FAIL ({len(failures)}): {', '.join(failures)}")
+        return 1
+    print(f"RESULT: PASS ({len(CHECKS)} premises validated)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/compose_lint/rules/CL0012_pids_limit.py
+++ b/src/compose_lint/rules/CL0012_pids_limit.py
@@ -53,9 +53,11 @@ class PidsLimitRule(BaseRule):
                 severity=Severity.MEDIUM,
                 service=service_name,
                 message=(
-                    f"PIDs cgroup limit is disabled (pids_limit: {value}). "
-                    "The container can create unlimited processes, enabling "
-                    "fork bomb attacks against the host."
+                    f"PIDs cgroup limit is explicitly disabled (pids_limit: "
+                    f"{value}). The container's process count is then bounded "
+                    "only by whatever the cgroup hierarchy allows — often very "
+                    "high or unbounded — risking PID/resource exhaustion (a fork "
+                    "bomb) on the host."
                 ),
                 line=lines.get(f"services.{service_name}.pids_limit"),
                 fix=(


### PR DESCRIPTION
Operationalizes the container-context grounding bar (the three follow-ups to the CL-0022/CL-0023 episode).

## 1. Runtime-validation suite + CI enforcement

`scripts/validate_rule_premises.py` runs a short `docker run` per runtime-testable rule and asserts its premise:
- **absence rules** → the insecure state is the Docker *default* (e.g. CL-0007 rootfs writable, CL-0003 `NoNewPrivs:0`, CL-0006 default caps present)
- **presence rules** → the flagged config produces the insecure behavior (e.g. CL-0002 `--privileged`→full caps, CL-0008 host net→host interfaces, CL-0011 `--cap-add`→cap set)

16 of 22 rules covered; the 6 image/supply-chain/config rules (CL-0004/0014/0015/0019/0020/0021) have no runtime state and are listed out of scope. busybox is **pinned by manifest-list digest** (no mutable ref). A new `rule-premises` CI job runs it and is wired into the `ci-ok` rollup, so a future rule that flags a Docker default — the CL-0022/CL-0023 failure mode — fails CI.

Local run: `RESULT: PASS (16 premises validated)`.

## 2. CL-0012 message softened

A container's `pids.max` is bounded by the cgroup hierarchy (often a high parent cap; `--pids-limit -1` gave 18516, not unlimited, on a test host). The finding no longer asserts a guaranteed unbounded host fork-bomb — it says the count is left to whatever the hierarchy allows. The rule (flag explicit `pids_limit` ≤ 0) is unchanged.

## 3. Remaining presence rules exercised

All 16 runtime-testable rules validated live (this is what the suite encodes). No further CL-0022-style flaws found.

## Docs / policy

- AGENTS.md + CONTRIBUTING.md: grounding must demonstrate the need **in a container context**, or be runtime-validated via the suite; new runtime rules must add a premise check.
- CONTRIBUTING.md rule-ID permanence scoped to "from 1.0" (matches AGENTS.md).

## Gate

`ruff`/`ruff format`/`mypy` (38 files) clean on `src/`+`tests/`; `pytest` 771 passed, 2 skips; the suite passes; `ci.yml` parses with `rule-premises` in the `ci-ok` needs. Folds into 0.12.1.