### PR TITLE
Pin download host and refuse redirects in corpus fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is read straight off disk and bypasses the parser's printable-character check,
   a raw ANSI escape into a terminal or CI log. They now render as visible
   `\uXXXX` escapes. JSON and SARIF output were already safe (`ensure_ascii`).
+- The corpus fetcher (`scripts/corpus/`, development tooling) now pins the
+  download host and refuses redirects. It rewrites `github.com` blob URLs to
+  `raw.githubusercontent.com`, but a candidate whose prefix didn't match was
+  left intact and fetched verbatim, and `urlopen` follows redirects by default —
+  so a malformed or hostile candidate URL could have turned a download into a
+  request against an internal or attacker-chosen host (SSRF). The fetcher now
+  rejects any non-`https://raw.githubusercontent.com/` URL before opening it and
+  uses an opener that does not follow redirects. Candidate URLs come from the
+  GitHub API, so this is defense-in-depth.
 
 ### Added
 

--- a/scripts/corpus/_common.py
+++ b/scripts/corpus/_common.py
@@ -17,6 +17,7 @@ import hashlib
 import json
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
@@ -71,11 +72,41 @@ def raw_url(blob_url: str) -> str:
     )
 
 
+# The fetcher only ever pulls raw file content from GitHub's raw host. Candidate
+# URLs come from the GitHub API, so this is defense-in-depth rather than the
+# primary trust boundary: pin scheme+host and refuse redirects so a malformed or
+# hostile candidate (or a `raw_url` rewrite that didn't match, leaving a
+# non-github URL intact) can't turn a download into a request against an
+# internal or attacker-chosen host (SSRF).
+RAW_HOST = "raw.githubusercontent.com"
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Refuse redirects; a 3xx surfaces as an HTTPError the caller records."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
+        return None
+
+
+_PINNED_OPENER = urllib.request.build_opener(_NoRedirect)
+
+
+def _validate_raw_url(url: str) -> None:
+    """Raise ValueError unless ``url`` is an https raw.githubusercontent.com URL."""
+    parts = urllib.parse.urlsplit(url)
+    if parts.scheme != "https" or parts.hostname != RAW_HOST:
+        raise ValueError(f"refusing non-{RAW_HOST} URL: {url!r}")
+
+
 def _download(item: dict) -> tuple[dict, bytes | None, str | None]:
     url = raw_url(item["url"])
+    try:
+        _validate_raw_url(url)
+    except ValueError:
+        return item, None, "bad_url"
     req = urllib.request.Request(url, headers={"User-Agent": "compose-lint-corpus/1"})
     try:
-        with urllib.request.urlopen(req, timeout=PER_FILE_TIMEOUT) as r:
+        with _PINNED_OPENER.open(req, timeout=PER_FILE_TIMEOUT) as r:
             data = r.read(MAX_FILE_BYTES + 1)
         if len(data) > MAX_FILE_BYTES:
             return item, None, "too_large"

--- a/scripts/corpus/fetch.py
+++ b/scripts/corpus/fetch.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
@@ -80,11 +81,40 @@ def raw_url(blob_url: str) -> str:
     return blob_url.replace("https://github.com/", "https://raw.githubusercontent.com/", 1).replace("/blob/", "/", 1)
 
 
+# Pin scheme+host and refuse redirects so a malformed/hostile candidate URL (or
+# a raw_url rewrite that didn't match, leaving a non-github URL intact) can't
+# turn a download into a request against an internal or attacker-chosen host
+# (SSRF defense-in-depth). Candidate URLs come from the GitHub API, so this is
+# belt-and-suspenders, not the primary trust boundary.
+RAW_HOST = "raw.githubusercontent.com"
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Refuse redirects; a 3xx surfaces as an HTTPError the caller records."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
+        return None
+
+
+_PINNED_OPENER = urllib.request.build_opener(_NoRedirect)
+
+
+def _validate_raw_url(url: str) -> None:
+    """Raise ValueError unless ``url`` is an https raw.githubusercontent.com URL."""
+    parts = urllib.parse.urlsplit(url)
+    if parts.scheme != "https" or parts.hostname != RAW_HOST:
+        raise ValueError(f"refusing non-{RAW_HOST} URL: {url!r}")
+
+
 def download(item: dict) -> tuple[dict, bytes | None, str | None]:
     url = raw_url(item["url"])
+    try:
+        _validate_raw_url(url)
+    except ValueError:
+        return item, None, "bad_url"
     req = urllib.request.Request(url, headers={"User-Agent": "compose-lint-corpus/1"})
     try:
