### PR TITLE
Guard the second source read in check --format sarif and fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`check --format sarif` and `fix` no longer abort a batch when a file becomes
+  unreadable mid-run.** Both re-read the source after parsing (for SARIF fix
+  edits / to apply fixes); if the file was deleted, unmounted, or had its
+  permissions changed between the parse and that second read, the `OSError` is
+  now recorded per-file and the scan continues to the remaining files instead of
+  crashing the whole run.
+
 ## [0.13.0] - 2026-07-05
 
 ### Added

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -452,7 +452,15 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
             # auto-fixable finding carries its machine-applicable edit so GitHub
             # Code Scanning can render a suggested change. Findings with no safe
             # fixer keep the prose `properties.fix` only.
-            text = Path(filepath).read_text(encoding="utf-8")
+            try:
+                text = Path(filepath).read_text(encoding="utf-8")
+            except OSError as e:
+                # Parsed above, but unreadable before this second read (deleted,
+                # unmounted, permission change). Record it and move on so one bad
+                # file can't abort the rest of the batch.
+                parse_errors.append((filepath, str(e)))
+                print(f"Error: {filepath}: {e}", file=sys.stderr)
+                continue
             fixes = collect_edits(findings, data, lines, text).fixed_edits
             all_sarif.extend(format_sarif(findings, filepath, fixes=fixes))
         else:
@@ -568,7 +576,14 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
             had_error = True
             continue
 
-        text = Path(filepath).read_text(encoding="utf-8")
+        try:
+            text = Path(filepath).read_text(encoding="utf-8")
+        except OSError as e:
+            # Parsed above, but unreadable now (deleted, unmounted, permission
+            # change) — record and continue so the rest of the batch still runs.
+            print(f"Error: {filepath}: {e}", file=sys.stderr)
+            had_error = True
+            continue
         findings = run_rules(
             data,
             lines,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -518,6 +518,73 @@ class TestFixSubcommand:
             cli.main(["fix", "--apply", str(f)])
         assert exc.value.code == 2
         assert "added or removed a service" in capsys.readouterr().err
+
+    def test_sarif_second_read_failure_recorded_not_crash(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # Regression (#381): the SARIF path re-reads the source after parsing to
+        # attach fix edits. If the file becomes unreadable between the parse and
+        # that second read, the batch must record the error and continue to the
+        # remaining files, not crash. load_compose reads through its own module,
+        # so patching cli.Path isolates the second read.
+        from compose_lint import cli
+
+        f1 = tmp_path / "a.yml"
+        f2 = tmp_path / "b.yml"
+        for f in (f1, f2):
+            f.write_text(_BARE_SERVICE)
+
+        class _UnreadableSecondRead:
+            def __init__(self, *a: object, **k: object) -> None:
+                self._p = Path(*a, **k)
+
+            def read_text(self, *a: object, **k: object) -> str:
+                raise OSError("simulated: file became unreadable")
+
+            def __getattr__(self, name: str) -> object:
+                return getattr(self._p, name)
+
+        monkeypatch.setattr(cli, "Path", _UnreadableSecondRead)
+        with pytest.raises(SystemExit) as exc:
+            cli.main(["--format", "sarif", str(f1), str(f2)])
+        assert exc.value.code == 2
+        err = capsys.readouterr().err
+        # Both files were reported; neither aborted the run.
+        assert str(f1) in err and str(f2) in err
+
+    def test_fix_second_read_failure_recorded_not_crash(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # Regression (#381): `fix` re-reads the source after parsing to apply
+        # edits; an unreadable second read must be recorded and skipped (the read
+        # fails before any write), not crash the batch.
+        from compose_lint import cli
+
+        f = tmp_path / "docker-compose.yml"
+        f.write_text(_BARE_SERVICE)
+
+        class _UnreadableSecondRead:
+            def __init__(self, *a: object, **k: object) -> None:
+                self._p = Path(*a, **k)
+
+            def read_text(self, *a: object, **k: object) -> str:
+                raise OSError("simulated: file became unreadable")
+
+            def __getattr__(self, name: str) -> object:
+                return getattr(self._p, name)
+
+        monkeypatch.setattr(cli, "Path", _UnreadableSecondRead)
+        with pytest.raises(SystemExit) as exc:
+            cli.main(["fix", "--apply", str(f)])
+        assert exc.value.code == 2
+        assert "simulated: file became unreadable" in capsys.readouterr().err
+        assert f.read_text() == _BARE_SERVICE  # nothing written
         assert f.read_text() == _BARE_SERVICE  # nothing written
 
 


### PR DESCRIPTION
Fixes #381.

## Bug
Both `check --format sarif` and `fix` re-read the source file with `Path.read_text` *after* `load_compose` has already parsed it — the SARIF path to attach machine-applicable fix edits (`cli.py:455`), fix mode to apply edits (`cli.py:571`). That second read sat **outside** the per-file `try/except`, so if the file became unreadable between the parse and the read (deleted, unmounted, permission change), the uncaught `OSError` aborted the **entire batch** — every remaining file silently skipped.

## Fix
Wrap both reads: on `OSError`, record the failure per-file (`parse_errors` / `had_error`), print `Error: <file>: <e>`, and `continue` — matching the existing `FileNotFoundError`/`ComposeError` handling right above each. A mid-batch unreadable file now exits 2 with the error noted (and surfaced as a SARIF notification), and the scan finishes the rest.

## Tests
Two in-process regression tests patch `cli.Path` (isolating the second read — `load_compose` reads through its own module) to raise `OSError`, and assert the batch records + continues rather than crashing, for both SARIF and fix.

All four gates green locally: `ruff check`, `ruff format --check`, `mypy src/` (strict), `pytest` (889 passed, +2).