### PR TITLE
Add profile catalog loader and image-ref matching

### DIFF
--- a/src/compose_lint/profiles/__init__.py
+++ b/src/compose_lint/profiles/__init__.py
@@ -1,6 +1,24 @@
 """Security profile catalog (see docs/adr/017-security-profile-catalog.md).
 
-This package holds the canonical profile JSON Schema under ``schema/`` and, in
-follow-up PRs, the loader and the bundled catalog. No runtime behavior is wired
-to it yet: ADR-017 ships the contract (schema + validation) only.
+Holds the canonical profile JSON Schema (``schema/``), the derived-profile
+catalog (``catalog/``), and the loader that matches a service image to a
+profile. Enrichment wiring into the rules is a follow-up PR; nothing here is
+called at lint time yet.
 """
+
+from __future__ import annotations
+
+from compose_lint.profiles.loader import load_catalog, load_profile, match_profile
+from compose_lint.profiles.models import MatchPrecision, ProfileMatch
+from compose_lint.profiles.refs import ImageRef, normalize_repository, parse_image_ref
+
+__all__ = [
+    "ImageRef",
+    "MatchPrecision",
+    "ProfileMatch",
+    "load_catalog",
+    "load_profile",
+    "match_profile",
+    "normalize_repository",
+    "parse_image_ref",
+]

