### PR TITLE
Drop redundant ellipsis bodies from abstract rule methods

### DIFF
--- a/src/compose_lint/rules/__init__.py
+++ b/src/compose_lint/rules/__init__.py
@@ -23,7 +23,6 @@ class BaseRule(abc.ABC):
     @abc.abstractmethod
     def metadata(self) -> RuleMetadata:
         """Return the rule's metadata."""
-        ...
 
     @abc.abstractmethod
     def check(
@@ -37,7 +36,6 @@ class BaseRule(abc.ABC):
 
         Yields Finding objects for each issue detected.
         """
-        ...
 
     def fix(
         self,


### PR DESCRIPTION
CodeQL flags the trailing '...' in BaseRule's abstract methods as an
ineffectual statement (alert #92): both methods already have docstrings,
which are complete method bodies on their own, so the extra Ellipsis
does nothing. Removing it clears the alert at the source instead of
suppressing it. No behavior change — abc.abstractmethod enforcement is
unaffected by the stub body.

Closes code-scanning alert #92.