### PR TITLE
Fix per-service enrichment dedup; clarify the runtime caveat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Profile-enrichment hints no longer collapse across services in text output.**
+  The fix-block dedup keyed on `rule_id` alone, so when two services were flagged
+  by the same rule but enrichment gave them **different** image-specific guidance
+  (e.g. postgres → `cap_add: [CHOWN, DAC_OVERRIDE, SETGID, SETUID]`, caddy →
+  `cap_add: [NET_BIND_SERVICE]`), the second service was rendered
+  `(see fix above)` — pointing at the *first* service's wrong-image recommendation.
+  The dedup now keys on `(rule_id, fix, references)`, so distinct hints each print
+  in full while identical fixes still collapse.
+
+### Changed
+
+- **Clearer profile-enrichment caveat.** The provenance tail `not independently
+  verified here` is replaced with `compose-lint can't see your runtime, confirm
+  it fits your setup` — it names the actual limit (a static linter reads the
+  compose text, not the running container, and can't confirm the recommendation
+  matches your invocation) rather than a vague disclaimer.
+
 ### Added
 
 - Profile schema **1.2** (ADR-017 §9): an optional `derivation.run_config` block

--- a/src/compose_lint/formatters/text.py
+++ b/src/compose_lint/formatters/text.py
@@ -255,8 +255,12 @@ def format_findings(
     """Format findings as human-readable colored text grouped by file and service.
 
     The fix block and reference URL are printed only on the first occurrence
-    of each rule id within a file; subsequent occurrences get a brief
-    `(see fix above)` marker. ``verbose=True`` restores per-finding fix
+    of each *distinct* fix within a file; subsequent occurrences with the same
+    fix get a brief `(see fix above)` marker. The dedup key includes the fix
+    text, not just the rule id, so profile enrichment — which makes a rule's fix
+    image-specific (e.g. postgres vs caddy get different `cap_add` hints) — is
+    never collapsed into another service's recommendation. ``verbose=True``
+    restores per-finding fix
     repetition for IDE tooling or local fix-it-now workflows. ``quiet=True``
     does the opposite — one line per finding, dropping the fix block,
     reference URL, source excerpt, and suppression reason — for CI and repeat
@@ -279,7 +283,12 @@ def format_findings(
     out.append(_colorize(_sanitize(filepath), _BOLD))
     out.append("")
 
-    seen_rules: set[str] = set()
+    # Dedup on (rule_id, fix, references), not rule_id alone: profile enrichment
+    # makes a rule's fix image-specific, so two services flagged by the same rule
+    # can carry genuinely different guidance. Keying on rule_id alone would mark
+    # the second "(see fix above)" and point it at the first service's (wrong-
+    # image) recommendation.
+    seen_fixes: set[tuple[str, str, tuple[str, ...]]] = set()
 
     for service, group in services_in_order:
         svc_line = next((f.line for f in group if f.line is not None), None)
@@ -320,7 +329,8 @@ def format_findings(
             line_label = str(f.line) if f.line else "?"
             message = _sanitize(f.message)
 
-            already_shown = f.rule_id in seen_rules
+            fix_key = (f.rule_id, f.fix or "", tuple(f.references or ()))
+            already_shown = fix_key in seen_fixes
             show_fix = not quiet and (verbose or not already_shown)
             suffix = ""
             if not quiet and already_shown and not verbose and (f.fix or f.references):
@@ -349,7 +359,7 @@ def format_findings(
             if show_fix and f.references:
                 out.append(f"          {_colorize('ref:', _DIM)} {f.references[0]}")
 
-            seen_rules.add(f.rule_id)
+            seen_fixes.add(fix_key)
 
         out.append("")
 

--- a/src/compose_lint/profiles/enrich.py
+++ b/src/compose_lint/profiles/enrich.py
@@ -101,7 +101,8 @@ def _provenance(dim: dict[str, Any], match: ProfileMatch) -> str:
     image = _short_image(str(derivation.get("validated_image") or match.image))
     return (
         f"csd-derived, confidence {confidence}, from {image}, "
-        f"{match.precision.value} match — not independently verified here"
+        f"{match.precision.value} match — compose-lint can't see your runtime, "
+        f"confirm it fits your setup"
     )
 
 

--- a/tests/test_profile_enrich.py
+++ b/tests/test_profile_enrich.py
@@ -77,9 +77,10 @@ def test_provenance_notes_confidence_and_precision() -> None:
     assert result.fix is not None
     assert "confidence high" in result.fix
     assert "tag match" in result.fix
-    # attributed, not asserted as compose-lint fact (ADR-017 §7)
+    # attributed, not asserted as compose-lint fact (ADR-017 §7): the caveat
+    # names the actual limit — a static linter can't see the runtime/invocation.
     assert "csd-derived" in result.fix
-    assert "not independently verified" in result.fix
+    assert "compose-lint can't see your runtime" in result.fix
     # digest is shortened, not the full 64 hex
     assert "a" * 64 not in result.fix
 

--- a/tests/test_text_formatter.py
+++ b/tests/test_text_formatter.py
@@ -443,3 +443,57 @@ def test_format_summary_escapes_bidi_in_path() -> None:
     out = format_summary([], f"compose{_RLO}.yml")
     assert _RLO not in out
     assert "\\u202e" in out
+
+
+def test_fix_dedup_keys_on_fix_not_rule_id() -> None:
+    # Profile enrichment makes a rule's fix image-specific, so two services
+    # flagged by the same rule can carry genuinely different guidance. The dedup
+    # must not collapse the second into "(see fix above)" pointing at the first
+    # service's (wrong-image) fix.
+    findings = [
+        Finding(
+            "CL-0006",
+            Severity.MEDIUM,
+            "db",
+            "caps not dropped",
+            line=2,
+            fix="cap_drop: [ALL]\nhint: cap_add: [CHOWN, DAC_OVERRIDE, SETGID, SETUID]",
+        ),
+        Finding(
+            "CL-0006",
+            Severity.MEDIUM,
+            "proxy",
+            "caps not dropped",
+            line=6,
+            fix="cap_drop: [ALL]\nprofile hint: cap_add: [NET_BIND_SERVICE]",
+        ),
+    ]
+    out = format_findings(findings, "compose.yml")
+    assert "CHOWN" in out
+    assert "NET_BIND_SERVICE" in out  # the second, distinct hint is not collapsed
+    assert "(see fix above)" not in out
+
+
+def test_fix_dedup_collapses_identical_fixes() -> None:
+    # Same rule + identical fix (no enrichment) still dedups to a single block.
+    findings = [
+        Finding(
+            "CL-0003",
+            Severity.MEDIUM,
+            "web",
+            "nnp",
+            line=2,
+            fix="- no-new-privileges:true",
+        ),
+        Finding(
+            "CL-0003",
+            Severity.MEDIUM,
+            "api",
+            "nnp",
+            line=5,
+            fix="- no-new-privileges:true",
+        ),
+    ]
+    out = format_findings(findings, "compose.yml")
+    assert out.count("- no-new-privileges:true") == 1
+    assert "(see fix above)" in out


### PR DESCRIPTION
Two fixes surfaced by end-to-end testing of profile enrichment against a real catalog (postgres + caddy in one compose).

## 1. Per-service hints no longer collapse (bug)
The text formatter's fix-block dedup keyed on `rule_id` alone — it predates enrichment. Enrichment makes a rule's fix **image-specific**, so two services flagged by the same rule carry different guidance. Keying on `rule_id` rendered the second service `(see fix above)`, pointing it at the **first service's wrong-image** recommendation:

```
service: db     CL-0006 …  profile hint → cap_add: [CHOWN, DAC_OVERRIDE, SETGID, SETUID]
service: proxy  CL-0006 …  (see fix above)      ← caddy told to use postgres's caps!
```

Now keyed on `(rule_id, fix, references)` — distinct hints each print in full, identical fixes (non-enriched rules like CL-0003) still collapse:

```
service: proxy  CL-0006 …  profile hint → cap_add: [NET_BIND_SERVICE]   ✓ correct
```

## 2. Clearer runtime caveat (wording)
`not independently verified here` → **`compose-lint can't see your runtime, confirm it fits your setup`**. It names the actual limit — a static linter reads the compose text, not the running container, so it can't confirm the recommendation matches your invocation — rather than a vague disclaimer. (A derived minimum is only valid for the invocation it was produced under; the linter has no way to check yours.)

## Tests
- `test_fix_dedup_keys_on_fix_not_rule_id` — distinct hints not collapsed
- `test_fix_dedup_collapses_identical_fixes` — identical fixes still dedup
- `test_profile_enrich` updated to the new wording
- Full suite: **876 passed, 6 skipped**

Both fixes keep enrichment in its lane — advisory, additive, honestly caveated — which is the right posture for a static consumer of an inherently invocation-dependent profile.