### PR TITLE
Align codeql-action pin comment in action.yml to v4.36.2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -131,6 +131,6 @@ runs:
 
     - name: Upload SARIF
       if: inputs.sarif-file != '' && always() && steps.find-files.outputs.files != ''
-      uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       with:
         sarif_file: ${{ inputs.sarif-file }}


### PR DESCRIPTION
Fixes the one inconsistent codeql-action pin comment: `action.yml` labeled the shared SHA `# v4` while ci/publish/scout/scorecard/codeql all use `# v4.36.2`. Same SHA, comment-only change; all six references now read `# v4.36.2`. actionlint clean.

Closes #383