### PR TITLE
Add rule metadata/finding consistency test and ADR-016

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and the `rule-premises` CI job already enforce. It captures *why* the policy
   exists (the CL-0022 rework and CL-0023 removal), which previously lived only in
   the CHANGELOG and the script's docstring, and extends ADR-002.
+- A registry-wide consistency test (`tests/test_rule_consistency.py`) that fails
+  if any rule's emitted `Finding.rule_id`/`severity` drift from its
+  `metadata.id`/`severity`. Each rule states these twice and nothing else tied
+  them together, so a typo could desynchronise the SARIF rule descriptor's
+  `security-severity` from a result's `level`. Deliberate per-finding escalation
+  (CL-0011, CL-0013) is declared in an allow-list; adding it elsewhere is a test
+  failure by design.
 
 ## [0.12.1] - 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- ADR-016 records the runtime rule-premise validation bar — the second,
+  `docker run`-based arm of rule grounding that `scripts/validate_rule_premises.py`
+  and the `rule-premises` CI job already enforce. It captures *why* the policy
+  exists (the CL-0022 rework and CL-0023 removal), which previously lived only in
+  the CHANGELOG and the script's docstring, and extends ADR-002.
+
 ## [0.12.1] - 2026-05-25
 
 ### Changed

--- a/docs/adr/016-runtime-rule-premise-validation.md
+++ b/docs/adr/016-runtime-rule-premise-validation.md
@@ -1,0 +1,119 @@
+# ADR-016: Runtime Validation of Rule Premises
+
+**Status:** Accepted (extends [ADR-002](002-rule-grounding.md))
+
+**Context:** ADR-002 requires every rule to map to an authoritative source
+(OWASP Docker Security Cheat Sheet, CIS Docker Benchmark, or Docker docs). That
+bar turned out to be necessary but not sufficient. compose-lint flags *runtime*
+misconfigurations, and a citation can be authoritative for **host/Linux**
+hardening while being false **inside a container**, where Docker's defaults
+already neutralize the risk. Two rules shipped on a source citation alone and
+were both wrong about the container's actual runtime state:
+
+- **CL-0022** flagged `tmpfs` mounts for missing `noexec,nosuid,nodev`. Docker
+  already mounts `tmpfs` with `noexec,nosuid,nodev` by default, so the rule
+  fired on the secure default. It was reworked (commit `88cfd84`) to flag only
+  the *explicit* re-enabling of `exec`/`suid`/`dev`.
+- **CL-0023** flagged the absence of `net.ipv4.ip_forward=0`. That sysctl is
+  `1` by default in a container's network namespace and the rule's premise did
+  not describe a real, attacker-relevant container state. It was **removed**
+  (commit `0cf44ed`) and its ID reclaimed under the pre-1.0 reclamation rule.
+
+Both failures share a root cause: nobody had checked the premise against a
+live container before shipping. A generic host-hardening source read as
+"authoritative grounding" under ADR-002 even though the container default made
+the finding a false positive. We need a check that proves the *runtime
+premise*, not just the existence of a citation.
+
+**Decision:** Add a second, runtime arm to the rule-grounding bar.
+
+A rule is admissible if it satisfies **either**:
+
+1. **Container-context source.** It cites OWASP/CIS/Docker documentation that
+   demonstrates the need **in a container context** (not generic host/Linux
+   hardening a container's defaults already neutralize); **or**
+2. **Runtime-validated premise.** If container-context grounding is thin, the
+   rule's premise is validated at runtime by a check in
+   `scripts/validate_rule_premises.py` that proves, via a short `docker run`:
+   - for an **absence rule** (fires when a hardening directive is missing) —
+     that the insecure state is genuinely Docker's *default*; and
+   - for a **presence rule** (fires on an explicit insecure directive) — that
+     the flagged configuration actually produces the insecure behavior.
+
+Concretely:
+
+- Any rule that **describes container runtime state** must have a premise check
+  in `scripts/validate_rule_premises.py`. Rules with no observable runtime state
+  — image/supply-chain and config-only concerns (currently CL-0004, CL-0014,
+  CL-0015, CL-0019, CL-0020, CL-0021) — are listed in that script's `_NON_RUNTIME`
+  set as intentionally out of scope and rely on source grounding alone.
+- The check is the *premise*, not the rule's parsing logic: it asserts the
+  underlying container behavior the rule warns about is real, independent of how
+  the rule reads the Compose file.
+- The suite runs in CI as the `rule-premises` job (`.github/workflows/ci.yml`),
+  feeds the `ci-ok` rollup gate, and uses a manifest-list-digest-pinned busybox
+  image so it carries no mutable ref. Locally it needs a working Docker; with no
+  Docker it skips (exit 0) rather than failing, so contributors without Docker
+  are not blocked but CI still enforces it.
+
+**Rationale:**
+
+- **Defends against the exact failure that produced it.** CL-0022 and CL-0023
+  would not have shipped in their original form had a `docker run` confirmed the
+  default. The runtime arm makes "is this actually insecure in a container?" a
+  CI gate rather than a reviewer's judgment call.
+- **Closes the gap ADR-002 left open.** ADR-002 ended the debate over *whether a
+  rule is opinion vs. standard*; it did not test whether the standard's premise
+  survives Docker's container defaults. This ADR adds that test without
+  weakening ADR-002 — source grounding is still required when it exists; runtime
+  validation is the alternative when container-context grounding is thin.
+- **Keeps false positives out before they become permanent.** From 1.0, rule
+  IDs and behavior are far costlier to change ([ADR-005](005-rule-id-scheme.md);
+  pre-1.0 reclamation is how CL-0023's ID was freed). A false-positive-prone
+  rule that ships into 1.0 is a long-lived liability and erodes trust in every
+  other finding. The runtime gate is cheapest to apply before the GA freeze.
+- **Premise vs. logic separation is deliberate.** Unit tests already prove a
+  rule parses Compose correctly; they cannot prove the parsed-for state is
+  insecure in a real container. The two test layers answer different questions
+  and both are required.
+
+**Consequences:**
+
+- Adding a runtime-describing rule now costs a `docker run`-based premise check
+  in addition to the unit tests and docs (codified as step 10 of the
+  CONTRIBUTING rule checklist). This is friction by design.
+- The `rule-premises` suite's wall-clock grows roughly linearly with the number
+  of runtime-testable rules (one+ container launch each). At 22 rules this is
+  well within the job's 10-minute budget; if it becomes a bottleneck, batching
+  multiple premise checks into a single container is the obvious lever.
+- A rule whose premise cannot be reduced to an observable busybox check, and
+  whose container-context source is thin, is not admissible — that is the
+  intended outcome, not a gap.
+
+**Alternatives rejected:**
+
+- **Source citation alone (status quo under ADR-002).** This is precisely what
+  let CL-0022 and CL-0023 ship. A citation proves a concern exists *somewhere*,
+  not that it is real inside a container.
+- **Trust unit tests to cover it.** Unit tests assert the rule reads YAML
+  correctly against fixtures the author wrote; they share the author's
+  assumption about the container default and so reproduce, rather than catch,
+  the CL-0022/CL-0023 error.
+- **A one-off manual review checklist instead of an automated gate.** Manual
+  review is what missed these two. An executable, CI-enforced check is the only
+  form that reliably blocks the regression.
+- **Validate against the full Docker/Compose runtime (real compose up).**
+  Heavier and flakier than a single pinned-busybox `docker run`, with no extra
+  signal for premises that reduce to "what is the namespace/mount/cgroup default."
+
+**Interaction with other work:**
+
+- **ADR-002 (rule grounding)** is extended, not superseded: source grounding
+  remains the primary bar; this ADR adds the runtime alternative and is the
+  authoritative record of *why* (the CL-0022/CL-0023 reversal, which previously
+  lived only in the CHANGELOG and the script's docstring).
+- **ADR-005 (rule ID scheme)** supplies the permanence/reclamation rule that
+  makes pre-1.0 the right window for this gate; CL-0023's reclaimed ID is the
+  worked example.
+- **CONTRIBUTING.md** already encodes the operational checklist (rule step 10
+  and the "Rule requirements" section); this ADR records the decision behind it.

--- a/tests/test_rule_consistency.py
+++ b/tests/test_rule_consistency.py
@@ -1,0 +1,144 @@
+"""Consistency between each rule's ``metadata`` and the ``Finding``s it emits.
+
+Every rule states its id and severity twice: once in ``RuleMetadata`` and
+again in every ``Finding`` it constructs (see e.g.
+``rules/CL0011_dangerous_cap_add.py``). Nothing structural ties the two
+together, so a typo can desynchronise them silently. That matters most for
+SARIF, where the rule descriptor's ``security-severity`` is derived from
+``metadata.severity`` while each result's ``level`` comes from the emitted
+``Finding.severity`` (``formatters/sarif.py``): a drift makes GitHub's
+rule-level and alert-level severities disagree — the same class of bug #279
+fixed for severity overrides. These tests turn such drift into a test failure
+before rule ids and severities become permanent at 1.0.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from compose_lint.models import Severity
+from compose_lint.parser import ComposeError, load_compose, loads
+from compose_lint.rules import get_registered_rules
+
+if TYPE_CHECKING:
+    from compose_lint.rules import BaseRule
+
+FIXTURES = Path(__file__).parent / "compose_files"
+
+RULE_ID_RE = re.compile(r"^CL-\d{4}$")
+
+# Rules that deliberately raise a finding's severity above the documented
+# baseline in ``metadata.severity``. Each value is the COMPLETE set of
+# severities the rule may emit and must contain the metadata baseline:
+#   CL-0011 raises ``cap_add: [ALL]`` from HIGH to CRITICAL.
+#   CL-0013 raises a full host-root bind mount from HIGH to CRITICAL.
+# Any other rule emitting a non-baseline severity is intentionally a failure
+# below, so per-finding escalation stays a deliberate, reviewed decision.
+VARIABLE_SEVERITY_RULES: dict[str, set[Severity]] = {
+    "CL-0011": {Severity.HIGH, Severity.CRITICAL},
+    "CL-0013": {Severity.HIGH, Severity.CRITICAL},
+}
+
+# Inline triggers for rules no committed fixture under ``compose_files/``
+# exercises (CL-0022 is only covered by inline snippets in its own test).
+# Extend this when a new rule's trigger isn't present as a fixture file.
+INLINE_TRIGGERS: tuple[str, ...] = (
+    "services:\n  tmpfs_exec:\n    image: nginx:1.27\n    tmpfs:\n      - /tmp:exec\n",
+)
+
+_RULES: list[BaseRule] = [cls() for cls in get_registered_rules()]
+_RULE_IDS = [rule.metadata.id for rule in _RULES]
+
+
+def _load_cases() -> list[tuple[str, dict[str, Any], dict[str, int]]]:
+    """Compose inputs to drive every rule over: valid fixtures + inline triggers."""
+    cases: list[tuple[str, dict[str, Any], dict[str, int]]] = []
+    for path in sorted(FIXTURES.glob("*.yml")):
+        if path.name.startswith("invalid"):
+            continue  # parser-error fixtures are not lint inputs
+        try:
+            data, lines = load_compose(path)
+        except ComposeError:
+            continue
+        if isinstance(data.get("services"), dict):
+            cases.append((path.name, data, lines))
+    for i, snippet in enumerate(INLINE_TRIGGERS):
+        data, lines = loads(snippet)
+        cases.append((f"<inline:{i}>", data, lines))
+    return cases
+
+
+_CASES = _load_cases()
+
+
+@pytest.mark.parametrize("rule", _RULES, ids=_RULE_IDS)
+def test_metadata_well_formed(rule: BaseRule) -> None:
+    meta = rule.metadata
+    assert RULE_ID_RE.match(meta.id), f"{meta.id!r} is not CL-NNNN"
+    module_tag = rule.__class__.__module__.rsplit(".", 1)[-1].split("_", 1)[0]
+    assert module_tag == meta.id.replace("-", ""), (
+        f"{meta.id}: module {rule.__class__.__module__} disagrees with metadata id"
+    )
+    assert meta.name.strip(), f"{meta.id}: empty name"
+    assert meta.description.strip(), f"{meta.id}: empty description"
+    assert isinstance(meta.severity, Severity), f"{meta.id}: severity is not a Severity"
+    assert meta.references, f"{meta.id}: no references"
+
+
+def test_variable_severity_allow_list_is_honest() -> None:
+    """The escalation allow-list must name real rules and include their baseline."""
+    by_id = {rule.metadata.id: rule for rule in _RULES}
+    for rule_id, allowed in VARIABLE_SEVERITY_RULES.items():
+        assert rule_id in by_id, f"allow-list names unknown rule {rule_id}"
+        assert len(allowed) > 1, f"{rule_id}: listed but declares a single severity"
+        baseline = by_id[rule_id].metadata.severity
+        assert baseline in allowed, (
+            f"{rule_id}: metadata severity {baseline} not in declared set {allowed}"
+        )
+
+
+def test_findings_agree_with_metadata() -> None:
+    """Every emitted finding's id and severity must match its rule's metadata.
+
+    Driven rule-by-rule so the emitted ``Finding.rule_id`` is compared against
+    the rule's own ``metadata.id`` (not against itself). Severity must equal
+    the baseline, or fall in the declared escalation set for the two rules that
+    vary it.
+    """
+    assert _CASES, "no usable compose fixtures found"
+    fired: set[str] = set()
+    total = 0
+    for rule in _RULES:
+        meta = rule.metadata
+        allowed = VARIABLE_SEVERITY_RULES.get(meta.id, {meta.severity})
+        for case_name, data, lines in _CASES:
+            for service_name, service_config in data["services"].items():
+                if not isinstance(service_config, dict):
+                    continue
+                for finding in rule.check(service_name, service_config, data, lines):
+                    total += 1
+                    fired.add(meta.id)
+                    assert finding.rule_id == meta.id, (
+                        f"{meta.id} emitted Finding.rule_id={finding.rule_id!r} "
+                        f"in {case_name}"
+                    )
+                    assert finding.severity in allowed, (
+                        f"{meta.id} emitted {finding.severity} in {case_name}; "
+                        f"allowed: {sorted(s.value for s in allowed)}. If this "
+                        "escalation is intended, declare it in "
+                        "VARIABLE_SEVERITY_RULES."
+                    )
+                    assert finding.references, (
+                        f"{meta.id} emitted a finding without references in {case_name}"
+                    )
+    assert total > 0, "fixtures triggered no findings"
+    missing = set(_RULE_IDS) - fired
+    assert not missing, (
+        f"no test input exercises {sorted(missing)}; add a fixture under "
+        "compose_files/ or an entry to INLINE_TRIGGERS so metadata/finding "
+        "consistency is actually checked for it"
+    )


### PR DESCRIPTION
## Summary

Two related changes hardening rule quality ahead of 1.0:

- **ADR-016 — Runtime Validation of Rule Premises.** Records the `docker run` premise gate (`scripts/validate_rule_premises.py` + the `rule-premises` CI job) as a formal decision, extending ADR-002. The policy has been enforced since the CL-0022 rework and CL-0023 removal, but its rationale lived only in the changelog and the script docstring; this captures the CL-0022/CL-0023 reversal as the motivating example.
- **Registry-wide consistency test** (`tests/test_rule_consistency.py`). Each rule states its id and severity twice — once in `RuleMetadata`, again in every `Finding`. Nothing tied the two together, so a typo could silently desynchronise them, making the SARIF rule descriptor's `security-severity` (from metadata) disagree with a result's `level` (from the finding). The test fails on that drift before ids/severities become permanent at 1.0.

## Test design notes

- Driven **rule-by-rule** over the existing fixtures plus one inline trigger, so all 22 rules are exercised and each emitted `Finding.rule_id` is compared against the rule's *own* `metadata.id` (not itself).
- `metadata.severity` is treated as the documented **baseline**. The two rules that deliberately escalate per-finding — CL-0011 (`cap_add: [ALL]` → CRITICAL) and CL-0013 (host-root mount → CRITICAL) — are declared in a `VARIABLE_SEVERITY_RULES` allow-list. Adding escalation to any other rule is a test failure by design.
- A coverage assertion fails if any registered rule is never exercised, so the test can't silently pass by checking nothing.

## Verification

`ruff check src/ tests/`, `ruff format --check`, `mypy src/`, and the full `pytest` (795 passed, +24) all pass. Drift-catching was confirmed by mutating a rule's emitted `severity` and `rule_id` — each produced a clear failure.