### PR TITLE
profiles: add bisection as a derivation source (schema 1.1)

### DIFF
--- a/docs/adr/017-security-profile-catalog.md
+++ b/docs/adr/017-security-profile-catalog.md
@@ -193,3 +193,36 @@ compose-lint fact.
 - Cross-field rules the JSON Schema cannot express (e.g. `status: validated` ⇒
   every dimension's `confidence` ≠ `low` and `validated_via` contains both
   sources) are enforced by the loader/CI, not the schema, and are noted there.
+
+### 8. Bisection as a derivation source (schema 1.1, amendment 2026-07-03)
+
+Runtime observation (the `caps`/`capadd` observers) sees only what a container
+exercises **during the observation window**. It is blind to **startup-only**
+capabilities — a container that starts as root and drops to an unprivileged user
+uses `SETUID`/`SETGID` exactly once, at init, and never again; observation
+records them as unused. Acting on that is dangerous: the field case that
+motivated this (netdata) observed `SETUID`/`SETGID` as removable, but dropping
+them leaves the container **healthy while silently running as root** — a
+health-check gate does not catch it.
+
+**Bisection** is the derivation that does: drop a capability, restart the
+container, and verify it still behaves *correctly* (not merely "is healthy" —
+e.g. that it still dropped to its intended user). It covers the full container
+lifetime, so it is the authoritative source for `cap_add`, especially startup
+caps. Schema 1.1 makes it first-class:
+
+- `derivation.observer: bisection` marks a dimension derived (or verified) by
+  bisection. A dimension may be observed *and* bisected — bisection is the
+  authoritative source, so it takes the `observer` slot.
+- `validated_via` gains `bisection`. A bisection dimension asserts
+  `[bisection, ci-smoke]` (the drop-and-restart verification plus compose-lint's
+  gate) in place of `[bpf-observation, ci-smoke]`.
+- **Bisection is kernel-authoritative**, so a bisection dimension carries
+  `confidence: high` (the kernel validated each capability by making the
+  container fail or succeed without it). It is exempt from the observation-window
+  `duration_seconds ≥ 300` floor — bisection is not a timed observation.
+
+All other `validated` requirements are unchanged (digest-pinned
+`validated_image`, committed hash-verified workload — the exerciser used to judge
+health during bisection — `ci-smoke`, and criteria per #359). `1.0` documents
+remain valid; `bisection` is opt-in under `1.1`.

--- a/scripts/validate_profiles.py
+++ b/scripts/validate_profiles.py
@@ -32,9 +32,11 @@ _PROFILES = REPO_ROOT / "src" / "compose_lint" / "profiles"
 DEFAULT_CATALOG = REPO_ROOT / "profiles" / "catalog"
 DEFAULT_SCHEMA = _PROFILES / "schema" / "profile.schema.json"
 
-# Both sources are required for a validated profile: csd emits bpf-observation,
-# and this gate backs the ci-smoke half.
+# Sources required for a validated profile, by derivation. Runtime observation
+# emits bpf-observation; bisection (observer=bisection, schema 1.1) emits
+# bisection. This gate backs the ci-smoke half in both cases.
 VALIDATED_VIA_REQUIRED = frozenset({"bpf-observation", "ci-smoke"})
+BISECTION_VIA_REQUIRED = frozenset({"bisection", "ci-smoke"})
 MIN_DURATION_SECONDS = 300
 VALIDATED_CONFIDENCE = frozenset({"high", "moderate"})
 
@@ -75,20 +77,27 @@ def check_document(
 
 def _check_validated_dimension(name: str, derivation: dict) -> list[str]:
     errors: list[str] = []
+    # Bisection (drop-a-cap/restart/verify) is a distinct, kernel-authoritative
+    # derivation: it covers the full container lifetime, so it needs neither the
+    # observation-window duration floor (it is not a timed observation) nor the
+    # bpf-observation source. It asserts [bisection, ci-smoke] instead. The
+    # confidence gate still applies (a bisection dimension carries `high`).
+    bisection = derivation.get("observer") == "bisection"
     confidence = derivation.get("confidence")
     if confidence not in VALIDATED_CONFIDENCE:
         errors.append(
             f"{name}: validated requires confidence high/moderate, got {confidence!r}"
         )
-    if derivation.get("duration_seconds", 0) < MIN_DURATION_SECONDS:
+    if not bisection and derivation.get("duration_seconds", 0) < MIN_DURATION_SECONDS:
         errors.append(
             f"{name}: validated requires duration_seconds >= {MIN_DURATION_SECONDS}"
         )
-    missing = VALIDATED_VIA_REQUIRED - set(derivation.get("validated_via", []))
+    required = BISECTION_VIA_REQUIRED if bisection else VALIDATED_VIA_REQUIRED
+    missing = required - set(derivation.get("validated_via", []))
     if missing:
         errors.append(
             f"{name}: validated requires validated_via to include "
-            f"{sorted(VALIDATED_VIA_REQUIRED)}, missing {sorted(missing)}"
+            f"{sorted(required)}, missing {sorted(missing)}"
         )
     return errors
 

--- a/src/compose_lint/profiles/schema/profile.schema.json
+++ b/src/compose_lint/profiles/schema/profile.schema.json
@@ -8,9 +8,9 @@
   "additionalProperties": false,
   "properties": {
     "schema_version": {
-      "description": "Catalog profile schema version (independent of csd's sidecar schema_version, which is recorded per-dimension under derivation.sidecar_schema_version).",
+      "description": "Catalog profile schema version (independent of csd's sidecar schema_version, which is recorded per-dimension under derivation.sidecar_schema_version). 1.1 adds bisection as a derivation source (observer=bisection, validated_via=bisection); 1.0 documents remain valid.",
       "type": "string",
-      "const": "1.0"
+      "enum": ["1.0", "1.1"]
     },
     "image": {
       "description": "Canonical repository reference WITHOUT tag or digest -- the match key. Registry and namespace normalized (docker.io/library/postgres, lscr.io/linuxserver/radarr).",
@@ -170,7 +170,10 @@
           "pattern": "^1\\.",
           "description": "csd sidecar schema (currently 1.x). Must be within the major the loader supports."
         },
-        "observer": { "enum": ["caps", "fs", "devices", "privileged", "capadd"] },
+        "observer": {
+          "enum": ["caps", "fs", "devices", "privileged", "capadd", "bisection"],
+          "description": "The csd observer that derived this dimension, OR `bisection` — a drop-a-cap/restart/verify derivation that covers the full container lifetime (schema 1.1). Bisection is kernel-authoritative: it is the only source that captures startup-only capabilities (e.g. SETUID/SETGID for a root->user privilege drop) that runtime observation cannot see."
+        },
         "validated_image": {
           "type": "string",
           "pattern": "@sha256:[a-f0-9]{64}$",
@@ -202,10 +205,10 @@
         },
         "validated_via": {
           "type": "array",
-          "items": { "enum": ["bpf-observation", "ci-smoke"] },
+          "items": { "enum": ["bpf-observation", "bisection", "ci-smoke"] },
           "minItems": 1,
           "uniqueItems": true,
-          "description": "csd emits [bpf-observation]; compose-lint CI appends ci-smoke after the smoke gate. Both required for status=validated (enforced by the loader/CI)."
+          "description": "Derivation source(s) plus the ci-smoke gate. Runtime observation emits [bpf-observation]; a bisection-derived dimension emits [bisection] (schema 1.1); compose-lint CI appends ci-smoke after the smoke gate. For status=validated the loader/CI requires ci-smoke plus the dimension's source (bpf-observation, or bisection for observer=bisection)."
         },
         "observation_backend": {
           "description": "How the kernel signal was captured -- forward-compat for csd's gadget transition. A profile derived with a csd-authored gadget is only reproducible if the gadget image+digest is recorded here, not just the ig version.",

--- a/tests/test_profile_schema.py
+++ b/tests/test_profile_schema.py
@@ -62,7 +62,9 @@ def test_schema_is_valid_draft202012(schema: dict[str, Any]) -> None:
 
 
 def test_schema_version_is_pinned(schema: dict[str, Any]) -> None:
-    assert schema["properties"]["schema_version"]["const"] == "1.0"
+    # 1.0 is the baseline; 1.1 adds bisection as a derivation source. Both remain
+    # valid so existing 1.0 documents are not invalidated.
+    assert schema["properties"]["schema_version"]["enum"] == ["1.0", "1.1"]
 
 
 def test_example_validates(

--- a/tests/test_validate_profiles.py
+++ b/tests/test_validate_profiles.py
@@ -104,6 +104,42 @@ def test_low_confidence_validated_fails(tmp_path: Path) -> None:
     assert "confidence" in result.stdout
 
 
+def test_bisection_validated_passes(tmp_path: Path) -> None:
+    # A bisection-derived dimension (schema 1.1) is validated on
+    # [bisection, ci-smoke] and is exempt from the observation-window duration
+    # floor -- bisection covers the full lifetime and is not a timed observation.
+    tree = _copy_good(tmp_path)
+
+    def to_bisection(d: dict) -> None:
+        d["schema_version"] = "1.1"
+        d["dimensions"]["capabilities"]["derivation"].update(
+            observer="bisection",
+            validated_via=["bisection", "ci-smoke"],
+            duration_seconds=5,  # well under the 300s floor; waived for bisection
+        )
+
+    _mutate(tree, to_bisection)
+    result = _run(tree / "catalog", tree)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_bisection_missing_bisection_source_fails(tmp_path: Path) -> None:
+    # observer=bisection but validated_via lacks `bisection` -> not validated.
+    tree = _copy_good(tmp_path)
+
+    def bad(d: dict) -> None:
+        d["schema_version"] = "1.1"
+        d["dimensions"]["capabilities"]["derivation"].update(
+            observer="bisection",
+            validated_via=["bpf-observation", "ci-smoke"],
+        )
+
+    _mutate(tree, bad)
+    result = _run(tree / "catalog", tree)
+    assert result.returncode == 1
+    assert "validated_via" in result.stdout and "bisection" in result.stdout
+
+
 def test_workload_hash_mismatch_fails(tmp_path: Path) -> None:
     tree = _copy_good(tmp_path)
     workload = tree / "profiles" / "workloads" / "postgres.sh"


### PR DESCRIPTION
Closes #362.

## Why

Runtime observation (the `caps`/`capadd` observers) sees only what a container exercises **during the observation window** — it's blind to **startup-only** capabilities. A container that starts as root and drops to an unprivileged user uses `SETUID`/`SETGID` exactly once, at init; observation records them as unused. Acting on that is dangerous: in the field case that motivated this (netdata), observation flagged `SETUID`/`SETGID` as removable, but dropping them leaves the container **healthy while silently running as root** — a health-check gate doesn't catch it.

So the most trustworthy `cap_add` profiles — the ones verified by bisection — had no faithful representation in the schema (`observer` had no `bisection`; and bisection's paired observation confidence is often `low`, which forced `exploratory`).

## What

Make bisection (drop-a-cap → restart → verify *correct behavior*, not just liveness) a first-class derivation source. Schema **1.1**, additive — **1.0 documents stay valid**:

- `derivation.observer` enum gains `bisection`; `validated_via` items gain `bisection`.
- A bisection dimension validates on **`[bisection, ci-smoke]`** instead of `[bpf-observation, ci-smoke]`, carries **`confidence: high`** (kernel-authoritative — the kernel validated each cap by making the container fail/succeed without it), and is **exempt from the `duration_seconds ≥ 300` floor** (bisection isn't a timed observation). Digest-pinning, committed hash-verified workload, ci-smoke, and #359 criteria are unchanged.
- `validate_profiles.py` branches on `observer == "bisection"`.
- ADR-017 gains **§8** documenting the source and its rationale.

## Tests

`869 passed, 6 skipped` (full suite). New: `test_bisection_validated_passes` (bisection dimension with a sub-300s window validates) and `test_bisection_missing_bisection_source_fails`; `test_schema_version_is_pinned` updated for the `["1.0","1.1"]` enum.

## Follow-ups (not here)
- Land the netdata capabilities profile in the catalog under this source.
- csd-side: a path to emit/author bisection-derived profiles (the bisection lives in `csd`'s `scripts/bisect_caps.sh`, separate from the `--format compose-lint-profile` formatter).