### PR TITLE
Bump install-example versions to v0.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: tmatens/compose-lint@94ddcaae5c63b7326ff34f4d0dd5115dbedbd7db # v0.10.0
+      - uses: tmatens/compose-lint@76a831a46ae7165a57c7ff4a8b9e08f7b9a63e6c # v0.13.0
         with:
           sarif-file: results.sarif
 ```
@@ -352,7 +352,7 @@ jobs:
         run: |
           apt-get update -qq
           apt-get install -yqq --no-install-recommends python3-pip
-          pip3 install --break-system-packages --no-cache-dir compose-lint==0.10.0
+          pip3 install --break-system-packages --no-cache-dir compose-lint==0.13.0
       - name: Run compose-lint
         run: compose-lint --fail-on high
 ```
@@ -371,7 +371,7 @@ compose-lint --format sarif docker-compose.yml > results.sarif
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/tmatens/compose-lint
-    rev: v0.10.0
+    rev: v0.13.0
     hooks:
       - id: compose-lint
 ```

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-As of v0.8.0, compose-lint ships 21 security rules, PyPI distribution, a published GitHub Action and Docker image, SARIF/JSON/text output, pre-commit support, per-service rule overrides, and `--explain`. The foundation is solid; the next milestone is the 1.0 stability commitment. Remaining investments make the tool more useful to the users already running it, not chase speculative distribution channels.
+As of v0.13.0, compose-lint ships 22 security rules, PyPI distribution, a published GitHub Action and Docker image, SARIF/JSON/text output, pre-commit support, per-service rule overrides, and `--explain`. The foundation is solid; the next milestone is the 1.0 stability commitment. Remaining investments make the tool more useful to the users already running it, not chase speculative distribution channels.
 
 ## Strategic framing
 

--- a/docs/hardening.md
+++ b/docs/hardening.md
@@ -13,7 +13,7 @@ docker run --rm \
   --user 65532:65532 \
   --pids-limit 256 \
   -v "$(pwd):/src:ro" \
-  composelint/compose-lint:0.8.0
+  composelint/compose-lint:0.13.0
 ```
 
 | Flag | Rule satisfied |
@@ -26,6 +26,6 @@ docker run --rm \
 
 `--network none` and `:ro` on the bind mount are extra hardening — compose-lint never reaches the network and only reads its inputs.
 
-For full supply-chain reproducibility (and to satisfy CL-0004 / CL-0019), replace the `:0.8.0` tag with a digest pin: `composelint/compose-lint@sha256:<digest>`. Get the current digest from [Docker Hub](https://hub.docker.com/r/composelint/compose-lint/tags) or with `docker buildx imagetools inspect composelint/compose-lint:0.8.0 --format '{{json .Manifest}}' | jq -r '.digest'`.
+For full supply-chain reproducibility (and to satisfy CL-0004 / CL-0019), replace the `:0.13.0` tag with a digest pin: `composelint/compose-lint@sha256:<digest>`. Get the current digest from [Docker Hub](https://hub.docker.com/r/composelint/compose-lint/tags) or with `docker buildx imagetools inspect composelint/compose-lint:0.13.0 --format '{{json .Manifest}}' | jq -r '.digest'`.
 
 A Compose-form equivalent that lints clean across every rule lives in [`tests/compose_files/safe_self_hosted.yml`](https://github.com/tmatens/compose-lint/blob/main/tests/compose_files/safe_self_hosted.yml).


### PR DESCRIPTION
Fixes the HIGH doc-staleness finding #374: the getting-started snippets pinned **v0.10.0** while current is **0.13.0**, so copy-pasters installed three-release-old builds.

Bumped every install-facing version reference:
- `README.md:319` — GitHub Action pin `@94ddcaa # v0.10.0` → `@76a831a # v0.13.0`
- `README.md:355` — Forgejo `pip3 install compose-lint==0.10.0` → `==0.13.0`
- `README.md:374` — pre-commit `rev: v0.10.0` → `v0.13.0`
- `docs/hardening.md:16,29` — image example `:0.8.0` → `:0.13.0` (incl. the digest-fetch command)
- `docs/ROADMAP.md:3` — preamble "As of v0.8.0 … 21 security rules" → "As of v0.13.0 … 22 security rules"

**Deliberately left alone:** the "21 rules" mentions in `docs/adr/014-fix-remediation.md` (a frozen decision record) and `docs/state-of-compose*.md` (a point-in-time corpus analysis) — those describe state at the time they were written, not current claims, so bumping the count would misrepresent the analysis.

The marketplace-smoke pin (v0.12.2) is out of scope here — it's already handled by #373.

Docs-only; no code or behavior change.