### PR TITLE
Decouple the Docker Hub overview from README.md

### DIFF
--- a/.github/actions/update-dockerhub-description/action.yml
+++ b/.github/actions/update-dockerhub-description/action.yml
@@ -1,7 +1,9 @@
 name: 'Update Docker Hub description'
 description: >
   Sync a Docker Hub repository's overview (long description) and short
-  description from a local README.md file. First-party replacement for
+  description from a local markdown file (default: the trimmed
+  docs/dockerhub-overview.md, kept under Docker Hub's 25000-byte cap —
+  NOT README.md, which is uncapped). First-party replacement for
   peter-evans/dockerhub-description — no third-party Node bundle holds the
   delete-capable Docker Hub PAT. Implementation is a single bash script
   invoking the Docker Hub v2 API; review diff before bumping.
@@ -21,9 +23,9 @@ inputs:
     description: Docker Hub repository in `<namespace>/<name>` form.
     required: true
   readme-filepath:
-    description: Path to the README whose contents become the overview.
+    description: Path to the markdown file whose contents become the overview.
     required: false
-    default: './README.md'
+    default: './docs/dockerhub-overview.md'
   short-description:
     description: One-line short description shown under the repo title.
     required: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,14 +332,16 @@ jobs:
           PY
 
   # Docker Hub's repository API rejects a `full_description` over 25000 bytes
-  # with HTTP 400, which is what README.md is synced into by the
-  # `dockerhub-description` job in publish.yml. Without this guard the limit is
-  # only discovered at release time, as a red — but by then cosmetic — job long
-  # after the tag is cut (v0.14.0 hit exactly that at 25319 bytes). Check it at
-  # edit time instead, where the fix is cheap.
+  # with HTTP 400, which is what docs/dockerhub-overview.md is synced into by
+  # the `dockerhub-description` job in publish.yml (the Hub overview is
+  # deliberately a separate, trimmed file so README.md is not byte-capped).
+  # Without this guard the limit is only discovered at release time, as a red —
+  # but by then cosmetic — job long after the tag is cut (v0.14.0 hit exactly
+  # that when README.md, then the synced file, reached 25319 bytes). Check it
+  # at edit time instead, where the fix is cheap.
   #
   # 25000 is the real ceiling, not a padded one: Docker Hub counts bytes and so
-  # does `wc -c`, and v0.14.0's rejection reported `actual 25319` for a README
+  # does `wc -c`, and v0.14.0's rejection reported `actual 25319` for a file
   # that measured 25319 here. A lower "safety" threshold would only invent a
   # second, fictional limit — the headroom line below gives early warning
   # instead.
@@ -353,15 +355,15 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Check README.md byte size
+      - name: Check docs/dockerhub-overview.md byte size
         env:
           LIMIT: "25000"
         run: |
           set -euo pipefail
-          size=$(wc -c < README.md)
-          echo "README.md: ${size} / ${LIMIT} bytes"
+          size=$(wc -c < docs/dockerhub-overview.md)
+          echo "docs/dockerhub-overview.md: ${size} / ${LIMIT} bytes"
           if [ "${size}" -gt "${LIMIT}" ]; then
-            echo "::error file=README.md::README.md is $((size - LIMIT)) bytes over the ${LIMIT}-byte Docker Hub description limit (${size}). Docker Hub will reject the overview sync with HTTP 400. Shorten it, or convert repeated inline links to reference-style links."
+            echo "::error file=docs/dockerhub-overview.md::docs/dockerhub-overview.md is $((size - LIMIT)) bytes over the ${LIMIT}-byte Docker Hub description limit (${size}). Docker Hub will reject the overview sync with HTTP 400. Shorten it."
             exit 1
           fi
           echo "Headroom: $((LIMIT - size)) bytes"

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -1,11 +1,11 @@
 name: Docker Hub description (manual)
 
-# Standalone, manually-triggered resync of the Docker Hub overview from the
-# README on the default branch. The automated sync is the dockerhub-description
-# job in publish.yml, but that runs during a release (tag push) — before the
-# post-release README version-pin bump has merged — so the overview can lag one
-# release behind. Run this after that bump lands, or any time the README's
-# marketing copy changes, to resync without cutting a release.
+# Standalone, manually-triggered resync of the Docker Hub overview from
+# docs/dockerhub-overview.md on the default branch (the Hub-facing overview is
+# deliberately decoupled from README.md and kept version-free, so it does not
+# depend on the post-release version-pin bump). The automated sync is the
+# dockerhub-description job in publish.yml, which runs during a release (tag
+# push); run this any time the overview changes between releases.
 #
 # No `environment: dockerhub`: that environment's deployment-branch policy is
 # tags-only (v*), which would block a default-branch dispatch. The DOCKERHUB_*
