### PR TITLE
Add profile contribution ci-smoke gate and guide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
       docker: ${{ steps.filter.outputs.docker }}
       workflows: ${{ steps.filter.outputs.workflows }}
       dockerfile: ${{ steps.filter.outputs.dockerfile }}
+      profiles: ${{ steps.filter.outputs.profiles }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -57,6 +58,7 @@ jobs:
               echo "docker=true"
               echo "workflows=true"
               echo "dockerfile=true"
+              echo "profiles=true"
             } >> "$GITHUB_OUTPUT"
             echo "push event — running all job groups."
             exit 0
@@ -65,7 +67,7 @@ jobs:
           echo "Changed files:"
           echo "${changed}"
           match() { echo "${changed}" | grep -qE "$1"; }
-          code=false; docker=false; workflows=false; dockerfile=false
+          code=false; docker=false; workflows=false; dockerfile=false; profiles=false
           # Python sources, tests, helper scripts, the package manifest,
           # hash-pinned lockfiles, and the action contract all warrant the
           # full lint/type/test/coverage/security/smoke suite.
@@ -81,11 +83,16 @@ jobs:
           if match '^Dockerfile$'; then
             dockerfile=true
           fi
+          # The profile catalog, its schema/loader, and the validator gate.
+          if match '^(src/compose_lint/profiles/|profiles/|scripts/validate_profiles\.py$)'; then
+            profiles=true
+          fi
           {
             echo "code=${code}"
             echo "docker=${docker}"
             echo "workflows=${workflows}"
             echo "dockerfile=${dockerfile}"
+            echo "profiles=${profiles}"
           } >> "$GITHUB_OUTPUT"
 
   lint:
@@ -636,6 +643,31 @@ jobs:
       - name: Validate each runtime rule's premise against a live container
         run: python scripts/validate_rule_premises.py
 
+  profile-validate:
+    name: Validate security profiles (ci-smoke gate)
+    needs: changes
+    if: needs.changes.outputs.profiles == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: |
+            requirements.lock
+            requirements-dev.lock
+            requirements-build.lock
+      - name: Install pinned dev env
+        run: pip install --require-hashes -r requirements-dev.lock
+      - name: Validate every catalog profile (schema + provenance + workload)
+        run: python scripts/validate_profiles.py
+
   # Single rollup job for branch protection. Required-status-checks should
   # point at this job name instead of the individual ci.yml job names, so
   # adding/renaming/removing jobs doesn't require a protection-rule edit.
@@ -664,6 +696,7 @@ jobs:
       - docker-smoke
       - action-smoke
       - rule-premises
+      - profile-validate
     if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   — e.g. the observed minimum `cap_add` for that image. Enrichment is advisory
   and additive only: it never creates, drops, or reclassifies a finding. Off by
   default; the bundled profile catalog ships empty until derived profiles land.
