### PR TITLE
Escape terminal-unsafe code points in text output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   O(n^2) on attacker-controlled input, a cheap DoS when sweeping untrusted
   Compose files. The rule now bails before scanning when the value contains no
   `@` (the pattern requires one, so this changes no findings).
+- The text formatter now escapes terminal-unsafe code points — C0/C1 controls
+  (ANSI/escape-sequence injection), DEL, and bidirectional/zero-width formatting
+  characters — in every string derived from an untrusted Compose file (finding
+  messages, fix text, service names, paths, and the on-disk source excerpt). A
+  crafted image or service name could previously smuggle a U+202E override (to
+  make a malicious tag render as a benign one) or, via the source excerpt that
+  is read straight off disk and bypasses the parser's printable-character check,
+  a raw ANSI escape into a terminal or CI log. They now render as visible
+  `\uXXXX` escapes. JSON and SARIF output were already safe (`ensure_ascii`).
 
 ### Added
 

--- a/src/compose_lint/formatters/text.py
+++ b/src/compose_lint/formatters/text.py
@@ -77,6 +77,40 @@ _PRESENCE_RULES = frozenset(
 
 _QUOTED = re.compile(r"'([^']+)'")
 
+# Code-point ranges (inclusive) that can spoof or corrupt terminal output when
+# an untrusted string from the Compose file (image name, service name, env key,
+# or a source line read straight off disk) is printed: C0/C1 controls —
+# ANSI/escape-sequence injection, including the ESC and CSI introducers — plus
+# DEL, and the bidirectional and zero-width formatting characters that visually
+# reorder or hide text (e.g. U+202E RIGHT-TO-LEFT OVERRIDE rendering a malicious
+# tag as a benign one). Built from hex so no invisible literals live in source;
+# tab and newline are deliberately excluded so excerpt layout survives.
+_UNSAFE_RANGES = (
+    (0x00, 0x08),
+    (0x0B, 0x1F),
+    (0x7F, 0x9F),
+    (0x200B, 0x200F),
+    (0x202A, 0x202E),
+    (0x2060, 0x2064),
+    (0x2066, 0x206F),
+    (0xFEFF, 0xFEFF),
+)
+_UNSAFE_OUTPUT_CHARS = re.compile(
+    "[" + "".join(f"{chr(lo)}-{chr(hi)}" for lo, hi in _UNSAFE_RANGES) + "]"
+)
+
+
+def _sanitize(text: str) -> str:
+    """Render terminal-unsafe code points as visible ``\\uXXXX`` escapes.
+
+    Findings and source excerpts carry attacker-controlled text. The source
+    excerpt in particular is read directly off disk (``_read_source_lines``),
+    bypassing the parser's printable-character check, so a crafted Compose file
+    could otherwise inject raw ANSI escapes or bidi overrides into a terminal
+    or CI log. Clean ASCII/Unicode text is returned unchanged.
+    """
+    return _UNSAFE_OUTPUT_CHARS.sub(lambda m: f"\\u{ord(m.group()):04x}", text)
+
 
 def _color_enabled() -> bool:
     """Decide whether to emit ANSI color, honoring the de-facto env standards.
@@ -157,7 +191,7 @@ def format_header(
     sep = _colorize("·", _DIM)
     config_str = config_path if config_path else "none"
     params = (
-        f"files: {', '.join(files)}"
+        f"files: {', '.join(_sanitize(f) for f in files)}"
         f"  {sep}  config: {config_str}"
         f"  {sep}  fail-on: {fail_on.value}"
     )
@@ -189,7 +223,7 @@ def _excerpt(
     """
     if line_num < 1 or line_num > len(source_lines):
         return []
-    raw = source_lines[line_num - 1].rstrip()
+    raw = _sanitize(source_lines[line_num - 1].rstrip())
     line_label = str(line_num)
     pad = " " * len(line_label)
     bar = _colorize("│", _DIM)
@@ -242,7 +276,7 @@ def format_findings(
     )
 
     out: list[str] = []
-    out.append(_colorize(filepath, _BOLD))
+    out.append(_colorize(_sanitize(filepath), _BOLD))
     out.append("")
 
     seen_rules: set[str] = set()
@@ -250,7 +284,9 @@ def format_findings(
     for service, group in services_in_order:
         svc_line = next((f.line for f in group if f.line is not None), None)
         header_suffix = f"  ({_colorize('line', _DIM)} {svc_line})" if svc_line else ""
-        out.append(f"  {_colorize('service:', _DIM)} {service}{header_suffix}")
+        out.append(
+            f"  {_colorize('service:', _DIM)} {_sanitize(service)}{header_suffix}"
+        )
         out.append(
             _colorize(
                 f"    {'line'.rjust(4)}  "
@@ -271,15 +307,18 @@ def format_findings(
                     f"    {line_label.rjust(4)}  "
                     f"{marker}  "
                     f"{_colorize(f.rule_id, _DIM)}  "
-                    f"{_colorize(f.message, _SUPPRESSED_COLOR)}"
+                    f"{_colorize(_sanitize(f.message), _SUPPRESSED_COLOR)}"
                 )
                 if not quiet:
-                    out.append(f"          {_colorize('reason:', _DIM)} {reason}")
+                    out.append(
+                        f"          {_colorize('reason:', _DIM)} {_sanitize(reason)}"
+                    )
                 continue
 
             severity_label = f.severity.value.upper().ljust(_LABEL_WIDTH)
             color = _COLORS.get(f.severity, "")
             line_label = str(f.line) if f.line else "?"
+            message = _sanitize(f.message)
 
             already_shown = f.rule_id in seen_rules
             show_fix = not quiet and (verbose or not already_shown)
@@ -291,7 +330,7 @@ def format_findings(
                 f"    {line_label.rjust(4)}  "
                 f"{_colorize(severity_label, color)}  "
                 f"{_colorize(f.rule_id, _DIM)}  "
-                f"{f.message}{suffix}"
+                f"{message}{suffix}"
             )
 
             if (
@@ -299,13 +338,11 @@ def format_findings(
                 and f.rule_id in _PRESENCE_RULES
                 and f.line is not None
             ):
-                for excerpt_line in _excerpt(
-                    f.line, source_lines, f.message, f.severity
-                ):
+                for excerpt_line in _excerpt(f.line, source_lines, message, f.severity):
                     out.append(f"          {excerpt_line}")
 
             if show_fix and f.fix:
-                fix_lines = f.fix.split("\n")
+                fix_lines = _sanitize(f.fix).split("\n")
                 out.append(f"          {_colorize('fix:', _DIM)} {fix_lines[0]}")
                 for fix_line in fix_lines[1:]:
                     out.append(f"               {fix_line}")
@@ -324,6 +361,7 @@ def format_summary(
     filepath: str,
 ) -> str:
     """Format a one-line summary of findings for a single file."""
+    filepath = _sanitize(filepath)
     if not findings:
         return _colorize(f"{filepath}: no issues found", _GREEN)
 

--- a/tests/test_text_formatter.py
+++ b/tests/test_text_formatter.py
@@ -19,9 +19,12 @@ from compose_lint.formatters.text import (
     _RESET,
     _colorize,
     _display_width,
+    _excerpt,
     _find_token,
+    _sanitize,
     format_aggregate_summary,
     format_findings,
+    format_summary,
     format_verdict,
 )
 from compose_lint.models import Finding, Severity
@@ -386,3 +389,57 @@ def test_underline_targets_standalone_token(tmp_path) -> None:  # type: ignore[n
     expected_col = raw.index(":80") + 1
     assert expected_col == 13
     assert (" " * expected_col + "──") in out
+
+
+# --- terminal-output sanitization (bidi / control-char injection) ---------
+
+# Built via chr()/\x escapes so no invisible code points live in this file.
+_RLO = chr(0x202E)  # RIGHT-TO-LEFT OVERRIDE
+_ZWSP = chr(0x200B)  # ZERO WIDTH SPACE
+
+
+def test_sanitize_escapes_bidi_and_control_chars() -> None:
+    # A bidi override can visually reorder a malicious image tag to read benign.
+    assert _sanitize(f"alpine{_RLO}3.18") == "alpine\\u202e3.18"
+    # ESC (the ANSI introducer) and other C0 controls are neutralized.
+    assert _sanitize("a\x1bb") == "a\\u001bb"
+    # Zero-width characters can hide text.
+    assert _sanitize(f"a{_ZWSP}b") == "a\\u200bb"
+
+
+def test_sanitize_leaves_clean_text_unchanged() -> None:
+    # ASCII, em-dash, and accented text must pass through untouched...
+    clean = "postgres:9.6.9-alpine — café"
+    assert _sanitize(clean) == clean
+    # ...and tab is preserved so YAML excerpt indentation still lines up.
+    assert _sanitize("\tindented") == "\tindented"
+
+
+def test_format_findings_escapes_bidi_in_message() -> None:
+    # An untrusted image name carrying a bidi override reaches the message.
+    finding = Finding(
+        "CL-0004",
+        Severity.HIGH,
+        "web",
+        f"Service uses unpinned image 'nginx{_RLO}latest'.",
+        line=3,
+    )
+    out = format_findings([finding], "compose.yml", quiet=True)
+    assert _RLO not in out
+    assert "\\u202e" in out
+
+
+def test_excerpt_escapes_control_chars_read_off_disk() -> None:
+    # The source excerpt is read straight off disk, bypassing the parser's
+    # printable-character check — a raw ESC on the offending line would inject
+    # an ANSI sequence into the terminal. It must be escaped instead.
+    source_lines = ["services:", "  web:", "    image: nginx\x1b[31mhack"]
+    out = "".join(_excerpt(3, source_lines, "image is bad", Severity.HIGH))
+    assert "\x1b" not in out
+    assert "\\u001b" in out
+
+
+def test_format_summary_escapes_bidi_in_path() -> None:
+    out = format_summary([], f"compose{_RLO}.yml")
+    assert _RLO not in out
+    assert "\\u202e" in out


### PR DESCRIPTION
## Summary

Escape terminal-unsafe code points (C0/C1 controls, DEL, and
bidirectional/zero-width formatting characters) in every string the text
formatter derives from an untrusted Compose file.

## Why

The text formatter printed finding messages, fix text, service names, paths,
and the on-disk **source excerpt** verbatim. Two concrete attacks via a crafted
Compose file:

- **Bidi spoofing.** A U+202E RIGHT-TO-LEFT OVERRIDE (or zero-width chars) in an
  image/service name visually reorders or hides text in a terminal/CI log — e.g.
  making a malicious image tag render as a benign one.
- **ANSI injection via the excerpt.** `_read_source_lines` reads the file
  straight off disk, **bypassing the parser's printable-character check**, so a
  raw ESC/C0 byte on the offending line injects control sequences into the
  terminal.

JSON and SARIF output were already safe (`json.dumps` defaults to
`ensure_ascii=True`); only the text formatter passed these through.

## The fix

Add `_sanitize`, which renders the unsafe code points as visible `\uXXXX`
escapes, and apply it at every untrusted-text print site (message, fix, service,
path, excerpt). Tab and newline are preserved so excerpt indentation/layout
survives. The character class is built from hex ranges so no invisible literals
live in the source. **Clean text is returned unchanged**, so existing output and
tests are unaffected.

## Type of change

- [x] Bug fix

## Checklist

- [x] Commits are signed (SSH)
- [x] One logical change per commit; no unrelated changes bundled in
- [x] `ruff check`, `ruff format --check`, `mypy src/`, and `pytest` all pass locally (800 passed)
- [x] New/changed behavior has tests — `_sanitize` unit tests (bidi, control, zero-width, clean-passthrough, tab) plus end-to-end escaping in `format_findings`, `_excerpt` (off-disk source), and `format_summary`
- [x] Docs updated where behavior changed — `CHANGELOG.md` (Security)
- [x] No AI attribution anywhere

## Breaking changes

None for clean inputs (sanitization is a no-op on text without the targeted code
points). The only output change is for files that contain control/bidi/zero-width
characters, which now render as `\uXXXX` instead of being emitted raw.
