### PR TITLE
Drop stale 'rewrite files' from not-in-scope list

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Exit code is `1` (two findings at or above the default `--fail-on high` threshol
 
 If you need broad IaC coverage across Terraform, Kubernetes, and more, KICS covers Docker Compose and is worth evaluating. If you want a lightweight, focused tool with zero config and actionable fix guidance for Compose files specifically, this is it.
 
-**Not in scope**: compose-lint does not validate Compose schema, scan images for CVEs, lint Dockerfiles, or rewrite files. Pair it with [dclint](https://github.com/zavoloklom/docker-compose-linter) for schema/structure, [Hadolint](https://github.com/hadolint/hadolint) for Dockerfiles, and [Trivy](https://github.com/aquasecurity/trivy) for image CVEs.
+**Not in scope**: compose-lint does not validate Compose schema, scan images for CVEs, or lint Dockerfiles. Pair it with [dclint](https://github.com/zavoloklom/docker-compose-linter) for schema/structure, [Hadolint](https://github.com/hadolint/hadolint) for Dockerfiles, and [Trivy](https://github.com/aquasecurity/trivy) for image CVEs.
 
 ## Rules
 


### PR DESCRIPTION
The **Not in scope** line claimed compose-lint "does not ... rewrite files," but the shipped `fix --apply` subcommand rewrites Compose files in place (atomic swap; see the *Fixing findings* section and `cli.py:_run_fix`). This drops the contradictory clause.

The other three exclusions — Compose schema validation, image CVE scanning, Dockerfile linting — remain accurate and are unchanged. Docs-only.