-        with urllib.request.urlopen(req, timeout=PER_FILE_TIMEOUT) as r:
+        with _PINNED_OPENER.open(req, timeout=PER_FILE_TIMEOUT) as r:
             data = r.read(MAX_FILE_BYTES + 1)
         if len(data) > MAX_FILE_BYTES:
             return item, None, "too_large"

--- a/tests/test_corpus_fetch_url.py
+++ b/tests/test_corpus_fetch_url.py
@@ -1,0 +1,60 @@
+"""URL-hardening tests for the corpus fetcher's download path.
+
+The corpus scripts pull raw file content from GitHub. A candidate URL whose
+prefix doesn't match the github.com->raw rewrite would otherwise be fetched
+verbatim, so the download path pins scheme+host (and refuses redirects) as
+SSRF defense-in-depth. These tests cover the host guard without touching the
+network. The script lives outside the importable package, so it is loaded by
+path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_COMMON = Path(__file__).resolve().parents[1] / "scripts" / "corpus" / "_common.py"
+
+
+def _load_common():  # type: ignore[no-untyped-def]
+    spec = importlib.util.spec_from_file_location("_corpus_common", _COMMON)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+common = _load_common()
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://raw.githubusercontent.com/o/r/sha/compose.yml",  # not https
+        "https://raw.githubusercontent.com.evil.example/o/r/x.yml",  # lookalike host
+        "https://evil.example/o/r/sha/compose.yml",  # wrong host
+        "https://github.com/o/r/blob/main/compose.yml",  # un-rewritten, non-raw
+        "file:///etc/passwd",  # non-http scheme
+    ],
+)
+def test_validate_raw_url_rejects_non_raw(url: str) -> None:
+    with pytest.raises(ValueError):
+        common._validate_raw_url(url)
+
+
+def test_validate_raw_url_accepts_raw_host() -> None:
+    # The happy path a real `raw_url(...)` produces must not be rejected.
+    common._validate_raw_url(
+        "https://raw.githubusercontent.com/owner/repo/abc123/compose.yml"
+    )
+
+
+def test_raw_url_keeps_non_github_host_so_guard_rejects_it() -> None:
+    # raw_url only rewrites the github.com host; a non-github candidate keeps
+    # its own host, so the host guard is what stops it from being fetched.
+    rewritten = common.raw_url("https://gitlab.com/o/r/blob/main/compose.yml")
+    assert rewritten.startswith("https://gitlab.com/")
+    with pytest.raises(ValueError):
+        common._validate_raw_url(rewritten)


### PR DESCRIPTION
## Summary

Harden the corpus fetcher's download path (development tooling under
`scripts/corpus/`) against SSRF: pin the host and refuse redirects.

## Why

The fetcher rewrites `github.com` blob URLs to `raw.githubusercontent.com` and
downloads them. Two gaps:

1. The rewrite is a string `replace`; a candidate whose prefix didn't match was
   left intact and fetched **verbatim** (any host, any scheme).
2. `urllib.request.urlopen` **follows redirects by default**, so even a
   correctly-pinned raw URL could be bounced to another host.

Together, a malformed or hostile candidate URL could turn a download into a
request against an internal or attacker-chosen host (SSRF). Candidate URLs come
from the GitHub API over TLS, so this is **defense-in-depth**, not a live hole —
but the fetcher runs locally with whatever network the operator has, so pinning
is cheap insurance.

## The fix

- `_validate_raw_url` rejects anything but an `https://raw.githubusercontent.com/`
  URL before it is opened (bad candidates are recorded as `bad_url` in the
  existing skip counter).
- Downloads go through a `build_opener` whose redirect handler refuses to
  follow 3xx — a redirect surfaces as an `HTTPError` the caller already records.

Applied to **both** download paths: the shared `_common._download` used by the
tier fetchers and the standalone `fetch.download`.

## Type of change

- [x] Bug fix (defense-in-depth hardening of dev tooling)

## Checklist

- [x] Commits are signed (SSH)
- [x] One logical change per commit; no unrelated changes bundled in
- [x] `ruff check`, `ruff format --check`, `mypy src/`, and `pytest` all pass locally (808 passed)
- [x] New/changed behavior has tests — `tests/test_corpus_fetch_url.py` covers the host guard (wrong scheme, lookalike host, wrong host, un-rewritten github URL, `file://`, and the happy path) without touching the network
- [x] Docs updated where behavior changed — `CHANGELOG.md` (Security)
- [x] No AI attribution anywhere

## Notes

`scripts/corpus/` is out of the package's `ruff`/`mypy` CI scope and had no test
harness; the new test loads `_common` by path so the guard is still covered. The
two scripts duplicate a small (~12-line) helper rather than coupling the
standalone `fetch.py` to `_common`'s sys.path-based import convention.

## Breaking changes

None.