@@ -33,4 +33,4 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           token: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: composelint/compose-lint
-          readme-filepath: ./README.md
+          readme-filepath: ./docs/dockerhub-overview.md

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -664,7 +664,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           token: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: composelint/compose-lint
-          readme-filepath: ./README.md
+          readme-filepath: ./docs/dockerhub-overview.md
 
   # Create the GitHub Release only after both production channels
   # (PyPI + Docker Hub) have published successfully. `needs:` gating

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -289,15 +289,18 @@ After approval, `publish` and `docker-publish` run in parallel.
       `uses: tmatens/compose-lint@<sha> # vX.Y.Z` lines. Review and
       squash-merge, then trigger **Actions → Marketplace smoke test →
       Run workflow** to verify the published Action end-to-end.
-- [ ] **Docker Hub overview (README) sync** — runs automatically in
+- [ ] **Docker Hub overview sync** — runs automatically in
       `publish.yml`'s `dockerhub-description` job after `docker-publish`,
       via the first-party composite action at
       `.github/actions/update-dockerhub-description` (which just forwards
-      to `scripts/update-dockerhub-description.sh`). Requires
-      `DOCKERHUB_TOKEN` to have **Read, Write, Delete** scope — Read &
-      Write is not enough for the description PATCH endpoint. Verify
+      to `scripts/update-dockerhub-description.sh`). Syncs
+      `docs/dockerhub-overview.md` (NOT `README.md` — the Hub overview is
+      a separate, trimmed, version-free file, so it needs no per-release
+      bump). Requires `DOCKERHUB_TOKEN` to have **Read, Write, Delete**
+      scope — Read & Write is not enough for the description PATCH
+      endpoint. Verify
       `https://hub.docker.com/r/composelint/compose-lint` reflects the
-      current README.
+      current overview file.
 - [ ] **README demo GIF** — only if this release changed the text-output
       appearance (finding layout, verdict line, colors) or you want the
       banner to show the new version. The demo toolchain installs

