### PR TITLE
Bump tuf to 7.0.0 and drop the stale pip-audit ignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,17 +280,12 @@ jobs:
         # Remove this ignore if the OSV record is withdrawn or a fix
         # release is published.
         #
-        # --ignore-vuln GHSA-qp9x-wp8f-qgjj: platform-dependent
-        # delegation path matching in tuf. Fixed in tuf 7.0.0, but
-        # sigstore 4.2.0 requires tuf~=6.0, so no fix is installable
-        # under current constraints. tuf is a transitive dev/publish
-        # dependency (via sigstore) and not part of the runtime image.
-        # Remove this ignore once sigstore allows tuf >= 7.
+        # An ignore is only for advisories with NO installable fix. If a
+        # fix exists, take it — bump the lockfile instead of suppressing.
         continue-on-error: true
         run: >-
           pip-audit --skip-editable
           --ignore-vuln PYSEC-2025-183
-          --ignore-vuln GHSA-qp9x-wp8f-qgjj
 
   # Fails the PR if `pyproject.toml` and `src/compose_lint/__init__.py`
   # disagree about the project version. The two strings drifted silently

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -113,7 +113,6 @@ jobs:
         run: >-
           pip-audit --skip-editable
           --ignore-vuln PYSEC-2025-183
-          --ignore-vuln GHSA-qp9x-wp8f-qgjj
       - run: python -m build
       - name: Verify dist contents
         run: |

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -1739,9 +1739,9 @@ tomli-w==1.2.0 \
     --hash=sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90 \
     --hash=sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021
     # via pip-audit
-tuf==6.0.0 \
-    --hash=sha256:458f663a233d95cc76dde0e1a3d01796516a05ce2781fefafebe037f7729601a \
-    --hash=sha256:9eed0f7888c5fff45dc62164ff243a05d47fb8a3208035eb268974287e0aee8d
+tuf==7.0.0 \
+    --hash=sha256:572bdbdc9ff4a82278a0d4773e6100863b9b33023f27575e84ca65b486dd0d79 \
+    --hash=sha256:9d2e6723538e0d5a3e482b6de805fcfe64481448d5853039ba6b06ba541efd7f
     # via sigstore
 twine==6.2.0 \
     --hash=sha256:418ebf08ccda9a8caaebe414433b0ba5e25eb5e4a927667122fbe8f829f985d8 \


### PR DESCRIPTION
Drops the `--ignore-vuln GHSA-qp9x-wp8f-qgjj` suppression from both pip-audit surfaces and takes the fix instead.

## Why the ignore is no longer valid

The justification comment said:

> Fixed in tuf 7.0.0, but sigstore 4.2.0 requires tuf~=6.0, so no fix is installable under current constraints.

That is no longer true. **sigstore 4.4.0 requires `tuf<8,>=6`**, so tuf 7.0.0 resolves cleanly.

## Why neither existing surface caught it

- **pip-audit** was suppressing the advisory by ID, on both the informational PR step and the release-time hard gate.
- **Renovate** never proposed tuf 7 — the existing pin was already satisfiable, so there was nothing for it to bump.

A fixable vulnerability sat invisible behind a justification that had quietly become false. The replacement comment states the standing rule: an ignore is only for advisories with **no installable fix**.

## Verification (run locally in a venv built from the updated lock)

| Check | Result |
|---|---|
| `uv pip compile … --upgrade-package tuf` | minimal diff — pin + hashes only |
| `pip install --require-hashes -r requirements-dev.lock` | clean |
| `pip check` | No broken requirements found |
| `import sigstore, tuf.ngclient` / `sigstore --version` | OK / 4.4.0 |
| `pip-audit --skip-editable --ignore-vuln PYSEC-2025-183` | **No known vulnerabilities found** |
| `actionlint` | clean |

## Scope

tuf is a transitive **dev/publish** dependency (via sigstore). It is not in the runtime image, the published wheel, or `requirements.lock`. The remaining `PYSEC-2025-183` ignore (disputed pyjwt advisory, no fix version) is unchanged, and the two workflows' ignore sets stay identical as their comments require.