### PR TITLE
profiles: require drop_test evidence block for observer=drop-test

### DIFF
--- a/docs/adr/017-security-profile-catalog.md
+++ b/docs/adr/017-security-profile-catalog.md
@@ -217,7 +217,7 @@ lifetime, so it is the authoritative source for `cap_add`, especially startup
 caps. Schema 1.1 makes it first-class:
 
 - `derivation.observer: drop-test` marks a dimension derived (or verified) by
-  drop-test. A dimension may be observed *and* bisected — drop-test is the
+  drop-test. A dimension may be observed *and* drop-tested — drop-test is the
   authoritative source, so it takes the `observer` slot.
 - `validated_via` gains `drop-test`. A drop-test dimension asserts
   `[drop-test, ci-smoke]` (the drop-and-restart verification plus compose-lint's
@@ -226,6 +226,13 @@ caps. Schema 1.1 makes it first-class:
   `confidence: high` (the kernel validated each capability by making the
   container fail or succeed without it). It is exempt from the observation-window
   `duration_seconds ≥ 300` floor — drop-test is not a timed observation.
+- **The evidence is mandatory.** A drop-test dimension must carry a
+  `derivation.drop_test` block — a non-empty `checks` list of
+  `{removed, required, observed}` (which candidate was removed, whether it proved
+  required, and the predicate's observed outcome). It cannot merely *claim* the
+  source; it must record what was tested and what happened, so the trust-critical
+  profiles that override observation are self-justifying. Emitted by csd's
+  drop-test producer; enforced for `observer: drop-test` by the loader/CI.
 
 All other `validated` requirements are unchanged (digest-pinned
 `validated_image`, committed hash-verified workload — the exerciser used to judge

--- a/scripts/validate_profiles.py
+++ b/scripts/validate_profiles.py
@@ -104,6 +104,14 @@ def _check_validated_dimension(name: str, derivation: dict) -> list[str]:
             f"{name}: validated requires validated_via to include "
             f"{sorted(required)}, missing {sorted(missing)}"
         )
+    # A drop-test dimension must carry its evidence: it can't just *claim* the
+    # source, it has to record what was removed and what happened. The schema
+    # enforces the block's shape; this makes it mandatory for observer=drop-test.
+    if drop_test and not derivation.get("drop_test"):
+        errors.append(
+            f"{name}: observer=drop-test requires a derivation.drop_test evidence "
+            f"block (the removed/required/observed checks)"
+        )
     return errors
 
 

--- a/src/compose_lint/profiles/schema/profile.schema.json
+++ b/src/compose_lint/profiles/schema/profile.schema.json
@@ -236,6 +236,39 @@
               }
             }
           }
+        },
+        "drop_test": {
+          "description": "Evidence for a drop-test-derived dimension (observer=drop-test): the leave-one-out checks that established the required minimum. Emitted by csd's drop-test producer; required by the loader/CI when observer=drop-test.",
+          "type": "object",
+          "required": ["checks"],
+          "additionalProperties": false,
+          "properties": {
+            "checks": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "required": ["removed", "required", "observed"],
+                "additionalProperties": false,
+                "properties": {
+                  "removed": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The candidate removed and re-tested -- a capability (e.g. SETUID) or a config element (e.g. /run/postgresql)."
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "true if removing it broke correctness (so it is in the minimum); false if the container stayed correct without it."
+                  },
+                  "observed": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The correctness predicate's observed outcome, e.g. 'daemon running as ROOT (privilege drop failed)' or 'postgres did not become ready in 60s'."
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/tests/test_validate_profiles.py
+++ b/tests/test_validate_profiles.py
@@ -118,8 +118,8 @@ def test_drop_test_validated_passes(tmp_path: Path) -> None:
             duration_seconds=5,  # well under the 300s floor; waived for drop-test
             drop_test={
                 "checks": [
-                    {"removed": "CHOWN", "required": False, "observed": "ok without it"},
-                    {"removed": "SETUID", "required": True, "observed": "daemon ran as root"},
+                    {"removed": "CHOWN", "required": False, "observed": "ok"},
+                    {"removed": "SETUID", "required": True, "observed": "ran as root"},
                 ]
             },
         )

--- a/tests/test_validate_profiles.py
+++ b/tests/test_validate_profiles.py
@@ -116,6 +116,12 @@ def test_drop_test_validated_passes(tmp_path: Path) -> None:
             observer="drop-test",
             validated_via=["drop-test", "ci-smoke"],
             duration_seconds=5,  # well under the 300s floor; waived for drop-test
+            drop_test={
+                "checks": [
+                    {"removed": "CHOWN", "required": False, "observed": "ok without it"},
+                    {"removed": "SETUID", "required": True, "observed": "daemon ran as root"},
+                ]
+            },
         )
 
     _mutate(tree, to_drop_test)
@@ -132,12 +138,31 @@ def test_drop_test_missing_source_fails(tmp_path: Path) -> None:
         d["dimensions"]["capabilities"]["derivation"].update(
             observer="drop-test",
             validated_via=["bpf-observation", "ci-smoke"],
+            drop_test={"checks": [{"removed": "X", "required": True, "observed": "y"}]},
         )
 
     _mutate(tree, bad)
     result = _run(tree / "catalog", tree)
     assert result.returncode == 1
     assert "validated_via" in result.stdout and "drop-test" in result.stdout
+
+
+def test_drop_test_missing_evidence_fails(tmp_path: Path) -> None:
+    # observer=drop-test but no derivation.drop_test evidence block -> not validated.
+    tree = _copy_good(tmp_path)
+
+    def bad(d: dict) -> None:
+        d["schema_version"] = "1.1"
+        d["dimensions"]["capabilities"]["derivation"].update(
+            observer="drop-test",
+            validated_via=["drop-test", "ci-smoke"],
+            duration_seconds=5,
+        )
+
+    _mutate(tree, bad)
+    result = _run(tree / "catalog", tree)
+    assert result.returncode == 1
+    assert "drop_test" in result.stdout and "evidence" in result.stdout
 
 
 def test_missing_criteria_fails(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes the loop opened by the "should the schema record the drop-test evidence?" discussion: **producer first, then schema designed against the producer's real output.** csd's drop-test producer (`scripts/drop_test.sh`) now emits `{removed, required, observed}` checks; this models that shape.

## What
- **Schema:** adds `derivation.drop_test` — `{ checks: [{removed, required, observed}] }` (non-empty). Additive within schema 1.1 (optional block; a `1.0`/observation profile is unaffected).
- **Validator:** `observer: drop-test` now **requires** the block. A profile can't just *claim* the source — it must record what was removed and what happened. This makes the trust-critical override profiles self-justifying (the whole point: drop-test overrides observation, so it should show its work).
- **ADR-017 §8:** documents the mandatory evidence + fixes a stray "bisected".

## Example
```yaml
derivation:
  observer: drop-test
  validated_via: [drop-test, ci-smoke]
  drop_test:
    checks:
      - { removed: SETUID, required: true,  observed: "daemon uid=0 — privilege drop failed" }
      - { removed: CHOWN,  required: false, observed: "healthy, daemon uid=201" }
```

## Tests
`872 passed, 6 skipped`. New `test_drop_test_missing_evidence_fails`; `test_drop_test_validated_passes` now carries a `drop_test` block.

## Follow-up
Backfill the two catalog profiles with real evidence (postgres tool-emitted from the producer; netdata transcribed from its documented drop-test run pending predicate hardening), then re-pin.