### PR TITLE
Use static MIT license badge to avoid shields GitHub error

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![PyPI](https://img.shields.io/pypi/v/compose-lint)](https://pypi.org/project/compose-lint/)
 [![Docker](https://img.shields.io/badge/docker-composelint%2Fcompose--lint-2496ED?logo=docker&logoColor=white)](https://hub.docker.com/r/composelint/compose-lint)
 [![Python](https://img.shields.io/pypi/pyversions/compose-lint)](https://pypi.org/project/compose-lint/)
-[![License](https://img.shields.io/github/license/tmatens/compose-lint)](https://github.com/tmatens/compose-lint/blob/main/LICENSE)
+[![License](https://img.shields.io/badge/license-MIT-green)](https://github.com/tmatens/compose-lint/blob/main/LICENSE)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/tmatens/compose-lint/badge)](https://scorecard.dev/viewer/?uri=github.com/tmatens/compose-lint)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12472/badge)](https://www.bestpractices.dev/projects/12472)
 


### PR DESCRIPTION
## Problem

The License badge intermittently renders **`license | github error`**.

## Root cause

The badge used the *dynamic* shields endpoint `img.shields.io/github/license/tmatens/compose-lint`, which makes shields.io call the GitHub API on each render. shields.io shares one anonymous GitHub token across all users, so when it's rate-limited the badge falls back to a `github error` message. The repo itself is fine — it's public and GitHub's license API correctly detects `MIT` (verified against `/repos/tmatens/compose-lint/license`).

## Fix

Switch to a static badge `img.shields.io/badge/license-MIT-green`. The license is a fixed fact, so a static badge is reliable and never depends on an upstream API call. The link target (the `LICENSE` file) is unchanged.
