### PR TITLE
Keep README under Docker Hub's 25000-byte description limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,6 +338,41 @@ jobs:
               sys.exit(f"::error::Version drift: pyproject.toml ({pyproject}) vs src/compose_lint/__init__.py ({init})")
           PY
 
+  # Docker Hub's repository API rejects a `full_description` over 25000 bytes
+  # with HTTP 400, which is what README.md is synced into by the
+  # `dockerhub-description` job in publish.yml. Without this guard the limit is
+  # only discovered at release time, as a red — but by then cosmetic — job long
+  # after the tag is cut (v0.14.0 hit exactly that at 25319 bytes). Check it at
+  # edit time instead, where the fix is cheap.
+  #
+  # 25000 is the real ceiling, not a padded one: Docker Hub counts bytes and so
+  # does `wc -c`, and v0.14.0's rejection reported `actual 25319` for a README
+  # that measured 25319 here. A lower "safety" threshold would only invent a
+  # second, fictional limit — the headroom line below gives early warning
+  # instead.
+  readme-size:
+    name: README fits Docker Hub description limit
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Check README.md byte size
+        env:
+          LIMIT: "25000"
+        run: |
+          set -euo pipefail
+          size=$(wc -c < README.md)
+          echo "README.md: ${size} / ${LIMIT} bytes"
+          if [ "${size}" -gt "${LIMIT}" ]; then
+            echo "::error file=README.md::README.md is $((size - LIMIT)) bytes over the ${LIMIT}-byte Docker Hub description limit (${size}). Docker Hub will reject the overview sync with HTTP 400. Shorten it, or convert repeated inline links to reference-style links."
+            exit 1
+          fi
+          echo "Headroom: $((LIMIT - size)) bytes"
+
   # If a PR bumps the `version` in pyproject.toml, CHANGELOG.md must already
   # contain a matching `## [X.Y.Z]` section. Without this, a release PR can
   # merge with no release notes and the Publish workflow's `create-release`
@@ -702,6 +737,7 @@ jobs:
       - coverage
       - security
       - version-consistency
+      - readme-size
       - changelog-gate
       - dco
       - no-ai-attribution

