### PR TITLE
Label profile enrichment experimental; notice when active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Profile enrichment is now labeled experimental.** The feature is already
+  opt-in and off by default (`profiles.enabled`); this makes its provisional
+  status explicit. When enrichment is active, compose-lint prints a one-line
+  stderr reminder that fix recommendations are advisory, derived for a specific
+  invocation, and not validated against your runtime — and the config docs mark
+  the section experimental. No behavior change to the findings themselves.
 - **Clearer profile-enrichment caveat.** The provenance tail `not independently
   verified here` is replaced with `compose-lint can't see your runtime, confirm
   it fits your setup` — it names the actual limit (a static linter reads the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,7 +81,15 @@ Excluded services still produce **SUPPRESSED** findings, with the per-service re
 - **Global `enabled: false` wins** over per-service exclusions: if a rule is disabled globally, every service is suppressed regardless of `exclude_services`.
 - **No inline suppression syntax** — there is no `# compose-lint: disable` comment form. Suppressions are tracked in config so reviewers can audit them.
 
-## Profile enrichment
+## Profile enrichment (experimental)
+
+> **Experimental preview.** Off by default and opt-in. Profile fix
+> recommendations are **advisory only**: a derived minimum is valid for the exact
+> invocation it was produced under (image digest, `user:`, `command:`, mounts,
+> …), and compose-lint does static analysis — it can't see your runtime, so it
+> can't confirm the recommendation fits your deployment. Treat a hint as a
+> pointer to verify, not a validated fact. When enrichment is active, compose-lint
+> prints a one-line reminder to stderr.
 
 Opt into image-specific fix guidance derived by
 [container-sec-derive](https://github.com/tmatens/container-sec-derive) (csd).

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -343,6 +343,16 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
         profile_lookup = functools.partial(
             load_profile, catalog_root=Path(profiles_path)
         )
+        # Profile enrichment is an experimental preview. It's already opt-in
+        # (profiles.enabled, off by default); this makes the provisional status
+        # explicit whenever it's active, so no one mistakes an advisory,
+        # invocation-specific hint for a validated fact about their deployment.
+        print(
+            "Note: profile fix recommendations are experimental — advisory only, "
+            "derived for a specific invocation, and not validated against your "
+            "runtime. Verify before applying.",
+            file=sys.stderr,
+        )
     elif profiles_enabled:
         print(
             "Warning: profiles.enabled is set but profiles.path is unset; "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -192,6 +192,29 @@ class TestCLI:
         )
         assert by_service["empty_security_opt"]["suppressed"] is False
 
+    def test_profile_enrichment_prints_experimental_notice(
+        self, tmp_path: Path
+    ) -> None:
+        # Enrichment is experimental: when it's active (opt-in), a one-line
+        # stderr reminder makes the provisional, unvalidated status explicit.
+        compose = tmp_path / "docker-compose.yml"
+        compose.write_text("services:\n  db:\n    image: postgres:16\n")
+        catalog = tmp_path / "catalog"
+        catalog.mkdir()
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text(f"profiles:\n  enabled: true\n  path: {catalog}\n")
+        result = run_cli(str(compose), "--config", str(config))
+        assert "experimental" in result.stderr
+        assert "profile fix recommendations" in result.stderr
+
+    def test_no_experimental_notice_when_profiles_disabled(
+        self, tmp_path: Path
+    ) -> None:
+        compose = tmp_path / "docker-compose.yml"
+        compose.write_text("services:\n  db:\n    image: postgres:16\n")
+        result = run_cli(str(compose))
+        assert "experimental" not in result.stderr
+
     def test_explain_prints_rule_doc(self) -> None:
         result = run_cli("--explain", "CL-0003")
         assert result.returncode == 0


### PR DESCRIPTION
Keeps profile fix recommendations behind their existing flag (`profiles.enabled`, off by default) but makes the **experimental / provisional** status explicit — "for now," per the fragility of consuming an invocation-specific profile via static analysis.

## Why
A derived minimum is only valid for the exact invocation it was produced under (image digest, `user:`, `command:`, mounts, seccomp…). compose-lint reads the compose text, not the running container, so it can't confirm a recommendation fits your deployment. The feature was already opt-in, but nothing signaled that it's a preview.

## What
- **stderr notice when enrichment is active:**
  ```
  Note: profile fix recommendations are experimental — advisory only, derived for a
  specific invocation, and not validated against your runtime. Verify before applying.
  ```
- **docs/configuration.md** — the *Profile enrichment* section is now marked **(experimental)** with a preview callout.
- No change to the findings or hints themselves.

## Tests
`test_profile_enrichment_prints_experimental_notice` (present when enabled) + `test_no_experimental_notice_when_profiles_disabled` (absent otherwise). ruff/format/mypy clean.

Chosen over adding a redundant second gate: the feature is already off-by-default and two-key opt-in, so the missing piece was the loud "this is experimental" signal, not more ceremony.