### PR TITLE
ci: author release bot PRs with the PAT so their checks fire (#342)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -895,7 +895,13 @@ jobs:
         env:
           TAG: ${{ github.ref_name }}
           SHA: ${{ steps.sha.outputs.sha }}
-          GH_TOKEN: ${{ github.token }}
+          # Open the PR with the PAT (not GITHUB_TOKEN): a GITHUB_TOKEN-authored
+          # PR does not trigger pull_request/push workflows (GitHub's recursion
+          # guard), so the PR would land with zero checks and sit blocked until a
+          # human closed+reopened it (#342). The PAT is already required by this
+          # job for the workflow-file push above, so this reuses it — no new
+          # secret. Its user authors the PR, so the required checks run.
+          GH_TOKEN: ${{ secrets.MARKETPLACE_SMOKE_PAT }}
         run: |
           version="${TAG#v}"
           branch="chore/marketplace-smoke-${version}"

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -36,6 +36,12 @@ jobs:
           ref: main
           fetch-depth: 0
           persist-credentials: true
+          # Push the release branch as the PAT user so the PR it authors below
+          # triggers checks (#342). Falls back to GITHUB_TOKEN when the secret is
+          # absent: unlike the marketplace-pin job this workflow touches no
+          # .github/workflows/* file, so GITHUB_TOKEN still functions — it just
+          # yields a check-less PR that needs a manual close+reopen.
+          token: ${{ secrets.MARKETPLACE_SMOKE_PAT || github.token }}
 
       - name: Validate version input
         env:
@@ -134,7 +140,10 @@ jobs:
       - name: Commit, push, open PR
         env:
           VERSION: ${{ inputs.version }}
-          GH_TOKEN: ${{ github.token }}
+          # Author the PR with the PAT so its checks run automatically (#342);
+          # fall back to GITHUB_TOKEN when the secret is absent (the PR then
+          # needs a manual close+reopen to start checks, the prior behavior).
+          GH_TOKEN: ${{ secrets.MARKETPLACE_SMOKE_PAT || github.token }}
         run: |
           branch="release/${VERSION}"
           git config user.name "github-actions[bot]"

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -183,7 +183,12 @@ The `bump-marketplace-smoke-pin` job opens a post-release PR updating
 `marketplace-smoke.yml` to the SHA the tag pointed at. `GITHUB_TOKEN`
 can't push commits that modify `.github/workflows/*`, so this job
 uses a repo-scoped PAT stored in the `MARKETPLACE_SMOKE_PAT` secret.
-The job preflights that secret and fails early if it's unset.
+The job preflights that secret and fails early if it's unset. The PR is
+also *authored* with that PAT (not `GITHUB_TOKEN`): a `GITHUB_TOKEN`-
+authored PR does not trigger `pull_request`/`push` workflows (GitHub's
+recursion guard), so it would land with zero checks and sit blocked
+until someone closed and reopened it. Authoring it as the PAT user makes
+the required checks run automatically.
 
 ### Provisioning `MARKETPLACE_SMOKE_PAT`
 
@@ -211,6 +216,13 @@ to revoke and audit.
 (e.g. `0.3.8`). Opens the "Prepare X.Y.Z release" PR: bumps both version
 strings, renames the CHANGELOG `[Unreleased]` section, inserts a fresh
 empty one, and links to the manual tag-signing step in the PR body.
+
+Like the marketplace-pin job, this PR is authored with the
+`MARKETPLACE_SMOKE_PAT` secret so its checks run automatically. Unlike
+that job it falls back to `GITHUB_TOKEN` when the secret is absent
+(release-prep touches no `.github/workflows/*` file, so the token still
+works) — but the fallback PR lands check-less and needs a manual
+close+reopen, so keep the secret configured.
 
 The signed annotated tag is **not** created here. Tag creation stays
 manual because (a) `GITHUB_TOKEN`-created tags don't trigger downstream


### PR DESCRIPTION
Closes #342.

## Problem
Both release bot PRs were authored via `GITHUB_TOKEN`:
- `release-prep.yml` → the "Prepare X.Y.Z release" version-bump PR
- `publish.yml` → the `bump-marketplace-smoke-pin` post-release PR

GitHub's recursive-workflow guard means a `GITHUB_TOKEN`-authored PR does **not** trigger `push`/`pull_request` workflows, so both landed with zero checks and sat `mergeable_state=blocked` until a human **closed and reopened** them — two manual web actions per release.

## Fix — reuse the PAT that already exists
The `bump-marketplace-smoke-pin` job **already requires** `MARKETPLACE_SMOKE_PAT` (it can't push its `.github/workflows/*` change with `GITHUB_TOKEN`, and preflights the secret). Its fine-grained scopes are already Contents / Workflows / **Pull requests**: write — enough to *author* a PR. So:

- **publish.yml** — switch the `gh pr create` step's `GH_TOKEN` from `github.token` → `secrets.MARKETPLACE_SMOKE_PAT`. One line; the PAT was already checked out for the push.
- **release-prep.yml** — reuse the same secret for both the checkout (branch push) and `gh pr create`, with a **`GITHUB_TOKEN` fallback**. Unlike the pin job, release-prep touches no workflow file, so `GITHUB_TOKEN` still functions when the secret is absent — the fallback just reproduces the old check-less PR that needs a manual close+reopen, so there is **zero regression** if the secret is ever unset.

**No new secret to provision.** The PAT already carries the needed scopes.

## Payoff
- Both bot PRs now land with checks running → no close/reopen dance.
- Release drivable end-to-end from automation/mobile, leaving only the deliberate `release` environment approval as a manual gate.

## Verification
- `actionlint` clean on both changed workflows (a required CI gate here).
- `changelog-gate` is exempt (no `pyproject.toml` version bump).
- Docs updated (`docs/CI.md`): both the marketplace-pin and release-prep sections now note the PAT authors the PR so checks fire, and the release-prep fallback caveat.

Note: I can't end-to-end exercise this without cutting a real release, but the change is minimal and the fallback guarantees no regression. The behavior activates on the next `release-prep` dispatch / tag publish.
