### PR TITLE
Add optional derivation.run_config to profile schema (1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Profile schema **1.2** (ADR-017 §9): an optional `derivation.run_config` block
+  recording the invocation a minimum was derived under — `user`, `command`,
+  `entrypoint`, `network`, `pid`, `devices`, `security_opt`, `mounts`, and `env`
+  (keys only, never values). A derived minimum is only valid for its invocation
+  (postgres run with `user:` set skips the root→user drop and needs none of the
+  startup caps a default-invocation profile lists), so a consumer can diff a
+  target service against it and downgrade to a hint on divergence. Emitted by
+  csd's drop-test producer, not hand-authored. Additive — all 1.0/1.1 documents
+  remain valid.
 - Opt-in profile enrichment (ADR-017). Set `profiles.enabled: true` and point
   `profiles.path` at a catalog of container-sec-derive (csd) profiles you trust;
   findings from CL-0006/0007/0002/0011/0016 then gain image-specific fix guidance

--- a/docs/adr/017-security-profile-catalog.md
+++ b/docs/adr/017-security-profile-catalog.md
@@ -238,3 +238,33 @@ All other `validated` requirements are unchanged (digest-pinned
 `validated_image`, committed hash-verified workload — the exerciser used to judge
 health during drop-test — `ci-smoke`, and criteria per #359). `1.0` documents
 remain valid; `drop-test` is opt-in under `1.1`.
+
+### 9. run_config — the invocation a minimum was derived under (schema 1.2, amendment 2026-07-03)
+
+A derived minimum is a function of **how the container was run**, not just the
+image. The same postgres image needs `[DAC_OVERRIDE, SETGID, SETUID]` under the
+default (root-then-`gosu`-drop) invocation and **none** of them when run with
+`user:` set — the entrypoint sees it is already non-root and skips the privilege
+drop. `caddy`'s `/data` is `tmpfs`-droppable for a static file server but a
+load-bearing persistent volume for a reverse proxy doing automatic HTTPS. A
+profile is only valid for the invocation it was produced under, and nothing in
+the schema recorded that invocation.
+
+Schema 1.2 adds an **optional** `derivation.run_config` block capturing it:
+`user`, `command`, `entrypoint`, `network`, `pid`, `devices`, `security_opt`,
+`mounts`, and `env` (**keys only** — values are never emitted, so a secret cannot
+land in committed evidence). It is **emitted by the derivation tool as a
+byproduct of the run, not hand-authored** (csd's drop-test producer builds it
+from the spec's `run:` block). A consumer applying the profile can diff a target
+service against `run_config` and downgrade to a hint when a load-bearing axis
+diverges, rather than misapplying a minimum derived under different conditions.
+
+`run_config` is optional and additive: it enlarges no existing constraint, so
+all `1.0`/`1.1` documents remain valid. It is descriptive, not causal — it
+records the *whole* invocation, not a minimal "which axes matter"; conservative
+consumers treat any security-relevant divergence as a warning. Conditions
+*outside* the invocation that also bound a minimum — the container runtime's
+default cap/seccomp baseline, host LSM enforcement, architecture, fresh-vs-
+initialized data state, and above all **workload coverage** (a minimum is only
+valid for what the workload exercised) — remain scope stated in each image's
+criteria doc (#359), not schema fields.

--- a/src/compose_lint/profiles/schema/profile.schema.json
+++ b/src/compose_lint/profiles/schema/profile.schema.json
@@ -8,9 +8,9 @@
   "additionalProperties": false,
   "properties": {
     "schema_version": {
-      "description": "Catalog profile schema version (independent of csd's sidecar schema_version, which is recorded per-dimension under derivation.sidecar_schema_version). 1.1 adds drop-test as a derivation source (observer=drop-test, validated_via=drop-test); 1.0 documents remain valid.",
+      "description": "Catalog profile schema version (independent of csd's sidecar schema_version, which is recorded per-dimension under derivation.sidecar_schema_version). 1.1 adds drop-test as a derivation source (observer=drop-test, validated_via=drop-test); 1.2 adds the optional derivation.run_config block (the invocation the minimum was derived under). All earlier documents remain valid.",
       "type": "string",
-      "enum": ["1.0", "1.1"]
+      "enum": ["1.0", "1.1", "1.2"]
     },
     "image": {
       "description": "Canonical repository reference WITHOUT tag or digest -- the match key. Registry and namespace normalized (docker.io/library/postgres, lscr.io/linuxserver/radarr).",
@@ -267,6 +267,54 @@
                   }
                 }
               }
+            }
+          }
+        },
+        "run_config": {
+          "description": "The invocation the minimum was derived under -- the orthogonal run context, NOT the derived dimension itself. Emitted by the derivation tool (a byproduct of the run), not hand-authored. A minimum is only valid for its invocation, so a consumer may diff a target service against this and downgrade to a hint when a load-bearing axis (user, mounts, network/pid mode) diverges: e.g. postgres run with `user:` set skips the root->user drop and needs none of the startup caps a default-invocation profile lists. `env` is keys only (no values), so a secret never lands in committed evidence.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "user": {
+              "type": "string",
+              "description": "The container user (`--user` / compose `user:`). Empty means the image default (for postgres, root, which triggers the root->user privilege drop)."
+            },
+            "command": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Command override (`docker run ... <cmd>` / compose `command:`). Empty means the image default CMD -- a different command profiles a different program, so the minimum does not carry over."
+            },
+            "entrypoint": {
+              "type": "string",
+              "description": "Entrypoint override (`--entrypoint` / compose `entrypoint:`). Empty means the image default."
+            },
+            "network": {
+              "type": "string",
+              "description": "Network mode (`--network` / compose `network_mode:`). Empty means the default."
+            },
+            "pid": {
+              "type": "string",
+              "description": "PID mode (`--pid` / compose `pid:`). Empty means the default."
+            },
+            "devices": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Device mappings (`--device` / compose `devices:`) present during derivation."
+            },
+            "security_opt": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "security_opt entries the derivation ran with (e.g. apparmor=unconfined)."
+            },
+            "mounts": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Bind/volume mounts present during derivation (source:dest[:opts])."
+            },
+            "env": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Environment variable KEYS set during derivation (no values -- values are never emitted)."
             }
           }
         }

