### PR TITLE
Profile schema 1.4: optional derivation.run_config.sysctls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Profile schema 1.4: optional `derivation.run_config.sysctls`.** Records the
+  kernel sysctl posture a *posture-dependent* capability minimum was derived under.
+  The canonical case is `net.ipv4.ip_unprivileged_port_start`: Docker defaults it
+  to 0 (all ports unprivileged, so a low-port bind needs no cap and NET_BIND_SERVICE
+  reads falsely-removable), while the kernel default of 1024 makes the cap required —
+  the "works on my Docker, breaks in k8s" divergence. csd already pins the hardened
+  posture and emits the `sysctls` list; this field lets the published profile state
+  which posture its minimum assumes, so a consumer can reconcile against their own
+  runtime instead of guessing. Optional and additive — all 1.0–1.3 documents remain
+  valid; absent/empty means no sysctl was pinned. See ADR-017 §11.
 - **`check --strict-config` / `fix --strict-config`.** Opt-in strict mode that
   turns config diagnostics that are normally stderr warnings — an unknown or
   typo'd rule id (`CL-001` vs `CL-0001`), an unknown top-level or per-rule key,

--- a/docs/adr/017-security-profile-catalog.md
+++ b/docs/adr/017-security-profile-catalog.md
@@ -294,3 +294,35 @@ remain valid, and it never substitutes for the per-dimension `validated_via`
 evidence (drop-test / bpf-observation / ci-smoke); it is *additional* evidence.
 csd's `scripts/apptier_verify.sh` produces it (worked example: immich's postgres
 and valkey, verified against immich's released stack and real REST API).
+
+### 11. run_config.sysctls — the kernel posture a posture-dependent minimum assumes (schema 1.4, amendment 2026-07-16)
+
+A capability minimum can be valid **only under a specific kernel sysctl**, and
+until 1.4 the schema had nowhere to record it — so the condition lived in prose in
+the profile's criteria doc, where a consumer could not act on it.
+
+The canonical case is **NET_BIND_SERVICE**. Whether binding a low port (`:80`,
+`:53`) needs a capability is not a property of the image but of
+`net.ipv4.ip_unprivileged_port_start` in the container's network namespace:
+
+- **Docker** defaults it to `0` (all ports unprivileged) → the bind needs **no**
+  capability, and NET_BIND_SERVICE reads *falsely-removable*.
+- The **kernel** default is `1024` → the bind **requires** the capability. Non-Docker
+  runtimes and hardened hosts commonly sit here (containerd/CRI-O, and therefore much
+  of Kubernetes, typically leave the kernel default unless configured), which is the
+  classic "works on my Docker, breaks in k8s" divergence.
+
+So the correct minimum is posture-dependent. csd derives under the **stricter**
+posture (pins `net.ipv4.ip_unprivileged_port_start=1024`) — the conservative,
+portable answer ("the cap is needed") — and already emits a `sysctls` list in its
+`run_config`. Schema 1.4 adds the matching optional
+`derivation.run_config.sysctls` field (an array of `"key=value"` strings) so the
+profile can state which posture its minimum assumes. A consumer (or compose-lint's
+consumer side) then reconciles: on default Docker the profile is *over-permissioned*
+for the low-port cap; on a `1024` host it is exactly right and dropping the cap
+would break the bind.
+
+The field is optional and additive — all `1.0`–`1.3` documents remain valid, and an
+absent/empty `sysctls` means no sysctl was pinned (the minimum holds under Docker's
+defaults). It records only what the derivation was pinned under; it does not, by
+itself, cause compose-lint to require that posture of a target.

