### PR TITLE
Prepare 0.14.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-07-29
+
 ### Added
 
 - **Profile schema 1.6: optional per-dimension `derivation.features` — the
@@ -1157,7 +1159,8 @@ First public release.
   inputs through `env:` rather than direct `${{ }}` interpolation to prevent
   shell injection.
 
-[Unreleased]: https://github.com/tmatens/compose-lint/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/tmatens/compose-lint/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/tmatens/compose-lint/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/tmatens/compose-lint/compare/v0.12.2...v0.13.0
 [0.12.2]: https://github.com/tmatens/compose-lint/compare/v0.12.1...v0.12.2
 [0.12.1]: https://github.com/tmatens/compose-lint/compare/v0.12.0...v0.12.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "compose-lint"
-version = "0.13.0"
+version = "0.14.0"
 description = "Security-focused linter for Docker Compose files. Catches dangerous misconfigurations before they reach production — grounded in OWASP and the CIS Docker Benchmark; emits SARIF for GitHub Code Scanning."
 readme = "README.md"
 license = "MIT"

--- a/src/compose_lint/__init__.py
+++ b/src/compose_lint/__init__.py
@@ -1,3 +1,3 @@
 """A security-focused linter for Docker Compose files."""
 
-__version__ = "0.13.0"
+__version__ = "0.14.0"


### PR DESCRIPTION
Automated release prep for `0.14.0`. Review the CHANGELOG entry and version bumps, then squash-merge.

**After this PR merges**, create and push a signed annotated tag from your workstation:

```
git checkout main && git pull --ff-only
git tag -s v0.14.0 -m "compose-lint 0.14.0"
git push origin v0.14.0
```

The tag push triggers `publish.yml`, which runs TestPyPI/Docker smoke tests, waits for your approval on the `release` environment, then publishes PyPI + Docker Hub, creates the GitHub Release, and opens a follow-up PR to bump the `marketplace-smoke` pin.
