### PR TITLE
Report every vulnerability that has a fix, at any severity

### DIFF
--- a/.github/workflows/vuln-report.yml
+++ b/.github/workflows/vuln-report.yml
@@ -1,0 +1,150 @@
+name: Fixable vulnerability report
+
+# Surfaces every vulnerability that has a fix available, at ANY severity,
+# as a single rolling issue.
+#
+# Rationale: the blocking gates elsewhere are severity-scoped on purpose
+# (ci.yml's dependency-review at `high`, scout-scan.yml's gate at
+# `critical`) so a fixable low/medium never blocks unrelated work. That
+# leaves a visibility gap: a fixable MEDIUM in the published image is
+# real, actionable, and silent. This workflow closes the gap by
+# *reporting* on fixability rather than severity, without changing what
+# blocks.
+#
+# It also runs pip-audit with NO --ignore-vuln suppressions, so an
+# advisory that is filtered out of the CI/release gates still shows up
+# here. That is the anti-rot property: a suppression whose justification
+# has gone stale is otherwise invisible to pip-audit (filtered by ID) and
+# to Renovate (the existing pin is still satisfiable) simultaneously.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 30 min after scout-scan.yml's 06:00 sweep, so the image scan below
+    # sees the same day's advisory data.
+    - cron: "30 6 * * *"
+
+permissions: {}
+
+jobs:
+  report:
+    name: Report fixable vulnerabilities
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements-dev.lock
+
+      - name: Install pinned env
+        run: |
+          pip install --require-hashes -r requirements-dev.lock
+          pip install --no-deps -e .
+
+      # No --ignore-vuln flags: this report is the un-suppressed view.
+      # continue-on-error because pip-audit exits non-zero when it finds
+      # anything, which is the normal case we want to report on — the
+      # report script fails the job if the JSON is missing or malformed.
+      - name: pip-audit (no suppressions)
+        continue-on-error: true
+        run: pip-audit --skip-editable --format json --output pip-audit.json
+
+      - uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Scan published image for fixable CVEs (all severities)
+        uses: docker/scout-action@2688993af7bafd6ba8c6a74ec652442be91dd82b # v1.23.1
+        with:
+          command: cves
+          image: composelint/compose-lint:latest
+          # Fixability is the filter — deliberately no `only-severities`.
+          only-fixed: true
+          exit-code: false
+          sarif-file: scout-fixable.sarif
+          # Same OpenVEX document the image attestation carries, so CVEs
+          # already marked not_affected don't page. See scout-scan.yml
+          # for why vex-author must be `.*`.
+          vex-location: .vex/compose-lint.openvex.json
+          vex-author: .*
+
+      - name: Build report body
+        id: build
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python scripts/vuln_report.py \
+            --pip-audit pip-audit.json \
+            --scout-sarif scout-fixable.sarif \
+            --image composelint/compose-lint:latest \
+            --run-url "${RUN_URL}" \
+            --out body.md
+
+      # Rolling issue: one issue, rewritten in place, closed when clean.
+      # An OPEN issue with this label means "there is something fixable
+      # right now" — there is no triage backlog to maintain.
+      - name: Reconcile rolling issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          COUNT: ${{ steps.build.outputs.count }}
+          HAS_FINDINGS: ${{ steps.build.outputs.has_findings }}
+          LABEL: fixable-vulns
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          gh label create "${LABEL}" \
+            --description "Rolling report: vulnerabilities with an available fix" \
+            --color B60205 --force
+
+          existing=$(gh issue list --state open --label "${LABEL}" \
+            --json number --jq '.[0].number // empty')
+
+          if [ "${HAS_FINDINGS}" = "true" ]; then
+            title="Fixable vulnerabilities (${COUNT})"
+            if [ -n "${existing}" ]; then
+              echo "Updating issue #${existing} (${COUNT} fixable)"
+              gh issue edit "${existing}" --title "${title}" --body-file body.md
+            else
+              echo "Opening new issue (${COUNT} fixable)"
+              gh issue create --title "${title}" --body-file body.md \
+                --label "${LABEL}"
+            fi
+          elif [ -n "${existing}" ]; then
+            echo "No fixable vulnerabilities left; closing #${existing}"
+            gh issue close "${existing}" --reason completed --comment \
+              "All previously reported vulnerabilities now have no available fix or are resolved. Verified by ${RUN_URL}."
+          else
+            echo "No fixable vulnerabilities and no open issue. Nothing to do."
+          fi
+
+      - name: Report scheduled failure as issue
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          WORKFLOW: ${{ github.workflow }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          title="Scheduled run failed: ${WORKFLOW}"
+          body=$(printf -- '- Workflow: **%s**\n- Run: %s\n- Commit: %s\n\nThe vulnerability report did not complete, so the rolling issue may be stale.' \
+            "${WORKFLOW}" "${RUN_URL}" "${GITHUB_SHA}")
+          existing=$(gh issue list --state open --search "\"${title}\" in:title" \
+            --json number --jq '.[0].number // empty')
+          if [ -n "${existing}" ]; then
+            gh issue comment "${existing}" --body "${body}"
+          else
+            gh issue create --title "${title}" --body "${body}"
+          fi

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -14,6 +14,7 @@ per-channel publish contract see [`DISTRIBUTION.md`](DISTRIBUTION.md).
 | `codeql.yml`              | Every PR + weekly (Mon 04:27 UTC)          | Static analysis, results in Code Scanning              |
 | `scorecard.yml`           | Branch-protection change + weekly          | OpenSSF Scorecard, results in Code Scanning            |
 | `scout-scan.yml`          | Daily (06:00 UTC) + manual                 | Docker Scout CVE scan against the published image      |
+| `vuln-report.yml`         | Daily (06:30 UTC) + manual                 | Rolling issue listing every vulnerability with a fix   |
 | `publish.yml`             | `v*` tag push                              | Release pipeline — see `RELEASING.md`                  |
 | `release-prep.yml`        | Manual (`workflow_dispatch`, maintainer)   | Opens the "Prepare X.Y.Z release" PR                   |
 | `publish-channel.yml`     | Manual (`workflow_dispatch`, maintainer)   | Emergency single-channel publish                       |
@@ -158,6 +159,46 @@ digest, which ships in the next patch release.
 
 ---
 
+## Fixable-vulnerability report — `vuln-report.yml`
+
+Runs daily (06:30 UTC), just after the Scout sweep. It answers one
+question: **is there anything with an available fix right now?**
+
+The blocking gates elsewhere are severity-scoped on purpose — the
+dependency review fails at `high`, the Scout gate at `critical` — so a
+fixable low or medium never blocks unrelated work. That leaves a
+visibility gap, because a fixable MEDIUM in the published image is real
+and actionable but silent. This workflow closes the gap by reporting on
+**fixability rather than severity**, without changing what blocks.
+
+Output is a single **rolling issue** labelled `fixable-vulns`:
+
+- The body is rewritten in place on every run — one issue, never a
+  stream of per-CVE issues.
+- It **closes itself** when nothing fixable is left. An open issue
+  therefore means "there is something to fix right now"; there is no
+  triage backlog to groom.
+- Advisories with **no** available fix are listed in a collapsed section
+  and deliberately do not open or close the issue.
+
+Two properties are worth preserving if you edit it:
+
+**It applies no `--ignore-vuln` suppressions.** An advisory filtered out
+of the `ci.yml` / `publish.yml` gates still appears here. This is the
+anti-rot property: a suppression whose written justification has gone
+stale is otherwise invisible to pip-audit (filtered by ID) *and* to
+Renovate (the existing pin is already satisfiable) at the same time. That
+is not hypothetical — the `tuf` ignore claimed "no fix is installable
+under current constraints" for months after `sigstore` relaxed the pin
+that made it true.
+
+**A scanner failure fails the job.** `scripts/vuln_report.py` errors out
+if either report is missing or has an unexpected shape rather than
+rendering an empty body, because a reporting job that silently reports
+clean is worse than no reporting job at all.
+
+---
+
 ## Release pipeline — `publish.yml`
 
 Tag-triggered. Full detail in [`RELEASING.md`](RELEASING.md) and the
@@ -276,9 +317,19 @@ still works weeks after release).
 | CodeQL alert                        | Security → Code Scanning, PR review comments           |
 | Scorecard finding                   | Security → Code Scanning (`scorecard` category)        |
 | Docker Scout CVE                    | Security → Code Scanning (`docker-scout` category)     |
