### PR TITLE
Correct security-scan cadence in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ compose-lint is built to be safe to depend on:
 - **Runtime image**: [distroless Python](https://github.com/GoogleContainerTools/distroless) on Debian, multi-arch (`linux/amd64` + `linux/arm64`), nonroot UID 65532, no shell or package manager at runtime. See [ADR-009](https://github.com/tmatens/compose-lint/blob/main/docs/adr/009-runtime-base-image.md).
 - **Supply chain**: every release ships SLSA build provenance and Sigstore attestations. Published to PyPI via Trusted Publishers (OIDC) — no manual `twine upload`, no long-lived API tokens.
 - **Vulnerability transparency**: each release ships an [OpenVEX](https://openvex.dev/) document declaring known pip CVEs `not_affected` with justification `vulnerable_code_not_present` — pip code is stripped from the runtime venv and only `.dist-info` metadata is retained for SCA scanner attribution.
-- **External audit**: tracked on [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/tmatens/compose-lint) and [OpenSSF Best Practices Baseline 2](https://www.bestpractices.dev/projects/12472); CodeQL, Docker Scout, and ClusterFuzzLite run on every PR.
+- **External audit**: tracked on [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/tmatens/compose-lint) and [OpenSSF Best Practices Baseline 2](https://www.bestpractices.dev/projects/12472); CodeQL runs on every PR, ClusterFuzzLite fuzzes code-touching PRs, and Docker Scout scans the published image daily.
 - **Reporting vulnerabilities**: see [SECURITY.md](https://github.com/tmatens/compose-lint/blob/main/.github/SECURITY.md).
 
 ## Contributing


### PR DESCRIPTION
The **Security posture** section claimed "CodeQL, Docker Scout, and ClusterFuzzLite run on every PR." Only CodeQL does. This corrects the cadence to match the workflows:

- **CodeQL** — unfiltered `pull_request` trigger in `codeql.yml`; runs on every PR. ✓
- **ClusterFuzzLite** — `cflite-pr.yml` is `pull_request` but path-filtered to `src/**`, `fuzz/**`, `.clusterfuzzlite/**` (+ its own workflow), so it only fuzzes code-touching PRs.
- **Docker Scout** — `scout-scan.yml` is `schedule` (daily) + `workflow_dispatch` and scans the *published image*; there's also a release-time Scout gate in `publish.yml`. It does **not** run on PRs. (PR-time SAST/SCA is bandit + pip-audit in `ci.yml`.)

Docs-only change; no code or workflow behavior affected.