### PR TITLE
Docs: name the public reference catalog; remove dead private-repo links

### DIFF
--- a/docs/adr/017-security-profile-catalog.md
+++ b/docs/adr/017-security-profile-catalog.md
@@ -9,8 +9,8 @@ service should drop capabilities; it cannot know that *this* image (say
 image-specific minimum is not statically derivable — it is a property of what the
 container does at runtime, observable only by watching a live container.
 
-Our sibling tool [container-sec-derive](https://github.com/tmatens/container-sec-derive)
-(`csd`) derives exactly that: it observes a running container via eBPF and emits a
+Our sibling tool container-sec-derive
+(`csd`, not publicly published) derives exactly that: it observes a running container via eBPF and emits a
 minimum-security config (caps, `read_only`/tmpfs, devices, minimized `cap_add`,
 privileged decomposition). It already ships a `--format compose-lint-profile`
 formatter that emits a per-image YAML entry "for the compose-lint catalog,"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,8 +91,9 @@ Excluded services still produce **SUPPRESSED** findings, with the per-service re
 > pointer to verify, not a validated fact. When enrichment is active, compose-lint
 > prints a one-line reminder to stderr.
 
-Opt into image-specific fix guidance derived by
-[container-sec-derive](https://github.com/tmatens/container-sec-derive) (csd).
+Opt into image-specific fix guidance derived by container-sec-derive (csd), a
+runtime derivation tool (not yet published; every catalog profile carries the
+evidence to audit it without the tool).
 When enabled, a finding from a rule that a derived profile covers
 (CL-0002/0006/0007/0011/0016) gains a `profile hint` line in its fix text stating
 the observed minimum for that image — for example, the exact `cap_add` a service
@@ -100,8 +101,13 @@ actually needs.
 
 compose-lint **ships no catalog of its own** (ADR-017 §7). You point `profiles.path`
 at a catalog you trust — your own derived profiles, or an external
-automation-maintained catalog you opt into. Both keys are required for enrichment;
-with `enabled` set but no `path`, compose-lint warns and enriches nothing.
+automation-maintained catalog you opt into. The reference catalog is
+[container-security-profiles](https://github.com/tmatens/container-security-profiles)
+(browsable at
+[tmatens.github.io/container-security-profiles](https://tmatens.github.io/container-security-profiles/)):
+clone it and point `profiles.path` at its `catalog/` directory. Both keys are
+required for enrichment; with `enabled` set but no `path`, compose-lint warns and
+enriches nothing.
 
 ```yaml
 profiles:

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -2,9 +2,11 @@
 
 compose-lint can enrich its fix guidance with **derived security profiles**: the
 observed minimum capabilities, filesystem, devices, and privilege a specific
-image actually needs. Profiles are produced by
-[container-sec-derive](https://github.com/tmatens/container-sec-derive) (`csd`),
-which watches a live container via eBPF, and contributed here as YAML. See
+image actually needs. Profiles are produced by container-sec-derive (`csd`), a
+runtime derivation tool (drop-test + live eBPF observation; not yet published),
+and live in the external
+[container-security-profiles](https://github.com/tmatens/container-security-profiles)
+catalog — profile contributions go there, not to this repository. See
 [ADR-017](adr/017-security-profile-catalog.md) for the model and
 [configuration.md](configuration.md#profile-enrichment) for how users opt in.
 
@@ -25,9 +27,11 @@ came from real observation and are reproducible.
 > profile without published criteria cannot be `validated`. The endorsed catalog
 > is a small, external,
 > automation-maintained artifact the user opts into (`profiles.path`), **not**
-> data bundled in the linter; the loader decoupling and the automation loop are
-> in progress. The rest of this guide describes the derivation mechanics, which
-> are unchanged.
+> data bundled in the linter. Both halves are live: the loader shipped in
+> 0.13.0, and the catalog is public at
+> [container-security-profiles](https://github.com/tmatens/container-security-profiles)
+> with scheduled re-derivation automation. The rest of this guide describes the
+> derivation mechanics, which are unchanged.
 
 ## What a profile is
 
@@ -66,11 +70,15 @@ fragments into one document keyed by the image.
 ### The acceptance contract (validated profiles)
 
 `csd`'s formatter refuses to emit a `validated` entry unless every term holds;
-the `profile-validate` CI job re-checks them here:
+the catalog's CI re-checks them with this repo's validator:
 
-- image pinned to a `@sha256:` digest (`derivation.validated_image`);
+- image pinned to a `@sha256:` digest (`derivation.validated_image`), and only
+  **immutable version tags** in `applies_to.tags`;
 - a committed workload script, hash-matched by `workload_sha256`;
-- `duration_seconds >= 300` per dimension;
+- evidence matching the derivation method: **drop-test** (remove each granted
+  element in turn, restart, re-verify the workload) requires the per-element
+  `drop_test.checks` block; **bpf-observation** requires
+  `duration_seconds >= 300` per dimension;
 - `confidence` is `high` or `moderate`;
 - clean observation (no coverage warnings, drop-rate < 1%, no replica
   disagreement).
@@ -81,28 +89,33 @@ they are review material and are never used to enrich (or fail) a lint.
 
 ## Where files go
 
+Profiles live in the external
+[container-security-profiles](https://github.com/tmatens/container-security-profiles)
+repository (not here — compose-lint ships no catalog):
+
 ```
-src/compose_lint/profiles/catalog/<registry>/<namespace>/<name>.yml   # validated
-src/compose_lint/profiles/catalog/exploratory/<...>/<name>.yml         # below-bar
-profiles/workloads/<name>.sh                                          # committed exerciser
+catalog/<registry>/<org>/<image>.yaml               # validated
+catalog/exploratory/<registry>/<org>/<image>.yaml   # below-bar / awaiting reproduction
+criteria/<registry>/<org>/<image>.md                # public, reviewable test criteria
+profiles/workloads/<name>.sh                        # committed exerciser
 ```
 
-The subdirectories are for humans; the loader indexes each document by its own
-`image` field, not by path. Workload scripts live at the repository root under
-`profiles/workloads/` (audit artifacts — they are **not** shipped in the wheel)
-and are referenced by the repo-relative `derivation.workload` path.
+The loader indexes each document by its own `image` field, not by path.
+Workload scripts are audit artifacts referenced by the repo-relative
+`derivation.workload` path. See that repository's `CONTRIBUTING.md` for the PR
+checklist.
 
 ## `validated_via` and the ci-smoke gate
 
-`csd` emits `validated_via: [bpf-observation]` — it will not claim a check it did
-not run. compose-lint's CI is the second source: once your PR passes the
-`profile-validate` job, add `ci-smoke` so the entry reads
-`validated_via: [bpf-observation, ci-smoke]`. A `validated` profile **must**
-declare both; the gate fails the PR if it claims `ci-smoke` without being a
-well-formed, digest-pinned, workload-verified artifact — the claim is only ever
-as good as the check backing it.
+`csd` will not claim a check it did not run (`validated_via` lists only what
+happened). The catalog repo's CI is the second source: it fetches this repo's
+schema and validator at a pinned commit (`contract/compose-lint.ref` there) and
+runs it on every change, so a `validated` profile reads e.g.
+`validated_via: [drop-test, ci-smoke]`. The gate fails a PR that claims
+`ci-smoke` without being a well-formed, digest-pinned, workload-verified
+artifact — the claim is only ever as good as the check backing it.
 
-Run the gate locally before opening a PR:
+The validator lives here and can be run against any catalog checkout:
 
 ```bash
 python scripts/validate_profiles.py


### PR DESCRIPTION
The external profile catalog described by ADR-017 §7 is now **public**: https://github.com/tmatens/container-security-profiles (browsable at https://tmatens.github.io/container-security-profiles/). This updates the profiles docs from describing a hypothetical catalog to naming the real one — and fixes several stale/dead references found on the way.

- **configuration.md**: the `profiles.path` section now names the reference catalog and how to use it (clone + point at `catalog/`). The `container-sec-derive` link is replaced with prose — csd is not published, so the link 404s for every reader (repo rule: no private tooling references).
- **profiles.md**: "Where files go" pointed at `src/compose_lint/profiles/catalog/…`, which no longer exists — contributions go to the catalog repo now. The trust-model note said the loader decoupling and automation loop were "in progress"; both are live (loader shipped in 0.13.0, catalog public with scheduled re-derivation). The acceptance contract adds the drop-test evidence terms (per-element `drop_test.checks`, no duration floor) alongside the bpf-observation ≥300s floor, matching what `scripts/validate_profiles.py` enforces today.
- **ADR-017**: dead csd link → plain text (minimal touch, historical record otherwise unchanged).

Docs-only; no code, no CHANGELOG entry (matching prior docs-only PRs).

Verified: the enrichment path documented here works against the public catalog — `compose-lint==0.13.0` + `profiles.path` → `profile hint` lines on CL-0006/CL-0007 for `postgres:16`.