### PR TITLE
scripts: make rule-premise skip loud + Docker-absent-safe (#378)

### DIFF
--- a/scripts/validate_rule_premises.py
+++ b/scripts/validate_rule_premises.py
@@ -22,6 +22,7 @@ observe and are listed as intentionally out of scope.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from typing import TYPE_CHECKING
@@ -234,10 +235,37 @@ CHECKS: list[tuple[str, str, Callable[[], tuple[bool, str]]]] = [
 ]
 
 
+def _docker_available() -> bool:
+    """Report whether a working Docker is reachable. Handles both the
+    daemon-down case (non-zero exit) and the not-installed case (the bare
+    ``subprocess.run`` would otherwise raise FileNotFoundError and crash)."""
+    try:
+        proc = subprocess.run(["docker", "version"], capture_output=True)
+    except FileNotFoundError:
+        return False
+    return proc.returncode == 0
+
+
 def main() -> int:
-    if subprocess.run(["docker", "version"], capture_output=True).returncode != 0:
-        print("SKIP: Docker not available", file=sys.stderr)
-        return 0
+    if not _docker_available():
+        # A silent skip (the old one-line message) let a contributor without
+        # Docker believe the premises were validated when they weren't — the gap
+        # would surface only in CI. Make the skip unmissable, and let a caller
+        # who *requires* the check demand it via CL_REQUIRE_DOCKER=1 (#378).
+        bar = "!" * 70
+        for line in (
+            "",
+            bar,
+            "!! rule-premise validation SKIPPED — Docker is not available.",
+            "!! The rules' runtime premises were NOT checked against a live",
+            "!! container, so a drifted premise passes here and surfaces only in",
+            "!! CI (the rule-premises job, which has Docker).",
+            "!! Set CL_REQUIRE_DOCKER=1 to treat this skip as a hard failure.",
+            bar,
+            "",
+        ):
+            print(line, file=sys.stderr)
+        return 1 if os.environ.get("CL_REQUIRE_DOCKER") == "1" else 0
 
     failures = []
     for rule_id, label, check in CHECKS:

--- a/tests/test_validate_rule_premises.py
+++ b/tests/test_validate_rule_premises.py
@@ -1,0 +1,54 @@
+"""Tests for the rule-premise validator's Docker-unavailable handling (#378).
+
+Runs the actual script (scripts/validate_rule_premises.py) as a subprocess with
+a PATH that hides `docker`, forcing the skip path deterministically regardless
+of whether the runner has Docker.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path as _Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "validate_rule_premises.py"
+
+
+def _run_without_docker(
+    tmp_path: _Path, **extra_env: str
+) -> subprocess.CompletedProcess[str]:
+    empty_bin = tmp_path / "emptybin"
+    empty_bin.mkdir()
+    # Override PATH so `docker` is not found (FileNotFoundError -> skip path);
+    # keep the rest of the environment so the interpreter still starts.
+    env = {**os.environ, "PATH": str(empty_bin)}
+    env.pop("CL_REQUIRE_DOCKER", None)
+    env.update(extra_env)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_skip_is_loud_when_docker_unavailable(tmp_path: _Path) -> None:
+    result = _run_without_docker(tmp_path)
+    # Default: a Docker-less contributor is not blocked, but the skip is loud.
+    assert result.returncode == 0, result.stderr
+    assert "SKIPPED" in result.stderr
+    assert "Docker is not available" in result.stderr
+    # A prominent banner, not a one-liner buried in output.
+    assert result.stderr.count("!") > 20
+
+
+def test_require_docker_makes_skip_a_hard_failure(tmp_path: _Path) -> None:
+    result = _run_without_docker(tmp_path, CL_REQUIRE_DOCKER="1")
+    assert result.returncode == 1, result.stderr
+    assert "SKIPPED" in result.stderr


### PR DESCRIPTION
Closes #378.

`validate_rule_premises.py` returned exit 0 with a one-line `SKIP` when Docker was unavailable, so a contributor without Docker could believe the premises validated when they didn't — the gap surfaced only in CI. It also assumed docker was **installed**: a bare `subprocess.run(["docker",...])` raises `FileNotFoundError` (crash), not a skip, when docker is absent.

**Fix:** `_docker_available()` handles both daemon-down and not-installed; the skip prints an unmissable banner; and `CL_REQUIRE_DOCKER=1` makes a skip a **hard failure** for callers that require the check.

Adds `tests/test_validate_rule_premises.py` (forces the skip via a docker-less PATH): loud-skip-exit-0 by default, exit-1 under `CL_REQUIRE_DOCKER=1`. ruff + pytest clean.