### PR TITLE
Disable Renovate poetry manager for pyproject.toml

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,10 @@
   "pip-compile": {
     "managerFilePatterns": ["/(^|/)requirements[\\w-]*\\.lock$/"]
   },
+  "poetry": {
+    "enabled": false,
+    "description": "pyproject.toml is already covered by pep621 + pip-compile. The poetry manager detects the same [project] deps but is not in the python group rule, so it spawned duplicate ungrouped PRs that bumped pyproject without regenerating the lockfiles (e.g. renovate/ruff-0.x, #329)."
+  },
   "packageRules": [
     {
       "description": "GitHub Actions: SHA-pin every uses: with version comment (CLAUDE.md).",


### PR DESCRIPTION
## Why

`pyproject.toml` is detected by three Renovate managers (visible in the Dependency Dashboard's *Detected Dependencies*): **pep621**, **pip-compile** (as the recorded source file of the `requirements*.lock` outputs), and **poetry**, which parses the same `[project]` tables.

Only pep621/pip-compile/pip_requirements are in the `python` group rule, so the poetry manager spawned duplicate, ungrouped PRs that bump `pyproject.toml` **without regenerating the hash-pinned lockfiles** — e.g. #329 (`renovate/ruff-0.x`), which would have reintroduced exactly the pyproject↔lock drift #333 fixed. The grouped pip-compile PR #335 covers the same updates with the locks regenerated.

## What

Disable the poetry manager. pep621 + pip-compile cover everything it detected. Renovate will autoclose its open branches (#329) on the next run.

Surfaced while closing out #334.