### PR TITLE
Feature a CRITICAL socket finding in the demo fixture

### DIFF
--- a/scripts/demo/docker-compose.yml
+++ b/scripts/demo/docker-compose.yml
@@ -1,10 +1,10 @@
 services:
-  db:
-    image: postgres:16
+  watchtower:
+    image: containrrr/watchtower:1.7.1
     read_only: true
     security_opt:
       - no-new-privileges:true
     cap_drop:
       - ALL
-    ports:
-      - "5432:5432"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Swaps the demo service from a hardened `postgres` (worst finding: a HIGH exposed port, CL-0005) to `watchtower` with a mounted Docker socket, so the demo now leads with **CL-0001 (CRITICAL)** — a more representative, higher-impact example (socket mounts are among the most common real-world Compose mistakes).

**Findings change:** `CL-0005 HIGH + CL-0019 MEDIUM` → `CL-0001 CRITICAL + CL-0013 HIGH + CL-0019 MEDIUM`.

### Follow-up needed (not in this PR)
This PR intentionally changes **only the fixture**. The following still describe the old findings and need regenerating to match (owner is handling the GIF):
- [ ] `docs/assets/demo.gif` — re-render via `scripts/demo/render.sh` (needs Docker)
- [ ] `README.md` — demo alt text (names CL-0005 / `--explain CL-0005`)
- [ ] `scripts/demo/demo.tape` — step-2 `compose-lint --explain CL-0005` → `CL-0001`; step-1 comment
- [ ] `scripts/demo/README.md` — "two findings: a HIGH exposed port…" description

Motivation: strengthens the compose-lint social preview image (built from this fixture's real output).