### PR TITLE
Add ADR-017 security profile catalog schema and validation

### DIFF
--- a/docs/adr/017-security-profile-catalog.md
+++ b/docs/adr/017-security-profile-catalog.md
@@ -1,0 +1,118 @@
+# ADR-017: Security Profile Catalog
+
+**Status:** Accepted (extends [ADR-002](002-rule-grounding.md), [ADR-014](014-fix-remediation.md))
+
+**Context:** compose-lint's rules are static and image-agnostic. CL-0006 knows a
+service should drop capabilities; it cannot know that *this* image (say
+`postgres`) needs only `CHOWN, SETGID, SETUID` and nothing else. That
+image-specific minimum is not statically derivable — it is a property of what the
+container does at runtime, observable only by watching a live container.
+
+Our sibling tool [container-sec-derive](https://github.com/tmatens/container-sec-derive)
+(`csd`) derives exactly that: it observes a running container via eBPF and emits a
+minimum-security config (caps, `read_only`/tmpfs, devices, minimized `cap_add`,
+privileged decomposition). It already ships a `--format compose-lint-profile`
+formatter that emits a per-image YAML entry "for the compose-lint catalog,"
+gated behind an acceptance contract (image pinned to a digest, a committed
+workload script, ≥5-minute observation window, confidence ≥ moderate, <1% trace
+drop-rate). **That catalog never existed on this side.** The producer was written
+against a contract the consumer never defined, so the two schemas are unverified
+on both ends.
+
+This ADR defines the consumer contract: what a profile document is, where it
+lives, how it is matched to a service, and how compose-lint uses it. It is the
+foundation the loader (a follow-up PR) and the enrichment wiring (a further
+follow-up) build on. It ships the schema and its validation only — no runtime
+behavior changes yet.
+
+**Decision:**
+
+### 1. One aggregate document per image
+
+`csd` emits one *fragment* per observer run (a caps run, a separate fs run, …),
+each discriminated by `derivation.observer`. A real profile for an image is the
+**union** of those fragments across dimensions. The catalog stores that union:
+**one document per image**, with an additive per-dimension sub-block under
+`dimensions`, each carrying its own `derivation` provenance (dimensions are
+derived in separate runs with their own digest, window, and confidence).
+Merging fragments into a document is a mechanical collect-under-one-key step,
+owned by the contribution flow, not by compose-lint at lint time.
+
+The canonical schema is `src/compose_lint/profiles/schema/profile.schema.json`
+(JSON Schema 2020-12), versioned by its own `schema_version` (starts at `"1.0"`),
+independent of `csd`'s sidecar `schema_version` (recorded per-dimension under
+`derivation.sidecar_schema_version`). compose-lint owns the *catalog schema*;
+`csd` owns the *derivation bar*. The two version independently.
+
+### 2. Matching key and staleness
+
+- **`image`** — the canonical repository reference **without** tag or digest
+  (`docker.io/library/postgres`, `lscr.io/linuxserver/radarr`), registry and
+  namespace normalized. This is the match key. It is deliberately stronger than
+  `csd`'s current bare short-name key (`postgres`), which collides across
+  registries and loses the namespace; reconciling `csd`'s formatter to emit the
+  normalized ref is a required follow-up in that repo.
+- **`derivation.validated_image`** — the full `name@sha256:…` actually observed.
+  Provenance, not a match key: the exact artifact this dimension was derived from.
+- **`applies_to`** (optional) — the staleness policy. Absent ⇒ the profile is
+  **advisory across all tags** of that image (enrichment only, never used to
+  fail). Present ⇒ the tag globs / digests it is validated for.
+- **Match precedence:** exact digest (`applies_to.digests`) → tag-glob
+  (`applies_to.tags`) → repository-only (advisory). A conformance/deviation check
+  (a rule that *fails* when a service exceeds its profile) is explicitly **out of
+  scope here** and deferred to its own ADR; it needs the match/staleness model
+  proven in production first.
+
+### 3. Consumption is enrichment-first
+
+A profile **never raises its own finding** under this ADR. When an existing
+static rule already fires on a service (CL-0006/0007/0002/0011/0016) and a
+`validated` profile matches that service's image, the rule appends the derived
+minimum to its `fix` guidance (ADR-014) — e.g. "csd-derived `postgres` profile
+needs only `cap_add: [CHOWN, SETGID, SETUID]` (confidence high, digest
+`sha256:…`)". This adds precision to guidance we already emit; it changes no rule
+semantics, cannot introduce a false positive, and keeps the runtime dependency
+surface at PyYAML only. Enrichment ships **off by default** for one release
+(gated on `.compose-lint.yml: profiles.enabled`) so the rollout is controlled.
+
+### 4. Provenance is reproducibility, including the gadget transition
+
+Every dimension records how it was derived: `tool`, `tool_version`,
+`sidecar_schema_version`, `observer`, `validated_image`, `validated_date`,
+`duration_seconds`, `confidence`, `workload` (repo-relative path to the committed
+exerciser) and `workload_sha256` (so the entry is reproducible and tamper-evident),
+and `validated_via` (`csd` emits `[bpf-observation]`; compose-lint CI appends
+`ci-smoke` after its own gate — both are required for `status: validated`).
+
+`csd` is migrating some observation from built-in Inspektor Gadget gadgets to
+**csd-authored gadgets**. A profile derived with a custom gadget is only
+reproducible if the gadget's image and digest are recorded — the upstream `ig`
+version alone no longer pins the observation. `derivation.observation_backend`
+therefore carries `ig_version` plus an optional `gadgets: [{name, image, digest}]`
+list. This is designed in now so custom-gadget provenance is not a retrofit.
+
+### 5. Validated vs. exploratory
+
+`status: validated` means the dimension cleared `csd`'s acceptance contract **and**
+compose-lint's `ci-smoke` gate. `status: exploratory` mirrors `csd`'s
+`--allow-exploratory`: a below-bar draft that carries a non-empty
+`acceptance_contract_violations` list, lives under `profiles/catalog/exploratory/`,
+and is **never** used for enrichment or (future) conformance — advisory review
+material only. The schema enforces the status/violations coupling with a
+conditional.
+
+**Consequences:**
+
+- Ships in this PR: the ADR, the JSON Schema, and a pytest guard
+  (`tests/test_profile_schema.py`) that checks the schema is a valid Draft 2020-12
+  schema and validates the example fixture — matching the existing
+  `test_corpus_snapshot_schema.py` pattern (validation via pytest, no new
+  workflow, no runtime dep).
+- Follow-ups (each its own PR): the ref-normalizing loader + hatch packaging +
+  seed profiles derived from `csd`'s postgres/caddy reference workloads; the
+  enrichment wiring; the contributor docs + a `profiles/catalog/**` PR-validation
+  workflow that appends `ci-smoke`. In `csd`: reconcile the formatter to the
+  normalized `image` key, `workload_sha256`, and `observation_backend`.
+- Cross-field rules the JSON Schema cannot express (e.g. `status: validated` ⇒
+  every dimension's `confidence` ≠ `low` and `validated_via` contains both
+  sources) are enforced by the loader/CI, not the schema, and are noted there.