--- a/docs/dockerhub-overview.md
+++ b/docs/dockerhub-overview.md
@@ -1,0 +1,45 @@
+# compose-lint
+
+**Security-focused linter for Docker Compose files.** Catches dangerous misconfigurations before they reach production — and auto-fixes the safe ones, dry-run first. Grounded in the [OWASP Docker Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html) and [CIS Docker Benchmark](https://www.cisecurity.org/benchmark/docker).
+
+In a scan of 6,444 public Docker Compose files on GitHub, **91% of those that parse had at least one security finding** — 68% had a finding rated HIGH or CRITICAL. [Read the full *State of Docker Compose Security* report →](https://github.com/tmatens/compose-lint/blob/main/docs/state-of-compose.md)
+
+![compose-lint scanning a docker-compose.yml: severity-sorted findings with fix guidance and reference URLs, then the FAIL verdict.](https://raw.githubusercontent.com/tmatens/compose-lint/main/docs/assets/demo.gif)
+
+**What it catches** — 22 rules, each citing its OWASP/CIS grounding ([full rules table](https://github.com/tmatens/compose-lint#rules)):
+
+- Privilege flaws — `privileged: true`, missing `cap_drop`, `no-new-privileges` not set, root user, host namespace sharing
+- Network exposure — wildcard port binds, `network_mode: host`
+- Supply-chain — unpinned images, missing digest pins
+- Filesystem and credential leaks — Docker socket mounts, sensitive host paths, plaintext credentials in `environment:`
+
+## Usage
+
+```bash
+docker run --rm -v "$(pwd):/src" composelint/compose-lint            # lint the current directory
+docker run --rm -v "$(pwd):/src" composelint/compose-lint fix        # preview auto-fixes (dry-run diff)
+docker run --rm -v "$(pwd):/src" composelint/compose-lint --explain CL-0001
+```
+
+Auto-detects `compose.yml` / `docker-compose.yml` variants; pass filenames to lint specific files. `fix --apply` writes the safe, mechanical fixes in place (atomic, re-parsed and re-linted before writing); context-dependent findings are reported for manual review, never auto-edited. Also on PyPI: `pip install compose-lint` (Python 3.10+).
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | No findings at or above the `--fail-on` threshold (default: `high`) |
+| 1 | One or more findings at or above the threshold |
+| 2 | compose-lint couldn't run |
+
+Output formats: human `text` (default), `json`, and `sarif` — SARIF uploads render findings and suggested fixes directly on GitHub pull requests. Suppressions live in a reviewable `.compose-lint.yml` with per-service reasons and stay visible in output, marked SUPPRESSED. See [configuration](https://github.com/tmatens/compose-lint/blob/main/docs/configuration.md) and [CI integration recipes](https://github.com/tmatens/compose-lint#ci-integration) (GitHub Actions, GitLab, Forgejo/Gitea, pre-commit).
+
+## This image
+
+- [Distroless Python](https://github.com/GoogleContainerTools/distroless) on Debian, multi-arch (`linux/amd64` + `linux/arm64`), nonroot UID 65532, no shell or package manager at runtime.
+- Every release ships SLSA build provenance, Sigstore attestations, and an [OpenVEX](https://openvex.dev/) document; Docker Scout scans the published image daily.
+- Tracked on [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/tmatens/compose-lint) and [OpenSSF Best Practices](https://www.bestpractices.dev/projects/12472).
+- To run the container itself fully hardened, see [docs/hardening.md](https://github.com/tmatens/compose-lint/blob/main/docs/hardening.md).
+
+## Links
+
+[GitHub](https://github.com/tmatens/compose-lint) · [PyPI](https://pypi.org/project/compose-lint/) · [Rule docs](https://github.com/tmatens/compose-lint/tree/main/docs/rules) · [Changelog](https://github.com/tmatens/compose-lint/blob/main/CHANGELOG.md) · [Security policy](https://github.com/tmatens/compose-lint/blob/main/.github/SECURITY.md) · [MIT license](https://github.com/tmatens/compose-lint/blob/main/LICENSE)

--- a/scripts/update-dockerhub-description.sh
+++ b/scripts/update-dockerhub-description.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Sync a Docker Hub repository's long-description (overview) and short
-# description from README.md. First-party replacement for
+# description from docs/dockerhub-overview.md (the trimmed, byte-capped
+# Hub-facing overview — not README.md). First-party replacement for
 # peter-evans/dockerhub-description; invoked from CI via
 # `.github/actions/update-dockerhub-description` and also runnable locally
 # for ad-hoc description refreshes.
@@ -10,7 +11,7 @@
 #     [SHORT_DESCRIPTION="..."] \
 #     scripts/update-dockerhub-description.sh [repo] [readme-path]
 #
-# Defaults: repo=composelint/compose-lint, readme-path=./README.md,
+# Defaults: repo=composelint/compose-lint, readme-path=./docs/dockerhub-overview.md,
 # short-description="Security-focused linter for Docker Compose files".
 #
 # Requires: curl, jq
@@ -20,7 +21,7 @@
 set -euo pipefail
 
 repo="${1:-composelint/compose-lint}"
-readme="${2:-./README.md}"
+readme="${2:-./docs/dockerhub-overview.md}"
 short_description="${SHORT_DESCRIPTION:-Security-focused linter for Docker Compose files}"
 
 : "${DOCKERHUB_USERNAME:?DOCKERHUB_USERNAME must be set}"


### PR DESCRIPTION
README.md doubled as the Docker Hub description, so the 25,000-byte `full_description` cap applied to the entire README — it sat at 24,992 bytes, #434 existed purely to get back under, and #440 needed a mid-flight trim. The ceiling was shaping every docs decision.

This syncs a dedicated **`docs/dockerhub-overview.md`** instead: a ~3.9 KB Hub-audience overview (hero + scan stat, docker-run usage, exit codes, image provenance/attestations, links back to GitHub). It is deliberately **version-free**, so it also drops out of the per-release version-pin bump and can't go stale the way the README snippets did.

Changes:
- new `docs/dockerhub-overview.md` (3,907 / 25,000 bytes — ~21 KB headroom)
- `publish.yml` + the manual `dockerhub-description.yml` sync the overview file
- composite-action and script defaults updated so a bare invocation can't sync the uncapped README
- `readme-size` CI gate now measures the overview file (job name kept stable for branch protection)
- RELEASING.md checklist updated

README.md itself is untouched here; a follow-up PR uses the freed headroom for the content fixes from the README review (false auto-fix claim, stale pins, auto-fix comparison column).