### PR TITLE
profiles: rename derivation source bisection -> drop-test

### DIFF
--- a/docs/adr/017-security-profile-catalog.md
+++ b/docs/adr/017-security-profile-catalog.md
@@ -196,7 +196,7 @@ compose-lint fact.
   every dimension's `confidence` ≠ `low` and `validated_via` contains both
   sources) are enforced by the loader/CI, not the schema, and are noted there.
 
-### 8. Bisection as a derivation source (schema 1.1, amendment 2026-07-03)
+### 8. drop-test as a derivation source (schema 1.1, amendment 2026-07-03)
 
 Runtime observation (the `caps`/`capadd` observers) sees only what a container
 exercises **during the observation window**. It is blind to **startup-only**
@@ -207,24 +207,27 @@ motivated this (netdata) observed `SETUID`/`SETGID` as removable, but dropping
 them leaves the container **healthy while silently running as root** — a
 health-check gate does not catch it.
 
-**Bisection** is the derivation that does: drop a capability, restart the
+**drop-test** is the derivation that does: drop a capability, restart the
 container, and verify it still behaves *correctly* (not merely "is healthy" —
-e.g. that it still dropped to its intended user). It covers the full container
+e.g. that it still dropped to its intended user). (The method is *leave-one-out*
+elimination — each candidate is removed individually and the container
+re-tested; the name follows `git bisect`'s colloquial "change-and-test to
+isolate" sense, not strict binary search.) It covers the full container
 lifetime, so it is the authoritative source for `cap_add`, especially startup
 caps. Schema 1.1 makes it first-class:
 
-- `derivation.observer: bisection` marks a dimension derived (or verified) by
-  bisection. A dimension may be observed *and* bisected — bisection is the
+- `derivation.observer: drop-test` marks a dimension derived (or verified) by
+  drop-test. A dimension may be observed *and* bisected — drop-test is the
   authoritative source, so it takes the `observer` slot.
-- `validated_via` gains `bisection`. A bisection dimension asserts
-  `[bisection, ci-smoke]` (the drop-and-restart verification plus compose-lint's
+- `validated_via` gains `drop-test`. A drop-test dimension asserts
+  `[drop-test, ci-smoke]` (the drop-and-restart verification plus compose-lint's
   gate) in place of `[bpf-observation, ci-smoke]`.
-- **Bisection is kernel-authoritative**, so a bisection dimension carries
+- **drop-test is kernel-authoritative**, so a drop-test dimension carries
   `confidence: high` (the kernel validated each capability by making the
   container fail or succeed without it). It is exempt from the observation-window
-  `duration_seconds ≥ 300` floor — bisection is not a timed observation.
+  `duration_seconds ≥ 300` floor — drop-test is not a timed observation.
 
 All other `validated` requirements are unchanged (digest-pinned
 `validated_image`, committed hash-verified workload — the exerciser used to judge
-health during bisection — `ci-smoke`, and criteria per #359). `1.0` documents
-remain valid; `bisection` is opt-in under `1.1`.
+health during drop-test — `ci-smoke`, and criteria per #359). `1.0` documents
+remain valid; `drop-test` is opt-in under `1.1`.

--- a/scripts/validate_profiles.py
+++ b/scripts/validate_profiles.py
@@ -33,10 +33,11 @@ DEFAULT_CATALOG = REPO_ROOT / "profiles" / "catalog"
 DEFAULT_SCHEMA = _PROFILES / "schema" / "profile.schema.json"
 
 # Sources required for a validated profile, by derivation. Runtime observation
-# emits bpf-observation; bisection (observer=bisection, schema 1.1) emits
-# bisection. This gate backs the ci-smoke half in both cases.
+# emits bpf-observation; drop-test (observer=drop-test, schema 1.1) — remove each
+# candidate and verify the container breaks without it — emits drop-test. This
+# gate backs the ci-smoke half in both cases.
 VALIDATED_VIA_REQUIRED = frozenset({"bpf-observation", "ci-smoke"})
-BISECTION_VIA_REQUIRED = frozenset({"bisection", "ci-smoke"})
+DROP_TEST_VIA_REQUIRED = frozenset({"drop-test", "ci-smoke"})
 MIN_DURATION_SECONDS = 300
 VALIDATED_CONFIDENCE = frozenset({"high", "moderate"})
 
@@ -80,22 +81,23 @@ def check_document(
 
 def _check_validated_dimension(name: str, derivation: dict) -> list[str]:
     errors: list[str] = []
-    # Bisection (drop-a-cap/restart/verify) is a distinct, kernel-authoritative
-    # derivation: it covers the full container lifetime, so it needs neither the
-    # observation-window duration floor (it is not a timed observation) nor the
-    # bpf-observation source. It asserts [bisection, ci-smoke] instead. The
-    # confidence gate still applies (a bisection dimension carries `high`).
-    bisection = derivation.get("observer") == "bisection"
+    # drop-test (remove a candidate, restart, verify it breaks) is a distinct,
+    # kernel-authoritative derivation: it covers the full container lifetime, so
+    # it needs neither the observation-window duration floor (it is not a timed
+    # observation) nor the bpf-observation source. It asserts [drop-test,
+    # ci-smoke] instead. The confidence gate still applies (a drop-test dimension
+    # carries `high`).
+    drop_test = derivation.get("observer") == "drop-test"
     confidence = derivation.get("confidence")
     if confidence not in VALIDATED_CONFIDENCE:
         errors.append(
             f"{name}: validated requires confidence high/moderate, got {confidence!r}"
         )
-    if not bisection and derivation.get("duration_seconds", 0) < MIN_DURATION_SECONDS:
+    if not drop_test and derivation.get("duration_seconds", 0) < MIN_DURATION_SECONDS:
         errors.append(
             f"{name}: validated requires duration_seconds >= {MIN_DURATION_SECONDS}"
         )
-    required = BISECTION_VIA_REQUIRED if bisection else VALIDATED_VIA_REQUIRED
+    required = DROP_TEST_VIA_REQUIRED if drop_test else VALIDATED_VIA_REQUIRED
     missing = required - set(derivation.get("validated_via", []))
     if missing:
         errors.append(

--- a/src/compose_lint/profiles/schema/profile.schema.json
+++ b/src/compose_lint/profiles/schema/profile.schema.json
@@ -8,7 +8,7 @@
   "additionalProperties": false,
   "properties": {
     "schema_version": {
-      "description": "Catalog profile schema version (independent of csd's sidecar schema_version, which is recorded per-dimension under derivation.sidecar_schema_version). 1.1 adds bisection as a derivation source (observer=bisection, validated_via=bisection); 1.0 documents remain valid.",
+      "description": "Catalog profile schema version (independent of csd's sidecar schema_version, which is recorded per-dimension under derivation.sidecar_schema_version). 1.1 adds drop-test as a derivation source (observer=drop-test, validated_via=drop-test); 1.0 documents remain valid.",
       "type": "string",
       "enum": ["1.0", "1.1"]
     },
@@ -171,8 +171,8 @@
           "description": "csd sidecar schema (currently 1.x). Must be within the major the loader supports."
         },
         "observer": {
-          "enum": ["caps", "fs", "devices", "privileged", "capadd", "bisection"],
-          "description": "The csd observer that derived this dimension, OR `bisection` — a drop-a-cap/restart/verify derivation that covers the full container lifetime (schema 1.1). Bisection is kernel-authoritative: it is the only source that captures startup-only capabilities (e.g. SETUID/SETGID for a root->user privilege drop) that runtime observation cannot see."
+          "enum": ["caps", "fs", "devices", "privileged", "capadd", "drop-test"],
+          "description": "The csd observer that derived this dimension, OR `drop-test` — a drop-a-cap/restart/verify derivation that covers the full container lifetime (schema 1.1). drop-test is kernel-authoritative: it is the only source that captures startup-only capabilities (e.g. SETUID/SETGID for a root->user privilege drop) that runtime observation cannot see."
         },
         "validated_image": {
           "type": "string",
@@ -205,10 +205,10 @@
         },
         "validated_via": {
           "type": "array",
-          "items": { "enum": ["bpf-observation", "bisection", "ci-smoke"] },
+          "items": { "enum": ["bpf-observation", "drop-test", "ci-smoke"] },
           "minItems": 1,
           "uniqueItems": true,
-          "description": "Derivation source(s) plus the ci-smoke gate. Runtime observation emits [bpf-observation]; a bisection-derived dimension emits [bisection] (schema 1.1); compose-lint CI appends ci-smoke after the smoke gate. For status=validated the loader/CI requires ci-smoke plus the dimension's source (bpf-observation, or bisection for observer=bisection)."
+          "description": "Derivation source(s) plus the ci-smoke gate. Runtime observation emits [bpf-observation]; a drop-test-derived dimension emits [drop-test] (schema 1.1); compose-lint CI appends ci-smoke after the smoke gate. For status=validated the loader/CI requires ci-smoke plus the dimension's source (bpf-observation, or drop-test for observer=drop-test)."
         },
         "observation_backend": {
           "description": "How the kernel signal was captured -- forward-compat for csd's gadget transition. A profile derived with a csd-authored gadget is only reproducible if the gadget image+digest is recorded here, not just the ig version.",

--- a/tests/test_profile_schema.py
+++ b/tests/test_profile_schema.py
@@ -62,7 +62,7 @@ def test_schema_is_valid_draft202012(schema: dict[str, Any]) -> None:
 
 
 def test_schema_version_is_pinned(schema: dict[str, Any]) -> None:
-    # 1.0 is the baseline; 1.1 adds bisection as a derivation source. Both remain
+    # 1.0 is the baseline; 1.1 adds drop-test as a derivation source. Both remain
     # valid so existing 1.0 documents are not invalidated.
     assert schema["properties"]["schema_version"]["enum"] == ["1.0", "1.1"]
 

--- a/tests/test_validate_profiles.py
+++ b/tests/test_validate_profiles.py
@@ -104,40 +104,40 @@ def test_low_confidence_validated_fails(tmp_path: Path) -> None:
     assert "confidence" in result.stdout
 
 
-def test_bisection_validated_passes(tmp_path: Path) -> None:
-    # A bisection-derived dimension (schema 1.1) is validated on
-    # [bisection, ci-smoke] and is exempt from the observation-window duration
-    # floor -- bisection covers the full lifetime and is not a timed observation.
+def test_drop_test_validated_passes(tmp_path: Path) -> None:
+    # A drop-test-derived dimension (schema 1.1) is validated on
+    # [drop-test, ci-smoke] and is exempt from the observation-window duration
+    # floor -- drop-test covers the full lifetime and is not a timed observation.
     tree = _copy_good(tmp_path)
 
-    def to_bisection(d: dict) -> None:
+    def to_drop_test(d: dict) -> None:
         d["schema_version"] = "1.1"
         d["dimensions"]["capabilities"]["derivation"].update(
-            observer="bisection",
-            validated_via=["bisection", "ci-smoke"],
-            duration_seconds=5,  # well under the 300s floor; waived for bisection
+            observer="drop-test",
+            validated_via=["drop-test", "ci-smoke"],
+            duration_seconds=5,  # well under the 300s floor; waived for drop-test
         )
 
-    _mutate(tree, to_bisection)
+    _mutate(tree, to_drop_test)
     result = _run(tree / "catalog", tree)
     assert result.returncode == 0, result.stdout + result.stderr
 
 
-def test_bisection_missing_bisection_source_fails(tmp_path: Path) -> None:
-    # observer=bisection but validated_via lacks `bisection` -> not validated.
+def test_drop_test_missing_source_fails(tmp_path: Path) -> None:
+    # observer=drop-test but validated_via lacks `drop-test` -> not validated.
     tree = _copy_good(tmp_path)
 
     def bad(d: dict) -> None:
         d["schema_version"] = "1.1"
         d["dimensions"]["capabilities"]["derivation"].update(
-            observer="bisection",
+            observer="drop-test",
             validated_via=["bpf-observation", "ci-smoke"],
         )
 
     _mutate(tree, bad)
     result = _run(tree / "catalog", tree)
     assert result.returncode == 1
-    assert "validated_via" in result.stdout and "bisection" in result.stdout
+    assert "validated_via" in result.stdout and "drop-test" in result.stdout
 
 
 def test_missing_criteria_fails(tmp_path: Path) -> None:


### PR DESCRIPTION
Renames the derivation source enum value `bisection` → **`drop-test`** (in `observer` and `validated_via`).

## Why
"bisection" failed the "understand from the name" test — its sibling `bpf-observation` is self-explanatory, but `bisection` either misleads (git-bisect → binary-search / fault-finding) or is opaque. `drop-test` says the action: **remove each element and test whether the container breaks without it.** `validated_via: [drop-test, ci-smoke]` reads plainly.

## Scope
Value-only rename **within schema 1.1** — the value was just added (#363) and only two profiles use it (a private catalog, both maintainer-authored). No external consumers, so no version bump. ADR-017 §8 now notes the method is *leave-one-out elimination* (the name follows git-bisect's colloquial "change-and-test to isolate" sense, not strict binary search).

Touches: schema enums + description, `validate_profiles.py` (`DROP_TEST_VIA_REQUIRED`, `observer == "drop-test"`), ADR §8, tests. `871 passed, 6 skipped`.

## Follow-up (this PR only renames)
- Catalog: rename `bisection` → `drop-test` in the two profiles + re-pin.
- csd: the drop-test *producer* (`scripts/bisect.sh` → emits evidence) is being built under this name.