### PR TITLE
profiles: enforce per-image criteria doc for validated (#359)

### DIFF
--- a/docs/adr/017-security-profile-catalog.md
+++ b/docs/adr/017-security-profile-catalog.md
@@ -185,11 +185,13 @@ compose-lint fact.
   a scheduled `derive → validate → update` loop on a BPF-capable host (`csd`'s
   self-hosted runner), seeded from `csd`'s postgres/caddy reference workloads,
   re-deriving on digest bumps, with the representative-workload requirement as an
-  explicit precondition. The **#359** criteria gate requires each profile to
-  reference a committed criteria doc (scenarios + pass criteria) beside its
-  workload, so `validate_profiles.py` fails a `validated` profile that lacks
-  reviewable criteria. In `csd`: reconcile the `compose-lint-profile` formatter
-  to this schema (tracked in **csd#218**).
+  explicit precondition. The **#359** criteria gate (implemented) requires each
+  `validated` profile to ship a committed criteria doc (scenarios + pass
+  criteria) that mirrors its catalog path — `catalog/<rel>.y*ml` ⇒
+  `criteria/<rel>.md`, non-empty — so `validate_profiles.py` fails a `validated`
+  profile that lacks reviewable criteria (`exploratory` drafts are exempt). In
+  `csd`: reconcile the `compose-lint-profile` formatter to this schema (done,
+  csd#218).
 - Cross-field rules the JSON Schema cannot express (e.g. `status: validated` ⇒
   every dimension's `confidence` ≠ `low` and `validated_via` contains both
   sources) are enforced by the loader/CI, not the schema, and are noted there.

--- a/scripts/validate_profiles.py
+++ b/scripts/validate_profiles.py
@@ -47,6 +47,8 @@ def check_document(
     validator: Draft202012Validator,
     repo_root: Path,
     exploratory_dir: Path,
+    catalog_dir: Path,
+    criteria_dir: Path,
 ) -> list[str]:
     """Return a list of human-readable violations for one profile document."""
     errors = [
@@ -66,6 +68,7 @@ def check_document(
             errors.append("validated profile must not live under catalog/exploratory/")
         for name, dim in dimensions.items():
             errors.extend(_check_validated_dimension(name, dim["derivation"]))
+        errors.extend(_check_criteria(path, catalog_dir, criteria_dir))
     elif status == "exploratory" and not under_exploratory:
         errors.append("exploratory profile must live under catalog/exploratory/")
 
@@ -117,6 +120,24 @@ def _check_workload(name: str, derivation: dict, repo_root: Path) -> list[str]:
     return []
 
 
+def _check_criteria(path: Path, catalog_dir: Path, criteria_dir: Path) -> list[str]:
+    """A validated profile must ship a committed per-image criteria doc (#359,
+    ADR-017 §7): the reviewable scenarios + pass criteria the derivation was
+    judged against. Convention: the doc mirrors the profile's catalog path —
+    ``catalog/<rel>.y*ml`` ⇒ ``criteria/<rel>.md`` — and must be non-empty."""
+    try:
+        rel = path.resolve().relative_to(catalog_dir)
+    except ValueError:
+        return []  # profile outside catalog_dir; no criteria path to derive
+    criteria_path = criteria_dir / rel.with_suffix(".md")
+    disp = f"criteria/{rel.with_suffix('.md')}"
+    if not criteria_path.is_file():
+        return [f"validated profile requires a committed criteria doc at {disp} (#359)"]
+    if not criteria_path.read_text(encoding="utf-8").strip():
+        return [f"criteria doc {disp} is empty (#359)"]
+    return []
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--catalog-dir", type=Path, default=DEFAULT_CATALOG)
@@ -127,6 +148,12 @@ def main(argv: list[str] | None = None) -> int:
         default=REPO_ROOT,
         help="root that workload paths resolve against",
     )
+    parser.add_argument(
+        "--criteria-dir",
+        type=Path,
+        default=None,
+        help="dir holding per-image criteria docs (default: <catalog-dir>/../criteria)",
+    )
     args = parser.parse_args(argv)
 
     schema = json.loads(args.schema.read_text(encoding="utf-8"))
@@ -134,6 +161,12 @@ def main(argv: list[str] | None = None) -> int:
     validator = Draft202012Validator(schema)
     exploratory_dir = (args.catalog_dir / "exploratory").resolve()
     repo_root = args.repo_root.resolve()
+    catalog_dir = args.catalog_dir.resolve()
+    criteria_dir = (
+        args.criteria_dir.resolve()
+        if args.criteria_dir is not None
+        else (catalog_dir.parent / "criteria")
+    )
 
     files = (
         sorted(args.catalog_dir.rglob("*.y*ml")) if args.catalog_dir.is_dir() else []
@@ -151,7 +184,9 @@ def main(argv: list[str] | None = None) -> int:
             print(f"FAIL {label}: top level is not a mapping")
             total += 1
             continue
-        errors = check_document(path, doc, validator, repo_root, exploratory_dir)
+        errors = check_document(
+            path, doc, validator, repo_root, exploratory_dir, catalog_dir, criteria_dir
+        )
         if errors:
             total += len(errors)
             for err in errors:

--- a/tests/fixtures/profile_validation/good/criteria/docker.io/library/postgres.md
+++ b/tests/fixtures/profile_validation/good/criteria/docker.io/library/postgres.md
@@ -1,0 +1,7 @@
+# postgres — validation criteria (fixture)
+
+Representative workload: `profiles/workloads/postgres.sh` (connect + CRUD + reload).
+
+## capabilities
+- Pass criteria: the workload succeeds with only the derived `cap_add`; no denied
+  capability check for a dropped cap.

--- a/tests/test_validate_profiles.py
+++ b/tests/test_validate_profiles.py
@@ -140,6 +140,25 @@ def test_bisection_missing_bisection_source_fails(tmp_path: Path) -> None:
     assert "validated_via" in result.stdout and "bisection" in result.stdout
 
 
+def test_missing_criteria_fails(tmp_path: Path) -> None:
+    # A validated profile must ship a committed per-image criteria doc (#359).
+    tree = _copy_good(tmp_path)
+    (tree / "criteria" / "docker.io" / "library" / "postgres.md").unlink()
+    result = _run(tree / "catalog", tree)
+    assert result.returncode == 1
+    assert "criteria" in result.stdout
+
+
+def test_empty_criteria_fails(tmp_path: Path) -> None:
+    tree = _copy_good(tmp_path)
+    (tree / "criteria" / "docker.io" / "library" / "postgres.md").write_text(
+        "\n  \n", encoding="utf-8"
+    )
+    result = _run(tree / "catalog", tree)
+    assert result.returncode == 1
+    assert "empty" in result.stdout
+
+
 def test_workload_hash_mismatch_fails(tmp_path: Path) -> None:
     tree = _copy_good(tmp_path)
     workload = tree / "profiles" / "workloads" / "postgres.sh"


### PR DESCRIPTION
Closes #359.

## Why
ADR-017 §7 makes committed, reviewable **per-image criteria** a hard gate for `validated` profiles — "a profile without published criteria cannot be `validated`." But nothing enforced it: a validated profile could ship with no criteria doc at all. This closes that gap.

## What
`validate_profiles.py` now requires, for every `validated` profile, a **non-empty criteria doc that mirrors the profile's catalog path**:

```
catalog/docker.io/netdata/netdata.yaml  ⇒  criteria/docker.io/netdata/netdata.md
```

- Convention-based — **no schema change** (no version bump). The criteria doc is located by the profile's own path, so there's no fragile image-ref parsing.
- `exploratory` drafts are exempt (they're advisory).
- New `--criteria-dir` flag (default `<catalog-dir>/../criteria`).
- ADR-017 updated from "planned" to the implemented convention.

## Tests
Full suite **871 passed, 6 skipped**. New: `test_missing_criteria_fails`, `test_empty_criteria_fails`; a criteria doc added to the `good` fixture (so the existing validated-profile tests exercise the gate).

Signed-off-by included (DCO).