### PR TITLE
rules: de-duplicate image-pinning constants (#384)

### DIFF
--- a/src/compose_lint/rules/CL0004_image_not_pinned.py
+++ b/src/compose_lint/rules/CL0004_image_not_pinned.py
@@ -6,22 +6,17 @@ from typing import TYPE_CHECKING, Any
 
 from compose_lint.models import Finding, RuleMetadata, Severity
 from compose_lint.rules import BaseRule, register_rule
-from compose_lint.rules._image import split_image_ref
+from compose_lint.rules._image import MUTABLE_TAGS, OWASP_IMAGE_REF, split_image_ref
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-OWASP_REF = (
-    "https://cheatsheetseries.owasp.org/cheatsheets/"
-    "Docker_Security_Cheat_Sheet.html#rule-13-enhance-supply-chain-security"
-)
+OWASP_REF = OWASP_IMAGE_REF
 
 CIS_REF = (
     "CIS Docker Benchmark 5.28 — Ensure that Docker commands always make "
     "use of the latest version of their image"
 )
-
-MUTABLE_TAGS = {"latest", "stable", "edge", "nightly", "dev", "test"}
 
 
 @register_rule

--- a/src/compose_lint/rules/CL0019_image_no_digest.py
+++ b/src/compose_lint/rules/CL0019_image_no_digest.py
@@ -6,18 +6,20 @@ from typing import TYPE_CHECKING, Any
 
 from compose_lint.models import Finding, RuleMetadata, Severity
 from compose_lint.rules import BaseRule, register_rule
-from compose_lint.rules._image import split_image_ref
+from compose_lint.rules._image import (
+    MUTABLE_TAGS as _MUTABLE_TAGS,
+)
+from compose_lint.rules._image import (
+    OWASP_IMAGE_REF,
+    split_image_ref,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-OWASP_REF = (
-    "https://cheatsheetseries.owasp.org/cheatsheets/"
-    "Docker_Security_Cheat_Sheet.html#rule-13-enhance-supply-chain-security"
-)
+OWASP_REF = OWASP_IMAGE_REF
 
-# Tags that CL-0004 already handles — we skip them to avoid overlap
-_MUTABLE_TAGS = {"latest", "stable", "edge", "nightly", "dev", "test"}
+# _MUTABLE_TAGS: tags CL-0004 already handles — we skip them to avoid overlap.
 
 
 @register_rule

--- a/src/compose_lint/rules/_image.py
+++ b/src/compose_lint/rules/_image.py
@@ -1,6 +1,17 @@
-"""Shared parsing helpers for OCI image references."""
+"""Shared parsing helpers and constants for OCI image references."""
 
 from __future__ import annotations
+
+# Rolling/mutable tags that don't pin a real, immutable version. Shared by the
+# image-pinning rules (CL-0004 flags them as unpinned; CL-0019 skips them since
+# CL-0004 already covers them) so the set can't drift between the two.
+MUTABLE_TAGS = frozenset({"latest", "stable", "edge", "nightly", "dev", "test"})
+
+# The OWASP supply-chain cheatsheet rule both image-pinning rules cite.
+OWASP_IMAGE_REF = (
+    "https://cheatsheetseries.owasp.org/cheatsheets/"
+    "Docker_Security_Cheat_Sheet.html#rule-13-enhance-supply-chain-security"
+)
 
 
 def split_image_ref(image: str) -> tuple[str, str | None]:


### PR DESCRIPTION
Addresses #384 (grouped LOW-severity assessment items). On inspection, the substantive win is the shared constant:

## Done — shared image constants (item 3)
CL-0004 and CL-0019 each defined the same `MUTABLE_TAGS` set **and** the same OWASP supply-chain reference URL. They *must* agree — CL-0019 skips exactly the tags CL-0004 flags — so the duplication was drift-prone. Both now live in the `rules/_image.py` module the two rules already import from.

## Already satisfied — CLI mutually-exclusive validation (item 4)
The issue flagged `cli.py:138-159` as unvalidated, but that region is argparse's `add_mutually_exclusive_group()` for `-v`/`-q`, which **is** enforced — covered by the existing `test_verbose_and_quiet_are_mutually_exclusive` (asserts `-v -q` → exit 2). No change needed. `--explain`'s conflicts (with FILE args and json/sarif) are likewise already validated in `_run_check`.

## Deliberately not done — FIXTURES / setup_method repetition (items 1-2)
`FIXTURES = Path(__file__).parent / "compose_files"` and a 2-line `setup_method` are self-contained one/two-line idioms. Hoisting them to a shared test module introduces cross-module import coupling (and 6 of the 22 files have non-uniform setups), which reads as *worse* than the trivial repetition. Judgment call to leave them.

`ruff`/`ruff format`/`mypy src/`/`pytest` all green (1137 passed).
