### PR TITLE
Document latest-only digest pins, non-root read_only, lockfile installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ Use it if you ship Compose to production, want defense in depth in a homelab, or
 pip install compose-lint
 ```
 
+That resolves the newest release at install time. For a reproducible install (CI, production tooling), pin the version and install the dependency set from the repo's hash-pinned lockfile, which release automation keeps current:
+
+```bash
+pip install --require-hashes -r requirements.lock   # dependencies, hash-pinned
+pip install --no-deps compose-lint==X.Y.Z           # the tool, version-pinned
+```
+
 **Docker** — [composelint/compose-lint](https://hub.docker.com/r/composelint/compose-lint)
 
 ```bash

--- a/docs/rules/CL-0004.md
+++ b/docs/rules/CL-0004.md
@@ -34,6 +34,24 @@ image: nginx:1.27-alpine@sha256:...
 
 Find current stable versions on Docker Hub or your registry.
 
+### Images that only publish `latest`
+
+Some projects (Excalidraw, for example) publish only a `latest` tag and no versioned tags, so "pin the tag" is not actionable. Digest-pinning still is — and this rule already treats a digest-pinned reference as valid, because the digest is the real pin and the tag is a cosmetic label:
+
+```yaml
+image: excalidraw/excalidraw:latest@sha256:<digest>
+```
+
+Get the current digest with:
+
+```bash
+docker buildx imagetools inspect excalidraw/excalidraw:latest --format '{{.Manifest.Digest}}'
+```
+
+then let [Renovate](https://docs.renovatebot.com/) bump the digest on a schedule.
+
+This does **not** break when the tag moves: Docker resolves by digest and ignores the tag for content, so you keep pulling the exact image you pinned and upgrades happen only when the pin changes. The only failure case is the pinned digest being deleted from the registry (rare on Docker Hub; possible on a self-hosted registry with garbage collection enabled).
+
 ## See also
 
 - [CL-0019](CL-0019.md) — digest pinning (stronger guarantee against tag mutation)

--- a/docs/rules/CL-0007.md
+++ b/docs/rules/CL-0007.md
@@ -66,6 +66,21 @@ Observed failure modes:
 
 If the entrypoint runs `chown`, either pre-own the mount as the target UID:GID in the image build, or drop that specific service from the rule scope.
 
+### Hardened non-root images
+
+An image built to run as a non-root user is not automatically read-only-ready — it typically still writes to paths its uid owns (caches, PID files, runtime state). The two hardening steps are independent: non-root limits *who* the process is, `read_only` limits *where* it can write, and the second still needs the writable paths declared. The same recipe applies — ephemeral writes to `tmpfs`, persistent writes to a named volume, `docker diff` to discover the paths:
+
+```yaml
+services:
+  web:
+    image: nginxinc/nginx-unprivileged:1.27   # runs as uid 101
+    read_only: true
+    tmpfs:
+      - /tmp
+      - /var/cache/nginx
+      - /var/run
+```
+
 ## Further reading
 
 - [Docker best practices: read-only containers (ploetzli)](https://blog.ploetzli.ch/2025/docker-best-practices-read-only-containers/)


### PR DESCRIPTION
Closes out three of the four doc commitments from the r/selfhosted feedback pass (#425); the text follows what was drafted in the issue comments.

- **CL-0004** — new "Images that only publish `latest`" section: digest-pin as `latest@sha256:<digest>` (already valid to the rule), fetch via `docker buildx imagetools inspect`, Renovate bumps the pin, plus the note that a moving tag doesn't break a digest-resolved pull.
- **CL-0007** — new "Hardened non-root images" section under Compatibility: non-root and `read_only` are independent hardening steps; worked `nginx-unprivileged` example with tmpfs declarations.
- **README** — reproducible/CI install note under the quick-start pip line: deps from the hash-pinned `requirements.lock` (`--require-hashes`), tool version-pinned with `--no-deps`. No per-release doc churn; release automation keeps the lockfile current.

Not included by design: the #426 tree-linting recipe (the issue itself documents the `find -exec` answer) and the Forgejo `container:` claim at README:344 (needs empirical verification on a real runner first).

README stays under the Docker Hub limit: 24,848 / 25,000 bytes.