+- Profile contribution path (ADR-017): `scripts/validate_profiles.py` (the
+  ci-smoke gate — schema, validated/exploratory invariants, and workload-hash
+  verification), a `profile-validate` CI job that runs it on catalog changes, and
+  a contributor guide (`docs/profiles.md`).
 
 ## [0.12.2] - 2026-06-13
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -1,0 +1,96 @@
+# Contributing a security profile
+
+compose-lint can enrich its fix guidance with **derived security profiles**: the
+observed minimum capabilities, filesystem, devices, and privilege a specific
+image actually needs. Profiles are produced by
+[container-sec-derive](https://github.com/tmatens/container-sec-derive) (`csd`),
+which watches a live container via eBPF, and contributed here as YAML. See
+[ADR-017](adr/017-security-profile-catalog.md) for the model and
+[configuration.md](configuration.md#profile-enrichment) for how users opt in.
+
+Profiles are **derived, never hand-authored.** A guessed cap list is exactly the
+mistake compose-lint exists to catch; the value of a profile is that its numbers
+came from real observation and are reproducible.
+
+## What a profile is
+
+One YAML document per image, conforming to
+[`profile.schema.json`](../src/compose_lint/profiles/schema/profile.schema.json).
+It carries one additive block per security dimension, each with its own
+`derivation` provenance, because `csd` observes each dimension in a separate run:
+
+| Dimension | Rule it informs | csd observer |
+|---|---|---|
+| `capabilities` | CL-0006 | `caps` |
+| `filesystem` | CL-0007 | `fs` |
+| `devices` | CL-0016 | `devices` |
+| `cap_add_validation` | CL-0011 | `capadd` |
+| `privileged_decomposition` | CL-0002 | `privileged` |
+
+A profile is the **union** of these across separate `csd` runs, collected under
+one `image` key.
+
+## Deriving a profile
+
+Run `csd` against a live, **digest-pinned** container, driven by a workload
+script that exercises the paths you care about, for at least five minutes:
+
+```bash
+csd --image docker.io/library/postgres@sha256:<digest> \
+    --observe caps \
+    --duration 600s \
+    --workload profiles/workloads/postgres.sh \
+    --format compose-lint-profile > entry.yml
+```
+
+Repeat per dimension (`--observe fs`, `--observe devices`, …) and merge the
+fragments into one document keyed by the image.
+
+### The acceptance contract (validated profiles)
+
+`csd`'s formatter refuses to emit a `validated` entry unless every term holds;
+the `profile-validate` CI job re-checks them here:
+
+- image pinned to a `@sha256:` digest (`derivation.validated_image`);
+- a committed workload script, hash-matched by `workload_sha256`;
+- `duration_seconds >= 300` per dimension;
+- `confidence` is `high` or `moderate`;
+- clean observation (no coverage warnings, drop-rate < 1%, no replica
+  disagreement).
+
+A run below the bar emits under an `exploratory:` block instead
+(`csd … --allow-exploratory`). Contribute those under `catalog/exploratory/`;
+they are review material and are never used to enrich (or fail) a lint.
+
+## Where files go
+
+```
+src/compose_lint/profiles/catalog/<registry>/<namespace>/<name>.yml   # validated
+src/compose_lint/profiles/catalog/exploratory/<...>/<name>.yml         # below-bar
+profiles/workloads/<name>.sh                                          # committed exerciser
+```
+
+The subdirectories are for humans; the loader indexes each document by its own
+`image` field, not by path. Workload scripts live at the repository root under
+`profiles/workloads/` (audit artifacts — they are **not** shipped in the wheel)
+and are referenced by the repo-relative `derivation.workload` path.
+
+## `validated_via` and the ci-smoke gate
+
+`csd` emits `validated_via: [bpf-observation]` — it will not claim a check it did
+not run. compose-lint's CI is the second source: once your PR passes the
+`profile-validate` job, add `ci-smoke` so the entry reads
+`validated_via: [bpf-observation, ci-smoke]`. A `validated` profile **must**
+declare both; the gate fails the PR if it claims `ci-smoke` without being a
+well-formed, digest-pinned, workload-verified artifact — the claim is only ever
+as good as the check backing it.
+
+Run the gate locally before opening a PR:
+
+```bash
+python scripts/validate_profiles.py
+```
+
+It validates every catalog document against the schema, enforces the
+validated/exploratory invariants the schema cannot express, and verifies each
+`workload_sha256` against the committed script.

--- a/scripts/validate_profiles.py
+++ b/scripts/validate_profiles.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Validate contributed security profiles — the compose-lint "ci-smoke" gate.
+
+Every document under the profile catalog must be schema-valid, digest-pinned,
+backed by a committed + hash-verified workload script, and satisfy the
+validated/exploratory invariants the JSON Schema cannot express. A ``validated``
+profile asserts ``validated_via: [bpf-observation, ci-smoke]``; this script is
+the ci-smoke half, so it fails when that assertion is not backed by a
+well-formed, reproducible artifact (ADR-017).
+
+Runs in CI (the ``profile-validate`` job) and locally:
+
+    python scripts/validate_profiles.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import yaml
+from jsonschema import Draft202012Validator
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_PROFILES = REPO_ROOT / "src" / "compose_lint" / "profiles"
+DEFAULT_CATALOG = _PROFILES / "catalog"
+DEFAULT_SCHEMA = _PROFILES / "schema" / "profile.schema.json"
+
+# Both sources are required for a validated profile: csd emits bpf-observation,
+# and this gate backs the ci-smoke half.
+VALIDATED_VIA_REQUIRED = frozenset({"bpf-observation", "ci-smoke"})
+MIN_DURATION_SECONDS = 300
+VALIDATED_CONFIDENCE = frozenset({"high", "moderate"})
+
+
+def check_document(
+    path: Path,
+    doc: dict,
+    validator: Draft202012Validator,
+    repo_root: Path,
+    exploratory_dir: Path,
+) -> list[str]:
+    """Return a list of human-readable violations for one profile document."""
+    errors = [
+        f"schema: {e.message} (at {'/'.join(str(p) for p in e.path) or '<root>'})"
+        for e in validator.iter_errors(doc)
+    ]
+    if errors:
+        # Cross-field checks below assume the schema-guaranteed shape.
+        return errors
+
+    status = doc["status"]
+    under_exploratory = exploratory_dir in path.resolve().parents
+    dimensions: dict = doc["dimensions"]
+
+    if status == "validated":
+        if under_exploratory:
+            errors.append("validated profile must not live under catalog/exploratory/")
+        for name, dim in dimensions.items():
+            errors.extend(_check_validated_dimension(name, dim["derivation"]))
+    elif status == "exploratory" and not under_exploratory:
+        errors.append("exploratory profile must live under catalog/exploratory/")
+
+    for name, dim in dimensions.items():
+        errors.extend(_check_workload(name, dim["derivation"], repo_root))
+
+    return errors
+
+
+def _check_validated_dimension(name: str, derivation: dict) -> list[str]:
+    errors: list[str] = []
+    confidence = derivation.get("confidence")
+    if confidence not in VALIDATED_CONFIDENCE:
+        errors.append(
+            f"{name}: validated requires confidence high/moderate, got {confidence!r}"
+        )
+    if derivation.get("duration_seconds", 0) < MIN_DURATION_SECONDS:
+        errors.append(
+            f"{name}: validated requires duration_seconds >= {MIN_DURATION_SECONDS}"
+        )
+    missing = VALIDATED_VIA_REQUIRED - set(derivation.get("validated_via", []))
+    if missing:
+        errors.append(
+            f"{name}: validated requires validated_via to include "
+            f"{sorted(VALIDATED_VIA_REQUIRED)}, missing {sorted(missing)}"
+        )
+    return errors
+
+
+def _check_workload(name: str, derivation: dict, repo_root: Path) -> list[str]:
+    workload = derivation["workload"]
+    want = derivation["workload_sha256"]
+    path = repo_root / workload
+    if not path.is_file():
+        return [f"{name}: workload script not found: {workload}"]
+    got = hashlib.sha256(path.read_bytes()).hexdigest()
+    if got != want:
+        return [
+            f"{name}: workload_sha256 mismatch for {workload} "
+            f"(declared {want[:12]}…, actual {got[:12]}…)"
+        ]
+    return []
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--catalog-dir", type=Path, default=DEFAULT_CATALOG)
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=REPO_ROOT,
+        help="root that workload paths resolve against",
+    )
+    args = parser.parse_args(argv)
+
+    schema = json.loads(args.schema.read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema)
+    exploratory_dir = (args.catalog_dir / "exploratory").resolve()
+    repo_root = args.repo_root.resolve()
+
+    files = (
+        sorted(args.catalog_dir.rglob("*.y*ml")) if args.catalog_dir.is_dir() else []
+    )
+    total = 0
+    for path in files:
+        label = _label(path, repo_root)
+        try:
+            doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            print(f"FAIL {label}: invalid YAML: {exc}")
+            total += 1
+            continue
+        if not isinstance(doc, dict):
+            print(f"FAIL {label}: top level is not a mapping")
+            total += 1
+            continue
+        errors = check_document(path, doc, validator, repo_root, exploratory_dir)
+        if errors:
+            total += len(errors)
+            for err in errors:
+                print(f"FAIL {label}: {err}")
+        else:
+            print(f"OK   {label}")
+
+    print(f"\n{len(files)} profile(s) checked, {total} error(s).")
+    return 1 if total else 0
+
+
+def _label(path: Path, repo_root: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(repo_root))
+    except ValueError:
+        return str(path)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/compose_lint/profiles/catalog/README.md
+++ b/src/compose_lint/profiles/catalog/README.md
@@ -6,8 +6,8 @@ One YAML document per image, conforming to
 Entries are **derived, not hand-authored.** A profile is produced by running
 [container-sec-derive](https://github.com/tmatens/container-sec-derive) against a
 live container (`--format compose-lint-profile`, ≥5-minute window, digest-pinned
-image) and contributed via PR through the profile-validation workflow, which
-appends `ci-smoke` to `validated_via`. See the contributor guide (forthcoming).
+image) and contributed via PR, gated by the `profile-validate` CI job. See the
+[contributor guide](../../../../docs/profiles.md).
 
 The match key is the canonical repository reference — files may be organized in
 `registry/namespace/` subdirectories for readability, but the loader indexes each

--- a/tests/fixtures/profile_validation/good/catalog/docker.io/library/postgres.yml
+++ b/tests/fixtures/profile_validation/good/catalog/docker.io/library/postgres.yml
@@ -1,0 +1,26 @@
+# Validation fixture: a well-formed VALIDATED profile with a committed,
+# hash-verified workload. Digest is a placeholder (not a real derivation).
+schema_version: "1.0"
+image: docker.io/library/postgres
+applies_to:
+  tags: ["16", "16.*"]
+status: validated
+dimensions:
+  capabilities:
+    cap_drop: [ALL]
+    cap_add: [CHOWN, SETGID, SETUID]
+    derivation:
+      tool: container-sec-derive
+      tool_version: "0.6.0"
+      sidecar_schema_version: "1.5"
+      observer: caps
+      validated_image: docker.io/library/postgres@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      validated_date: "2026-07-02"
+      duration_seconds: 600
+      confidence: high
+      workload: profiles/workloads/postgres.sh
+      workload_sha256: 986ae634987bf53546c5d6f799783e79e52a02c85f5583697d50df08d394f1c0
+      validated_via: [bpf-observation, ci-smoke]
+      observation_backend:
+        ig_version: v0.51.0
+        gadgets: []

--- a/tests/fixtures/profile_validation/good/profiles/workloads/postgres.sh
+++ b/tests/fixtures/profile_validation/good/profiles/workloads/postgres.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Minimal postgres exerciser (fixture).
+set -e
+pg_isready || true

--- a/tests/test_validate_profiles.py
+++ b/tests/test_validate_profiles.py
@@ -1,0 +1,141 @@
+"""Tests for the profile ci-smoke gate (scripts/validate_profiles.py, ADR-017).
+
+Runs the actual script as a subprocess — the same entry point CI invokes —
+starting from a known-good fixture tree and mutating it to trigger each failure
+mode.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import yaml
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "validate_profiles.py"
+GOOD = Path(__file__).parent / "fixtures" / "profile_validation" / "good"
+
+
+def _run(catalog_dir: Path, repo_root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--catalog-dir",
+            str(catalog_dir),
+            "--repo-root",
+            str(repo_root),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _copy_good(tmp_path: Path) -> Path:
+    tree = tmp_path / "tree"
+    shutil.copytree(GOOD, tree)
+    return tree
+
+
+def _profile(tree: Path) -> Path:
+    return tree / "catalog" / "docker.io" / "library" / "postgres.yml"
+
+
+def _mutate(tree: Path, fn: Callable[[dict], None]) -> None:
+    path = _profile(tree)
+    doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    fn(doc)
+    path.write_text(yaml.safe_dump(doc, sort_keys=False), encoding="utf-8")
+
+
+def test_good_fixture_passes(tmp_path: Path) -> None:
+    tree = _copy_good(tmp_path)
+    result = _run(tree / "catalog", tree)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_empty_catalog_passes(tmp_path: Path) -> None:
+    catalog = tmp_path / "catalog"
+    catalog.mkdir()
+    result = _run(catalog, tmp_path)
+    assert result.returncode == 0, result.stdout
+
+
+def test_bundled_catalog_passes() -> None:
+    # The real (currently empty) bundled catalog must validate with defaults.
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_missing_ci_smoke_fails(tmp_path: Path) -> None:
+    tree = _copy_good(tmp_path)
+    _mutate(
+        tree,
+        lambda d: d["dimensions"]["capabilities"]["derivation"].update(
+            validated_via=["bpf-observation"]
+        ),
+    )
+    result = _run(tree / "catalog", tree)
+    assert result.returncode == 1
+    assert "validated_via" in result.stdout
+
+
+def test_low_confidence_validated_fails(tmp_path: Path) -> None:
+    tree = _copy_good(tmp_path)
+    _mutate(
+        tree,
+        lambda d: d["dimensions"]["capabilities"]["derivation"].update(
+            confidence="low"
+        ),
+    )
+    result = _run(tree / "catalog", tree)
+    assert result.returncode == 1
+    assert "confidence" in result.stdout
+
+
+def test_workload_hash_mismatch_fails(tmp_path: Path) -> None:
+    tree = _copy_good(tmp_path)
+    workload = tree / "profiles" / "workloads" / "postgres.sh"
+    workload.write_text("#!/bin/sh\n# tamper\n")
+    result = _run(tree / "catalog", tree)
+    assert result.returncode == 1
+    assert "workload_sha256 mismatch" in result.stdout
+
+
+def test_missing_workload_fails(tmp_path: Path) -> None:
+    tree = _copy_good(tmp_path)
+    (tree / "profiles" / "workloads" / "postgres.sh").unlink()
+    result = _run(tree / "catalog", tree)
+    assert result.returncode == 1
+    assert "workload script not found" in result.stdout
+
+
+def test_schema_invalid_fails(tmp_path: Path) -> None:
+    tree = _copy_good(tmp_path)
+    _mutate(tree, lambda d: d.update(image="Docker.IO/BAD"))
+    result = _run(tree / "catalog", tree)
+    assert result.returncode == 1
+    assert "schema" in result.stdout
+
+
+def test_exploratory_outside_exploratory_dir_fails(tmp_path: Path) -> None:
+    tree = _copy_good(tmp_path)
+
+    def make_exploratory(doc: dict) -> None:
+        doc["status"] = "exploratory"
+        doc["acceptance_contract_violations"] = ["duration_seconds 120 < 300"]
+
+    _mutate(tree, make_exploratory)
+    result = _run(tree / "catalog", tree)
+    assert result.returncode == 1
+    assert "exploratory" in result.stdout


### PR DESCRIPTION
## What

PR 4 of the csd → compose-lint profile pipeline (follows #353, #354, #355). Adds the **contribution / ci-smoke gate** — the honest path that lets real derived profiles land — plus the contributor guide.

## The gate

`scripts/validate_profiles.py` validates every document under the catalog and is what "ci-smoke" in `validated_via` actually attests:

- **Schema** — each file against `profile.schema.json` (Draft 2020-12).
- **Cross-field invariants the schema can't express** — a `validated` profile requires every dimension to have `confidence` high/moderate, `duration_seconds >= 300`, and `validated_via` containing **both** `bpf-observation` and `ci-smoke`; it must not live under `catalog/exploratory/`. An `exploratory` profile must.
- **Workload reproducibility** — `workload_sha256` is verified against the committed exerciser script at `derivation.workload`.

csd emits `validated_via: [bpf-observation]` and won't claim a check it didn't run; this gate is the second source. A profile that *claims* `ci-smoke` without being a well-formed, digest-pinned, workload-verified artifact fails the PR — the claim is only as good as the check backing it.

## CI wiring

- New `profiles` path filter in the `changes` job (matches `src/compose_lint/profiles/`, `profiles/`, and the validator).
- New `profile-validate` job (mirrors `rule-premises`: pinned checkout/setup-python, `--require-hashes` dev install, runs the script), added to the `ci-ok` rollup so branch protection covers it.

## Layout defined

- Profiles: `src/compose_lint/profiles/catalog/<registry>/<ns>/<name>.yml` (validated) or `catalog/exploratory/…` (below-bar).
- Workloads: `profiles/workloads/<name>.sh` at repo root — audit artifacts, **not** shipped in the wheel — referenced by the repo-relative `derivation.workload`.

## Tests / docs

- `test_validate_profiles.py` runs the real script as a subprocess from a known-good fixture tree, mutating it to exercise each failure mode (missing ci-smoke, low confidence, workload hash mismatch, missing workload, schema-invalid, exploratory placement) + empty-catalog and bundled-catalog pass.
- `docs/profiles.md` contributor guide (derive with csd, the acceptance contract, file layout, the `validated_via` mechanic); catalog `README.md` now links it; `CHANGELOG.md`.
- Local: `ruff`, `mypy src/` strict, ci.yml YAML-validated, full `pytest` (869 passed, 2 skipped).

## Remaining

5. In csd: reconcile the formatter to the normalized `image` key + `workload_sha256` + `observation_backend`.

Then **real seeding** — genuinely validated profiles for popular apps — can flow through this gate from live csd runs on a host (BPF/root/docker), which is the one thing that can't be produced in-sandbox.
