### PR TITLE
Let green automergeable PRs merge any time, not just Mondays

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,7 @@
     ":semanticCommitsDisabled"
   ],
   "schedule": ["before 4am on monday"],
+  "automergeSchedule": ["at any time"],
   "osvVulnerabilityAlerts": true,
   "vulnerabilityAlerts": {
     "description": "Open a security PR the moment an advisory lands instead of waiting for the weekly schedule. osvVulnerabilityAlerts covers the uv/pip-compile *.lock files that GitHub's native Dependabot does not parse. Security PRs are NOT given a blanket automerge here: only patch-level fixes match the existing automerge packageRule, so minor/major security bumps open as labelled PRs for manual review. This is the continuous-detection half of the pip-audit split (PR audit informational, publish audit blocking — see .github/workflows/ci.yml).",


### PR DESCRIPTION
## Problem

The top-level `schedule` (`before 4am on monday`) gates **all** Renovate actions, including **automerge**. A PR that becomes green and automergeable mid-week therefore sits unmerged until the next Monday window — even routine patch/digest bumps that already passed CI. This stranded the rebased #344/#347 today: both were green for over an hour but Renovate wouldn't merge them until next Monday.

## Fix

Add `"automergeSchedule": ["at any time"]` so **automerge** runs whenever a PR is green, while **branch creation/updates** stay on the weekly cadence (`schedule` unchanged). One-line change.

This also makes the same-day OSV security PRs (from the pip-audit split, #351) actually merge same-day when the fix is patch-level, instead of waiting for the weekly window.

Config-only; no version bump.