### PR TITLE
config: add opt-in strict-config mode (#380)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`check --strict-config` / `fix --strict-config`.** Opt-in strict mode that
+  turns config diagnostics that are normally stderr warnings — an unknown or
+  typo'd rule id (`CL-001` vs `CL-0001`), an unknown top-level or per-rule key,
+  an unknown `profiles` key — into hard errors (exit 2). Without it, a malformed
+  config's warning can be lost in a redirect and silently disable the wrong rule;
+  strict mode fails the run loudly instead. Default behavior is unchanged.
+
 ### Fixed
 
 - **`check --format sarif` and `fix` no longer abort a batch when a file becomes

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,6 +130,8 @@ A `.compose-lint.yml` that silently fails to take effect is a security risk — 
 
 Warnings never change the exit code; only the hard errors above do.
 
+Pass **`--strict-config`** to `check` or `fix` to promote every warning above (unknown rule id, unknown top-level/per-rule/`profiles` key) to a hard error (exit 2). Use it in CI, or wherever stderr is redirected, so a typo can't silently disable the wrong rule.
+
 ## Output formats
 
 `--format` selects the output (`text` default, `json`, `sarif`). Text writes a human banner, per-file summary, and verdict; `json` and `sarif` emit only the machine document on stdout so redirects stay clean.

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -129,6 +129,16 @@ def _add_check_subparser(
         help="path to .compose-lint.yml config file",
     )
     check.add_argument(
+        "--strict-config",
+        action="store_true",
+        default=False,
+        help=(
+            "treat config diagnostics (unknown/typo'd rule id, unknown key) as "
+            "errors instead of stderr warnings, so a malformed config fails "
+            "loudly rather than silently disabling the wrong rule"
+        ),
+    )
+    check.add_argument(
         "--skip-suppressed",
         action="store_true",
         default=False,
@@ -208,6 +218,15 @@ def _add_fix_subparser(
         "--config",
         metavar="PATH",
         help="path to .compose-lint.yml config file (suppressions are honored)",
+    )
+    fix.add_argument(
+        "--strict-config",
+        action="store_true",
+        default=False,
+        help=(
+            "treat config diagnostics (unknown/typo'd rule id, unknown key) as "
+            "errors instead of stderr warnings"
+        ),
     )
 
 
@@ -332,8 +351,12 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
     config_path = _effective_config_path(args.config)
 
     try:
-        disabled_rules, severity_overrides, excluded_services = load_config(args.config)
-        profiles_enabled, profiles_path = load_profiles_config(args.config)
+        disabled_rules, severity_overrides, excluded_services = load_config(
+            args.config, strict=args.strict_config
+        )
+        profiles_enabled, profiles_path = load_profiles_config(
+            args.config, strict=args.strict_config
+        )
     except ConfigError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(2)
@@ -541,7 +564,9 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
     failure signal, so residual manual-only findings do not change the code.
     """
     try:
-        disabled_rules, severity_overrides, excluded_services = load_config(args.config)
+        disabled_rules, severity_overrides, excluded_services = load_config(
+            args.config, strict=args.strict_config
+        )
     except ConfigError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(2)

--- a/src/compose_lint/config.py
+++ b/src/compose_lint/config.py
@@ -28,13 +28,18 @@ class ConfigError(Exception):
     """Raised when a config file is invalid."""
 
 
-def _warn(message: str) -> None:
-    """Emit a non-fatal config diagnostic to stderr.
+def _warn(message: str, strict: bool = False) -> None:
+    """Emit a config diagnostic — a stderr warning, or a hard error under strict.
 
     Mirrors the CLI's unknown-service warning (ADR-010): a misconfiguration that
     silently weakens a security control should be visible, but config and
-    Compose files evolve independently, so it must not hard-fail the run.
+    Compose files evolve independently, so by default it must not hard-fail the
+    run. Under strict-config (``--strict-config``, #380) the same diagnostics are
+    raised as ``ConfigError`` instead, so a typo'd rule id or key fails loudly
+    rather than silently no-op'ing where stderr may be suppressed.
     """
+    if strict:
+        raise ConfigError(message)
     print(f"Warning: {message}", file=sys.stderr)
 
 
@@ -61,6 +66,7 @@ ExcludedServices = dict[str, dict[str, str | None]]
 
 def load_config(
     path: str | Path | None = None,
+    strict: bool = False,
 ) -> tuple[dict[str, str | None], dict[str, Severity], ExcludedServices]:
     """Load a .compose-lint.yml config file.
 
@@ -70,6 +76,9 @@ def load_config(
     per-service reason (see ADR-010).
     If path is None, looks for .compose-lint.yml in the current directory.
     If no config file is found, returns empty defaults.
+    When strict is True, config diagnostics that are normally warnings (unknown
+    top-level key, unknown/typo'd rule id, unknown rule key) are raised as
+    ConfigError instead (#380).
     """
     data = _read_raw_config(path)
     if data is None:
@@ -79,10 +88,11 @@ def load_config(
         if str(key) not in _KNOWN_TOP_LEVEL_KEYS:
             _warn(
                 f"config: unknown top-level key '{key}' (recognized: "
-                f"{', '.join(sorted(_KNOWN_TOP_LEVEL_KEYS))}); it has no effect"
+                f"{', '.join(sorted(_KNOWN_TOP_LEVEL_KEYS))}); it has no effect",
+                strict,
             )
 
-    return _parse_rules(data.get("rules", {}))
+    return _parse_rules(data.get("rules", {}), strict)
 
 
 def _read_raw_config(path: str | Path | None) -> dict[str, Any] | None:
@@ -120,7 +130,10 @@ def _read_raw_config(path: str | Path | None) -> dict[str, Any] | None:
     return data
 
 
-def load_profiles_config(path: str | Path | None = None) -> tuple[bool, str | None]:
+def load_profiles_config(
+    path: str | Path | None = None,
+    strict: bool = False,
+) -> tuple[bool, str | None]:
     """Return ``(enabled, catalog_path)`` for profile enrichment (ADR-017 §7).
 
     Off by default, and with **no built-in catalog**: enrichment is a no-op
@@ -141,7 +154,8 @@ def load_profiles_config(path: str | Path | None = None) -> tuple[bool, str | No
         if str(key) not in _KNOWN_PROFILES_KEYS:
             _warn(
                 f"config: profiles has unknown key '{key}' (recognized: "
-                f"{', '.join(sorted(_KNOWN_PROFILES_KEYS))}); it has no effect"
+                f"{', '.join(sorted(_KNOWN_PROFILES_KEYS))}); it has no effect",
+                strict,
             )
 
     enabled = profiles.get("enabled", False)
@@ -160,6 +174,7 @@ def load_profiles_config(path: str | Path | None = None) -> tuple[bool, str | No
 
 def _parse_rules(
     rules: Any,
+    strict: bool = False,
 ) -> tuple[dict[str, str | None], dict[str, Severity], ExcludedServices]:
     """Parse the rules section of a config file."""
     if not isinstance(rules, dict):
@@ -179,14 +194,16 @@ def _parse_rules(
         if rule_id not in known_ids:
             _warn(
                 f"config: unknown rule id '{rule_id}'; the override has no effect "
-                "(check for a typo or a retired rule)"
+                "(check for a typo or a retired rule)",
+                strict,
             )
 
         for key in rule_config:
             if str(key) not in _KNOWN_RULE_KEYS:
                 _warn(
                     f"config: rule '{rule_id}' has unknown key '{key}' (recognized: "
-                    f"{', '.join(sorted(_KNOWN_RULE_KEYS))}); it has no effect"
+                    f"{', '.join(sorted(_KNOWN_RULE_KEYS))}); it has no effect",
+                    strict,
                 )
 
         if "enabled" in rule_config:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -192,6 +192,26 @@ class TestCLI:
         )
         assert by_service["empty_security_opt"]["suppressed"] is False
 
+    def test_strict_config_typoed_rule_id_exits_usage(self, tmp_path: Path) -> None:
+        # A typo'd rule id under --strict-config is a hard error (exit 2), not a
+        # stderr warning that could be lost in a redirect (#380).
+        compose = tmp_path / "docker-compose.yml"
+        compose.write_text("services:\n  db:\n    image: postgres:16\n")
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text("rules:\n  CL-001:\n    enabled: false\n")
+        result = run_cli("--strict-config", "--config", str(config), str(compose))
+        assert result.returncode == 2
+        assert "unknown rule id 'CL-001'" in result.stderr
+
+    def test_strict_config_absent_only_warns(self, tmp_path: Path) -> None:
+        compose = tmp_path / "docker-compose.yml"
+        compose.write_text("services:\n  db:\n    image: postgres:16\n")
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text("rules:\n  CL-001:\n    enabled: false\n")
+        result = run_cli("--config", str(config), str(compose))
+        assert result.returncode in (0, 1)
+        assert "unknown rule id 'CL-001'" in result.stderr
+
     def test_profile_enrichment_prints_experimental_notice(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,7 +9,7 @@ import pytest
 if TYPE_CHECKING:
     from pathlib import Path
 
-from compose_lint.config import ConfigError, load_config
+from compose_lint.config import ConfigError, load_config, load_profiles_config
 from compose_lint.models import Severity
 
 
@@ -182,6 +182,52 @@ class TestConfigValidation:
         config.write_text("rules:\n  CL-0001:\n    enabled: true\n")
         disabled, _overrides, _excluded = load_config(config)
         assert "CL-0001" not in disabled
+
+
+class TestStrictConfig:
+    """strict=True escalates config diagnostics to errors (issue #380)."""
+
+    def test_unknown_rule_id_raises(self, tmp_path: Path) -> None:
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text("rules:\n  CL-001:\n    enabled: false\n")
+        with pytest.raises(ConfigError, match="unknown rule id 'CL-001'"):
+            load_config(config, strict=True)
+
+    def test_unknown_top_level_key_raises(self, tmp_path: Path) -> None:
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text("fail_on: high\nrules:\n  CL-0001:\n    enabled: false\n")
+        with pytest.raises(ConfigError, match="unknown top-level key 'fail_on'"):
+            load_config(config, strict=True)
+
+    def test_unknown_rule_key_raises(self, tmp_path: Path) -> None:
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text("rules:\n  CL-0001:\n    severty: high\n")
+        with pytest.raises(ConfigError, match="unknown key 'severty'"):
+            load_config(config, strict=True)
+
+    def test_valid_config_still_loads_under_strict(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text("rules:\n  CL-0001:\n    enabled: false\n")
+        disabled, _overrides, _excluded = load_config(config, strict=True)
+        assert "CL-0001" in disabled
+        assert capsys.readouterr().err == ""
+
+    def test_default_mode_still_warns_not_raises(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Backward compatibility: without strict, an unknown id is a warning.
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text("rules:\n  CL-001:\n    enabled: false\n")
+        load_config(config)  # no raise
+        assert "unknown rule id 'CL-001'" in capsys.readouterr().err
+
+    def test_profiles_unknown_key_raises_under_strict(self, tmp_path: Path) -> None:
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text("profiles:\n  enabled: true\n  bogus: 1\n")
+        with pytest.raises(ConfigError, match="profiles has unknown key 'bogus'"):
+            load_profiles_config(config, strict=True)
 
 
 class TestExcludeServices:


### PR DESCRIPTION
Closes #380.

## Problem
Config diagnostics (unknown/typo'd rule id like `CL-001`, unknown top-level/per-rule/`profiles` key) were **stderr warnings only** — if stderr is redirected or suppressed, a malformed config silently disables the wrong rule.

## Change
Thread a `strict` flag through `load_config` / `load_profiles_config`: when set, `_warn` raises `ConfigError` (caught by the CLI → exit 2) instead of printing. Exposed as **`--strict-config`** on both `check` and `fix`. **Default behavior unchanged.**

## Tests
- Unit (`TestStrictConfig`): each diagnostic raises under strict; a valid config still loads silently; default mode still warns (back-comat).
- CLI: a typo'd rule id exits 2 under `--strict-config`, warns (exit 0/1) otherwise.

Documented in `docs/configuration.md` + CHANGELOG. `ruff`/`ruff format`/`mypy src/`/`pytest` all green.