### PR TITLE
profiles: add app_tier_verified (schema 1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Profile schema 1.3: `app_tier_verified`.** An optional top-level block on a
+  profile recording that the whole hardening was verified at the **service** level
+  — the multi-container stack brought up with every dimension applied and a real
+  service-level check passed — a stronger signal than the per-dimension workload,
+  which exercises only one container. Fields: `service`, `service_version`,
+  `method`, `check`, `verified_date`, `result`, and an optional `over_hardening`
+  (`applied` + `result`) that proves the check catches a too-tight config (not a
+  rubber stamp). Requires `status: validated` (schema) and `result: pass`
+  (ci-smoke gate). Optional and additive — all 1.0–1.2 documents remain valid, and
+  it never substitutes for the per-dimension `validated_via` evidence. ADR-017 §10.
+
 ### Fixed
 
 - **Profile-enrichment hints no longer collapse across services in text output.**

--- a/docs/adr/017-security-profile-catalog.md
+++ b/docs/adr/017-security-profile-catalog.md
@@ -268,3 +268,29 @@ default cap/seccomp baseline, host LSM enforcement, architecture, fresh-vs-
 initialized data state, and above all **workload coverage** (a minimum is only
 valid for what the workload exercised) — remain scope stated in each image's
 criteria doc (#359), not schema fields.
+
+### 10. app_tier_verified — service-level verification of the whole profile (schema 1.3, amendment 2026-07-04)
+
+A per-dimension `derivation` is backed by a workload that exercises **that one
+container**. But many images ship as part of a **multi-container service** (a
+database + cache + app tiers), and a minimum that keeps the one container correct
+in isolation can still break the *service* when applied. The stronger evidence is
+to bring up the whole stack with the hardening applied and confirm the service
+does its real job — using the upstream project's own fixtures + API rather than a
+hand-rolled probe.
+
+Schema 1.3 adds an **optional top-level** `app_tier_verified` block recording that
+verification for the whole profile (not per-dimension, because the stack runs with
+every dimension applied at once): `service`, `service_version`, `method`, `check`
+(prose), `verified_date`, `result`, and an optional `over_hardening` object
+(`applied` + `result`). The `over_hardening` field is what earns the trust — "the
+check passed" is weak alone, but "…and a deliberately-too-tight config was shown to
+FAIL the same check" proves the gate is not a rubber stamp.
+
+`app_tier_verified` is only meaningful for a cleared profile, so the schema
+requires `status: validated` when it is present, and the ci-smoke gate additionally
+requires `result: pass`. It is optional and additive — all `1.0`–`1.2` documents
+remain valid, and it never substitutes for the per-dimension `validated_via`
+evidence (drop-test / bpf-observation / ci-smoke); it is *additional* evidence.
+csd's `scripts/apptier_verify.sh` produces it (worked example: immich's postgres
+and valkey, verified against immich's released stack and real REST API).

--- a/scripts/validate_profiles.py
+++ b/scripts/validate_profiles.py
@@ -70,6 +70,12 @@ def check_document(
         for name, dim in dimensions.items():
             errors.extend(_check_validated_dimension(name, dim["derivation"]))
         errors.extend(_check_criteria(path, catalog_dir, criteria_dir))
+        atv = doc.get("app_tier_verified")
+        if atv is not None and atv.get("result") != "pass":
+            errors.append(
+                "app_tier_verified.result must be 'pass' for a validated profile "
+                f"(got {atv.get('result')!r})"
+            )
     elif status == "exploratory" and not under_exploratory:
         errors.append("exploratory profile must live under catalog/exploratory/")
 

--- a/src/compose_lint/profiles/schema/profile.schema.json
+++ b/src/compose_lint/profiles/schema/profile.schema.json
@@ -8,9 +8,9 @@
   "additionalProperties": false,
   "properties": {
     "schema_version": {
-      "description": "Catalog profile schema version (independent of csd's sidecar schema_version, which is recorded per-dimension under derivation.sidecar_schema_version). 1.1 adds drop-test as a derivation source (observer=drop-test, validated_via=drop-test); 1.2 adds the optional derivation.run_config block (the invocation the minimum was derived under). All earlier documents remain valid.",
+      "description": "Catalog profile schema version (independent of csd's sidecar schema_version, which is recorded per-dimension under derivation.sidecar_schema_version). 1.1 adds drop-test as a derivation source (observer=drop-test, validated_via=drop-test); 1.2 adds the optional derivation.run_config block (the invocation the minimum was derived under); 1.3 adds the optional top-level app_tier_verified block (service-level verification of the whole profile). All earlier documents remain valid.",
       "type": "string",
-      "enum": ["1.0", "1.1", "1.2"]
+      "enum": ["1.0", "1.1", "1.2", "1.3"]
     },
     "image": {
       "description": "Canonical repository reference WITHOUT tag or digest -- the match key. Registry and namespace normalized (docker.io/library/postgres, lscr.io/linuxserver/radarr).",
@@ -46,6 +46,7 @@
       "items": { "type": "string" },
       "minItems": 1
     },
+    "app_tier_verified": { "$ref": "#/$defs/appTierVerified" },
     "dimensions": {
       "description": "Per-security-dimension derived config. All optional and additive -- a caps-only profile is valid. Each maps to a compose-lint rule.",
       "type": "object",
@@ -133,6 +134,13 @@
         "properties": { "status": { "const": "validated" } }
       },
       "then": { "not": { "required": ["acceptance_contract_violations"] } }
+    },
+    {
+      "if": { "required": ["app_tier_verified"] },
+      "then": {
+        "required": ["status"],
+        "properties": { "status": { "const": "validated" } }
+      }
     }
   ],
   "$defs": {
@@ -144,6 +152,48 @@
     "absPath": { "type": "string", "pattern": "^/" },
     "devPath": { "type": "string", "pattern": "^/dev/" },
     "digest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+    "appTierVerified": {
+      "description": "1.3 (optional, top-level). The whole profile was additionally verified at the SERVICE level: the multi-container stack was brought up with this hardening applied and a real service-level check passed. Stronger than a per-dimension workload, which exercises only the one container. When present, status must be 'validated'.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["service", "method", "check", "verified_date", "result"],
+      "properties": {
+        "service": {
+          "type": "string",
+          "description": "The composed service verified end-to-end (e.g. immich)."
+        },
+        "service_version": {
+          "type": "string",
+          "description": "Version/tag of the stack it was verified against (e.g. v2.7.5)."
+        },
+        "method": {
+          "type": "string",
+          "description": "How the whole stack was brought up and driven (e.g. container-sec-derive scripts/apptier_verify.sh)."
+        },
+        "check": {
+          "type": "string",
+          "description": "What the service-level check exercised, in prose (e.g. the real API calls)."
+        },
+        "verified_date": { "type": "string", "format": "date" },
+        "result": { "enum": ["pass", "fail"] },
+        "over_hardening": {
+          "description": "Optional but recommended: proves the check catches a too-tight config (it is not a rubber stamp) by recording an over-restriction shown to FAIL the same service-level check.",
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["applied", "result"],
+          "properties": {
+            "applied": {
+              "type": "string",
+              "description": "The over-hardening applied, e.g. 'dropped SETUID from the database'."
+            },
+            "result": {
+              "type": "string",
+              "description": "What broke, e.g. 'database unhealthy (could not switch to the postgres user) -> immich never starts'."
+            }
+          }
+        }
+      }
+    },
     "derivation": {
       "description": "Per-dimension provenance. Distinct per dimension because csd derives each observer in a separate run with its own digest/confidence/window.",
       "type": "object",

--- a/tests/test_profile_schema.py
+++ b/tests/test_profile_schema.py
@@ -63,9 +63,15 @@ def test_schema_is_valid_draft202012(schema: dict[str, Any]) -> None:
 
 def test_schema_version_is_pinned(schema: dict[str, Any]) -> None:
     # 1.0 is the baseline; 1.1 adds drop-test as a derivation source; 1.2 adds
-    # the optional derivation.run_config block. All remain valid so existing
-    # documents are not invalidated.
-    assert schema["properties"]["schema_version"]["enum"] == ["1.0", "1.1", "1.2"]
+    # the optional derivation.run_config block; 1.3 adds the optional top-level
+    # app_tier_verified block. All remain valid so existing documents are not
+    # invalidated.
+    assert schema["properties"]["schema_version"]["enum"] == [
+        "1.0",
+        "1.1",
+        "1.2",
+        "1.3",
+    ]
 
 
 def test_example_validates(
@@ -173,4 +179,59 @@ def test_run_config_rejects_unknown_key(
         "user": "",
         "cap_add": ["SYS_ADMIN"],
     }
+    assert not validator.is_valid(example)
+
+
+def _app_tier_verified() -> dict[str, Any]:
+    return {
+        "service": "immich",
+        "service_version": "v2.7.5",
+        "method": "container-sec-derive scripts/apptier_verify.sh",
+        "check": "immich REST API: sign-up, login, upload, read-back, search",
+        "verified_date": "2026-07-04",
+        "result": "pass",
+        "over_hardening": {
+            "applied": "dropped SETUID from the database",
+            "result": "database unhealthy -> immich never starts",
+        },
+    }
+
+
+def test_app_tier_verified_accepted(
+    validator: Draft202012Validator, example: dict[str, Any]
+) -> None:
+    # A validated profile may record a whole-service verification (schema 1.3).
+    # Optional and additive: existing documents omit it.
+    example["schema_version"] = "1.3"
+    example["app_tier_verified"] = _app_tier_verified()
+    assert validator.is_valid(example), list(validator.iter_errors(example))
+
+
+def test_app_tier_verified_requires_validated_status(
+    validator: Draft202012Validator, example: dict[str, Any]
+) -> None:
+    # An exploratory profile has not cleared the bar, so it cannot claim a
+    # service-level verification.
+    example["status"] = "exploratory"
+    example["acceptance_contract_violations"] = ["below the confidence bar"]
+    example["app_tier_verified"] = _app_tier_verified()
+    assert not validator.is_valid(example)
+
+
+def test_app_tier_verified_requires_result(
+    validator: Draft202012Validator, example: dict[str, Any]
+) -> None:
+    atv = _app_tier_verified()
+    del atv["result"]
+    example["app_tier_verified"] = atv
+    assert not validator.is_valid(example)
+
+
+def test_over_hardening_rejects_unknown_key(
+    validator: Draft202012Validator, example: dict[str, Any]
+) -> None:
+    # additionalProperties closure on the over_hardening evidence.
+    atv = _app_tier_verified()
+    atv["over_hardening"]["cap"] = "SETUID"
+    example["app_tier_verified"] = atv
     assert not validator.is_valid(example)


### PR DESCRIPTION
Adds an optional top-level **`app_tier_verified`** block to the profile schema (1.3): evidence that a profile's whole hardening was verified at the **service** level — the multi-container stack brought up with every dimension applied and a real service-level check passed. Stronger than a per-dimension workload, which exercises only the one container.

## The field

```yaml
app_tier_verified:
  service: immich
  service_version: v2.7.5
  method: container-sec-derive scripts/apptier_verify.sh
  check: "immich REST API — sign-up, login, upload a photo, read back, search — all passing"
  verified_date: "2026-07-04"
  result: pass
  over_hardening:                 # proves the check catches a too-tight config
    applied: "dropped SETUID from the database"
    result: "database unhealthy → immich never starts"
```

**`over_hardening` is what earns the trust:** "the check passed" is weak alone; "…and a deliberately-too-tight config was shown to FAIL the same check" proves the gate isn't a rubber stamp.

## Constraints

- Schema requires **`status: validated`** when `app_tier_verified` is present.
- The ci-smoke gate (`validate_profiles.py`) additionally requires **`result: pass`**.
- **Optional and additive** — all 1.0–1.2 documents remain valid; it never substitutes for the per-dimension `validated_via` evidence (drop-test / bpf-observation / ci-smoke), it's *additional*.

## Changes

- `profile.schema.json`: `schema_version` enum gains `1.3`; new `appTierVerified` `$def` + top-level `app_tier_verified` property; `allOf` conditional (present ⇒ validated).
- `validate_profiles.py`: `result: pass` guard for validated profiles.
- `docs/adr/017`: amendment §10.
- Tests: new field accepted; rejected on exploratory; `result` required; `over_hardening` closure. **42 profile/validator/loader tests pass.**

Produced by csd's `scripts/apptier_verify.sh`; the catalog will adopt it for immich's postgres + valkey (a follow-up PR bumping the contract ref).