--- a/src/compose_lint/profiles/catalog/README.md
+++ b/src/compose_lint/profiles/catalog/README.md
@@ -1,0 +1,20 @@
+# Security profile catalog
+
+One YAML document per image, conforming to
+[`../schema/profile.schema.json`](../schema/profile.schema.json) (ADR-017).
+
+Entries are **derived, not hand-authored.** A profile is produced by running
+[container-sec-derive](https://github.com/tmatens/container-sec-derive) against a
+live container (`--format compose-lint-profile`, ≥5-minute window, digest-pinned
+image) and contributed via PR through the profile-validation workflow, which
+appends `ci-smoke` to `validated_via`. See the contributor guide (forthcoming).
+
+The match key is the canonical repository reference — files may be organized in
+`registry/namespace/` subdirectories for readability, but the loader indexes each
+document by its own `image` field, not by path.
+
+Below-bar drafts (`status: exploratory`) live under `exploratory/` and are never
+used for enrichment or conformance — review material only.
+
+This directory ships empty: profiles come from real observation runs, so none are
+committed until a derivation lands.

--- a/src/compose_lint/profiles/loader.py
+++ b/src/compose_lint/profiles/loader.py
@@ -1,0 +1,112 @@
+"""Load and match security profiles from the catalog (ADR-017).
+
+The catalog is a set of YAML documents (one per image) bundled under
+``compose_lint/profiles/catalog/``. ``load_profile`` is the consumer entry
+point used by enrichment: it returns only *validated* matches, because
+exploratory profiles are review material and must never drive guidance
+(ADR-017). ``match_profile`` and ``load_catalog`` are lower-level and surface
+any status, for tooling and tests.
+
+Runtime dependency stays PyYAML only; documents are trusted to be schema-valid
+because CI validates every catalog file (see tests/test_profile_schema.py and
+the profile-validation workflow).
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import importlib.resources
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from compose_lint.profiles.models import MatchPrecision, ProfileMatch
+from compose_lint.profiles.refs import ImageRef, parse_image_ref
+
+Catalog = dict[str, dict[str, Any]]
+
+
+def _read_catalog_dir(root: Path) -> Catalog:
+    catalog: Catalog = {}
+    if not root.is_dir():
+        return catalog
+    for path in sorted(root.rglob("*.y*ml")):
+        if not path.is_file():
+            continue
+        doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if isinstance(doc, dict) and isinstance(doc.get("image"), str):
+            catalog[doc["image"]] = doc
+    return catalog
+
+
+def load_catalog(root: Path | None = None) -> Catalog:
+    """Load all catalog documents, indexed by their canonical ``image`` key.
+
+    ``root`` defaults to the bundled ``compose_lint/profiles/catalog`` directory;
+    tests pass a fixture directory.
+    """
+    if root is not None:
+        return _read_catalog_dir(root)
+    resource = importlib.resources.files("compose_lint.profiles") / "catalog"
+    with importlib.resources.as_file(resource) as path:
+        return _read_catalog_dir(path)
+
+
+def _precision(ref: ImageRef, doc: Mapping[str, Any]) -> MatchPrecision | None:
+    """Resolve match precision, or None when the profile is stale for this ref.
+
+    A profile pinned via ``applies_to`` that explicitly disagrees with the
+    service's digest or tag is treated as *stale* (no match) rather than applied
+    to an artifact it was never validated against. An unscoped profile, or a
+    service too unpinned to check, matches at advisory REPO precision.
+    """
+    applies = doc.get("applies_to")
+    if not isinstance(applies, Mapping):
+        return MatchPrecision.REPO
+
+    digests = applies.get("digests")
+    if ref.digest is not None and isinstance(digests, list) and digests:
+        return MatchPrecision.DIGEST if ref.digest in digests else None
+
+    tags = applies.get("tags")
+    if ref.tag is not None and isinstance(tags, list) and tags:
+        matched = any(fnmatch.fnmatch(ref.tag, str(pat)) for pat in tags)
+        return MatchPrecision.TAG if matched else None
+
+    return MatchPrecision.REPO
+
+
+def match_profile(image: str, catalog: Catalog) -> ProfileMatch | None:
+    """Resolve a profile for ``image`` from ``catalog``, of any status."""
+    ref = parse_image_ref(image)
+    doc = catalog.get(ref.repository)
+    if doc is None:
+        return None
+
+    precision = _precision(ref, doc)
+    if precision is None:
+        return None
+
+    dimensions = doc.get("dimensions")
+    return ProfileMatch(
+        image=ref.repository,
+        status=str(doc.get("status", "")),
+        precision=precision,
+        dimensions=dimensions if isinstance(dimensions, dict) else {},
+    )
+
+
+def load_profile(image: str) -> ProfileMatch | None:
+    """Return the *validated* catalog profile for ``image``, or None.
+
+    Exploratory profiles are intentionally not surfaced here (ADR-017); they are
+    below-bar review material and must not drive enrichment.
+    """
+    match = match_profile(image, load_catalog())
+    if match is None or not match.is_validated:
+        return None
+    return match

--- a/src/compose_lint/profiles/models.py
+++ b/src/compose_lint/profiles/models.py
@@ -1,0 +1,40 @@
+"""Dataclasses for a matched security profile (ADR-017)."""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+from typing import Any
+
+
+class MatchPrecision(enum.Enum):
+    """How specifically a profile matched the service's image.
+
+    DIGEST/TAG mean the service's pinned digest or tag was confirmed against the
+    profile's ``applies_to``. REPO is a repository-level (advisory) match: the
+    image matches but the profile carries no ``applies_to`` scope, or the
+    service is unpinned, so the profile is guidance rather than an exact fit.
+    """
+
+    DIGEST = "digest"
+    TAG = "tag"
+    REPO = "repo"
+
+
+@dataclass(frozen=True)
+class ProfileMatch:
+    """A catalog profile resolved for a specific service image."""
+
+    image: str
+    """Canonical repository match key (registry/namespace/name)."""
+
+    status: str
+    """``validated`` or ``exploratory`` (see ADR-017)."""
+
+    precision: MatchPrecision
+    dimensions: dict[str, Any]
+    """Raw per-dimension blocks (capabilities, filesystem, ...)."""
+
+    @property
+    def is_validated(self) -> bool:
+        return self.status == "validated"

--- a/src/compose_lint/profiles/refs.py
+++ b/src/compose_lint/profiles/refs.py
@@ -1,0 +1,67 @@
+"""Image-reference normalization for profile matching (ADR-017).
+
+The catalog match key is the *canonical* repository reference — registry and
+namespace expanded to their Docker defaults so that ``postgres``,
+``postgres:16``, ``docker.io/library/postgres`` and
+``docker.io/library/postgres@sha256:...`` all match the same profile. This
+mirrors containerd/Docker reference normalization; the rules layer's
+``split_image_ref`` handles only tag/digest splitting, so the registry+namespace
+expansion lives here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from compose_lint.rules._image import split_image_ref
+
+_DOCKER_IO = "docker.io"
+
+
+@dataclass(frozen=True)
+class ImageRef:
+    """A parsed image reference.
+
+    ``repository`` is the normalized match key (registry/namespace/name, no tag
+    or digest). ``tag`` and ``digest`` are as written on the service, used for
+    staleness checks against a profile's ``applies_to``.
+    """
+
+    repository: str
+    tag: str | None
+    digest: str | None
+
+
+def normalize_repository(name: str) -> str:
+    """Expand a bare image name to its canonical ``registry/namespace/name``.
+
+    Examples:
+        postgres                     -> docker.io/library/postgres
+        linuxserver/radarr           -> docker.io/linuxserver/radarr
+        lscr.io/linuxserver/radarr   -> lscr.io/linuxserver/radarr
+        ghcr.io/tmatens/foo          -> ghcr.io/tmatens/foo
+        localhost:5000/foo           -> localhost:5000/foo
+    """
+    if not name:
+        return name
+
+    first, slash, rest = name.partition("/")
+    if slash and ("." in first or ":" in first or first == "localhost"):
+        registry, path = first.lower(), rest
+    else:
+        registry, path = _DOCKER_IO, name
+
+    if registry == _DOCKER_IO and "/" not in path:
+        path = f"library/{path}"
+
+    return f"{registry}/{path}"
+
+
+def parse_image_ref(image: str) -> ImageRef:
+    """Parse a service ``image:`` string into a normalized ``ImageRef``."""
+    digest: str | None = None
+    if "@" in image:
+        digest = image.partition("@")[2] or None
+
+    name, tag = split_image_ref(image)
+    return ImageRef(repository=normalize_repository(name), tag=tag, digest=digest)

--- a/src/compose_lint/profiles/schema/profile.schema.json
+++ b/src/compose_lint/profiles/schema/profile.schema.json
@@ -183,8 +183,8 @@
         },
         "duration_seconds": {
           "type": "integer",
-          "minimum": 300,
-          "description": "csd's 5-minute contribution floor; below this the dimension is exploratory-only."
+          "minimum": 1,
+          "description": "Observation window. csd's 5-minute (>=300s) contribution floor is a validated-status gate enforced by the loader/CI, not this schema -- exploratory profiles legitimately run shorter."
         },
         "confidence": {
           "enum": ["high", "moderate", "low"],

--- a/tests/fixtures/profiles/catalog/docker.io/library/postgres.yml
+++ b/tests/fixtures/profiles/catalog/docker.io/library/postgres.yml
@@ -1,0 +1,26 @@
+# Fixture profile for loader tests. Placeholder digests/hashes -- not a real
+# csd derivation.
+schema_version: "1.0"
+image: docker.io/library/postgres
+applies_to:
+  tags: ["16", "16.*"]
+status: validated
+dimensions:
+  capabilities:
+    cap_drop: [ALL]
+    cap_add: [CHOWN, DAC_OVERRIDE, FOWNER, SETGID, SETUID]
+    derivation:
+      tool: container-sec-derive
+      tool_version: "0.6.0"
+      sidecar_schema_version: "1.5"
+      observer: caps
+      validated_image: docker.io/library/postgres@sha256:a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4
+      validated_date: "2026-07-02"
+      duration_seconds: 600
+      confidence: high
+      workload: profiles/workloads/postgres.sh
+      workload_sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+      validated_via: [bpf-observation, ci-smoke]
+      observation_backend:
+        ig_version: v0.51.0
+        gadgets: []

--- a/tests/fixtures/profiles/catalog/exploratory/docker.io/library/nginx.yml
+++ b/tests/fixtures/profiles/catalog/exploratory/docker.io/library/nginx.yml
@@ -1,0 +1,27 @@
+# Fixture exploratory profile (below the acceptance bar). Placeholder values --
+# not a real csd derivation. Exercises that load_profile() does NOT surface it.
+schema_version: "1.0"
+image: docker.io/library/nginx
+status: exploratory
+acceptance_contract_violations:
+  - "duration_seconds 120 < 300"
+  - "confidence low"
+dimensions:
+  capabilities:
+    cap_drop: [ALL]
+    cap_add: [CHOWN, SETGID, SETUID, NET_BIND_SERVICE]
+    derivation:
+      tool: container-sec-derive
+      tool_version: "0.6.0"
+      sidecar_schema_version: "1.5"
+      observer: caps
+      validated_image: docker.io/library/nginx@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+      validated_date: "2026-07-02"
+      duration_seconds: 120
+      confidence: low
+      workload: profiles/workloads/nginx.sh
+      workload_sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      validated_via: [bpf-observation]
+      observation_backend:
+        ig_version: v0.51.0
+        gadgets: []

--- a/tests/fixtures/profiles/catalog/lscr.io/linuxserver/radarr.yml
+++ b/tests/fixtures/profiles/catalog/lscr.io/linuxserver/radarr.yml
@@ -1,0 +1,27 @@
+# Fixture profile pinned to specific digests (staleness test). Placeholder
+# digests/hashes -- not a real csd derivation.
+schema_version: "1.0"
+image: lscr.io/linuxserver/radarr
+applies_to:
+  digests:
+    - sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+status: validated
+dimensions:
+  filesystem:
+    read_only: true
+    tmpfs: [/run, /tmp]
+    derivation:
+      tool: container-sec-derive
+      tool_version: "0.6.0"
+      sidecar_schema_version: "1.5"
+      observer: fs
+      validated_image: lscr.io/linuxserver/radarr@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      validated_date: "2026-07-02"
+      duration_seconds: 600
+      confidence: moderate
+      workload: profiles/workloads/radarr.sh
+      workload_sha256: fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210
+      validated_via: [bpf-observation, ci-smoke]
+      observation_backend:
+        ig_version: v0.51.0
+        gadgets: []

--- a/tests/test_profile_loader.py
+++ b/tests/test_profile_loader.py
@@ -1,0 +1,121 @@
+"""Tests for catalog loading and profile matching (ADR-017)."""
+
+from __future__ import annotations
+
+import importlib.resources
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from compose_lint.profiles import (
+    MatchPrecision,
+    load_catalog,
+    load_profile,
+    match_profile,
+)
+
+if TYPE_CHECKING:
+    from compose_lint.profiles.loader import Catalog
+
+FIXTURE_CATALOG = Path(__file__).parent / "fixtures" / "profiles" / "catalog"
+
+
+@pytest.fixture(scope="module")
+def catalog() -> Catalog:
+    return load_catalog(FIXTURE_CATALOG)
+
+
+@pytest.fixture(scope="module")
+def schema() -> dict[str, Any]:
+    resource = (
+        importlib.resources.files("compose_lint.profiles")
+        / "schema"
+        / "profile.schema.json"
+    )
+    return json.loads(resource.read_text(encoding="utf-8"))
+
+
+def test_catalog_indexed_by_image_key(catalog: Catalog) -> None:
+    assert "docker.io/library/postgres" in catalog
+    assert "lscr.io/linuxserver/radarr" in catalog
+    # Exploratory docs are loaded too (path is irrelevant; key is the image).
+    assert "docker.io/library/nginx" in catalog
+
+
+def test_every_fixture_is_schema_valid(
+    catalog: Catalog, schema: dict[str, Any]
+) -> None:
+    validator = Draft202012Validator(schema)
+    for image, doc in catalog.items():
+        errors = list(validator.iter_errors(doc))
+        assert not errors, (image, errors)
+
+
+def test_bundled_catalog_loads_without_error() -> None:
+    # Ships empty today, but the resource traversal (and packaging) must work.
+    assert isinstance(load_catalog(), dict)
+
+
+def test_match_by_repo_when_unpinned_service(catalog: Catalog) -> None:
+    # postgres profile is tag-scoped, but a bare/untagged service still gets an
+    # advisory repository-level match.
+    match = match_profile("postgres", catalog)
+    assert match is not None
+    assert match.image == "docker.io/library/postgres"
+    assert match.precision is MatchPrecision.REPO
+
+
+def test_match_by_tag_glob(catalog: Catalog) -> None:
+    match = match_profile("postgres:16.4", catalog)
+    assert match is not None
+    assert match.precision is MatchPrecision.TAG
+
+
+def test_tag_outside_scope_is_stale(catalog: Catalog) -> None:
+    # applies_to.tags = ["16", "16.*"]; a 15.x tag is out of scope -> no match.
+    assert match_profile("postgres:15", catalog) is None
+
+
+def test_match_by_digest(catalog: Catalog) -> None:
+    digest = "sha256:" + "c" * 64
+    match = match_profile(f"lscr.io/linuxserver/radarr@{digest}", catalog)
+    assert match is not None
+    assert match.precision is MatchPrecision.DIGEST
+
+
+def test_digest_outside_scope_is_stale(catalog: Catalog) -> None:
+    other = "sha256:" + "e" * 64
+    assert match_profile(f"lscr.io/linuxserver/radarr@{other}", catalog) is None
+
+
+def test_digest_pinned_profile_advisory_for_unpinned_service(catalog: Catalog) -> None:
+    # radarr is digest-scoped; a service without a digest can't be checked
+    # against it, so it falls back to an advisory repo match rather than None.
+    match = match_profile("lscr.io/linuxserver/radarr", catalog)
+    assert match is not None
+    assert match.precision is MatchPrecision.REPO
+
+
+def test_unknown_image_returns_none(catalog: Catalog) -> None:
+    assert match_profile("docker.io/library/redis", catalog) is None
+
+
+def test_dimensions_surfaced(catalog: Catalog) -> None:
+    match = match_profile("postgres:16", catalog)
+    assert match is not None
+    assert "CHOWN" in match.dimensions["capabilities"]["cap_add"]
+
+
+def test_load_profile_returns_validated_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "compose_lint.profiles.loader.load_catalog",
+        lambda: load_catalog(FIXTURE_CATALOG),
+    )
+    # validated postgres resolves...
+    assert load_profile("postgres:16") is not None
+    # ...but the exploratory nginx profile is never surfaced for enrichment.
+    assert match_profile("nginx", load_catalog(FIXTURE_CATALOG)) is not None
+    assert load_profile("nginx") is None

