### PR TITLE
docs(adr): ADR-018 — confidence as a multi-axis score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Profile schema 1.4: optional `derivation.run_config.sysctls`.** Records the
+  kernel sysctl posture a *posture-dependent* capability minimum was derived under.
+  The canonical case is `net.ipv4.ip_unprivileged_port_start`: Docker defaults it
+  to 0 (all ports unprivileged, so a low-port bind needs no cap and NET_BIND_SERVICE
+  reads falsely-removable), while the kernel default of 1024 makes the cap required —
+  the "works on my Docker, breaks in k8s" divergence. csd already pins the hardened
+  posture and emits the `sysctls` list; this field lets the published profile state
+  which posture its minimum assumes, so a consumer can reconcile against their own
+  runtime instead of guessing. Optional and additive — all 1.0–1.3 documents remain
+  valid; absent/empty means no sysctl was pinned. See ADR-017 §11.
 - **`check --strict-config` / `fix --strict-config`.** Opt-in strict mode that
   turns config diagnostics that are normally stderr warnings — an unknown or
   typo'd rule id (`CL-001` vs `CL-0001`), an unknown top-level or per-rule key,

--- a/docs/adr/017-security-profile-catalog.md
+++ b/docs/adr/017-security-profile-catalog.md
@@ -294,3 +294,35 @@ remain valid, and it never substitutes for the per-dimension `validated_via`
 evidence (drop-test / bpf-observation / ci-smoke); it is *additional* evidence.
 csd's `scripts/apptier_verify.sh` produces it (worked example: immich's postgres
 and valkey, verified against immich's released stack and real REST API).
+
+### 11. run_config.sysctls — the kernel posture a posture-dependent minimum assumes (schema 1.4, amendment 2026-07-16)
+
+A capability minimum can be valid **only under a specific kernel sysctl**, and
+until 1.4 the schema had nowhere to record it — so the condition lived in prose in
+the profile's criteria doc, where a consumer could not act on it.
+
+The canonical case is **NET_BIND_SERVICE**. Whether binding a low port (`:80`,
+`:53`) needs a capability is not a property of the image but of
+`net.ipv4.ip_unprivileged_port_start` in the container's network namespace:
+
+- **Docker** defaults it to `0` (all ports unprivileged) → the bind needs **no**
+  capability, and NET_BIND_SERVICE reads *falsely-removable*.
+- The **kernel** default is `1024` → the bind **requires** the capability. Non-Docker
+  runtimes and hardened hosts commonly sit here (containerd/CRI-O, and therefore much
+  of Kubernetes, typically leave the kernel default unless configured), which is the
+  classic "works on my Docker, breaks in k8s" divergence.
+
+So the correct minimum is posture-dependent. csd derives under the **stricter**
+posture (pins `net.ipv4.ip_unprivileged_port_start=1024`) — the conservative,
+portable answer ("the cap is needed") — and already emits a `sysctls` list in its
+`run_config`. Schema 1.4 adds the matching optional
+`derivation.run_config.sysctls` field (an array of `"key=value"` strings) so the
+profile can state which posture its minimum assumes. A consumer (or compose-lint's
+consumer side) then reconciles: on default Docker the profile is *over-permissioned*
+for the low-port cap; on a `1024` host it is exactly right and dropping the cap
+would break the bind.
+
+The field is optional and additive — all `1.0`–`1.3` documents remain valid, and an
+absent/empty `sysctls` means no sysctl was pinned (the minimum holds under Docker's
+defaults). It records only what the derivation was pinned under; it does not, by
+itself, cause compose-lint to require that posture of a target.

