### PR TITLE
Make pip-audit informational on PRs, blocking at release

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,11 @@
     ":semanticCommitsDisabled"
   ],
   "schedule": ["before 4am on monday"],
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "description": "Open a security PR the moment an advisory lands instead of waiting for the weekly schedule. osvVulnerabilityAlerts covers the uv/pip-compile *.lock files that GitHub's native Dependabot does not parse. Security PRs are NOT given a blanket automerge here: only patch-level fixes match the existing automerge packageRule, so minor/major security bumps open as labelled PRs for manual review. This is the continuous-detection half of the pip-audit split (PR audit informational, publish audit blocking — see .github/workflows/ci.yml).",
+    "labels": ["security"]
+  },
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["before 4am on monday"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,17 @@ jobs:
       - name: Bandit (source SAST)
         run: bandit -r src/ -ll
       - name: pip-audit (dependency CVEs)
+        # INFORMATIONAL on PRs (continue-on-error) — not a merge gate.
+        # pip-audit queries a live advisory DB, so a newly disclosed CVE
+        # against an *unchanged* pinned dep flips this red with no code
+        # change, which would block every unrelated open PR at once (see
+        # the 2026-06 cryptography/msgpack incident). Detection of new
+        # advisories is handled continuously by Renovate's OSV alerts
+        # (renovate.json), and the hard gate runs at release time in
+        # publish.yml's `build` job, where the build/publish toolchain
+        # actually executes. Keep the --ignore-vuln set in sync with that
+        # publish-time step.
+        #
         # --skip-editable skips compose-lint itself (it isn't on PyPI
         # for the local install path); PyYAML and any future runtime
         # deps are still scanned.
@@ -268,6 +279,7 @@ jobs:
         # under current constraints. tuf is a transitive dev/publish
         # dependency (via sigstore) and not part of the runtime image.
         # Remove this ignore once sigstore allows tuf >= 7.
+        continue-on-error: true
         run: >-
           pip-audit --skip-editable
           --ignore-vuln PYSEC-2025-183

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,6 +102,18 @@ jobs:
         run: |
           pip install --require-hashes -r requirements-dev.lock
           pip install --no-deps -e .
+      - name: pip-audit (block release on dependency CVEs)
+        # Release-time HARD gate for the build/publish toolchain (twine,
+        # sigstore, build, cryptography, ...). On PRs the same audit is
+        # informational (see ci.yml) because the advisory DB is queried
+        # live and a CVE newly disclosed against an unchanged pinned dep
+        # must not block unrelated work. At publish those deps actually
+        # run and touch release integrity, so a known advisory must stop
+        # the release. Keep the --ignore-vuln set identical to ci.yml's.
+        run: >-
+          pip-audit --skip-editable
+          --ignore-vuln PYSEC-2025-183
+          --ignore-vuln GHSA-qp9x-wp8f-qgjj
       - run: python -m build
       - name: Verify dist contents
         run: |

--- a/docs/ASSURANCE.md
+++ b/docs/ASSURANCE.md
@@ -98,7 +98,7 @@ Common Python-level weakness classes and their mitigations:
 | Resource exhaustion (CWE-400)                        | Iterative parser traversals; ClusterFuzzLite runs as a continuous gate.     |
 | Type confusion in rule predicates                    | `mypy --strict` on every commit; rules receive plain types only (AGENTS.md). |
 | Logic bug in a rule (false negative or positive)     | Per-rule positive + negative + hardened-but-unusual fixtures; corpus snapshot regression gate; mutation testing on rule predicates via `mutmut`. |
-| Outdated dependency with known CVE                   | `pip-audit`, `dependency-review`, Renovate weekly; OpenVEX document for stripped-component CVEs (ADR-012). |
+| Outdated dependency with known CVE                   | `pip-audit` (informational on PRs, blocking at release in `publish.yml`); `dependency-review`; Renovate weekly + same-day OSV security alerts; OpenVEX document for stripped-component CVEs (ADR-012). |
 | Tampered release artifact                            | Sigstore + cosign + SLSA provenance + SBOM + post-release `verify-release-signatures` job. |
 
 ## Continuous-assurance tooling
@@ -108,11 +108,16 @@ prompting:
 
 - **CI gate (every PR + push)**: `ruff`, `ruff format --check`,
   `mypy src/`, `pytest` matrix on Python 3.10–3.14, `bandit`,
-  `pip-audit`, `actionlint`, `dependency-review`, `dockerfile-digests`
+  `actionlint`, `dependency-review`, `dockerfile-digests`
   manifest-list check, `docker-smoke` (clean fixture exits 0, insecure
   fixture exits 1, SARIF is valid JSON), `action-smoke`, DCO trailer
   check, no-AI-attribution check, version-string consistency,
-  CHANGELOG-bump gate.
+  CHANGELOG-bump gate. (`pip-audit` also runs here but is informational
+  — the blocking dependency-CVE gate is at release time; see below.)
+- **Dependency-CVE gate**: `pip-audit` is `continue-on-error` on PRs (a
+  live-advisory disclosure must not block unrelated work); Renovate OSV
+  alerts open a same-day security PR; `publish.yml` runs `pip-audit` as a
+  hard gate before any artifact is built.
 - **Static analysis**: CodeQL (security-and-quality queries) on push,
   PR, and weekly schedule; Bandit per push.
 - **Fuzzing**: ClusterFuzzLite per-PR (`cflite-pr.yml`) and weekly

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -31,7 +31,7 @@ cancels in-progress runs when you push new commits to the same PR.
 | `lint`                    | `ruff check` + `ruff format --check` on `src/` and `tests/`                               |
 | `type-check`              | `mypy src/` in strict mode                                                                |
 | `test`                    | `pytest` across the Python matrix — 3.10, 3.11, 3.12, 3.13, 3.14                          |
-| `security`                | `bandit -r src/ -ll` + `pip-audit` for CVEs in hash-pinned dev deps                       |
+| `security`                | `bandit -r src/ -ll` (blocking) + `pip-audit` for dep CVEs (informational on PRs — see note) |
 | `dependency-review`       | Blocks PRs adding deps with known high-severity CVEs or disallowed licenses               |
 | `actionlint`              | Lints every workflow under `.github/workflows/` (embeds shellcheck for `run:` blocks)     |
 | `dockerfile-digests`      | Fails if any `FROM @sha256:` in the Dockerfile is a per-arch manifest instead of an index |
@@ -43,6 +43,25 @@ cancels in-progress runs when you push new commits to the same PR.
 `version-consistency` and `changelog-gate` were added in 0.3.8 to catch
 the historically painful release-bump mistakes at review time rather
 than tag-push time.
+
+### Dependency-CVE gate (`pip-audit`)
+
+`pip-audit` queries a live advisory database, so a CVE newly disclosed
+against an *unchanged*, already-pinned dependency turns the check red with
+no code change — and because the lock is shared with `main`, that would
+block every open PR at once. To avoid blocking unrelated work on a
+time-of-disclosure accident, the gate is split three ways:
+
+- **On PRs** the `pip-audit` step is `continue-on-error` — it still runs
+  and is visible in the job log, but does not fail `ci-ok`. (`bandit` in
+  the same job stays blocking.)
+- **Continuous detection** comes from Renovate's OSV alerts
+  (`osvVulnerabilityAlerts`), which open a security PR the day an advisory
+  lands instead of waiting for the weekly schedule.
+- **At release time** the same `pip-audit` invocation is a hard gate in
+  `publish.yml`'s `build` job, where the build/publish toolchain actually
+  runs and touches release integrity. The `--ignore-vuln` set is kept
+  identical in both places.
 
 ### Dependency lockfiles
 


### PR DESCRIPTION
## Problem

`pip-audit` queries a **live** advisory database, so a CVE newly disclosed against an *unchanged*, already-pinned dependency flips the check red with no code change. Because `requirements-dev.lock` is shared with `main`, that blocks **every open PR at once** — which is exactly what happened in 2026-06 when advisories landed against `cryptography` and `msgpack` and stalled unrelated Renovate PRs (#344, #347) until the lock was bumped (#350).

## Fix — decouple disclosure timing from the PR gate, three ways

| When | Behaviour |
|---|---|
| **On PRs** (`ci.yml`) | `pip-audit` step is `continue-on-error` — still runs and is visible in the log, but no longer fails `ci-ok`. `bandit` in the same job stays blocking. |
| **Continuously** (`renovate.json`) | `osvVulnerabilityAlerts` opens a security PR the day an advisory lands instead of waiting for the weekly schedule. OSV covers the uv/pip-compile `*.lock` files that native Dependabot doesn't parse. |
| **At release** (`publish.yml`) | The same `pip-audit` invocation is a **hard gate** in the `build` job, where the build/publish toolchain actually runs and touches release integrity. |

The `--ignore-vuln` set is kept identical between `ci.yml` and `publish.yml`.

## Why not blanket-automerge security PRs

Security PRs are **not** given blanket automerge: only patch-level fixes match the existing automerge `packageRule`, so minor/major security bumps (like 46→48 cryptography) open as `security`-labelled PRs for manual review. This preserves the repo's existing "minor/major = manual" stance.

## Trade-off (intentional)

A known-vulnerable dep can now sit on a PR/`main` without blocking merges. That window is covered by (a) same-day OSV PRs and (b) the release-time hard gate — so nothing ships with a known toolchain CVE, while unrelated work is no longer hostage to a disclosure accident.

Docs (`docs/CI.md`, `docs/ASSURANCE.md`) updated to describe the split. No version bump.