--- a/tests/test_profile_refs.py
+++ b/tests/test_profile_refs.py
@@ -1,0 +1,53 @@
+"""Tests for image-reference normalization used in profile matching (ADR-017)."""
+
+from __future__ import annotations
+
+import pytest
+
+from compose_lint.profiles.refs import normalize_repository, parse_image_ref
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("postgres", "docker.io/library/postgres"),
+        ("nginx", "docker.io/library/nginx"),
+        ("linuxserver/radarr", "docker.io/linuxserver/radarr"),
+        ("docker.io/library/postgres", "docker.io/library/postgres"),
+        ("docker.io/postgres", "docker.io/library/postgres"),
+        ("lscr.io/linuxserver/radarr", "lscr.io/linuxserver/radarr"),
+        ("ghcr.io/tmatens/foo", "ghcr.io/tmatens/foo"),
+        ("localhost:5000/foo", "localhost:5000/foo"),
+        ("registry.example.com:5000/team/app", "registry.example.com:5000/team/app"),
+        ("", ""),
+    ],
+)
+def test_normalize_repository(name: str, expected: str) -> None:
+    assert normalize_repository(name) == expected
+
+
+def test_registry_host_is_lowercased() -> None:
+    assert normalize_repository("GHCR.io/Tmatens/Foo") == "ghcr.io/Tmatens/Foo"
+
+
+def test_parse_strips_tag_and_digest_to_match_key() -> None:
+    ref = parse_image_ref("postgres:16")
+    assert ref.repository == "docker.io/library/postgres"
+    assert ref.tag == "16"
+    assert ref.digest is None
+
+
+def test_parse_captures_digest() -> None:
+    digest = "sha256:" + "a" * 64
+    ref = parse_image_ref(f"postgres:16@{digest}")
+    assert ref.repository == "docker.io/library/postgres"
+    assert ref.tag == "16"
+    assert ref.digest == digest
+
+
+def test_parse_digest_only() -> None:
+    digest = "sha256:" + "b" * 64
+    ref = parse_image_ref(f"lscr.io/linuxserver/radarr@{digest}")
+    assert ref.repository == "lscr.io/linuxserver/radarr"
+    assert ref.tag is None
+    assert ref.digest == digest