--- a/docs/adr/018-confidence-as-multi-axis.md
+++ b/docs/adr/018-confidence-as-multi-axis.md
@@ -1,0 +1,143 @@
+# ADR-018: Confidence as a multi-axis score, not a single scalar
+
+**Status:** Accepted (amends [ADR-017 §4 Confidence](017-security-profile-catalog.md)).
+
+**Context:** A profile's `derivation.confidence` is today a single scalar —
+`high | moderate | low`. In practice that one word was being asked to answer four
+different questions at once, and it answered only one of them:
+
+1. **Was the experiment sound?** (leave-one-out drop-test, a discriminating
+   correctness check, every granted element tested)
+2. **Did the workload bound the image's feature surface?** (or only a subset)
+3. **On what environment was it derived?** (kernel, cgroup version, confinement
+   posture, runtime, userns)
+4. **Was it observed in a real deployment, or only a synthetic lab run?**
+
+`high` almost always meant "(1) yes" — a sound drop-test — while silently
+implying "(2) yes" to a consumer who reads `high` as *this is my minimum*. Those
+two claims come apart exactly when a feature was not exercised or the environment
+differs.
+
+**The receipt.** `netdata` was published at `confidence: high`. Its workload
+asserted per-process metrics (so `SYS_PTRACE` was correctly kept) but never drove
+per-container **network** metrics — whose collector enters container network
+namespaces. `SYS_ADMIN` read as removable because that path was never exercised;
+the `high` label hid the coverage gap entirely. (The removal turned out correct
+anyway — netdata degrades to a privilege-free fallback — but only a *live
+deployment* settled that, which is itself the point: see item 4.) A single scalar
+had no way to say "sound experiment, partial coverage."
+
+## Decision
+
+Model confidence as **four orthogonal axes** plus a derived overall. The overall
+is the **weakest link**, never an average — a profile is only as trustworthy as
+its least-covered axis.
+
+### The axes
+
+| Axis | Question | Values |
+|---|---|---|
+| `rigor` | Was the drop-test experiment sound? | `high` / `moderate` / `low` |
+| `coverage` | Did the workload bound the feature surface? | `bounded` / `partial` / `smoke` |
+| `environment` | What was held fixed? (descriptive) | a record: kernel, cgroup, confinement, runtime, userns |
+| `observation` | Lab run, or confirmed on a live deployment? | `lab` / `production` |
+
+- **`rigor`** — `high`: leave-one-out drop-test; the correctness check asserts real
+  *function* **and** the privilege drop (not a liveness endpoint); every granted
+  element is a tested candidate (a non-empty `fixed` is already rejected by the
+  producer). `moderate`: drop-test with a known check weakness. `low`:
+  observation-only.
+- **`coverage`** — `bounded`: the workload provably exercises everything that
+  could need a privilege, so no unexercised path can raise the minimum. `partial`:
+  an **unexercised feature could exercise a privileged operation** — a capability,
+  device, namespace, or extra mount — beyond the derived minimum; **requires an
+  explicit `uncovered:` list**. `smoke`: only readiness/health.
+  The test is *privilege*, not features: a feature-rich app whose optional
+  features are all **userland** stays `bounded` (a WordPress plugin or a Postgres
+  extension is application code and cannot grant a Linux capability), whereas a
+  monitoring/network tool whose optional collectors enter namespaces, open raw
+  sockets, or touch devices is `partial`.
+- **`environment`** — descriptive, not graded. Records the axes a cap's necessity
+  can depend on, because a cap removable here can be required elsewhere (a
+  stricter AppArmor/SELinux policy, containerd/CRI-O, an older kernel, rootless).
+- **`observation`** — `production`: additionally confirmed on a live deployment
+  running this exact config, carrying real traffic/features. `lab`: synthetic
+  workload on a derivation host only. **This is the strongest signal and the old
+  rubric ignored it** — the netdata question was only settled by the live box.
+
+### Overall
+
+```
+overall = min(rigor, map(coverage))     # bounded→high, partial→moderate, smoke→low
+```
+
+`observation: production` does **not** inflate `overall` — production still only
+exercises what production runs — but it is surfaced as a distinct badge that a
+consumer should weigh above any lab `high`.
+
+### What is programmatic vs. human
+
+Deliberately, only one axis needs per-profile judgment, and it fails safe:
+
+- **`environment`** — 100% auto-populated from the derivation host (`uname`,
+  cgroup version, `docker info`, the `security_opt` used).
+- **`observation`** — set from provenance: the deploy-check pipeline knows it ran
+  against a live compose (`production`); a lab drop-test is `lab`. No one guesses.
+- **`rigor`** — mostly computable: "drop-test used" and "no `fixed`" are known
+  from the run and already enforced. The one seam — "is the correctness check
+  *discriminating*?" — is made programmatic by having the check self-declare its
+  assertions (`# asserts: function-roundtrip, non-root-uid`) and validating them;
+  until then it is a review item.
+- **`coverage`** — the genuinely human axis: deciding "did we exercise everything
+  that could need a privilege" requires external knowledge of the image's full
+  feature set, which is not derivable from the container. **It therefore defaults
+  to `partial`** (→ `overall: moderate`); a human only ever *upgrades* to
+  `bounded` with justification. Uncertainty resolves **downward**. This default
+  alone would have caught netdata: it defaults to `moderate` and stays there
+  unless someone proves the surface bounded.
+
+### Schema & migration
+
+The structured block is a **future backward-compatible schema minor**: `confidence`
+becomes `oneOf: [the existing scalar, the block]`, so old profiles stay valid and
+producers migrate incrementally. That bump is deferred until a consumer
+(compose-lint enrichment) actually reads the axes.
+
+**Interim (now), no schema change:** the catalog recalibrates the existing scalar
+to the computed `overall` — `high` is retained only where `coverage: bounded` is
+defensible, everything else drops to `moderate` — and records the per-dimension
+`coverage` classification and any `uncovered:` scope in the criteria docs. This
+is applied across the catalog in the companion change.
+
+## Consequences
+
+- **The interim scalar recalibration** (companion catalog change) drops a
+  capabilities dimension from `high` to `moderate` where an unexercised feature is
+  **documented to need more capability** than the derived minimum:
+  - `netdata` — per-container network collector (`cgroup-network` → `SYS_ADMIN`),
+    ebpf collectors.
+  - `home-assistant` — hardware/USB/Bluetooth/network integrations (devices,
+    D-Bus, `NET_ADMIN`/`NET_RAW`).
+  - `uptime-kuma` — ping monitors add `NET_RAW`.
+  - `adguardhome` — the DHCP server adds `NET_ADMIN`.
+  - `pihole` — DHCP (`NET_ADMIN`), NTP (`SYS_TIME`), `SYS_NICE` — the vendor's own
+    conditional caps, none in the DNS-only minimum.
+  - `alloy` — configurable collection pipelines (process/ebpf) can need
+    `SYS_PTRACE`/BPF.
+  Each gets an `uncovered:`-style note in its criteria doc.
+- **Profiles that stay `high` genuinely earn it** — their *privilege* surface is
+  bounded by start-up + one primary function even when their *feature* surface is
+  large: the databases (extensions/replication are userland), the web/CMS apps
+  (WordPress/Nextcloud/paperless plugins are userland), the proxies and brokers,
+  and the zero-cap stores (memcached, minio, prometheus, loki, keycloak).
+  Filesystem dimensions likewise stay `high` where the optional feature affects
+  caps/devices, not the write surface (e.g. a ping monitor needs `NET_RAW`, not a
+  new tmpfs).
+- **Under the structured field (target state), `coverage` defaults to `partial`**
+  and every `bounded` must be affirmatively justified — a stricter bar than this
+  interim pass, which only *demotes on known evidence*. The migration will surface
+  the profiles currently assumed-bounded-by-omission.
+- **The honest answer to "should this be `high` if we didn't run it ourselves":**
+  for profiles we *do* run (the deploy-check / homelab services — netdata among
+  them), `observation: production` is the strong signal; for the rest, cap
+  `overall` at what the workload provably bounds.

