### PR TITLE
Add release signing key for the remote release path

### DIFF
--- a/.github/allowed_signers
+++ b/.github/allowed_signers
@@ -23,3 +23,8 @@
 # Todd Matens — release signing key (used to sign vX.Y.Z annotated tags
 # from v0.3.7 onward). Verified against tag v0.7.0 (commit 23da963).
 tmatens@gmail.com namespaces="git" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINz74LQz7YwG5+9fSmqshOfarZt53sBYgFMTGMKJoBY+
+
+# Todd Matens — release signing key for the remote/automated release path (added 2026-06-13).
+# Same principal as the key above; signs vX.Y.Z annotated tags cut from the remote release
+# flow rather than from a workstation. Grants release-signing authority (see GOVERNANCE.md).
+tmatens@gmail.com namespaces="git" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDrB4X76XPEJmLX70W/hdIky3KvboFvWJJKCpL5RE1pT


### PR DESCRIPTION
Adds a second release-signing key under the same maintainer principal (`tmatens@gmail.com`), for signing `vX.Y.Z` annotated tags cut from the remote/automated release path rather than from a workstation. `namespaces="git"` scoped, matching the existing entry. Key fingerprint `SHA256:osV/HmharyjeoCfWCOUKD87D7O5kF+mTbDgqtfs9ezc`.

Per `.github/allowed_signers`' own procedure, adding a key **grants release-signing authority** — please review and merge as a release-authority grant (GOVERNANCE.md). After merge, the next tag signed with this key verifies against `publish.yml`'s `verify-tag` job.

Diff is a single appended entry; no existing key is changed or removed.