+| Vulnerability with an available fix | Rolling issue labelled `fixable-vulns`                 |
 | Scheduled workflow failure          | Email to workflow author + red X on Actions tab        |
 | Renovate PR                         | Opens a PR tagged accordingly                          |
 
 The Security tab is the single pane of glass for everything except
 PR-gating failures (which stay on the PR) and Renovate bumps (which
 open their own PRs).
+
+The two security surfaces are complementary rather than redundant: the
+Security tab is the **passive** record — deduplicated, auto-resolving,
+and complete across severities — while the `fixable-vulns` issue is the
+**active** channel that actually notifies, filtered to what is
+actionable today. Note that the Security tab covers image and code
+findings only; Python dependency advisories reach it through no path at
+all, since `pip-audit` emits no SARIF. For those, the rolling issue is
+the *only* standing surface.

--- a/scripts/vuln_report.py
+++ b/scripts/vuln_report.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Build the rolling "fixable vulnerabilities" issue body.
+
+Consumes a pip-audit JSON report and (optionally) a Docker Scout SARIF
+report, and emits a Markdown body plus a has-findings flag.
+
+Design notes
+------------
+* **Fixability, not severity, decides whether this pages.** An advisory
+  with an available fix lands in the gating tables at any severity; one
+  with no fix is listed in a collapsed section that does not open or
+  close the issue.
+* **No suppressions are applied here.** The report deliberately runs
+  pip-audit without ``--ignore-vuln`` so that an advisory suppressed in
+  ``ci.yml``/``publish.yml`` still shows up. A suppression whose stated
+  justification has gone stale (see the tuf/``GHSA-qp9x-wp8f-qgjj``
+  case) is otherwise invisible to every scanner at once.
+* **Missing or unparseable input is a hard error**, never an implicit
+  "all clear". A reporting job that silently reports clean is worse
+  than no reporting job.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+MARKER = "<!-- vuln-report:managed -->"
+
+
+class ReportError(RuntimeError):
+    """Input was missing or did not have the expected shape."""
+
+
+def _load_json(path: Path, what: str) -> Any:
+    if not path.is_file():
+        raise ReportError(f"{what}: {path} does not exist")
+    if path.stat().st_size == 0:
+        raise ReportError(f"{what}: {path} is empty")
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ReportError(f"{what}: {path} is not valid JSON: {exc}") from exc
+
+
+def parse_pip_audit(path: Path) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+    """Return (fixable, unfixable) rows from a pip-audit JSON report."""
+    data = _load_json(path, "pip-audit report")
+    if not isinstance(data, dict) or "dependencies" not in data:
+        raise ReportError("pip-audit report has no 'dependencies' key; shape changed?")
+
+    fixable: list[dict[str, str]] = []
+    unfixable: list[dict[str, str]] = []
+    for dep in data["dependencies"]:
+        if dep.get("skip_reason"):
+            continue
+        for vuln in dep.get("vulns") or []:
+            fixes = [str(v) for v in (vuln.get("fix_versions") or [])]
+            row = {
+                "id": str(vuln.get("id", "?")),
+                "package": str(dep.get("name", "?")),
+                "installed": str(dep.get("version", "?")),
+                "fixed_in": ", ".join(fixes) if fixes else "—",
+            }
+            (fixable if fixes else unfixable).append(row)
+
+    fixable.sort(key=lambda r: (r["package"], r["id"]))
+    unfixable.sort(key=lambda r: (r["package"], r["id"]))
+    return fixable, unfixable
+
+
+def _severity_band(score: str) -> str:
+    """Map a SARIF ``security-severity`` CVSS score to a band name."""
+    try:
+        value = float(score)
+    except (TypeError, ValueError):
+        return "unknown"
+    if value >= 9.0:
+        return "critical"
+    if value >= 7.0:
+        return "high"
+    if value >= 4.0:
+        return "medium"
+    if value > 0.0:
+        return "low"
+    return "none"
+
+
+def parse_scout_sarif(path: Path) -> list[dict[str, str]]:
+    """Return rows for image CVEs from a Docker Scout SARIF report.
+
+    Scout is invoked with ``only-fixed: true``, so every result here is
+    by definition fixable and no fix-version filtering is applied.
+    """
+    data = _load_json(path, "Scout SARIF report")
+    runs = data.get("runs") if isinstance(data, dict) else None
+    if not isinstance(runs, list):
+        raise ReportError("Scout SARIF has no 'runs' list; shape changed?")
+
+    rows: list[dict[str, str]] = []
+    for run in runs:
+        driver = (run.get("tool") or {}).get("driver") or {}
+        rules = {r.get("id"): r for r in (driver.get("rules") or []) if r.get("id")}
+        for result in run.get("results") or []:
+            rule_id = result.get("ruleId") or "?"
+            rule = rules.get(rule_id, {})
+            props = rule.get("properties") or {}
+            detail = (
+                (rule.get("shortDescription") or {}).get("text")
+                or (result.get("message") or {}).get("text")
+                or ""
+            )
+            rows.append(
+                {
+                    "id": str(rule_id),
+                    "severity": _severity_band(props.get("security-severity", "")),
+                    "detail": " ".join(str(detail).split())[:160] or "—",
+                }
+            )
+
+    order = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+    rows.sort(key=lambda r: (order.get(r["severity"], 9), r["id"]))
+    return rows
+
+
+def _table(headers: list[str], rows: list[list[str]]) -> str:
+    out = ["| " + " | ".join(headers) + " |"]
+    out.append("|" + "|".join(["---"] * len(headers)) + "|")
+    out += ["| " + " | ".join(r) + " |" for r in rows]
+    return "\n".join(out)
+
+
+def build_body(
+    py_fixable: list[dict[str, str]],
+    py_unfixable: list[dict[str, str]],
+    img_fixable: list[dict[str, str]],
+    image: str,
+    run_url: str,
+) -> str:
+    total = len(py_fixable) + len(img_fixable)
+    noun = "vulnerability" if total == 1 else "vulnerabilities"
+    tail = (
+        " — every advisory below has a fix available, at any severity."
+        if total
+        else " — nothing to fix right now."
+    )
+    parts = [
+        MARKER,
+        f"**{total} fixable {noun}**{tail}",
+        "",
+        "This issue is maintained automatically: the body is rewritten on "
+        "each run and the issue **closes itself** when the fixable list is "
+        "empty. An open issue therefore means there is something to fix "
+        "right now.",
+        "",
+    ]
+
+    parts.append("## Python dependencies (`requirements-dev.lock`)")
+    parts.append("")
+    if py_fixable:
+        parts.append(
+            _table(
+                ["Advisory", "Package", "Installed", "Fixed in"],
+                [
+                    [f"`{r['id']}`", r["package"], r["installed"], r["fixed_in"]]
+                    for r in py_fixable
+                ],
+            )
+        )
+        parts.append("")
+        parts.append(
+            "Bump with "
+            "`uv pip compile ... --upgrade-package <name>` for a minimal diff "
+            "(see CLAUDE.md → Regenerating lockfiles)."
+        )
+    else:
+        parts.append("None. ✅")
+    parts.append("")
+
+    parts.append(f"## Published image (`{image}`)")
+    parts.append("")
+    if img_fixable:
+        parts.append(
+            _table(
+                ["CVE", "Severity", "Detail"],
+                [[f"`{r['id']}`", r["severity"], r["detail"]] for r in img_fixable],
+            )
+        )
+        parts.append("")
+        parts.append(
+            "Image CVEs are usually cleared by bumping the base image digest "
+            "in `Dockerfile` (Renovate proposes these) and cutting a release."
+        )
+    else:
+        parts.append("None. ✅")
+    parts.append("")
+
+    if py_unfixable:
+        parts.append(
+            f"<details><summary>Known, no fix available "
+            f"({len(py_unfixable)}) — does not gate this issue</summary>"
+        )
+        parts.append("")
+        parts.append(
+            _table(
+                ["Advisory", "Package", "Installed"],
+                [[f"`{r['id']}`", r["package"], r["installed"]] for r in py_unfixable],
+            )
+        )
+        parts.append("")
+        parts.append("</details>")
+        parts.append("")
+
+    parts += [
+        "---",
+        "",
+        "This report applies **no `--ignore-vuln` suppressions**, so an "
+        "advisory suppressed in `ci.yml` or `publish.yml` still appears "
+        "here. That is deliberate — a suppression whose justification has "
+        "gone stale is otherwise invisible to pip-audit (it is filtered by "
+        "ID) *and* to Renovate (the pin is already satisfiable) at the same "
+        "time.",
+        "",
+        f"[Workflow run]({run_url})" if run_url else "",
+    ]
+    return "\n".join(p for p in parts if p is not None).rstrip() + "\n"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--pip-audit", type=Path, required=True)
+    ap.add_argument("--scout-sarif", type=Path)
+    ap.add_argument("--image", default="composelint/compose-lint:latest")
+    ap.add_argument("--run-url", default="")
+    ap.add_argument("--out", type=Path, required=True)
+    args = ap.parse_args()
+
+    try:
+        py_fixable, py_unfixable = parse_pip_audit(args.pip_audit)
+        img_fixable = parse_scout_sarif(args.scout_sarif) if args.scout_sarif else []
+    except ReportError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+
+    body = build_body(py_fixable, py_unfixable, img_fixable, args.image, args.run_url)
+    args.out.write_text(body, encoding="utf-8")
+
+    total = len(py_fixable) + len(img_fixable)
+    print(
+        f"fixable: python={len(py_fixable)} image={len(img_fixable)} "
+        f"total={total}; unfixable (informational): {len(py_unfixable)}"
+    )
+
+    if step_output := os.environ.get("GITHUB_OUTPUT"):
+        with open(step_output, "a", encoding="utf-8") as fh:
+            fh.write(f"count={total}\n")
+            fh.write(f"has_findings={'true' if total else 'false'}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_vuln_report.py
+++ b/tests/test_vuln_report.py
@@ -1,0 +1,161 @@
+"""Tests for the rolling fixable-vulnerability report (scripts/vuln_report.py).
+
+Runs the actual script as a subprocess — the same entry point CI invokes —
+over synthetic pip-audit and Docker Scout payloads.
+
+The behaviour that matters most here is the *negative* case: a missing or
+malformed scanner report must fail loudly rather than render an empty
+"nothing to fix" body, which would read as an all-clear.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "vuln_report.py"
+
+PIP_AUDIT_MIXED = {
+    "dependencies": [
+        {
+            "name": "tuf",
+            "version": "6.0.0",
+            "vulns": [{"id": "GHSA-qp9x-wp8f-qgjj", "fix_versions": ["7.0.0"]}],
+        },
+        {
+            "name": "pyjwt",
+            "version": "2.10.1",
+            "vulns": [{"id": "PYSEC-2025-183", "fix_versions": []}],
+        },
+        {"name": "compose-lint", "skip_reason": "editable", "vulns": []},
+    ]
+}
+
+SCOUT_SARIF = {
+    "runs": [
+        {
+            "tool": {
+                "driver": {
+                    "rules": [
+                        {
+                            "id": "CVE-2026-0001",
+                            "shortDescription": {"text": "zlib overflow"},
+                            "properties": {"security-severity": "5.5"},
+                        },
+                        {
+                            "id": "CVE-2026-0002",
+                            "shortDescription": {"text": "openssl issue"},
+                            "properties": {"security-severity": "9.8"},
+                        },
+                    ]
+                }
+            },
+            "results": [
+                {"ruleId": "CVE-2026-0001"},
+                {"ruleId": "CVE-2026-0002"},
+            ],
+        }
+    ]
+}
+
+
+def run(
+    tmp_path: Path, pip_audit: object, sarif: object | None = None
+) -> tuple[subprocess.CompletedProcess[str], Path]:
+    pa = tmp_path / "pip-audit.json"
+    pa.write_text(json.dumps(pip_audit) if pip_audit is not None else "", "utf-8")
+    out = tmp_path / "body.md"
+    cmd = [sys.executable, str(SCRIPT), "--pip-audit", str(pa), "--out", str(out)]
+    if sarif is not None:
+        sf = tmp_path / "scout.sarif"
+        sf.write_text(json.dumps(sarif), "utf-8")
+        cmd += ["--scout-sarif", str(sf)]
+    return subprocess.run(cmd, capture_output=True, text=True), out
+
+
+def test_fixable_and_unfixable_are_separated(tmp_path: Path) -> None:
+    proc, out = run(tmp_path, PIP_AUDIT_MIXED)
+    assert proc.returncode == 0, proc.stderr
+    body = out.read_text("utf-8")
+
+    # The fixable advisory drives the report.
+    assert "GHSA-qp9x-wp8f-qgjj" in body
+    assert "7.0.0" in body
+    assert "**1 fixable vulnerability**" in body
+
+    # The unfixable one is present but demoted, and excluded from the count.
+    assert "PYSEC-2025-183" in body
+    assert "no fix available" in body
+    assert "does not gate this issue" in body
+
+
+def test_editable_skip_is_ignored(tmp_path: Path) -> None:
+    _, out = run(tmp_path, PIP_AUDIT_MIXED)
+    assert "compose-lint |" not in out.read_text("utf-8")
+
+
+def test_clean_report_has_no_findings(tmp_path: Path) -> None:
+    proc, out = run(tmp_path, {"dependencies": [], "fixes": []})
+    assert proc.returncode == 0, proc.stderr
+    assert "**0 fixable vulnerabilities**" in out.read_text("utf-8")
+    assert "total=0" in proc.stdout
+
+
+def test_image_cves_are_reported_with_severity_bands(tmp_path: Path) -> None:
+    proc, out = run(tmp_path, {"dependencies": []}, SCOUT_SARIF)
+    assert proc.returncode == 0, proc.stderr
+    body = out.read_text("utf-8")
+    assert "CVE-2026-0002" in body and "critical" in body
+    assert "CVE-2026-0001" in body and "medium" in body
+    # Critical sorts above medium.
+    assert body.index("CVE-2026-0002") < body.index("CVE-2026-0001")
+    # A medium image CVE counts: fixability gates, not severity.
+    assert "**2 fixable vulnerabilities**" in body
+
+
+def test_missing_pip_audit_report_fails_loudly(tmp_path: Path) -> None:
+    out = tmp_path / "body.md"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--pip-audit",
+            str(tmp_path / "nope.json"),
+            "--out",
+            str(out),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 1
+    assert "does not exist" in proc.stderr
+    assert not out.exists(), "must not emit an all-clear body on scanner failure"
+
+
+def test_empty_pip_audit_report_fails_loudly(tmp_path: Path) -> None:
+    proc, out = run(tmp_path, None)
+    assert proc.returncode == 1
+    assert "is empty" in proc.stderr
+    assert not out.exists()
+
+
+def test_unexpected_pip_audit_shape_fails_loudly(tmp_path: Path) -> None:
+    proc, out = run(tmp_path, {"unexpected": True})
+    assert proc.returncode == 1
+    assert "shape changed" in proc.stderr
+    assert not out.exists()
+
+
+def test_unexpected_sarif_shape_fails_loudly(tmp_path: Path) -> None:
+    proc, out = run(tmp_path, {"dependencies": []}, {"not": "sarif"})
+    assert proc.returncode == 1
+    assert "shape changed" in proc.stderr
+    assert not out.exists()
+
+
+def test_report_states_it_applies_no_suppressions(tmp_path: Path) -> None:
+    _, out = run(tmp_path, {"dependencies": []})
+    assert "no `--ignore-vuln` suppressions" in out.read_text("utf-8")


### PR DESCRIPTION
Implements the standing policy: **be aware of every vulnerability that has a fix, regardless of severity.**

## The gap this closes

The blocking gates are severity-scoped deliberately — `ci.yml`'s dependency review fails at `high`, `scout-scan.yml`'s gate at `critical` — so a fixable low/medium never blocks unrelated work. **That stays exactly as-is; this PR changes no thresholds and no gating behaviour.**

The cost of that scoping is visibility: a fixable MEDIUM in the published image is real, actionable, and completely silent. (v0.14.0 cleared six fixable MEDIUM CVEs from the image — nothing would have told us they were there.) This reports on **fixability instead of severity**, without touching what blocks.

## Shape

A daily workflow (06:30 UTC, after the Scout sweep) maintaining **one rolling issue** labelled `fixable-vulns`:

- Body rewritten in place each run — one issue, not a stream of per-CVE issues.
- **Closes itself** when nothing fixable remains. An open issue means "something to fix right now"; no backlog to groom.
- Advisories with **no** fix are listed in a collapsed section and do not open/close the issue.

## Two deliberate properties

**1. No `--ignore-vuln` suppressions are applied.** An advisory filtered out of the CI/release gates still appears here.

This is the anti-rot property, and it is not hypothetical. The `tuf` ignore removed in #435 read *"no fix is installable under current constraints"* — true when written, false for months afterward once sigstore relaxed its pin. It was invisible to **pip-audit** (filtered by ID) and to **Renovate** (the existing pin was still satisfiable) *simultaneously*. Nothing in the pipeline could have surfaced it. This report structurally can.

**2. A scanner failure fails the job.** `scripts/vuln_report.py` errors on a missing or unexpectedly-shaped report rather than rendering an empty body — a reporting job that silently reports clean is worse than none. Four of the nine tests cover exactly this.

## Verification

| Check | Result |
|---|---|
| `pytest tests/test_vuln_report.py` | 9 passed |
| `ruff check` / `ruff format --check` (src, tests, script) | clean |
| `actionlint` | clean |
| Rendering dry-run against **real** `pip-audit` output | correct (currently 0 fixable) |
| `docker/scout-action` inputs confirmed at pinned SHA | `only-fixed` ✔, `format` is SBOM-only → used `sarif-file` |
| Action SHA pins | match existing repo pins |

## Note on the image section

The Scout SARIF parse is defensive but its exact field rendering can't be exercised from a sandbox without pulling the image. It is written to **fail loudly** on shape mismatch rather than under-report. I'll dispatch the workflow once merged and confirm the first real issue body renders correctly.

## Not included

- **Threshold changes** — none, per the above.
- **Dependabot** — no `.github/dependabot.yml` exists and Renovate is the configured tool, so there's no second alert stream to reconcile.