### PR TITLE
Scope CI/CodeQL/Scorecard triggers to cut wait on non-code PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,82 @@ concurrency:
 permissions: {}
 
 jobs:
+  # Detects which classes of files a PR touches so the expensive jobs below
+  # (the 5-version test matrix, coverage, container smokes, rule-premises)
+  # can skip when nothing they exercise changed — a docs- or metadata-only
+  # PR returns a green `ci-ok` in seconds instead of waiting on container
+  # spin-ups. This is per-job gating, NOT a workflow-level `paths:` filter:
+  # the only required status check is `ci-ok`, and a workflow-level filter
+  # would stop `ci-ok` from ever reporting on a skipped PR, leaving the
+  # required check pending forever. `ci-ok` already counts `skipped` as a
+  # pass, so gating jobs here is safe. Filters are deliberately inclusive —
+  # any source/test/dependency change runs the full suite — and on `push`
+  # everything runs unconditionally so main always gets a complete pass.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      docker: ${{ steps.filter.outputs.docker }}
+      workflows: ${{ steps.filter.outputs.workflows }}
+      dockerfile: ${{ steps.filter.outputs.dockerfile }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Compute change filters
+        id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # On push (no PR diff context) run every group — main must always
+          # get a full validation pass.
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            {
+              echo "code=true"
+              echo "docker=true"
+              echo "workflows=true"
+              echo "dockerfile=true"
+            } >> "$GITHUB_OUTPUT"
+            echo "push event — running all job groups."
+            exit 0
+          fi
+          changed=$(git diff --name-only "${BASE_SHA}" "${HEAD_SHA}")
+          echo "Changed files:"
+          echo "${changed}"
+          match() { echo "${changed}" | grep -qE "$1"; }
+          code=false; docker=false; workflows=false; dockerfile=false
+          # Python sources, tests, helper scripts, the package manifest,
+          # hash-pinned lockfiles, and the action contract all warrant the
+          # full lint/type/test/coverage/security/smoke suite.
+          if match '^(src/|tests/|scripts/|pyproject\.toml$|requirements[.-].*lock$|action\.yml$)'; then
+            code=true
+          fi
+          if match '^(Dockerfile$|\.dockerignore$|requirements\.lock$|requirements-build\.lock$|pyproject\.toml$|src/)'; then
+            docker=true
+          fi
+          if match '^\.github/workflows/'; then
+            workflows=true
+          fi
+          if match '^Dockerfile$'; then
+            dockerfile=true
+          fi
+          {
+            echo "code=${code}"
+            echo "docker=${docker}"
+            echo "workflows=${workflows}"
+            echo "dockerfile=${dockerfile}"
+          } >> "$GITHUB_OUTPUT"
+
   lint:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
@@ -40,6 +115,8 @@ jobs:
       - run: ruff format --check src/ tests/
 
   type-check:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
@@ -63,6 +140,8 @@ jobs:
       - run: mypy src/
 
   test:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
@@ -98,6 +177,8 @@ jobs:
   # level so a config drift can't silently lower it.
   coverage:
     name: Test coverage (>= 80% statement)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
@@ -136,6 +217,8 @@ jobs:
 
   security:
     name: Security scan (bandit + pip-audit)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
@@ -367,6 +450,8 @@ jobs:
   # Renovate's github-releases datasource handles version bumps.
   actionlint:
     name: Lint GitHub Actions workflows
+    needs: changes
+    if: needs.changes.outputs.workflows == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 3
     permissions:
@@ -392,6 +477,8 @@ jobs:
   # don't surface until docker-publish at release time.
   dockerfile-digests:
     name: Verify Dockerfile digests are manifest lists
+    needs: changes
+    if: needs.changes.outputs.dockerfile == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 2
     permissions:
@@ -409,6 +496,11 @@ jobs:
   # the gate cheap; the release pipeline covers multi-arch.
   docker-smoke:
     name: Smoke test Dockerfile (amd64)
+    # Build inputs are detected centrally by the `changes` job (the `docker`
+    # group: Dockerfile, .dockerignore, the runtime/build lockfiles,
+    # pyproject.toml, src/). On push, that group is always true.
+    needs: changes
+    if: needs.changes.outputs.docker == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
@@ -416,29 +508,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
           persist-credentials: false
-      - name: Determine if Docker-relevant files changed
-        id: changes
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if git diff --name-only "${BASE_SHA}" "${HEAD_SHA}" \
-              | grep -qE '^(Dockerfile|\.dockerignore|requirements\.lock|requirements-build\.lock|pyproject\.toml|src/)'; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "No Docker-relevant files changed — skipping build."
-          fi
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-        if: steps.changes.outputs.run == 'true'
       - name: Build image
-        if: steps.changes.outputs.run == 'true'
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
@@ -448,7 +520,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Clean fixture exits 0
-        if: steps.changes.outputs.run == 'true'
         run: |
           cat > /tmp/clean.yml <<'YAML'
           services:
@@ -464,7 +535,6 @@ jobs:
           YAML
           docker run --rm -v /tmp/clean.yml:/src/docker-compose.yml composelint/compose-lint:pr-smoke
       - name: Insecure fixture exits 1
-        if: steps.changes.outputs.run == 'true'
         run: |
           cat > /tmp/insecure.yml <<'YAML'
           services:
@@ -479,7 +549,6 @@ jobs:
             exit 1
           fi
       - name: SARIF output is valid JSON
-        if: steps.changes.outputs.run == 'true'
         run: |
           cat > /tmp/test.yml <<'YAML'
           services:
@@ -491,6 +560,8 @@ jobs:
 
   action-smoke:
     name: Smoke test action.yml
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
@@ -537,6 +608,8 @@ jobs:
   # flags a Docker default — before it ships. Runners have Docker preinstalled.
   rule-premises:
     name: Validate rule premises (live container)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
@@ -563,6 +636,7 @@ jobs:
   ci-ok:
     name: ci-ok
     needs:
+      - changes
       - lint
       - type-check
       - test

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,23 @@ name: CodeQL
 on:
   push:
     branches: [main]
+    # Only re-analyze when something CodeQL actually scans changes. The
+    # matrix covers two languages: `python` (sources) and `actions`
+    # (workflow/composite-action YAML). A docs- or config-only change has
+    # nothing for either to analyze, so skip it and spare the wait. The
+    # weekly `schedule` run below still re-scans everything, catching new
+    # advisories on otherwise-unchanged code. CodeQL is not a required
+    # status check (only `ci-ok` is), so a skipped run never wedges a PR.
+    paths:
+      - "**/*.py"
+      - "action.yml"
+      - ".github/workflows/**"
   pull_request:
     branches: [main]
+    paths:
+      - "**/*.py"
+      - "action.yml"
+      - ".github/workflows/**"
   schedule:
     # Weekly run catches new advisories on unchanged code.
     - cron: "27 4 * * 1"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,11 +1,15 @@
 name: OpenSSF Scorecard
 
 on:
+  # Scorecard measures repo-level posture (branch protection, signing,
+  # workflow permissions, pinned deps) that is essentially static from one
+  # commit to the next, so a per-push run adds nothing over the weekly
+  # `schedule` and the `branch_protection_rule` trigger that fires when the
+  # posture actually changes. `publish_results` still works from the weekly
+  # schedule run on the default branch, so the public badge keeps updating.
   branch_protection_rule:
   schedule:
     - cron: "13 5 * * 1"
-  push:
-    branches: [main]
 
 permissions: {}
 


### PR DESCRIPTION
## Why

Every PR — including README/docs edits and Renovate config tweaks — ran the **entire** CI suite plus a full CodeQL analysis. A docs-only change waited ~5–10 min for a green check that tested nothing relevant. This is about contributor wait time, not CI minutes.

The only required status check is `ci-ok` (the rollup in `ci.yml`), which already counts `skipped` as a pass — that's what makes per-job gating safe.

## Changes

**`ci.yml` — gate expensive jobs behind a `changes` detection job**
- New cheap `changes` job diffs the PR and emits `code` / `docker` / `workflows` / `dockerfile` booleans (git-diff based, no third-party action — consistent with how the repo already installs actionlint).
- Gated jobs: `lint`, `type-check`, `test` (×5 matrix), `coverage`, `security`, `action-smoke`, `rule-premises` → `code`; `docker-smoke` → `docker`; `actionlint` → `workflows`; `dockerfile-digests` → `dockerfile`.
- Per-**job** gating, not a workflow-level `paths:` filter — a workflow-level filter would leave the required `ci-ok` pending forever on a skipped PR.
- Always-run (cheap content gates): `version-consistency`, `changelog-gate`, `dco`, `no-ai-attribution`, `dependency-review`.
- Folds `docker-smoke`'s bespoke inline change-detection into the shared job; adds `changes` to the `ci-ok` rollup so a broken detector fails the gate rather than silently skipping the suite.
- Filters are deliberately inclusive (any src/test/dep change runs everything); `push` to main always runs the full suite.

**`codeql.yml` — scope PR/push runs to scannable changes**
- Filter to `**/*.py`, `action.yml`, `.github/workflows/**` (CodeQL's matrix covers both the `python` and `actions` languages). Weekly `schedule` still re-scans everything. Not a required check, so skips never block.

**`scorecard.yml` — drop the per-push run**
- Keep `schedule` + `branch_protection_rule`; posture is static commit-to-commit and `publish_results` still updates the badge from the weekly run.

## Effect

A docs/metadata-only PR returns a green `ci-ok` in seconds instead of waiting on the test matrix and container jobs.

## Validation

- `actionlint` v1.7.12 (the version pinned in CI) passes clean on all three files.
- This PR touches workflows, so CI's own `actionlint` job (with shellcheck) runs the full check here.