--- a/src/compose_lint/profiles/__init__.py
+++ b/src/compose_lint/profiles/__init__.py
@@ -1,0 +1,6 @@
+"""Security profile catalog (see docs/adr/017-security-profile-catalog.md).
+
+This package holds the canonical profile JSON Schema under ``schema/`` and, in
+follow-up PRs, the loader and the bundled catalog. No runtime behavior is wired
+to it yet: ADR-017 ships the contract (schema + validation) only.
+"""

--- a/src/compose_lint/profiles/schema/profile.schema.json
+++ b/src/compose_lint/profiles/schema/profile.schema.json
@@ -1,0 +1,240 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tmatens/compose-lint/profiles/profile.schema.json",
+  "title": "compose-lint security profile",
+  "description": "A derived, evidence-backed minimum-security profile for one container image. Produced by container-sec-derive (csd); consumed by compose-lint as fix-guidance enrichment. One document per image; dimensions are additive. See docs/adr/017-security-profile-catalog.md.",
+  "type": "object",
+  "required": ["schema_version", "image", "status", "dimensions"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "description": "Catalog profile schema version (independent of csd's sidecar schema_version, which is recorded per-dimension under derivation.sidecar_schema_version).",
+      "type": "string",
+      "const": "1.0"
+    },
+    "image": {
+      "description": "Canonical repository reference WITHOUT tag or digest -- the match key. Registry and namespace normalized (docker.io/library/postgres, lscr.io/linuxserver/radarr).",
+      "type": "string",
+      "pattern": "^[a-z0-9]+([._-][a-z0-9]+)*(/[a-z0-9]+([._-][a-z0-9]+)*)*$"
+    },
+    "applies_to": {
+      "description": "Optional staleness/matching policy. Absent => advisory across all tags (enrichment only, never conformance). Present => the tag/digest set this profile is validated for.",
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "tags": {
+          "description": "Exact tags or glob patterns, e.g. [\"16\", \"16.*\"].",
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1
+        },
+        "digests": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/digest" },
+          "minItems": 1
+        }
+      }
+    },
+    "status": {
+      "description": "validated = cleared csd's acceptance contract AND compose-lint's ci-smoke gate; exploratory = below bar, advisory draft only (lives under catalog/exploratory/, never used for enrichment or conformance).",
+      "enum": ["validated", "exploratory"]
+    },
+    "acceptance_contract_violations": {
+      "description": "Required and non-empty when status=exploratory; must be absent when status=validated. Mirrors csd's --allow-exploratory annotation.",
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 1
+    },
+    "dimensions": {
+      "description": "Per-security-dimension derived config. All optional and additive -- a caps-only profile is valid. Each maps to a compose-lint rule.",
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "properties": {
+        "capabilities": {
+          "description": "CL-0006. Minimum capability set.",
+          "type": "object",
+          "required": ["cap_drop", "cap_add", "derivation"],
+          "additionalProperties": false,
+          "properties": {
+            "cap_drop": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/capName" },
+              "default": ["ALL"]
+            },
+            "cap_add": { "type": "array", "items": { "$ref": "#/$defs/capName" } },
+            "derivation": { "$ref": "#/$defs/derivation" }
+          }
+        },
+        "filesystem": {
+          "description": "CL-0007. read_only + tmpfs.",
+          "type": "object",
+          "required": ["read_only", "derivation"],
+          "additionalProperties": false,
+          "properties": {
+            "read_only": { "type": "boolean" },
+            "tmpfs": { "type": "array", "items": { "$ref": "#/$defs/absPath" } },
+            "derivation": { "$ref": "#/$defs/derivation" }
+          }
+        },
+        "devices": {
+          "description": "CL-0002 / CL-0016. Minimum /dev grant plus any caps implied by device access.",
+          "type": "object",
+          "required": ["devices", "derivation"],
+          "additionalProperties": false,
+          "properties": {
+            "devices": { "type": "array", "items": { "$ref": "#/$defs/devPath" } },
+            "derived_caps": { "type": "array", "items": { "$ref": "#/$defs/capName" } },
+            "derivation": { "$ref": "#/$defs/derivation" }
+          }
+        },
+        "cap_add_validation": {
+          "description": "CL-0011. Minimized cap_add for an already-granted dangerous cap.",
+          "type": "object",
+          "required": ["recommended_cap_add", "derivation"],
+          "additionalProperties": false,
+          "properties": {
+            "recommended_cap_add": { "type": "array", "items": { "$ref": "#/$defs/capName" } },
+            "validated_caps": { "type": "array", "items": { "$ref": "#/$defs/capName" } },
+            "derivation": { "$ref": "#/$defs/derivation" }
+          }
+        },
+        "privileged_decomposition": {
+          "description": "CL-0002. Non-privileged equivalent of privileged: true.",
+          "type": "object",
+          "required": ["cap_add", "devices", "partial", "derivation"],
+          "additionalProperties": false,
+          "properties": {
+            "cap_add": { "type": "array", "items": { "$ref": "#/$defs/capName" } },
+            "devices": { "type": "array", "items": { "$ref": "#/$defs/devPath" } },
+            "partial": {
+              "type": "boolean",
+              "description": "true when the security_opt/AppArmor/seccomp axis was NOT observed (no denial gadget at pin). A partial decomposition must never be used to conformance-fail."
+            },
+            "security_opt_unobserved": { "type": "boolean" },
+            "derivation": { "$ref": "#/$defs/derivation" }
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "required": ["status"],
+        "properties": { "status": { "const": "exploratory" } }
+      },
+      "then": { "required": ["acceptance_contract_violations"] }
+    },
+    {
+      "if": {
+        "required": ["status"],
+        "properties": { "status": { "const": "validated" } }
+      },
+      "then": { "not": { "required": ["acceptance_contract_violations"] } }
+    }
+  ],
+  "$defs": {
+    "capName": {
+      "type": "string",
+      "pattern": "^(CAP_)?[A-Z][A-Z0-9_]*$",
+      "description": "Linux capability, with or without CAP_ prefix; the loader normalizes."
+    },
+    "absPath": { "type": "string", "pattern": "^/" },
+    "devPath": { "type": "string", "pattern": "^/dev/" },
+    "digest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+    "derivation": {
+      "description": "Per-dimension provenance. Distinct per dimension because csd derives each observer in a separate run with its own digest/confidence/window.",
+      "type": "object",
+      "required": [
+        "tool",
+        "tool_version",
+        "sidecar_schema_version",
+        "observer",
+        "validated_image",
+        "validated_date",
+        "duration_seconds",
+        "confidence",
+        "workload",
+        "workload_sha256",
+        "validated_via",
+        "observation_backend"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "tool": { "const": "container-sec-derive" },
+        "tool_version": { "type": "string", "minLength": 1 },
+        "sidecar_schema_version": {
+          "type": "string",
+          "pattern": "^1\\.",
+          "description": "csd sidecar schema (currently 1.x). Must be within the major the loader supports."
+        },
+        "observer": { "enum": ["caps", "fs", "devices", "privileged", "capadd"] },
+        "validated_image": {
+          "type": "string",
+          "pattern": "@sha256:[a-f0-9]{64}$",
+          "description": "Full name@digest actually observed -- the exact artifact this dimension was derived against."
+        },
+        "validated_date": {
+          "type": "string",
+          "format": "date",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+        },
+        "duration_seconds": {
+          "type": "integer",
+          "minimum": 300,
+          "description": "csd's 5-minute contribution floor; below this the dimension is exploratory-only."
+        },
+        "confidence": {
+          "enum": ["high", "moderate", "low"],
+          "description": "low is only permitted when the document status is exploratory (enforced by the loader/CI, not this schema)."
+        },
+        "workload": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Repo-relative path to the committed exerciser script that produced this run."
+        },
+        "workload_sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$",
+          "description": "Hash of the workload script -- makes the entry reproducible and tamper-evident."
+        },
+        "validated_via": {
+          "type": "array",
+          "items": { "enum": ["bpf-observation", "ci-smoke"] },
+          "minItems": 1,
+          "uniqueItems": true,
+          "description": "csd emits [bpf-observation]; compose-lint CI appends ci-smoke after the smoke gate. Both required for status=validated (enforced by the loader/CI)."
+        },
+        "observation_backend": {
+          "description": "How the kernel signal was captured -- forward-compat for csd's gadget transition. A profile derived with a csd-authored gadget is only reproducible if the gadget image+digest is recorded here, not just the ig version.",
+          "type": "object",
+          "required": ["ig_version"],
+          "additionalProperties": false,
+          "properties": {
+            "ig_version": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Pinned upstream Inspektor Gadget release."
+            },
+            "gadgets": {
+              "description": "csd-authored gadgets used (empty/absent for built-in-gadget-only runs).",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["name", "image", "digest"],
+                "additionalProperties": false,
+                "properties": {
+                  "name": { "type": "string", "minLength": 1 },
+                  "image": { "type": "string", "minLength": 1 },
+                  "digest": { "$ref": "#/$defs/digest" }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/profiles/postgres.example.yml
+++ b/tests/fixtures/profiles/postgres.example.yml
@@ -1,0 +1,46 @@
+# Example security profile (ADR-017). Illustrative only -- the digests and
+# workload hashes are placeholders, not a real csd derivation. Used by
+# tests/test_profile_schema.py to validate the schema against a well-formed
+# document.
+schema_version: "1.0"
+image: docker.io/library/postgres
+applies_to:
+  tags: ["16", "16.*"]
+status: validated
+dimensions:
+  capabilities:
+    cap_drop: [ALL]
+    cap_add: [CHOWN, DAC_OVERRIDE, FOWNER, SETGID, SETUID]
+    derivation:
+      tool: container-sec-derive
+      tool_version: "0.6.0"
+      sidecar_schema_version: "1.5"
+      observer: caps
+      validated_image: docker.io/library/postgres@sha256:a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4
+      validated_date: "2026-07-02"
+      duration_seconds: 600
+      confidence: high
+      workload: profiles/workloads/postgres.sh
+      workload_sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+      validated_via: [bpf-observation, ci-smoke]
+      observation_backend:
+        ig_version: v0.51.0
+        gadgets: []
+  filesystem:
+    read_only: true
+    tmpfs: [/run, /tmp, /var/run/postgresql]
+    derivation:
+      tool: container-sec-derive
+      tool_version: "0.6.0"
+      sidecar_schema_version: "1.5"
+      observer: fs
+      validated_image: docker.io/library/postgres@sha256:a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4
+      validated_date: "2026-07-02"
+      duration_seconds: 600
+      confidence: high
+      workload: profiles/workloads/postgres.sh
+      workload_sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+      validated_via: [bpf-observation, ci-smoke]
+      observation_backend:
+        ig_version: v0.51.0
+        gadgets: []

--- a/tests/test_profile_schema.py
+++ b/tests/test_profile_schema.py
@@ -1,0 +1,142 @@
+"""Schema guard for the security profile catalog (ADR-017).
+
+Mirrors tests/test_corpus_snapshot_schema.py: validation runs under the normal
+pytest CI job, no dedicated workflow and no runtime dependency. It proves the
+committed JSON Schema is itself a valid Draft 2020-12 schema, that a well-formed
+example validates, and that the load-bearing constraints (digest pinning, the
+status/violations coupling, additionalProperties closure) actually reject
+malformed documents.
+
+The catalog-file loader and per-file PR validation land in follow-up PRs; this
+test locks the contract they build on.
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib.resources
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from jsonschema import Draft202012Validator
+
+EXAMPLE_PATH = Path(__file__).parent / "fixtures" / "profiles" / "postgres.example.yml"
+
+
+def _load_schema() -> dict[str, Any]:
+    # Reach the schema the way the loader will in a later PR: as package data
+    # under compose_lint.profiles, not via a source-tree-relative path.
+    resource = (
+        importlib.resources.files("compose_lint.profiles")
+        / "schema"
+        / "profile.schema.json"
+    )
+    return json.loads(resource.read_text(encoding="utf-8"))
+
+
+def _load_example() -> dict[str, Any]:
+    return yaml.safe_load(EXAMPLE_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def schema() -> dict[str, Any]:
+    return _load_schema()
+
+
+@pytest.fixture(scope="module")
+def validator(schema: dict[str, Any]) -> Draft202012Validator:
+    return Draft202012Validator(schema)
+
+
+@pytest.fixture()
+def example() -> dict[str, Any]:
+    return _load_example()
+
+
+def test_schema_is_valid_draft202012(schema: dict[str, Any]) -> None:
+    # Raises SchemaError if the schema document is itself malformed.
+    Draft202012Validator.check_schema(schema)
+
+
+def test_schema_version_is_pinned(schema: dict[str, Any]) -> None:
+    assert schema["properties"]["schema_version"]["const"] == "1.0"
+
+
+def test_example_validates(
+    validator: Draft202012Validator, example: dict[str, Any]
+) -> None:
+    assert validator.is_valid(example), list(validator.iter_errors(example))
+
+
+def test_image_is_required(
+    validator: Draft202012Validator, example: dict[str, Any]
+) -> None:
+    del example["image"]
+    assert not validator.is_valid(example)
+
+
+def test_validated_image_must_be_digest_pinned(
+    validator: Draft202012Validator, example: dict[str, Any]
+) -> None:
+    example["dimensions"]["capabilities"]["derivation"]["validated_image"] = (
+        "docker.io/library/postgres:16"
+    )
+    assert not validator.is_valid(example)
+
+
+def test_validated_status_rejects_violations(
+    validator: Draft202012Validator, example: dict[str, Any]
+) -> None:
+    # status=validated must not carry acceptance_contract_violations.
+    example["acceptance_contract_violations"] = ["duration_seconds 120 < 300"]
+    assert not validator.is_valid(example)
+
+
+def test_exploratory_status_requires_violations(
+    validator: Draft202012Validator, example: dict[str, Any]
+) -> None:
+    example["status"] = "exploratory"
+    assert not validator.is_valid(example)
+
+    example["acceptance_contract_violations"] = ["confidence low"]
+    assert validator.is_valid(example), list(validator.iter_errors(example))
+
+
+def test_unknown_observer_rejected(
+    validator: Draft202012Validator, example: dict[str, Any]
+) -> None:
+    example["dimensions"]["capabilities"]["derivation"]["observer"] = "egress"
+    assert not validator.is_valid(example)
+
+
+def test_additional_properties_closed(
+    validator: Draft202012Validator, example: dict[str, Any]
+) -> None:
+    variant = copy.deepcopy(example)
+    variant["unexpected_top_level"] = True
+    assert not validator.is_valid(variant)
+
+    variant = copy.deepcopy(example)
+    variant["dimensions"]["capabilities"]["oops"] = True
+    assert not validator.is_valid(variant)
+
+
+def test_gadget_provenance_shape(
+    validator: Draft202012Validator, example: dict[str, Any]
+) -> None:
+    # A csd-authored gadget must record image + digest, not just a name.
+    backend = example["dimensions"]["capabilities"]["derivation"]["observation_backend"]
+    backend["gadgets"] = [{"name": "trace_socket"}]
+    assert not validator.is_valid(example)
+
+    backend["gadgets"] = [
+        {
+            "name": "trace_socket",
+            "image": "ghcr.io/tmatens/csd-gadgets/trace_socket",
+            "digest": "sha256:" + "b" * 64,
+        }
+    ]
+    assert validator.is_valid(example), list(validator.iter_errors(example))


### PR DESCRIPTION
## What

First PR of the compose-lint side of the csd → compose-lint profile pipeline. Ships the **consumer contract** for csd-derived per-image security profiles: **ADR-017**, the canonical **JSON Schema**, and a pytest guard. No runtime behavior changes.

Context: csd already emits `--format compose-lint-profile` gated behind an acceptance contract "for the compose-lint catalog" — but that catalog schema never existed here, so the two ends were unverified. This defines it.

## Design (see ADR-017)

- **One aggregate document per image.** csd emits one fragment per observer run; a real profile is their union. The catalog stores that union with additive per-dimension blocks (`capabilities`, `filesystem`, `devices`, `cap_add_validation`, `privileged_decomposition`), each carrying its own `derivation` provenance.
- **Matching:** `image` (normalized repo ref, no tag/digest) is the match key; `validated_image` (`name@sha256:…`) is provenance; `applies_to` is the optional staleness policy. Precedence: digest → tag-glob → repo-advisory.
- **Enrichment-first consumption** (later PR): a profile never raises its own finding — it enriches an existing rule's `fix` text. Conformance is a separate future ADR.
- **Gadget-transition-ready provenance:** `derivation.observation_backend` records `ig_version` **and** an optional `gadgets: [{name, image, digest}]` list, so a profile derived with a csd-authored gadget stays reproducible.
- **validated vs exploratory** mirrors csd's `--allow-exploratory`; the schema enforces the status ↔ violations coupling.

## Contents

- `docs/adr/017-security-profile-catalog.md`
- `src/compose_lint/profiles/schema/profile.schema.json` (Draft 2020-12)
- `src/compose_lint/profiles/__init__.py` (subpackage marker; no loader yet)
- `tests/test_profile_schema.py` + `tests/fixtures/profiles/postgres.example.yml`

## Validation

Follows the `test_corpus_snapshot_schema.py` pattern — validation via pytest, no new workflow, no new runtime dep (PyYAML only; `jsonschema` is already a dev dep). Local: `ruff check`/`format`, `mypy src/` (strict), full `pytest` (818 passed, 2 skipped), and `check-jsonschema --check-metaschema` all green.

## Follow-ups (each its own PR)

1. Ref-normalizing loader + hatch packaging + seed profiles (postgres/caddy from csd's reference workloads).
2. Enrichment wiring into CL-0006/0007/0002/0011/0016, gated on `.compose-lint.yml: profiles.enabled` (off by default one release).
3. Contributor docs + `profiles/catalog/**` PR-validation workflow (appends `ci-smoke`).
4. **In csd:** reconcile the formatter to the normalized `image` key, `workload_sha256`, and `observation_backend` (the one real behavior change on that side).
