### PR TITLE
Fix factual contradictions found in docs accuracy pass

### DIFF
--- a/docs/ASSURANCE.md
+++ b/docs/ASSURANCE.md
@@ -57,7 +57,7 @@ snippet.
 | # | Attacker goal                                                   | Mechanism                                                       | Mitigation                                                                                                       |
 |---|-----------------------------------------------------------------|-----------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------|
 | 1 | Execute attacker code in the linter process                     | YAML deserialization gadget; embedded Python tag                | All YAML is parsed via `yaml.SafeLoader` (compose) or `yaml.safe_load` (config). No `yaml.load`, no `eval`/`exec` on parsed values. Custom `LineLoader` is asserted to subclass `SafeLoader` at import time. |
-| 2 | Crash the linter or hang it indefinitely                        | Pathological YAML structures (deep nesting, billion-laughs)     | Parser traversals are iterative, not recursive (fix for #61). Continuous fuzzing on parser + engine via ClusterFuzzLite (`cflite-pr.yml` per-PR, `cflite-batch.yml` weekly).                |
+| 2 | Crash the linter or hang it indefinitely                        | Pathological YAML structures (deep nesting, billion-laughs)     | Parser traversals are iterative, not recursive (fix for #61). Continuous fuzzing on parser + engine via ClusterFuzzLite (`cflite-pr.yml` per-PR, `cflite-batch.yml` daily).                |
 | 3 | Cause a false negative — slip a real misconfig past the linter  | Hardened-but-unusual syntax, alternate-form constructs          | Every rule ships positive *and* negative tests; `tests/compose_files/safe_*.yml` enforces hardened-but-unusual fixtures (CONTRIBUTING.md §"Adding a new rule"). Corpus snapshot (`tests/corpus_snapshot.json.gz`) locks output across 1,500+ real-world Compose files; PRs that change findings show the diff. Rule-loader test catches mutation-untested code paths via `mutmut`. |
 | 4 | Cause a false positive — make the linter fail benign files      | Adjacent-but-clean configs (named volumes, sub-form syntax)     | Same negative-test discipline as #3, plus the corpus snapshot regression gate.                                    |
 | 5 | Exfiltrate data from the linter or its host                     | Make the linter open a network connection                       | Product code performs no network I/O. Documented hardened `docker run` recipe pins `--network none` and is exercised in CI (`docker-smoke` matrix).                                            |
@@ -120,9 +120,9 @@ prompting:
   hard gate before any artifact is built.
 - **Static analysis**: CodeQL (security-and-quality queries) on push,
   PR, and weekly schedule; Bandit per push.
-- **Fuzzing**: ClusterFuzzLite per-PR (`cflite-pr.yml`) and weekly
+- **Fuzzing**: ClusterFuzzLite per-PR (`cflite-pr.yml`) and daily
   batch (`cflite-batch.yml`) against the parser and engine.
-- **Supply-chain scoring**: OpenSSF Scorecard on push and weekly.
+- **Supply-chain scoring**: OpenSSF Scorecard weekly and on branch-protection changes.
 - **Release-time gates** (`publish.yml`): annotated-tag check, tag-
   reachable-from-main check, SSH tag-signature verification (via
   `.github/allowed_signers`), TestPyPI smoke, multi-arch Docker smoke

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -163,10 +163,10 @@ per-channel contract in [`DISTRIBUTION.md`](DISTRIBUTION.md). Summary:
 in parallel → `create-release` → `bump-marketplace-smoke-pin`.
 
 `verify-tag` is the first gate: it asserts the tag is annotated (not
-lightweight) and the tag commit is reachable from `origin/main`. Every
-downstream job inherits the check via `needs:`. Full SSH signature
-verification is not yet wired — it would require committing an
-allowed-signers file listing the maintainer's SSH signing key.
+lightweight), that the tag commit is reachable from `origin/main`, and
+that the tag's SSH signature verifies against `.github/allowed_signers`
+via `git verify-tag` — the cryptographic root of the release provenance
+chain. Every downstream job inherits the check via `needs:`.
 
 `release-gate` is the single human-in-the-loop gate: one approval on the
 `release` environment covers every channel. Per-channel environments

--- a/docs/SECURITY-EXPECTATIONS.md
+++ b/docs/SECURITY-EXPECTATIONS.md
@@ -24,10 +24,14 @@ pipeline, this is the page to read.
    `--network none`, and CI runs the full smoke battery under that flag
    set on every release.
 
-3. **It will not modify your Compose files.** compose-lint only reads
-   its inputs. There is no `--fix`, no rewrite mode, no in-place edit.
-   (A future `--fix` mode would be additive and opt-in, never the
-   default — see [docs/ROADMAP.md](ROADMAP.md).)
+3. **It will not modify your Compose files unless you ask.** `check`
+   (the default command) only reads its inputs. The `fix` command is
+   dry-run by default — it prints a unified diff and writes nothing;
+   only `fix --apply` rewrites in place, via an atomic swap that
+   preserves permission bits. It applies only safe, mechanical edits,
+   never touches suppressed findings, and re-parses and re-lints every
+   change before writing — see [docs/ROADMAP.md](ROADMAP.md) and the
+   Fixing findings section of the README.
 
 4. **Released artifacts are signed.** Every release ships:
    - PyPI wheel + sdist with PEP 740 trusted-publisher attestations and

--- a/docs/severity.md
+++ b/docs/severity.md
@@ -67,6 +67,7 @@ CIS reference numbers in rule docs are pinned to **CIS Docker Benchmark v1.7.0**
 | CL-0018 (Explicit root user) | Hardening gap | Single container | MEDIUM |
 | CL-0019 (Image tag without digest) | Supply chain* | Host | MEDIUM |
 | CL-0015 (Healthcheck disabled) | Hardening gap | Single container | LOW |
+| CL-0022 (tmpfs re-enables exec/suid/dev) | Hardening gap | Single container | LOW |
 
 *CL-0004 and CL-0019 are supply chain risks that don't fit the runtime exploitation model cleanly. They are scored MEDIUM based on the combination of an unlikely-but-uncontrollable attack vector (upstream registry compromise) and a host-level blast radius. CL-0019 is the stronger guarantee of the two; CL-0004 catches the obvious mutable-tag cases.
 
@@ -95,6 +96,7 @@ These rules trigger only when a developer wrote something specifically dangerous
 - **CL-0015** — `healthcheck.disable: true` or `test: ["NONE"]`
 - **CL-0016** — `devices:` mapping a sensitive host device (e.g. `/dev/mem`, `/dev/kmem`)
 - **CL-0017** — `volumes:` using `:rshared` (shared mount propagation)
+- **CL-0022** — `tmpfs` mount passing `exec`, `suid`, or `dev` (re-enabling Docker's default `noexec,nosuid,nodev`)
 
 Other rules (CL-0005, CL-0008, CL-0009, CL-0010, CL-0011, CL-0013, CL-0018) are also presence-based but target patterns common enough in real compose files that they do not need this caveat.
 


### PR DESCRIPTION
Audited README + docs against the actual code and workflows. This PR corrects the concrete contradictions found (docs-only):

| Doc | Was | Now (ground truth) |
|-----|-----|--------------------|
| `SECURITY-EXPECTATIONS.md` | "no `--fix`, no rewrite mode, no in-place edit" | describes the shipped `fix`/`fix --apply` behavior (`cli.py`, `fix.py`) |
| `CI.md` | "Full SSH signature verification is not yet wired" | `verify-tag` runs `git verify-tag` against `.github/allowed_signers` (`publish.yml:62`) |
| `ASSURANCE.md` | `cflite-batch.yml` "weekly" (×2) | daily — cron is `17 4 * * *` |
| `ASSURANCE.md` | "Scorecard on push and weekly" | weekly + branch-protection changes — `scorecard.yml` has no `push` trigger |
| `severity.md` | matrix + rule list covered only CL-0001–CL-0021 | add missing **CL-0022** (LOW) |

**Note:** the profiles.md catalog-path fix from the original finding list is dropped — #415 already corrected it (and reframed it as the external catalog repo's layout) after this branch was cut. Rebased onto that.

Deliberately **not** included (out of scope): the README "68% HIGH or CRITICAL" stat (unsupported by the linked report — pending a decision), CLI-reference completeness, and version-pinned/frozen artifacts (state-of-compose report, ADRs).