### PR TITLE
Wire opt-in profile enrichment into findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Opt-in profile enrichment (ADR-017). When `profiles.enabled: true` is set in
+  `.compose-lint.yml`, findings from CL-0006/0007/0002/0011/0016 gain
+  image-specific fix guidance from a matching container-sec-derive (csd) profile
+  — e.g. the observed minimum `cap_add` for that image. Enrichment is advisory
+  and additive only: it never creates, drops, or reclassifies a finding. Off by
+  default; the bundled profile catalog ships empty until derived profiles land.
+
 ## [0.12.2] - 2026-06-13
 
 ### Security

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,12 +81,34 @@ Excluded services still produce **SUPPRESSED** findings, with the per-service re
 - **Global `enabled: false` wins** over per-service exclusions: if a rule is disabled globally, every service is suppressed regardless of `exclude_services`.
 - **No inline suppression syntax** — there is no `# compose-lint: disable` comment form. Suppressions are tracked in config so reviewers can audit them.
 
+## Profile enrichment
+
+Opt into image-specific fix guidance derived by
+[container-sec-derive](https://github.com/tmatens/container-sec-derive) (csd).
+When enabled, a finding from a rule that a derived profile covers
+(CL-0002/0006/0007/0011/0016) gains a `csd profile:` line in its fix text stating
+the observed minimum for that image — for example, the exact `cap_add` a service
+actually needs.
+
+```yaml
+profiles:
+  enabled: true   # default: false
+```
+
+Enrichment is **advisory and additive only**: it never creates, drops, or
+reclassifies a finding, so turning it on cannot change your pass/fail result — it
+only makes existing guidance more specific. It matches a service's `image:` to a
+profile in the bundled catalog; the catalog ships empty until derived profiles
+land, so with no matching profile the option is a no-op. See
+[ADR-017](adr/017-security-profile-catalog.md) for the profile model.
+
 ## Validation
 
 A `.compose-lint.yml` that silently fails to take effect is a security risk — the user believes a rule is suppressed or re-tuned when it is not. compose-lint validates the file on load:
 
 - **Unknown rule IDs warn.** `rules:` keys are checked against the registered rule set. A typo (`CL-001`) or a retired ID (`CL-9999`) prints a stderr warning so the override isn't silently dropped.
-- **Unknown top-level keys warn.** Only `rules` is recognized at the top level. A misplaced CLI flag (e.g. a top-level `fail_on:`) or any other key warns instead of being ignored.
+- **Unknown top-level keys warn.** Only `rules` and `profiles` are recognized at the top level. A misplaced CLI flag (e.g. a top-level `fail_on:`) or any other key warns instead of being ignored.
+- **Unknown `profiles` keys warn, and `profiles.enabled` must be a real boolean.** Only `enabled` is recognized in the `profiles` block; a non-boolean `enabled` is a hard error (exit 2), like the per-rule `enabled`.
 - **Unknown per-rule keys warn.** Inside a rule block, only `enabled`, `reason`, `severity`, and `exclude_services` are recognized. A typo'd `severty:` warns.
 - **`enabled` must be a real boolean.** A quoted `'false'`, `0`, or any non-boolean is a **hard error** (exit 2), not a silent no-op that would leave the rule on. YAML's boolean keywords (`true`/`false`, `yes`/`no`, `on`/`off`) all parse to a real boolean and work as expected.
 

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import NoReturn
 
 from compose_lint import __version__
-from compose_lint.config import ConfigError, load_config
+from compose_lint.config import ConfigError, load_config, load_profiles_enabled
 from compose_lint.config_emit import render_config
 from compose_lint.engine import filter_findings, run_rules
 from compose_lint.explain import UnknownRuleError, load_rule_doc
@@ -37,6 +37,7 @@ from compose_lint.formatters.text import (
 from compose_lint.formatters.text import format_findings as format_text
 from compose_lint.models import Finding, Severity
 from compose_lint.parser import ComposeError, ComposeNotApplicableError, load_compose
+from compose_lint.profiles.loader import load_profile
 
 
 def _severity_type(value: str) -> Severity:
@@ -331,9 +332,12 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
 
     try:
         disabled_rules, severity_overrides, excluded_services = load_config(args.config)
+        profiles_enabled = load_profiles_enabled(args.config)
     except ConfigError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(2)
+
+    profile_lookup = load_profile if profiles_enabled else None
 
     if not args.files:
         args.files = _discover_compose_files()
@@ -408,6 +412,7 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
             severity_overrides=severity_overrides,
             excluded_services=excluded_services,
             on_error=_record_rule_error,
+            profile_lookup=profile_lookup,
         )
 
         if args.skip_suppressed:

--- a/src/compose_lint/config.py
+++ b/src/compose_lint/config.py
@@ -10,10 +10,13 @@ import yaml
 
 from compose_lint.models import Severity
 
-# The only top-level key the config schema defines today (docs/configuration.md).
+# Top-level keys the config schema defines today (docs/configuration.md).
 # Anything else is almost certainly a typo or a misplaced CLI flag (e.g. a
 # top-level `fail_on:`), so we warn rather than silently drop it (issue #279 G1).
-_KNOWN_TOP_LEVEL_KEYS = frozenset({"rules"})
+_KNOWN_TOP_LEVEL_KEYS = frozenset({"rules", "profiles"})
+
+# Recognized keys inside the `profiles` block (ADR-017).
+_KNOWN_PROFILES_KEYS = frozenset({"enabled"})
 
 # Recognized keys inside a per-rule block. A key outside this set (a typo'd
 # `severty:` or a `reason:` with no `enabled: false`) is silently inert today;
@@ -68,11 +71,27 @@ def load_config(
     If path is None, looks for .compose-lint.yml in the current directory.
     If no config file is found, returns empty defaults.
     """
-    empty: tuple[dict[str, str | None], dict[str, Severity], ExcludedServices] = (
-        {},
-        {},
-        {},
-    )
+    data = _read_raw_config(path)
+    if data is None:
+        return {}, {}, {}
+
+    for key in data:
+        if str(key) not in _KNOWN_TOP_LEVEL_KEYS:
+            _warn(
+                f"config: unknown top-level key '{key}' (recognized: "
+                f"{', '.join(sorted(_KNOWN_TOP_LEVEL_KEYS))}); it has no effect"
+            )
+
+    return _parse_rules(data.get("rules", {}))
+
+
+def _read_raw_config(path: str | Path | None) -> dict[str, Any] | None:
+    """Read and parse a config file to a mapping, or None when there is none.
+
+    Returns None when no config file is found (implicit path) or the file is
+    empty. Raises ConfigError for an explicitly-named missing file, a read
+    error, invalid YAML, or a non-mapping top level.
+    """
     if path is not None:
         config_path = Path(path)
         if not config_path.exists():
@@ -80,7 +99,7 @@ def load_config(
     else:
         config_path = Path(".compose-lint.yml")
         if not config_path.exists():
-            return empty
+            return None
 
     try:
         content = config_path.read_text(encoding="utf-8")
@@ -93,19 +112,42 @@ def load_config(
         raise ConfigError(f"Invalid YAML in config file: {e}") from e
 
     if data is None:
-        return empty
+        return None
 
     if not isinstance(data, dict):
         raise ConfigError("Config file must be a YAML mapping")
 
-    for key in data:
-        if str(key) not in _KNOWN_TOP_LEVEL_KEYS:
+    return data
+
+
+def load_profiles_enabled(path: str | Path | None = None) -> bool:
+    """Return whether profile enrichment is opted in (``profiles.enabled``).
+
+    Off by default (ADR-017). Reads the same file as ``load_config``; the
+    top-level key-validation warning is emitted there, so this only validates
+    the ``profiles`` block itself.
+    """
+    data = _read_raw_config(path)
+    if data is None:
+        return False
+
+    profiles = data.get("profiles", {})
+    if not isinstance(profiles, dict):
+        raise ConfigError("'profiles' must be a mapping")
+
+    for key in profiles:
+        if str(key) not in _KNOWN_PROFILES_KEYS:
             _warn(
-                f"config: unknown top-level key '{key}' (recognized: "
-                f"{', '.join(sorted(_KNOWN_TOP_LEVEL_KEYS))}); it has no effect"
+                f"config: profiles has unknown key '{key}' (recognized: "
+                f"{', '.join(sorted(_KNOWN_PROFILES_KEYS))}); it has no effect"
             )
 
-    return _parse_rules(data.get("rules", {}))
+    enabled = profiles.get("enabled", False)
+    if not isinstance(enabled, bool):
+        raise ConfigError(
+            f"Config: profiles.enabled must be true or false, not {enabled!r}"
+        )
+    return enabled
 
 
 def _parse_rules(

--- a/src/compose_lint/engine.py
+++ b/src/compose_lint/engine.py
@@ -7,10 +7,13 @@ from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
 from compose_lint.models import Finding, Severity
+from compose_lint.profiles.enrich import enrich_fix
 from compose_lint.rules import get_registered_rules
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from compose_lint.profiles.models import ProfileMatch
 
 
 def _default_rule_error(rule_id: str, service_name: str, exc: Exception) -> None:
@@ -29,6 +32,7 @@ def run_rules(
     severity_overrides: dict[str, Severity] | None = None,
     excluded_services: dict[str, dict[str, str | None]] | None = None,
     on_error: Callable[[str, str, Exception], None] | None = None,
+    profile_lookup: Callable[[str], ProfileMatch | None] | None = None,
 ) -> list[Finding]:
     """Run all registered rules against the parsed Compose data.
 
@@ -43,6 +47,11 @@ def run_rules(
     CLI maps such a failure to exit 2 ("compose-lint itself couldn't run",
     ADR-006) so a directory sweep is never silently truncated and a crash is
     never mistaken for a clean lint failure.
+
+    When ``profile_lookup`` is supplied, each service's image is resolved to a
+    validated csd-derived profile (ADR-017) and matching findings get
+    image-specific guidance appended to their ``fix`` text. This is purely
+    additive — the set and classification of findings is unchanged.
     """
     disabled = disabled_rules or {}
     overrides = severity_overrides or {}
@@ -54,6 +63,21 @@ def run_rules(
     rules = [cls() for cls in rule_classes]
 
     services = data.get("services", {})
+
+    # Resolve each service's derived profile once (ADR-017). Enrichment only
+    # appends image-specific guidance to a finding's fix text; it never changes
+    # which findings are produced. Off unless profile_lookup is supplied.
+    service_matches: dict[str, ProfileMatch | None] = {}
+    if profile_lookup is not None:
+        for service_name, service_config in services.items():
+            image = (
+                service_config.get("image")
+                if isinstance(service_config, dict)
+                else None
+            )
+            service_matches[service_name] = (
+                profile_lookup(image) if isinstance(image, str) and image else None
+            )
 
     for rule in rules:
         rule_id = rule.metadata.id
@@ -88,6 +112,9 @@ def run_rules(
                         suppressed=True,
                         suppression_reason=reason or default,
                     )
+                match = service_matches.get(service_name)
+                if match is not None:
+                    finding = enrich_fix(finding, match)
                 findings.append(finding)
 
     findings.sort(key=lambda f: (f.line is None, f.line or 0))

--- a/src/compose_lint/profiles/enrich.py
+++ b/src/compose_lint/profiles/enrich.py
@@ -1,0 +1,110 @@
+"""Enrich rule findings with csd-derived profile guidance (ADR-017).
+
+Enrichment is *advisory only*: it never creates, drops, or reclassifies a
+finding — it appends the observed minimum for the matched image to an existing
+finding's ``fix`` text so the guidance is image-specific instead of generic.
+The rules stay untouched; the engine calls ``enrich_fix`` after a rule fires.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from compose_lint.models import Finding
+    from compose_lint.profiles.models import ProfileMatch
+
+# Which profile dimension backs each rule's guidance.
+DIMENSION_BY_RULE: dict[str, str] = {
+    "CL-0006": "capabilities",
+    "CL-0007": "filesystem",
+    "CL-0002": "privileged_decomposition",
+    "CL-0011": "cap_add_validation",
+    "CL-0016": "devices",
+}
+
+
+def enrich_fix(finding: Finding, match: ProfileMatch) -> Finding:
+    """Return ``finding`` with derived guidance appended to ``fix``.
+
+    Unchanged when the rule has no backing dimension, the profile lacks that
+    dimension, or the dimension yields nothing actionable.
+    """
+    dim_key = DIMENSION_BY_RULE.get(finding.rule_id)
+    if dim_key is None:
+        return finding
+    dimension = match.dimensions.get(dim_key)
+    if not isinstance(dimension, dict):
+        return finding
+
+    guidance = _guidance(finding.rule_id, dimension)
+    if guidance is None:
+        return finding
+
+    note = f"csd profile: {guidance} {_provenance(dimension, match)}"
+    new_fix = f"{finding.fix}\n{note}" if finding.fix else note
+    return replace(finding, fix=new_fix)
+
+
+def _flow(items: list[Any]) -> str:
+    return "[" + ", ".join(str(i) for i in items) + "]"
+
+
+def _guidance(rule_id: str, dim: dict[str, Any]) -> str | None:
+    if rule_id == "CL-0006":
+        cap_add = dim.get("cap_add") or []
+        if not cap_add:
+            return "observed no added capabilities — cap_drop: [ALL]"
+        return f"observed minimum is cap_drop: [ALL] + cap_add: {_flow(cap_add)}"
+
+    if rule_id == "CL-0007":
+        if not dim.get("read_only"):
+            return None
+        tmpfs = dim.get("tmpfs") or []
+        if tmpfs:
+            return f"observed read_only: true with tmpfs: {_flow(tmpfs)}"
+        return "observed read_only: true (no writable paths needed)"
+
+    if rule_id == "CL-0002":
+        cap_add = dim.get("cap_add") or []
+        devices = dim.get("devices") or []
+        base = (
+            "observed non-privileged equivalent: "
+            f"cap_add: {_flow(cap_add)} + devices: {_flow(devices)}"
+        )
+        if dim.get("partial"):
+            base += " (partial: security_opt/AppArmor/seccomp not observed)"
+        return base
+
+    if rule_id == "CL-0011":
+        recommended = dim.get("recommended_cap_add") or []
+        return f"observed minimized cap_add: {_flow(recommended)}"
+
+    if rule_id == "CL-0016":
+        devices = dim.get("devices") or []
+        if not devices:
+            return None
+        text = f"observed device access: {_flow(devices)}"
+        derived = dim.get("derived_caps") or []
+        if derived:
+            text += f" (implies cap_add: {_flow(derived)})"
+        return text
+
+    return None
+
+
+def _provenance(dim: dict[str, Any], match: ProfileMatch) -> str:
+    derivation = dim.get("derivation")
+    derivation = derivation if isinstance(derivation, dict) else {}
+    confidence = derivation.get("confidence", "unknown")
+    image = _short_image(str(derivation.get("validated_image") or match.image))
+    return f"[confidence {confidence}, from {image}, {match.precision.value} match]"
+
+
+def _short_image(image: str) -> str:
+    """Shorten a name@sha256:<64hex> reference for a one-line note."""
+    name, sep, digest = image.partition("@sha256:")
+    if sep and len(digest) > 12:
+        return f"{name}@sha256:{digest[:12]}"
+    return image

--- a/tests/test_config_profiles.py
+++ b/tests/test_config_profiles.py
@@ -1,0 +1,65 @@
+"""Tests for the profiles config block (ADR-017)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from compose_lint.config import ConfigError, load_config, load_profiles_enabled
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write(tmp_path: Path, body: str) -> str:
+    cfg = tmp_path / ".compose-lint.yml"
+    cfg.write_text(body, encoding="utf-8")
+    return str(cfg)
+
+
+def test_disabled_by_default(tmp_path: Path) -> None:
+    assert load_profiles_enabled(_write(tmp_path, "rules: {}\n")) is False
+
+
+def test_enabled_true(tmp_path: Path) -> None:
+    cfg = _write(tmp_path, "profiles:\n  enabled: true\n")
+    assert load_profiles_enabled(cfg) is True
+
+
+def test_enabled_false(tmp_path: Path) -> None:
+    cfg = _write(tmp_path, "profiles:\n  enabled: false\n")
+    assert load_profiles_enabled(cfg) is False
+
+
+def test_missing_explicit_file_raises() -> None:
+    with pytest.raises(ConfigError):
+        load_profiles_enabled("/nonexistent/.compose-lint.yml")
+
+
+def test_non_bool_enabled_raises(tmp_path: Path) -> None:
+    cfg = _write(tmp_path, "profiles:\n  enabled: 'yes'\n")
+    with pytest.raises(ConfigError):
+        load_profiles_enabled(cfg)
+
+
+def test_profiles_not_a_mapping_raises(tmp_path: Path) -> None:
+    cfg = _write(tmp_path, "profiles: true\n")
+    with pytest.raises(ConfigError):
+        load_profiles_enabled(cfg)
+
+
+def test_unknown_profiles_key_warns(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    cfg = _write(tmp_path, "profiles:\n  enabled: true\n  bogus: 1\n")
+    load_profiles_enabled(cfg)
+    assert "unknown key 'bogus'" in capsys.readouterr().err
+
+
+def test_profiles_key_not_flagged_as_unknown_top_level(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    cfg = _write(tmp_path, "profiles:\n  enabled: true\n")
+    load_config(cfg)
+    assert "unknown top-level key" not in capsys.readouterr().err

--- a/tests/test_profile_enrich.py
+++ b/tests/test_profile_enrich.py
@@ -1,0 +1,97 @@
+"""Tests for profile-based fix enrichment (ADR-017)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from compose_lint.engine import run_rules
+from compose_lint.models import Finding, Severity
+from compose_lint.profiles import load_catalog, match_profile
+from compose_lint.profiles.enrich import enrich_fix
+
+FIXTURE_CATALOG = Path(__file__).parent / "fixtures" / "profiles" / "catalog"
+
+
+def _match(image: str):  # type: ignore[no-untyped-def]
+    return match_profile(image, load_catalog(FIXTURE_CATALOG))
+
+
+def _finding(rule_id: str, fix: str | None = None) -> Finding:
+    return Finding(
+        rule_id=rule_id,
+        severity=Severity.MEDIUM,
+        service="db",
+        message="finding",
+        fix=fix,
+    )
+
+
+def test_cl0006_appends_capability_guidance() -> None:
+    match = _match("postgres:16")
+    assert match is not None
+    result = enrich_fix(_finding("CL-0006"), match)
+    assert result.fix is not None
+    assert "csd profile:" in result.fix
+    assert "cap_add: [CHOWN" in result.fix
+
+
+def test_cl0007_appends_filesystem_guidance() -> None:
+    digest = "sha256:" + "c" * 64
+    match = match_profile(
+        f"lscr.io/linuxserver/radarr@{digest}", load_catalog(FIXTURE_CATALOG)
+    )
+    assert match is not None
+    result = enrich_fix(_finding("CL-0007"), match)
+    assert result.fix is not None
+    assert "read_only: true" in result.fix
+
+
+def test_unmapped_rule_is_untouched() -> None:
+    match = _match("postgres:16")
+    assert match is not None
+    original = _finding("CL-0004", fix="pin the image")
+    assert enrich_fix(original, match) is original
+
+
+def test_missing_dimension_is_untouched() -> None:
+    # The postgres fixture has no `devices` dimension (CL-0016's backing).
+    match = _match("postgres:16")
+    assert match is not None
+    original = _finding("CL-0016", fix="review devices")
+    assert enrich_fix(original, match) is original
+
+
+def test_existing_fix_is_preserved_and_appended() -> None:
+    match = _match("postgres:16")
+    assert match is not None
+    result = enrich_fix(_finding("CL-0006", fix="drop capabilities"), match)
+    assert result.fix is not None
+    assert result.fix.startswith("drop capabilities\n")
+    assert "csd profile:" in result.fix
+
+
+def test_provenance_notes_confidence_and_precision() -> None:
+    match = _match("postgres:16")  # tag-scoped profile -> TAG precision
+    assert match is not None
+    result = enrich_fix(_finding("CL-0006"), match)
+    assert result.fix is not None
+    assert "confidence high" in result.fix
+    assert "tag match" in result.fix
+    # digest is shortened, not the full 64 hex
+    assert "a" * 64 not in result.fix
+
+
+def test_engine_enriches_when_lookup_supplied() -> None:
+    data = {"services": {"db": {"image": "postgres:16"}}}
+    findings = run_rules(data, {}, profile_lookup=_match)
+    cl0006 = [f for f in findings if f.rule_id == "CL-0006"]
+    assert cl0006
+    assert "csd profile:" in (cl0006[0].fix or "")
+
+
+def test_engine_leaves_fix_untouched_without_lookup() -> None:
+    data = {"services": {"db": {"image": "postgres:16"}}}
+    findings = run_rules(data, {})
+    cl0006 = [f for f in findings if f.rule_id == "CL-0006"]
+    assert cl0006
+    assert "csd profile:" not in (cl0006[0].fix or "")


### PR DESCRIPTION
## What

PR 3 of the csd → compose-lint profile pipeline (follows #353, #354). Wires **opt-in profile enrichment** — the first user-visible behavior. When a derived profile matches a service, findings gain image-specific fix guidance.

## Behavior

- New config gate `profiles.enabled` (**off by default**, ADR-017):
  ```yaml
  profiles:
    enabled: true
  ```
- When on, findings from **CL-0006 / CL-0007 / CL-0002 / CL-0011 / CL-0016** get a `csd profile:` line appended to their `fix` text stating the observed minimum for that image, e.g. `observed minimum is cap_drop: [ALL] + cap_add: [CHOWN, SETGID, SETUID]`, with a provenance note `[confidence high, from postgres@sha256:aaaa…, tag match]`.
- **Additive only** — enrichment never creates, drops, or reclassifies a finding, so enabling it cannot change pass/fail. Verified by an engine test.

## Design / seam

- `run_rules` gains an optional `profile_lookup: Callable[[str], ProfileMatch | None]`. Each service's image is resolved once; matching findings are enriched. Rules are untouched (the ADR's "never changes rule semantics" guarantee is structural).
- Wired into the **`check`** command only — `fix`/`suppress` operate on `TextEdit`s, not the `fix` string, so enrichment is irrelevant there.
- `profiles/enrich.py` maps rule → dimension and builds the guidance; `_short_image` trims the digest for a one-line note.
- Config: extracted a shared `_read_raw_config`; added `load_profiles_enabled`. `load_config`'s 3-tuple contract is unchanged (17 call sites untouched). `profiles` is now a recognized top-level key; `profiles.enabled` must be a real boolean (hard error otherwise, like per-rule `enabled`).

## Tests / docs

- `test_profile_enrich.py` (per-rule guidance, unmapped/missing-dimension no-op, existing-fix preserved, provenance, engine on/off), `test_config_profiles.py` (default off, true/false, non-bool error, non-mapping error, unknown-key warn, `profiles` not flagged by `load_config`).
- `docs/configuration.md` + `CHANGELOG.md [Unreleased]`.
- Local: `ruff`, `ruff format`, `mypy src/` strict, full `pytest` (860 passed, 2 skipped), CLI smoke (enabled = clean no-op with the empty catalog; invalid value = exit 2).

## Follow-ups

4. Contributor docs + `profiles/catalog/**` PR-validation workflow (appends `ci-smoke`) — also what unblocks real seeding.
5. In csd: reconcile the formatter to the normalized `image` key + `workload_sha256` + `observation_backend`.

Real profiles still require live csd runs on a host (BPF/root/docker) — not fabricated here — so the catalog stays empty until those land through the PR 4 workflow.
