### PR TITLE
Drop the dormant pyjwt ignore, leaving pip-audit unsuppressed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,21 +271,19 @@ jobs:
         # for the local install path); PyYAML and any future runtime
         # deps are still scanned.
         #
-        # --ignore-vuln PYSEC-2025-183: disputed advisory against pyjwt
-        # claiming "weak encryption". The pyjwt maintainers dispute it
-        # because the encryption key length is chosen by the application
-        # consuming the library, not the library itself. There is no
-        # fix version. pyjwt is a transitive dev/publish dependency
-        # (via sigstore/tuf/twine) and not part of the runtime image.
-        # Remove this ignore if the OSV record is withdrawn or a fix
-        # release is published.
-        #
-        # An ignore is only for advisories with NO installable fix. If a
-        # fix exists, take it — bump the lockfile instead of suppressing.
+        # There are deliberately NO --ignore-vuln entries. An ignore is
+        # only ever justified for an advisory with no installable fix,
+        # and every such entry rots: its justification depends on facts
+        # (someone else's pin, an unfixed upstream) that change without
+        # notice, while the suppression stays. A rotted ignore is
+        # invisible to pip-audit, which filters it by ID, and to
+        # Renovate, whose pin is still satisfiable, at the same time —
+        # see the tuf/GHSA-qp9x-wp8f-qgjj case. Prefer bumping the
+        # lockfile. If an unfixable advisory ever genuinely needs
+        # suppressing, add it here AND to publish.yml, and expect
+        # vuln-report.yml to keep listing it.
         continue-on-error: true
-        run: >-
-          pip-audit --skip-editable
-          --ignore-vuln PYSEC-2025-183
+        run: pip-audit --skip-editable
 
   # Fails the PR if `pyproject.toml` and `src/compose_lint/__init__.py`
   # disagree about the project version. The two strings drifted silently

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,10 +109,12 @@ jobs:
         # live and a CVE newly disclosed against an unchanged pinned dep
         # must not block unrelated work. At publish those deps actually
         # run and touch release integrity, so a known advisory must stop
-        # the release. Keep the --ignore-vuln set identical to ci.yml's.
-        run: >-
-          pip-audit --skip-editable
-          --ignore-vuln PYSEC-2025-183
+        # the release. Keep the --ignore-vuln set identical to ci.yml's,
+        # which currently means: none at all. See ci.yml for why an
+        # ignore is a last resort. If this gate ever blocks a release on
+        # an advisory with no fix, the escape hatch is to add the ignore
+        # to BOTH files in a PR — not to bypass the tag.
+        run: pip-audit --skip-editable
       - run: python -m build
       - name: Verify dist contents
         run: |


### PR DESCRIPTION
Removes the last `--ignore-vuln` entry. Both pip-audit invocations now run **completely unsuppressed**.

## Why it's safe to drop

`PYSEC-2025-183` no longer matches anything. PyPI reports **no advisories against pyjwt 2.13.0**; the record only covers `<=2.10.1`:

| pyjwt version | PYSEC-2025-183 reported? |
|---|---|
| 2.9.0 / 2.10.1 | yes (no fix version) |
| **2.13.0 (current lock)** | **no** |

`pip-audit --skip-editable` with **no flags at all** → `No known vulnerabilities found`, exit 0.

## Why drop it rather than keep it

This was the *legitimate* class of suppression — disputed, no fix version — unlike the rotted tuf entry removed in #435. It goes anyway because **a suppression that currently matches nothing is indistinguishable from one whose justification has quietly expired.** It costs the same review attention and protects against nothing. The comment left behind states when adding one back would be justified.

## The trade-off, stated plainly

This slightly widens what can block a **release**: a newly disclosed, unfixable advisory against a pinned build dep would now stop the publish pipeline. Accepting that deliberately, because:

- The pipeline **fails closed before publishing** — nothing ships and the version number stays reusable (proven during v0.14.0's pyasn1 block).
- **PR runs stay `continue-on-error`**, so unrelated work is never blocked.
- The escape hatch is a PR adding the ignore back to *both* files — not bypassing the tag.

## Does this touch VEX? No.

Verified, since it's a reasonable thing to suspect — the two mechanisms don't overlap:

| | `--ignore-vuln` | OpenVEX |
|---|---|---|
| Scope | Python dev/publish deps | Published image (`pkg:oci/compose-lint`) |
| Consumer | pip-audit CLI | Docker Scout `vex-location` + cosign attestation |
| Contents | (now empty) | 4 CVEs — none pyjwt or tuf |

`requirements.lock` (what's actually in the image) is **PyYAML only**; pyjwt and tuf are build-time only and never reach the image. `.vex/compose-lint.openvex.json` is unchanged.

## Verification

`actionlint` clean · both gates reproduced locally through the pip-proxy → exit 0 · no `--ignore-vuln` flags remain in either run command.

Follow-up to #435; the rolling report from #436 would surface this advisory regardless, since it applies no suppressions by design.