--- a/src/compose_lint/profiles/schema/profile.schema.json
+++ b/src/compose_lint/profiles/schema/profile.schema.json
@@ -8,9 +8,9 @@
   "additionalProperties": false,
   "properties": {
     "schema_version": {
-      "description": "Catalog profile schema version (independent of csd's sidecar schema_version, which is recorded per-dimension under derivation.sidecar_schema_version). 1.1 adds drop-test as a derivation source (observer=drop-test, validated_via=drop-test); 1.2 adds the optional derivation.run_config block (the invocation the minimum was derived under); 1.3 adds the optional top-level app_tier_verified block (service-level verification of the whole profile). All earlier documents remain valid.",
+      "description": "Catalog profile schema version (independent of csd's sidecar schema_version, which is recorded per-dimension under derivation.sidecar_schema_version). 1.1 adds drop-test as a derivation source (observer=drop-test, validated_via=drop-test); 1.2 adds the optional derivation.run_config block (the invocation the minimum was derived under); 1.3 adds the optional top-level app_tier_verified block (service-level verification of the whole profile); 1.4 adds the optional derivation.run_config.sysctls field (the kernel sysctl posture a posture-dependent minimum was derived under). All earlier documents remain valid.",
       "type": "string",
-      "enum": ["1.0", "1.1", "1.2", "1.3"]
+      "enum": ["1.0", "1.1", "1.2", "1.3", "1.4"]
     },
     "image": {
       "description": "Canonical repository reference WITHOUT tag or digest -- the match key. Registry and namespace normalized (docker.io/library/postgres, lscr.io/linuxserver/radarr).",
@@ -355,6 +355,11 @@
               "type": "array",
               "items": { "type": "string" },
               "description": "security_opt entries the derivation ran with (e.g. apparmor=unconfined)."
+            },
+            "sysctls": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "1.4 (optional). Kernel sysctls (`key=value`, `--sysctl` / compose `sysctls:`) the derivation was PINNED under, when the minimum is posture-dependent. The canonical case is `net.ipv4.ip_unprivileged_port_start=1024`: Docker defaults it to 0 (all ports unprivileged) so a low-port bind needs no capability and NET_BIND_SERVICE reads falsely-removable; the derivation pins the hardened posture, and this field records that the minimum is only valid under it. A consumer whose runtime uses a different value (e.g. plain Docker's 0, where the cap is droppable; or containerd/CRI-O's kernel default of 1024, where it is required) can reconcile against this rather than guess. Empty/absent means no sysctl was pinned (the minimum holds under Docker's defaults)."
             },
             "mounts": {
               "type": "array",

--- a/tests/test_profile_schema.py
+++ b/tests/test_profile_schema.py
@@ -64,13 +64,14 @@ def test_schema_is_valid_draft202012(schema: dict[str, Any]) -> None:
 def test_schema_version_is_pinned(schema: dict[str, Any]) -> None:
     # 1.0 is the baseline; 1.1 adds drop-test as a derivation source; 1.2 adds
     # the optional derivation.run_config block; 1.3 adds the optional top-level
-    # app_tier_verified block. All remain valid so existing documents are not
-    # invalidated.
+    # app_tier_verified block; 1.4 adds the optional derivation.run_config.sysctls
+    # field. All remain valid so existing documents are not invalidated.
     assert schema["properties"]["schema_version"]["enum"] == [
         "1.0",
         "1.1",
         "1.2",
         "1.3",
+        "1.4",
     ]
 
 
@@ -178,6 +179,28 @@ def test_run_config_rejects_unknown_key(
     example["dimensions"]["capabilities"]["derivation"]["run_config"] = {
         "user": "",
         "cap_add": ["SYS_ADMIN"],
+    }
+    assert not validator.is_valid(example)
+
+
+def test_run_config_sysctls_accepted(
+    validator: Draft202012Validator, example: dict[str, Any]
+) -> None:
+    # Schema 1.4: the kernel sysctl posture a posture-dependent minimum was
+    # pinned under (the canonical case is ip_unprivileged_port_start for
+    # NET_BIND_SERVICE). Optional array of "key=value" strings.
+    example["schema_version"] = "1.4"
+    example["dimensions"]["capabilities"]["derivation"]["run_config"] = {
+        "sysctls": ["net.ipv4.ip_unprivileged_port_start=1024"],
+    }
+    assert validator.is_valid(example), list(validator.iter_errors(example))
+
+
+def test_run_config_sysctls_must_be_array(
+    validator: Draft202012Validator, example: dict[str, Any]
+) -> None:
+    example["dimensions"]["capabilities"]["derivation"]["run_config"] = {
+        "sysctls": "net.ipv4.ip_unprivileged_port_start=1024",
     }
     assert not validator.is_valid(example)
 


### PR DESCRIPTION
Amends ADR-017 §4. The single `derivation.confidence` scalar was conflating four questions and answering only one.

**The receipt:** `netdata` shipped `confidence: high`, but its workload asserted per-*process* metrics and never drove per-*container-network* metrics — so `SYS_ADMIN` read as removable with no signal that coverage was partial. A single scalar had no way to say "sound experiment, partial coverage."

**Decision:** four orthogonal axes — `rigor`, `coverage`, `environment`, `observation` — with `overall = min(rigor, coverage)` (weakest-link, never an average). `observation: production` is a distinct badge, not a numeric bump.

**Key property — mostly mechanizable:** only `coverage` needs human judgment, and it **defaults to `partial`** (fail-safe *down*); `environment`/`observation` auto-populate from the run/provenance; `rigor` is mostly computable. That default alone would have caught netdata.

Structured block is a future backward-compatible schema minor (`oneOf: [scalar, block]`); interim is a scalar recalibration to the computed `overall` across the catalog (companion change in container-security-profiles).