--- a/README.md
+++ b/README.md
@@ -155,27 +155,27 @@ If you need broad IaC coverage across Terraform, Kubernetes, and more, KICS cove
 | ID | Severity | Description | OWASP | CIS |
 |----|----------|-------------|-------|-----|
 | [CL-0001](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0001.md) | CRITICAL | Container runtime socket mounted | [Rule #1](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1-do-not-expose-the-docker-daemon-socket-even-to-the-containers) | 5.32 |
-| [CL-0002](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0002.md) | CRITICAL | Privileged mode enabled | [Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-specific-capabilities-needed-by-a-container) | 5.5 |
+| [CL-0002](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0002.md) | CRITICAL | Privileged mode enabled | [Rule #3][owasp3] | 5.5 |
 | [CL-0003](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0003.md) | MEDIUM | Privilege escalation not blocked | [Rule #4](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-4-prevent-in-container-privilege-escalation) | 5.26 |
-| [CL-0004](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0004.md) | MEDIUM | Image not pinned to version | [Rule #13](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-13-enhance-supply-chain-security) | 5.28 |
+| [CL-0004](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0004.md) | MEDIUM | Image not pinned to version | [Rule #13][owasp13] | 5.28 |
 | [CL-0005](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0005.md) | HIGH | Ports bound to all interfaces | [Rule #5a](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-5a-be-careful-when-mapping-container-ports-to-the-host-with-firewalls-like-ufw) | 5.14 |
-| [CL-0006](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0006.md) | MEDIUM | No capability restrictions | [Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-specific-capabilities-needed-by-a-container) | 5.4 |
-| [CL-0007](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0007.md) | MEDIUM | Filesystem not read-only | [Rule #8](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-8-set-filesystem-and-volumes-to-read-only) | 5.13 |
+| [CL-0006](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0006.md) | MEDIUM | No capability restrictions | [Rule #3][owasp3] | 5.4 |
+| [CL-0007](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0007.md) | MEDIUM | Filesystem not read-only | [Rule #8][owasp8] | 5.13 |
 | [CL-0008](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0008.md) | HIGH | Host network mode | [Rule #5](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-5-be-mindful-of-inter-container-connectivity) | 5.10 |
 | [CL-0009](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0009.md) | HIGH | Security profile disabled | [Rule #6](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-6-use-linux-security-module-seccomp-apparmor-or-selinux-for-runtime-security) | 5.2, 5.3, 5.22 |
-| [CL-0010](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0010.md) | HIGH | Host namespace sharing | [Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-specific-capabilities-needed-by-a-container) | 5.16, 5.17, 5.21, 5.31 |
-| [CL-0011](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0011.md) | HIGH | Dangerous capabilities added | [Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-specific-capabilities-needed-by-a-container) | 5.4 |
+| [CL-0010](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0010.md) | HIGH | Host namespace sharing | [Rule #3][owasp3] | 5.16, 5.17, 5.21, 5.31 |
+| [CL-0011](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0011.md) | HIGH | Dangerous capabilities added | [Rule #3][owasp3] | 5.4 |
 | [CL-0012](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0012.md) | MEDIUM | PIDs cgroup limit disabled | — | 5.29 |
-| [CL-0013](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0013.md) | HIGH | Sensitive host path mounted | [Rule #8](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-8-set-filesystem-and-volumes-to-read-only) | 5.6 |
+| [CL-0013](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0013.md) | HIGH | Sensitive host path mounted | [Rule #8][owasp8] | 5.6 |
 | [CL-0014](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0014.md) | MEDIUM | Logging driver disabled | — | — |
 | [CL-0015](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0015.md) | LOW | Healthcheck disabled | — | 4.6, 5.27 |
 | [CL-0016](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0016.md) | HIGH | Dangerous host device exposed | — | 5.18 |
 | [CL-0017](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0017.md) | MEDIUM | Shared mount propagation | — | 5.20 |
 | [CL-0018](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0018.md) | MEDIUM | Explicit root user | [Rule #2](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-2-set-a-user) | — |
-| [CL-0019](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0019.md) | MEDIUM | Image tag without digest | [Rule #13](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-13-enhance-supply-chain-security) | — |
-| [CL-0020](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0020.md) | HIGH | Credential-shaped env key with literal value | [Rule #12](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-12-utilize-docker-secrets-for-sensitive-data-management) | — |
-| [CL-0021](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0021.md) | HIGH | Credential embedded in connection-string env value | [Rule #12](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-12-utilize-docker-secrets-for-sensitive-data-management) | — |
-| [CL-0022](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0022.md) | LOW | tmpfs mount re-enables exec/suid/dev | [Rule #8](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-8-set-filesystem-and-volumes-to-read-only) | — |
+| [CL-0019](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0019.md) | MEDIUM | Image tag without digest | [Rule #13][owasp13] | — |
+| [CL-0020](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0020.md) | HIGH | Credential-shaped env key with literal value | [Rule #12][owasp12] | — |
+| [CL-0021](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0021.md) | HIGH | Credential embedded in connection-string env value | [Rule #12][owasp12] | — |
+| [CL-0022](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0022.md) | LOW | tmpfs mount re-enables exec/suid/dev | [Rule #8][owasp8] | — |
 
 ## Severity Levels
 
@@ -401,3 +401,8 @@ See [CONTRIBUTING.md](https://github.com/tmatens/compose-lint/blob/main/CONTRIBU
 ## License
 
 [MIT](https://github.com/tmatens/compose-lint/blob/main/LICENSE)
+
+[owasp3]: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-specific-capabilities-needed-by-a-container
+[owasp8]: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-8-set-filesystem-and-volumes-to-read-only
+[owasp12]: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-12-utilize-docker-secrets-for-sensitive-data-management
+[owasp13]: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-13-enhance-supply-chain-security


### PR DESCRIPTION
## What

1. README.md **25319 → 24447 bytes** (553 headroom) — repeated OWASP cheat-sheet
   URLs in the Rules table converted to reference-style links.
2. New `readme-size` CI job enforcing the 25000-byte ceiling at edit time,
   wired into the required `ci-ok` aggregator.

## Why

v0.14.0's `dockerhub-description` job failed:

```
Error: PATCH returned HTTP 400
{"message":"httperror 400: request had 1 validation error","errinfo":{"fielderrors":
 {"full_description":"Exceeded max number of bytes 25000 - actual 25319"}}}
```

The **image publish was unaffected** — `docker-publish` succeeded, cosign-signed
and verified. Only the Docker Hub *overview text* failed to sync. But the limit
was only discovered at release time, after the tag was cut.

## Lossless, not a doc cut

No prose, links, or the demo GIF's alt text were removed. The Rules table
repeated four long OWASP URLs inline — the capabilities rule 4×, read-only
filesystem 3×. Reference-style links are a pure encoding change:

- all **81** links preserved
- expanding the 4 references back out reproduces the previous text **exactly**
- no unused definitions; every reference resolves

## Why the guard is 25000 exact, not padded

Docker Hub counts bytes and so does `wc -c` — and the rejection reported
`actual 25319` for a README that measures 25319 locally. The check *is* the
constraint, not an approximation of it, so there's nothing for margin to
absorb; a lower threshold would just invent a second, fictional ceiling. The
job prints remaining headroom instead, so you get early warning without
relocating the wall.

Verified in both directions: passes at 24447 (553 headroom), and correctly
fails the pre-fix README with `319 bytes over`. `actionlint` clean.

It runs unconditionally rather than gated on README changes, matching the
neighbouring `version-consistency` / `changelog-gate` invariant guards (~2s,
and can't be dodged by a rename).

## Follow-up

The live Docker Hub overview is still stale. Once this merges it can be
resynced immediately via the existing **Docker Hub description (manual)**
`workflow_dispatch` — no release needed.