### PR TITLE
profiles: reject mutable rolling tags for validated profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Validated profiles must declare immutable version tags.** The profile ci-smoke
+  gate (`scripts/validate_profiles.py`) now rejects a `status: validated` profile
+  whose `applies_to.tags` includes a mutable rolling tag (`latest`, `stable`,
+  `edge`, `main`, `nightly`, …): such a tag points to a different image over time,
+  so a derivation done against it cannot be trusted to still apply to the image a
+  consumer later pulls. Exploratory profiles are unaffected, and no existing catalog
+  profile uses a mutable tag, so this guards against a future mistake without
+  changing current data.
 - **Profile schema 1.3: `app_tier_verified`.** An optional top-level block on a
   profile recording that the whole hardening was verified at the **service** level
   — the multi-container stack brought up with every dimension applied and a real

--- a/scripts/validate_profiles.py
+++ b/scripts/validate_profiles.py
@@ -40,6 +40,14 @@ VALIDATED_VIA_REQUIRED = frozenset({"bpf-observation", "ci-smoke"})
 DROP_TEST_VIA_REQUIRED = frozenset({"drop-test", "ci-smoke"})
 MIN_DURATION_SECONDS = 300
 VALIDATED_CONFIDENCE = frozenset({"high", "moderate"})
+# A validated profile is derived against a specific image and published for others
+# to rely on. A mutable rolling tag points to a different image over time, so the
+# derivation cannot be trusted to still apply — a profile derived against whatever
+# `:latest` resolved to on derivation day may be wrong for the image a consumer
+# pulls tomorrow. Validated profiles must declare immutable, versioned tags.
+MUTABLE_TAGS = frozenset(
+    {"latest", "stable", "edge", "main", "master", "nightly", "rolling", "dev", "current"}
+)
 
 
 def check_document(
@@ -67,6 +75,17 @@ def check_document(
     if status == "validated":
         if under_exploratory:
             errors.append("validated profile must not live under catalog/exploratory/")
+        mutable = [
+            t for t in (doc.get("applies_to") or {}).get("tags", [])
+            if str(t).strip().lower() in MUTABLE_TAGS
+        ]
+        if mutable:
+            errors.append(
+                "validated profile applies_to.tags must be immutable version tags, "
+                f"not mutable rolling tags {sorted(set(mutable))}: such a tag points "
+                "to a different image over time, so the derivation cannot be trusted "
+                "to still apply (derive against a pinned version)"
+            )
         for name, dim in dimensions.items():
             errors.extend(_check_validated_dimension(name, dim["derivation"]))
         errors.extend(_check_criteria(path, catalog_dir, criteria_dir))

--- a/tests/test_validate_profiles.py
+++ b/tests/test_validate_profiles.py
@@ -104,6 +104,17 @@ def test_low_confidence_validated_fails(tmp_path: Path) -> None:
     assert "confidence" in result.stdout
 
 
+def test_mutable_tag_validated_fails(tmp_path: Path) -> None:
+    # A validated profile must declare immutable version tags: a mutable rolling
+    # tag (:latest) points to a different image over time, so the derivation can't
+    # be trusted to still apply (a profile derived against whatever :latest was).
+    tree = _copy_good(tmp_path)
+    _mutate(tree, lambda d: d.__setitem__("applies_to", {"tags": ["latest"]}))
+    result = _run(tree / "catalog", tree)
+    assert result.returncode == 1
+    assert "mutable" in result.stdout
+
+
 def test_drop_test_validated_passes(tmp_path: Path) -> None:
     # A drop-test-derived dimension (schema 1.1) is validated on
     # [drop-test, ci-smoke] and is exempt from the observation-window duration


### PR DESCRIPTION
Adds a guard to the profile ci-smoke gate (`scripts/validate_profiles.py`): a **validated** profile's `applies_to.tags` must be immutable version tags — a mutable rolling tag (`latest`, `stable`, `edge`, `main`, `nightly`, …) is rejected.

## Why
A validated catalog profile is derived against a specific image and published for others to rely on. If it declares `:latest`, that tag points to a different image over time, so the derivation can't be trusted to still apply — a profile derived against whatever `:latest` resolved to on derivation day may be wrong for the image a consumer pulls later. (This exact gap let a profile get derived against a `:latest` build that didn't match a deployment's pinned digest.)

## Scope
- **Validated** profiles only; exploratory profiles are unaffected.
- No existing catalog profile uses a mutable tag (all declare versioned tags like `16`, `v1.16.2`, `11.4`), so this guards against a future mistake — it changes no current data.
- New test `test_mutable_tag_validated_fails`; full `test_validate_profiles.py` green (15 passed).

Consumed by the external `container-security-profiles` catalog via the pinned contract; that repo will bump its `contract/compose-lint.ref` to pick this up.