### PR TITLE
Bump pyasn1 to 0.6.4 to clear PYSEC-2026-3455/56/57

### DIFF
--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -946,9 +946,9 @@ py-serializable==2.1.0 \
     --hash=sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103 \
     --hash=sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304
     # via cyclonedx-python-lib
-pyasn1==0.6.3 \
-    --hash=sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf \
-    --hash=sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde
+pyasn1==0.6.4 \
+    --hash=sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81 \
+    --hash=sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b
     # via sigstore
 pycparser==3.0 ; implementation_name != 'PyPy' and platform_python_implementation != 'PyPy' \
     --hash=sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29 \


### PR DESCRIPTION
## What

Bump `pyasn1` 0.6.3 → 0.6.4 in `requirements-dev.lock`.

## Why

The v0.14.0 publish run failed its `build` pre-gate at the release-time
`pip-audit` step: pyasn1 0.6.3 has three advisories disclosed after v0.13.0
— **PYSEC-2026-3455 / 3456 / 3457** — all fixed in **0.6.4**.

pyasn1 is a **dev/build-only** transitive dependency (via the sigstore
signing toolchain); it is not a runtime dependency (runtime is PyYAML only),
so there is no wheel or Docker-image impact. Minimal upgrade via
`uv pip compile --upgrade-package pyasn1` — the diff is pyasn1's pin + hashes
only. `pip-audit --skip-editable` is clean after the bump.

Unblocks the v0.14.0 release.