--- a/tests/test_profile_schema.py
+++ b/tests/test_profile_schema.py
@@ -62,9 +62,10 @@ def test_schema_is_valid_draft202012(schema: dict[str, Any]) -> None:
 
 
 def test_schema_version_is_pinned(schema: dict[str, Any]) -> None:
-    # 1.0 is the baseline; 1.1 adds drop-test as a derivation source. Both remain
-    # valid so existing 1.0 documents are not invalidated.
-    assert schema["properties"]["schema_version"]["enum"] == ["1.0", "1.1"]
+    # 1.0 is the baseline; 1.1 adds drop-test as a derivation source; 1.2 adds
+    # the optional derivation.run_config block. All remain valid so existing
+    # documents are not invalidated.
+    assert schema["properties"]["schema_version"]["enum"] == ["1.0", "1.1", "1.2"]
 
 
 def test_example_validates(
@@ -142,3 +143,34 @@ def test_gadget_provenance_shape(
         }
     ]
     assert validator.is_valid(example), list(validator.iter_errors(example))
+
+
+def test_run_config_accepted(
+    validator: Draft202012Validator, example: dict[str, Any]
+) -> None:
+    # The derivation may record the invocation the minimum was derived under.
+    # It is optional (existing documents omit it) and tool-emitted.
+    derivation = example["dimensions"]["capabilities"]["derivation"]
+    derivation["run_config"] = {
+        "user": "",
+        "command": [],
+        "entrypoint": "",
+        "network": "",
+        "pid": "",
+        "devices": [],
+        "security_opt": [],
+        "mounts": [],
+        "env": ["POSTGRES_PASSWORD"],
+    }
+    assert validator.is_valid(example), list(validator.iter_errors(example))
+
+
+def test_run_config_rejects_unknown_key(
+    validator: Draft202012Validator, example: dict[str, Any]
+) -> None:
+    # additionalProperties closure: run_config carries a fixed set of axes.
+    example["dimensions"]["capabilities"]["derivation"]["run_config"] = {
+        "user": "",
+        "cap_add": ["SYS_ADMIN"],
+    }
+    assert not validator.is_valid(example)


### PR DESCRIPTION
The contract half of "a profile is only valid for the invocation it was derived under" (part of the csd **maturing-profiles** track, compose-lint#360).

## Why
A derived minimum is a function of *how the container was run*, not just the image:
- `postgres` needs `[DAC_OVERRIDE, SETGID, SETUID]` under the default root-then-`gosu`-drop run, and **none** of them when run with `user:` set (the entrypoint skips the privilege drop).
- `caddy`'s `/data` is `tmpfs`-droppable for a static file server but a load-bearing persistent volume for a reverse proxy doing HTTPS.

Nothing in the schema recorded that invocation, so a consumer couldn't tell whether a target service's config matched the profile's derivation context.

## What
Schema **1.2** adds an **optional** `derivation.run_config`:
```
user, command, entrypoint, network, pid, devices, security_opt, mounts, env
```
`env` is **keys only** — values are never emitted, so a secret can't land in committed evidence. The block is **emitted by csd's drop-test producer as a byproduct of the run** (from the spec's `run:` block), not hand-authored. A consumer diffs a target service against it and downgrades to a hint on divergence.

## Scope / non-goals (ADR-017 §9)
- **Additive + optional** — enlarges no existing constraint; all 1.0/1.1 documents stay valid (`test_schema_version_is_pinned` now `["1.0","1.1","1.2"]`).
- **Descriptive, not causal** — records the *whole* invocation, not a minimal "which axes matter"; conservative consumers warn on any security-relevant divergence.
- Conditions *outside* the invocation that also bound a minimum — the runtime's default cap/seccomp baseline, host LSM, architecture, fresh-vs-initialized data, and above all **workload coverage** — remain scope in each image's criteria doc (#359), not schema fields.

## Tests
`test_run_config_accepted` + `test_run_config_rejects_unknown_key`; ADR-017 §9 + CHANGELOG. Full suite: **874 passed, 6 skipped**.

Producer side: container-sec-derive#231 (emits `run_config`). The consumption diff is a follow-up. Once this lands I'll bump the catalog's `contract/compose-lint.ref` and ship the postgres/caddy profiles carrying `run_config`.