### PR TITLE
Echo behavior-changing caveats on the fix --apply path

### DIFF
--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -21,6 +21,7 @@ from compose_lint.explain import UnknownRuleError, load_rule_doc
 from compose_lint.fix import (
     apply_edits,
     collect_edits,
+    render_caveat_banner,
     render_file_diff,
     reparse_or_error,
     verify_apply,
@@ -687,6 +688,14 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
 
         if args.apply:
             _atomic_write(Path(filepath), patched)
+            # The behavior-changing caveats must surface here too, not only on
+            # the dry run — nothing forces a dry run first, so a one-shot
+            # `fix --apply` would otherwise mutate files silently (issue #428).
+            print(
+                render_caveat_banner(result.caveats),
+                end="",
+                file=sys.stderr,
+            )
             print(
                 f"{filepath}: applied {len(result.edits)} fix(es) across "
                 f"{len(result.fixed)} finding(s)",

--- a/src/compose_lint/fix.py
+++ b/src/compose_lint/fix.py
@@ -439,10 +439,19 @@ def render_file_diff(
     diff = "".join(chunks)
     if not diff:
         return ""
-    banner = "".join(
+    return render_caveat_banner(caveats) + diff
+
+
+def render_caveat_banner(caveats: list[tuple[str, str]]) -> str:
+    """Render one ``⚠ behavior-changing`` line per caveat, newline-terminated.
+
+    Shared by the dry-run diff header and the ``--apply`` summary (issue #428):
+    the caveat must reach the user on whichever path they took, in the same
+    form, so the warning cannot be bypassed by skipping the dry run.
+    """
+    return "".join(
         f"⚠ behavior-changing · {rule_id}: {caveat}\n" for rule_id, caveat in caveats
     )
-    return banner + diff
 
 
 def reparse_or_error(patched: str) -> str | None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -458,6 +458,28 @@ class TestFixSubcommand:
         assert stat.S_IMODE(f.stat().st_mode) == 0o640
         assert "read_only: true" in f.read_text()
 
+    def test_apply_prints_behavior_changing_caveats(self, tmp_path: Path) -> None:
+        # Regression (#428): the caveat banner must surface on the apply path
+        # too, not only in the dry-run diff — nothing forces a dry run first,
+        # so a one-shot `fix --apply` would otherwise mutate files silently.
+        f = tmp_path / "docker-compose.yml"
+        f.write_text(_BARE_SERVICE)
+        result = run_cli("fix", "--apply", str(f))
+        assert result.returncode == 0
+        assert "⚠ behavior-changing · CL-0007" in result.stderr
+        # Caveats are human status: stderr only, stdout stays data-clean.
+        assert result.stdout == ""
+
+    def test_apply_hardening_only_prints_no_caveat(self, tmp_path: Path) -> None:
+        # CL-0003 (no-new-privileges) is hardening-only; an apply run whose
+        # edits all carry no caveat must not print a behavior-changing line.
+        f = tmp_path / "docker-compose.yml"
+        f.write_text(_BARE_SERVICE)
+        result = run_cli("fix", "--apply", "--only", "CL-0003", str(f))
+        assert result.returncode == 0
+        assert "behavior-changing" not in result.stderr
+        assert "applied 1 fix(es)" in result.stderr
+
     def test_only_restricts_to_named_rule(self, tmp_path: Path) -> None:
         f = tmp_path / "docker-compose.yml"
         f.write_text(_BARE_SERVICE)


### PR DESCRIPTION
The `⚠ behavior-changing` banner was rendered only on the dry-run path; `compose-lint fix --apply` wrote behavior-changing edits and printed only `applied N fix(es)`, so a one-shot apply (the CI / pipeline case) never surfaced the caveat at the moment it mattered.

This extracts the banner into `render_caveat_banner()` (shared with `render_file_diff`, so the two paths cannot drift) and prints it on stderr alongside the applied summary.

Per the issue's acceptance criteria:
- caveats print on `--apply` in the same `⚠ behavior-changing · CL-XXXX: …` form as dry-run
- runs whose edits all carry no caveat (e.g. `--only CL-0003`) print no banner
- no interactive prompt, no TTY-conditional behavior; stdout stays data-clean

Fixes #428