### PR DESCRIPTION
## What

PR 2 of the csd → compose-lint profile pipeline (follows #353). Ships the **catalog loader + image-ref matching + packaging**, fully exercised against fixtures. No rule wiring yet — enrichment is the next PR.

## Contents

- `profiles/refs.py` — `normalize_repository` / `parse_image_ref`. Expands a service image to its canonical `registry/namespace/name` match key (`postgres` → `docker.io/library/postgres`), reusing the rules layer's `split_image_ref` for tag/digest splitting.
- `profiles/models.py` — `ProfileMatch` + `MatchPrecision` (digest / tag / repo-advisory).
- `profiles/loader.py` — `load_catalog` (indexes bundled YAML by each doc's `image` field, PyYAML only), `match_profile` (any status), `load_profile` (**validated-only** — exploratory profiles are never surfaced for enrichment, per ADR-017).
- `profiles/catalog/README.md` — the catalog ships **empty**; entries are derived from live csd runs, not hand-authored (see below).
- Tests: `test_profile_refs.py`, `test_profile_loader.py` (matching, staleness, precision, validated-only, and a guard that every fixture is schema-valid).

## Matching + staleness

- Precedence: **digest → tag-glob → repo-advisory**.
- An `applies_to`-pinned profile that **disagrees** with the service's digest or tag is treated as **stale** (no match), not applied to an artifact it was never validated against.
- An unscoped profile, or a service too unpinned to check, matches at advisory **repo** precision (safe — enrichment never fails, only guides).

## Schema tweak

Relaxes `derivation.duration_seconds` floor (was `minimum: 300`). The ≥300s window is a **validated-status contribution gate** enforced by the loader/CI, not a universal invariant — exploratory profiles legitimately run shorter. Consistent with the other cross-field rules ADR-017 already places in the loader/CI.

## Packaging

Verified the built wheel ships `profiles/schema/*.json` and `profiles/catalog/**`; no `pyproject` change needed (files under the package are included by hatchling).

## Note on seeding

Genuinely **validated** seed profiles require running csd against live containers (≥5 min, digest-pinned, real eBPF) — a host task, not something honestly fabricated here. So the bundled catalog is empty; `load_profile` returns `None` until real derivations land via the contribution workflow (PR 4).

## Local checks

`ruff check` / `format --check`, `mypy src/` (strict), full `pytest` (844 passed, 2 skipped), wheel-content verified.

## Follow-ups

3. Enrichment wiring into CL-0006/0007/0002/0011/0016, gated `.compose-lint.yml: profiles.enabled` (off by default one release).
4. Contributor docs + `profiles/catalog/**` PR-validation workflow (appends `ci-smoke`).
5. In csd: reconcile the formatter to the normalized `image` key + `workload_sha256` + `observation_backend`.