--- a/src/compose_lint/profiles/schema/profile.schema.json
+++ b/src/compose_lint/profiles/schema/profile.schema.json
@@ -8,9 +8,9 @@
   "additionalProperties": false,
   "properties": {
     "schema_version": {
-      "description": "Catalog profile schema version (independent of csd's sidecar schema_version, which is recorded per-dimension under derivation.sidecar_schema_version). 1.1 adds drop-test as a derivation source (observer=drop-test, validated_via=drop-test); 1.2 adds the optional derivation.run_config block (the invocation the minimum was derived under); 1.3 adds the optional top-level app_tier_verified block (service-level verification of the whole profile). All earlier documents remain valid.",
+      "description": "Catalog profile schema version (independent of csd's sidecar schema_version, which is recorded per-dimension under derivation.sidecar_schema_version). 1.1 adds drop-test as a derivation source (observer=drop-test, validated_via=drop-test); 1.2 adds the optional derivation.run_config block (the invocation the minimum was derived under); 1.3 adds the optional top-level app_tier_verified block (service-level verification of the whole profile); 1.4 adds the optional derivation.run_config.sysctls field (the kernel sysctl posture a posture-dependent minimum was derived under). All earlier documents remain valid.",
       "type": "string",
-      "enum": ["1.0", "1.1", "1.2", "1.3"]
+      "enum": ["1.0", "1.1", "1.2", "1.3", "1.4"]
     },
     "image": {
       "description": "Canonical repository reference WITHOUT tag or digest -- the match key. Registry and namespace normalized (docker.io/library/postgres, lscr.io/linuxserver/radarr).",
@@ -355,6 +355,11 @@
               "type": "array",
               "items": { "type": "string" },
               "description": "security_opt entries the derivation ran with (e.g. apparmor=unconfined)."
+            },
+            "sysctls": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "1.4 (optional). Kernel sysctls (`key=value`, `--sysctl` / compose `sysctls:`) the derivation was PINNED under, when the minimum is posture-dependent. The canonical case is `net.ipv4.ip_unprivileged_port_start=1024`: Docker defaults it to 0 (all ports unprivileged) so a low-port bind needs no capability and NET_BIND_SERVICE reads falsely-removable; the derivation pins the hardened posture, and this field records that the minimum is only valid under it. A consumer whose runtime uses a different value (e.g. plain Docker's 0, where the cap is droppable; or containerd/CRI-O's kernel default of 1024, where it is required) can reconcile against this rather than guess. Empty/absent means no sysctl was pinned (the minimum holds under Docker's defaults)."
             },
             "mounts": {
               "type": "array",

--- a/tests/test_profile_schema.py
+++ b/tests/test_profile_schema.py
@@ -64,13 +64,14 @@ def test_schema_is_valid_draft202012(schema: dict[str, Any]) -> None:
 def test_schema_version_is_pinned(schema: dict[str, Any]) -> None:
     # 1.0 is the baseline; 1.1 adds drop-test as a derivation source; 1.2 adds
     # the optional derivation.run_config block; 1.3 adds the optional top-level
-    # app_tier_verified block. All remain valid so existing documents are not
-    # invalidated.
+    # app_tier_verified block; 1.4 adds the optional derivation.run_config.sysctls
+    # field. All remain valid so existing documents are not invalidated.
     assert schema["properties"]["schema_version"]["enum"] == [
         "1.0",
         "1.1",
         "1.2",
         "1.3",
+        "1.4",
     ]
 
 
@@ -178,6 +179,28 @@ def test_run_config_rejects_unknown_key(
     example["dimensions"]["capabilities"]["derivation"]["run_config"] = {
         "user": "",
         "cap_add": ["SYS_ADMIN"],
+    }
+    assert not validator.is_valid(example)
+
+
+def test_run_config_sysctls_accepted(
+    validator: Draft202012Validator, example: dict[str, Any]
+) -> None:
+    # Schema 1.4: the kernel sysctl posture a posture-dependent minimum was
+    # pinned under (the canonical case is ip_unprivileged_port_start for
+    # NET_BIND_SERVICE). Optional array of "key=value" strings.
+    example["schema_version"] = "1.4"
+    example["dimensions"]["capabilities"]["derivation"]["run_config"] = {
+        "sysctls": ["net.ipv4.ip_unprivileged_port_start=1024"],
+    }
+    assert validator.is_valid(example), list(validator.iter_errors(example))
+
+
+def test_run_config_sysctls_must_be_array(
+    validator: Draft202012Validator, example: dict[str, Any]
+) -> None:
+    example["dimensions"]["capabilities"]["derivation"]["run_config"] = {
+        "sysctls": "net.ipv4.ip_unprivileged_port_start=1024",
     }
     assert not validator.is_valid(example)
 


### PR DESCRIPTION
Closes #418.

Adds an optional `derivation.run_config.sysctls` array (of `"key=value"` strings) to the profile schema, recording the **kernel sysctl posture a posture-dependent minimum was derived under**.

**Why:** whether a low-port bind needs NET_BIND_SERVICE is a property of `net.ipv4.ip_unprivileged_port_start`, not the image — Docker defaults it to 0 (cap falsely-removable), the kernel default is 1024 (cap required), and containerd/CRI-O/much of Kubernetes sit at the kernel default. csd derives under the pinned hardened posture and already emits a `sysctls` list; the schema had nowhere to put it, so 7 catalog profiles (traefik, httpd, wordpress, nextcloud, pihole, ntfy, adguardhome) carry the posture in prose. This lets the published profile state its assumption so a consumer can reconcile against their own runtime.

**Scope:** schema + ADR-017 §11 + CHANGELOG + tests. Purely additive — all 1.0–1.3 documents remain valid; `additionalProperties: false` still rejects unknown run_config keys, and `sysctls` is typed (array of strings).

**Tests:** `test_profile_schema.py` — enum pin updated to include 1.4, plus positive (sysctls accepted), type (non-array rejected), and the existing unknown-key rejection all pass (18/18).

Moving the 7 catalog profiles' posture from prose into structured `run_config.sysctls` is the follow-up PR in container-security-profiles (needs the contract SHA bumped to a commit carrying this schema first).