### PR TITLE
Correct the Forgejo container-jobs claim in the CI recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ Or install from PyPI directly:
 
 ### Forgejo Actions
 
-Forgejo Actions runs GitHub-Actions-compatible workflows via `act_runner`, with two practical differences: cross-instance action refs need full URLs (`https://code.forgejo.org/...`), and most default runner configs don't support `container:` jobs — so install via `apt` + `pip` rather than a Python base image:
+Forgejo Actions runs GitHub-Actions-compatible workflows via `act_runner`, with two practical differences: cross-instance action refs need full URLs (`https://code.forgejo.org/...`), and JS actions like `checkout` need `node` inside the job container ([act#107](https://github.com/nektos/act/issues/107)) — `container:` jobs run fine, but a node-less Python image fails at checkout, so install via `apt` + `pip` on the default image instead:
 
 ```yaml
 # .forgejo/workflows/validate.yml
@@ -372,7 +372,7 @@ jobs:
         run: compose-lint --fail-on high
 ```
 
-Forgejo has no SARIF UI today — `--format sarif` still produces a valid document, but there's no security-tab equivalent to render it. Verified on Forgejo 11.0.12, April 2026.
+Forgejo has no SARIF UI today — `--format sarif` still produces a valid document, but there's no security-tab equivalent to render it. Verified on Forgejo 15.0.2, runner 12.9.0, July 2026.
 
 ### SARIF output
 


### PR DESCRIPTION
Resolves the last open point from #425: the README asserted "most default runner configs don't support `container:` jobs." Verified **false** on a live, stock docker-backed `forgejo-runner` (12.9.0 against Forgejo 15.0.2) — a `container: python:3.13-slim` job runs fine, including `pip install compose-lint` and a lint pass.

What actually fails is the natural companion step: `actions/checkout` is a JavaScript action, the runner does not inject `node` into a custom job container ([nektos/act#107](https://github.com/nektos/act/issues/107)), and `python:*-slim` ships no node — the job dies at checkout with `exec: "node": executable file not found in $PATH`. So the apt+pip-on-default-image recipe was the right recommendation for the wrong reason. This keeps the recipe and states the real constraint, so readers whose images carry node (or who check out with plain git) know `container:` is available.

Also refreshes the verified-on note to Forgejo 15.0.2 / runner 12.9.0, July 2026.

README stays under the Docker Hub limit: 24,993 / 25,000 bytes (7 bytes headroom — the next edit to this file should convert some inline links to reference style).