### PR TITLE
tests: guard that every fixture service is asserted by a test (#379)

### DIFF
--- a/tests/test_CL0006.py
+++ b/tests/test_CL0006.py
@@ -97,3 +97,17 @@ class TestCapDropRule:
             )
         )
         assert len(findings) == 0
+
+    def test_safe_drop_all_no_add_no_findings(self) -> None:
+        # cap_drop: [ALL] with no cap_add — the most-hardened case, which must
+        # not trip CL-0006. (Surfaced by the fixture-coverage check, #379.)
+        data, lines = load_compose(FIXTURES / "safe_cap_hardened.yml")
+        findings = list(
+            self.rule.check(
+                "drop_all_no_add",
+                data["services"]["drop_all_no_add"],
+                data,
+                lines,
+            )
+        )
+        assert len(findings) == 0

--- a/tests/test_fixture_coverage.py
+++ b/tests/test_fixture_coverage.py
@@ -1,0 +1,71 @@
+"""Fixture-scenario coverage guard (#379).
+
+Rule tests load multi-service YAML fixtures and assert findings service by
+service (``data["services"]["<name>"]``). Nothing otherwise forces a matching
+assertion when a new service variant is added to a fixture, so a coverage gap
+can open silently — a hardened or malformed variant ships untested.
+
+This meta-test walks every fixture that has a real ``services:`` mapping and
+requires each service name to appear (quoted) somewhere in the test sources. It
+is a tripwire, not a proof: a service whose name is a common word could be
+matched incidentally, and whole-file CLI fixtures are covered by name where a
+per-service unit test references them. But a uniquely-named new variant with no
+test at all — the case this guards — trips it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from compose_lint.parser import ComposeError, load_compose
+
+TESTS_DIR = Path(__file__).parent
+FIXTURES_DIR = TESTS_DIR / "compose_files"
+
+
+def _fixture_services() -> list[tuple[str, str]]:
+    """Return (fixture_name, service_name) for every service in a fixture that
+    parses to a real services mapping. Fragments, v1, and invalid fixtures (no
+    services mapping) have no per-service scenario to assert and are skipped."""
+    out: list[tuple[str, str]] = []
+    for fixture in sorted(FIXTURES_DIR.glob("*.yml")):
+        try:
+            data, _lines = load_compose(fixture)
+        except (ComposeError, OSError):
+            continue
+        services = data.get("services") if isinstance(data, dict) else None
+        if not isinstance(services, dict):
+            continue
+        out.extend((fixture.name, str(service)) for service in services)
+    return out
+
+
+# Concatenated test sources (excluding this file, which names services only in
+# prose) — the corpus a service must appear in to count as referenced.
+_TEST_SOURCES = "\n".join(
+    p.read_text(encoding="utf-8")
+    for p in sorted(TESTS_DIR.glob("test_*.py"))
+    if p.name != Path(__file__).name
+)
+
+
+@pytest.mark.parametrize(
+    ("fixture", "service"),
+    _fixture_services(),
+    ids=lambda v: v if isinstance(v, str) else str(v),
+)
+def test_every_fixture_service_is_referenced(fixture: str, service: str) -> None:
+    referenced = f'"{service}"' in _TEST_SOURCES or f"'{service}'" in _TEST_SOURCES
+    assert referenced, (
+        f"service '{service}' in tests/compose_files/{fixture} is not referenced "
+        f"by any test — add a case asserting its expected findings (or remove it "
+        f"from the fixture)."
+    )
+
+
+def test_guard_actually_scans_something() -> None:
+    # Defend the guard itself: if the fixture glob or parser silently found no
+    # services, the parametrized test would vacuously pass.
+    assert len(_fixture_services()) > 20


### PR DESCRIPTION
Closes #379.

## What
Rule tests load multi-service fixtures and assert findings service by service (`data["services"]["<name>"]`), but nothing forced a matching assertion when a new service variant was added to a fixture — a gap could open silently.

`tests/test_fixture_coverage.py` is a parametrized meta-test: it walks every fixture with a real `services:` mapping and requires each service name to appear (quoted) in the test sources. Fragments / v1 / invalid fixtures (no services mapping) have no per-service scenario and are skipped. A self-check guards against the glob silently finding nothing.

## It found a real gap
The guard immediately surfaced `safe_cap_hardened.yml`'s **`drop_all_no_add`** (`cap_drop: [ALL]`, no `cap_add` — the most-hardened case) as never asserted. Added the missing CL-0006 no-findings case.

Tripwire, not a proof (a common-word service name could match incidentally), but a uniquely-named untested variant trips it. `ruff`/`mypy`/`pytest` all green (1137 passed).