### PR TITLE
Profile schema 1.5: surface reference_url on enriched findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Profile schema 1.5: optional top-level `reference_url`.** An HTTPS link to the
+  profile's rendered, human-readable page — the full derivation context (evidence
+  table, invocation, criteria prose, provenance) that a one-line enrichment hint
+  cannot carry. When present, enrichment surfaces it on the enriched finding's
+  `references` (first, so the text formatter's `ref:` line shows the image-specific
+  page rather than the rule's generic citation; JSON carries all references). The
+  reference catalog publishes these pages at
+  [tmatens.github.io/container-security-profiles](https://tmatens.github.io/container-security-profiles/).
+  Optional and additive — all 1.0–1.4 documents remain valid. See ADR-017 §12.
+
 - **Profile schema 1.4: optional `derivation.run_config.sysctls`.** Records the
   kernel sysctl posture a *posture-dependent* capability minimum was derived under.
   The canonical case is `net.ipv4.ip_unprivileged_port_start`: Docker defaults it

--- a/docs/adr/017-security-profile-catalog.md
+++ b/docs/adr/017-security-profile-catalog.md
@@ -326,3 +326,28 @@ The field is optional and additive — all `1.0`–`1.3` documents remain valid,
 absent/empty `sysctls` means no sysctl was pinned (the minimum holds under Docker's
 defaults). It records only what the derivation was pinned under; it does not, by
 itself, cause compose-lint to require that posture of a target.
+
+### 12. reference_url — the rendered page behind the hint (schema 1.5, amendment 2026-07-17)
+
+A derived minimum is a function of **(image digest × exact invocation × workload
+coverage)**, but an enrichment hint is one line appended to a finding's fix text.
+It cannot carry the evidence table, the invocation it was derived under, the
+criteria prose, or the re-derive-if conditions — the context a reader needs to
+judge whether the minimum applies to *their* service. The honest resolution of
+"advisory, not authoritative" is not a smarter hint; it is a **link** to a page
+that carries what the hint cannot.
+
+Schema 1.5 adds the optional top-level `reference_url`: an HTTPS URL to the
+profile's rendered, human-readable page, set by the **catalog publisher** (the
+reference catalog generates one page per profile on GitHub Pages from the same
+YAML + criteria doc + manifest — no second source of truth). compose-lint stays
+data-free (§7): it never constructs or assumes a URL shape, it only surfaces the
+field verbatim on enriched findings' `references` — first, so the text
+formatter's single `ref:` line shows the image-specific evidence page rather
+than the rule's generic citation. JSON output carries the full list.
+
+The field is optional and additive — all `1.0`–`1.4` documents remain valid, and
+a profile without it enriches exactly as before. Because enrichment only ever
+consumes *validated* profiles from a catalog the user explicitly configured and
+trusts (§7), the URL inherits that trust decision; the https-only pattern is a
+floor, not a substitute for it.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,7 +120,10 @@ reclassifies a finding, so turning it on cannot change your pass/fail result —
 only makes existing guidance more specific, and the hint is **attributed and
 marked unverified** (it names its source and that compose-lint did not
 independently reproduce it). It matches a service's `image:` to a profile in your
-configured catalog; with no matching profile it is a no-op. See
+configured catalog; with no matching profile it is a no-op. When a profile carries
+a `reference_url` (schema 1.5) — the reference catalog points each profile at its
+rendered page on the site above — the enriched finding's `ref:` line links there,
+so the full evidence behind the hint is one click away. See
 [ADR-017](adr/017-security-profile-catalog.md) for the profile model and the
 trust rationale (§7).
 

--- a/src/compose_lint/profiles/enrich.py
+++ b/src/compose_lint/profiles/enrich.py
@@ -44,7 +44,16 @@ def enrich_fix(finding: Finding, match: ProfileMatch) -> Finding:
 
     note = f"profile hint ({_provenance(dimension, match)}): {guidance}"
     new_fix = f"{finding.fix}\n{note}" if finding.fix else note
-    return replace(finding, fix=new_fix)
+
+    # Surface the profile's rendered page (schema 1.5 reference_url) alongside
+    # the hint: the one-line note is inherently under-qualified, and the page
+    # carries the full derivation context. Prepended, because the image-specific
+    # evidence outranks the rule's generic references (text output shows only
+    # the first reference).
+    references = finding.references
+    if match.reference_url and match.reference_url not in references:
+        references = [match.reference_url, *references]
+    return replace(finding, fix=new_fix, references=references)
 
 
 def _flow(items: list[Any]) -> str:

--- a/src/compose_lint/profiles/loader.py
+++ b/src/compose_lint/profiles/loader.py
@@ -89,11 +89,13 @@ def match_profile(image: str, catalog: Catalog) -> ProfileMatch | None:
         return None
 
     dimensions = doc.get("dimensions")
+    reference_url = doc.get("reference_url")
     return ProfileMatch(
         image=ref.repository,
         status=str(doc.get("status", "")),
         precision=precision,
         dimensions=dimensions if isinstance(dimensions, dict) else {},
+        reference_url=reference_url if isinstance(reference_url, str) else None,
     )
 
 

--- a/src/compose_lint/profiles/models.py
+++ b/src/compose_lint/profiles/models.py
@@ -35,6 +35,9 @@ class ProfileMatch:
     dimensions: dict[str, Any]
     """Raw per-dimension blocks (capabilities, filesystem, ...)."""
 
+    reference_url: str | None = None
+    """The profile's rendered human-readable page (schema 1.5), if published."""
+
     @property
     def is_validated(self) -> bool:
         return self.status == "validated"

--- a/src/compose_lint/profiles/schema/profile.schema.json
+++ b/src/compose_lint/profiles/schema/profile.schema.json
@@ -8,9 +8,9 @@
   "additionalProperties": false,
   "properties": {
     "schema_version": {
-      "description": "Catalog profile schema version (independent of csd's sidecar schema_version, which is recorded per-dimension under derivation.sidecar_schema_version). 1.1 adds drop-test as a derivation source (observer=drop-test, validated_via=drop-test); 1.2 adds the optional derivation.run_config block (the invocation the minimum was derived under); 1.3 adds the optional top-level app_tier_verified block (service-level verification of the whole profile); 1.4 adds the optional derivation.run_config.sysctls field (the kernel sysctl posture a posture-dependent minimum was derived under). All earlier documents remain valid.",
+      "description": "Catalog profile schema version (independent of csd's sidecar schema_version, which is recorded per-dimension under derivation.sidecar_schema_version). 1.1 adds drop-test as a derivation source (observer=drop-test, validated_via=drop-test); 1.2 adds the optional derivation.run_config block (the invocation the minimum was derived under); 1.3 adds the optional top-level app_tier_verified block (service-level verification of the whole profile); 1.4 adds the optional derivation.run_config.sysctls field (the kernel sysctl posture a posture-dependent minimum was derived under); 1.5 adds the optional top-level reference_url field (the profile's rendered human-readable page). All earlier documents remain valid.",
       "type": "string",
-      "enum": ["1.0", "1.1", "1.2", "1.3", "1.4"]
+      "enum": ["1.0", "1.1", "1.2", "1.3", "1.4", "1.5"]
     },
     "image": {
       "description": "Canonical repository reference WITHOUT tag or digest -- the match key. Registry and namespace normalized (docker.io/library/postgres, lscr.io/linuxserver/radarr).",
@@ -45,6 +45,11 @@
       "type": "array",
       "items": { "type": "string" },
       "minItems": 1
+    },
+    "reference_url": {
+      "description": "1.5 (optional). HTTPS URL of this profile's rendered, human-readable page -- the full derivation context (evidence table, invocation, criteria prose, provenance) that a one-line enrichment hint cannot carry. Set by the catalog publisher; compose-lint surfaces it verbatim as a reference on enriched findings so the reader can judge applicability themselves.",
+      "type": "string",
+      "pattern": "^https://"
     },
     "app_tier_verified": { "$ref": "#/$defs/appTierVerified" },
     "dimensions": {

--- a/tests/fixtures/profiles/catalog/docker.io/library/postgres.yml
+++ b/tests/fixtures/profiles/catalog/docker.io/library/postgres.yml
@@ -1,10 +1,11 @@
 # Fixture profile for loader tests. Placeholder digests/hashes -- not a real
 # csd derivation.
-schema_version: "1.0"
+schema_version: "1.5"
 image: docker.io/library/postgres
 applies_to:
   tags: ["16", "16.*"]
 status: validated
+reference_url: https://example.com/profiles/docker.io/library/postgres.html
 dimensions:
   capabilities:
     cap_drop: [ALL]

--- a/tests/test_profile_enrich.py
+++ b/tests/test_profile_enrich.py
@@ -16,13 +16,16 @@ def _match(image: str):  # type: ignore[no-untyped-def]
     return match_profile(image, load_catalog(FIXTURE_CATALOG))
 
 
-def _finding(rule_id: str, fix: str | None = None) -> Finding:
+def _finding(
+    rule_id: str, fix: str | None = None, references: list[str] | None = None
+) -> Finding:
     return Finding(
         rule_id=rule_id,
         severity=Severity.MEDIUM,
         service="db",
         message="finding",
         fix=fix,
+        references=references or [],
     )
 
 
@@ -83,6 +86,33 @@ def test_provenance_notes_confidence_and_precision() -> None:
     assert "compose-lint can't see your runtime" in result.fix
     # digest is shortened, not the full 64 hex
     assert "a" * 64 not in result.fix
+
+
+def test_reference_url_prepended_to_references() -> None:
+    # The postgres fixture carries reference_url (schema 1.5); an enriched
+    # finding gains it FIRST (text output shows only the first reference, and
+    # the image-specific page outranks the rule's generic references).
+    match = _match("postgres:16")
+    assert match is not None
+    rule_ref = "https://owasp.org/some-generic-guidance"
+    result = enrich_fix(_finding("CL-0006", references=[rule_ref]), match)
+    assert result.references == [
+        "https://example.com/profiles/docker.io/library/postgres.html",
+        rule_ref,
+    ]
+
+
+def test_no_reference_url_leaves_references_untouched() -> None:
+    # The radarr fixture has no reference_url.
+    digest = "sha256:" + "c" * 64
+    match = match_profile(
+        f"lscr.io/linuxserver/radarr@{digest}", load_catalog(FIXTURE_CATALOG)
+    )
+    assert match is not None
+    rule_ref = "https://owasp.org/some-generic-guidance"
+    result = enrich_fix(_finding("CL-0007", references=[rule_ref]), match)
+    assert result.fix is not None  # still enriched
+    assert result.references == [rule_ref]
 
 
 def test_engine_enriches_when_lookup_supplied() -> None:

--- a/tests/test_profile_loader.py
+++ b/tests/test_profile_loader.py
@@ -109,6 +109,20 @@ def test_dimensions_surfaced(catalog: Catalog) -> None:
     assert "CHOWN" in match.dimensions["capabilities"]["cap_add"]
 
 
+def test_reference_url_surfaced(catalog: Catalog) -> None:
+    # postgres carries reference_url (schema 1.5); radarr does not.
+    match = match_profile("postgres:16", catalog)
+    assert match is not None
+    assert (
+        match.reference_url
+        == "https://example.com/profiles/docker.io/library/postgres.html"
+    )
+
+    unset = match_profile("lscr.io/linuxserver/radarr", catalog)
+    assert unset is not None
+    assert unset.reference_url is None
+
+
 def test_load_profile_returns_validated_only() -> None:
     # validated postgres resolves...
     assert load_profile("postgres:16", FIXTURE_CATALOG) is not None

--- a/tests/test_profile_schema.py
+++ b/tests/test_profile_schema.py
@@ -65,13 +65,15 @@ def test_schema_version_is_pinned(schema: dict[str, Any]) -> None:
     # 1.0 is the baseline; 1.1 adds drop-test as a derivation source; 1.2 adds
     # the optional derivation.run_config block; 1.3 adds the optional top-level
     # app_tier_verified block; 1.4 adds the optional derivation.run_config.sysctls
-    # field. All remain valid so existing documents are not invalidated.
+    # field; 1.5 adds the optional top-level reference_url field. All remain
+    # valid so existing documents are not invalidated.
     assert schema["properties"]["schema_version"]["enum"] == [
         "1.0",
         "1.1",
         "1.2",
         "1.3",
         "1.4",
+        "1.5",
     ]
 
 
@@ -119,6 +121,26 @@ def test_unknown_observer_rejected(
     validator: Draft202012Validator, example: dict[str, Any]
 ) -> None:
     example["dimensions"]["capabilities"]["derivation"]["observer"] = "egress"
+    assert not validator.is_valid(example)
+
+
+def test_reference_url_accepted(
+    validator: Draft202012Validator, example: dict[str, Any]
+) -> None:
+    # 1.5: optional top-level pointer to the profile's rendered page. Optional
+    # regardless of the document's declared version (additive, like the rest).
+    example["reference_url"] = (
+        "https://example.com/profiles/docker.io/library/postgres.html"
+    )
+    assert validator.is_valid(example), list(validator.iter_errors(example))
+
+
+def test_reference_url_must_be_https(
+    validator: Draft202012Validator, example: dict[str, Any]
+) -> None:
+    example["reference_url"] = (
+        "http://example.com/profiles/docker.io/library/postgres.html"
+    )
     assert not validator.is_valid(example)
 
 


### PR DESCRIPTION
## What

Adds the optional top-level `reference_url` field to the profile schema (**1.5**) and wires it through enrichment: when a matched profile carries it, the enriched finding's `references` gains the URL **first**, so the text formatter's single `ref:` line links the image-specific evidence page instead of the rule's generic citation. JSON output carries the full list.

## Why

A profile hint is one line appended to fix text — it cannot carry the evidence table, invocation, criteria prose, or re-derive-if conditions that make the minimum judgeable. The honest resolution of "advisory, not authoritative" is a link to the page that carries what the hint cannot (ADR-017 §12, new). The reference catalog already renders one page per profile at [tmatens.github.io/container-security-profiles](https://tmatens.github.io/container-security-profiles/); the catalog side adds the field next (contract-pin bump + per-profile URLs), closing container-security-profiles#6.

## Design

- compose-lint stays data-free (ADR-017 §7): it never constructs or assumes a URL shape — it surfaces the publisher-set field verbatim. The https-only pattern is a floor; trust comes from the user-configured catalog.
- Optional + additive: all 1.0–1.4 documents remain valid; profiles without the field enrich exactly as before.

## Tests

Schema (accepts, https-only, enum pin), loader (carried / absent→None), enrich (prepended before rule refs, untouched when absent). `ruff`, `mypy --strict`, 1141 passed.