### PR TITLE
Fix README review findings: false fix claim, stale pins, positioning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Disables still produce suppressed findings. `reason` flows to `suppression_reaso
 
 ## Quality checks
 
-`ruff check`, `ruff format --check`, `mypy src/` (strict), `pytest`. All four must pass. CI test matrix: Python 3.10–3.14 on ubuntu-24.04.
+`ruff check src/ tests/`, `ruff format --check src/ tests/`, `mypy src/` (strict), `pytest`. All four must pass, scoped exactly as written — CI lints only `src/` and `tests/`, and a bare `ruff check` also sweeps `scripts/`, which has known, accepted violations. CI test matrix: Python 3.10–3.14 on ubuntu-24.04.
 
 ## Adding a rule
 
@@ -84,6 +84,10 @@ is non-fatal — it's ignored, and extraction still succeeds.
 ## Publishing
 
 Trusted Publishers (OIDC) only — no manual `twine upload`. Sigstore attestations enabled. Wheel must not contain `.env`, `.git/`, `AGENTS.md`, `CLAUDE.md`, memory/session/IDE files.
+
+## Docs surfaces
+
+`docs/dockerhub-overview.md` is the Docker Hub description — hard 25000-byte cap (CI-enforced by the `readme-size` job; Docker Hub 400s over it) and deliberately version-free so it never needs a per-release bump. `README.md` is GitHub/PyPI-facing, not synced anywhere, and has no byte cap — but its integration snippets carry version pins that the RELEASING.md checklist bumps each release (as does `docs/hardening.md`).
 
 ## Things to avoid
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # compose-lint
 
-**Security-focused linter for Docker Compose files.** Catches dangerous misconfigurations before they reach production. Grounded in OWASP and the CIS Docker Benchmark.
+**Security-focused linter for Docker Compose files.** Catches dangerous misconfigurations before they reach production — and auto-fixes the safe ones, dry-run first. Grounded in OWASP and the CIS Docker Benchmark.
 
 [![CI](https://github.com/tmatens/compose-lint/actions/workflows/ci.yml/badge.svg)](https://github.com/tmatens/compose-lint/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/compose-lint)](https://pypi.org/project/compose-lint/)
@@ -66,6 +66,13 @@ Or pass files explicitly:
 
 ```bash
 compose-lint docker-compose.yml docker-compose.prod.yml
+```
+
+Preview the safe auto-fixes as a unified diff, then apply them (see [Fixing findings](#fixing-findings)):
+
+```bash
+compose-lint fix              # dry-run diff, writes nothing
+compose-lint fix --apply      # write the fixes in place
 ```
 
 Don't recognize a rule ID in the output? `--explain` prints the full rule doc — what it catches, why it matters, the fix, and the OWASP/CIS reference — without leaving the terminal:
@@ -144,14 +151,16 @@ Exit code is `1` (two findings at or above the default `--fail-on high` threshol
 
 ## How it compares
 
-| Tool | Compose security rules | Scope | Zero config |
-|------|----------------------|-------|-------------|
-| **compose-lint** | Yes | Docker Compose | Yes |
-| **KICS** | Yes | Broad IaC (Terraform, K8s, Compose, ...) | No |
-| **Hadolint** | No — Dockerfile only | Dockerfile | Yes |
-| **dclint** | Yes — schema/structure only | Docker Compose | Yes |
-| **Trivy** | No — image/CVE + IaC misconfig scanning, no dedicated Compose ruleset | Dockerfiles, images, IaC | Yes |
-| **Checkov** | No — no dedicated Compose ruleset | Broad IaC (Terraform, K8s, ...) | No |
+| Tool | Compose security rules | Auto-fix | Scope | Zero config |
+|------|----------------------|----------|-------|-------------|
+| **compose-lint** | Yes | Yes — dry-run diff first | Docker Compose | Yes |
+| **KICS** | Yes | Yes (`remediate` command) | Broad IaC (Terraform, K8s, Compose, ...) | No |
+| **Hadolint** | No — Dockerfile only | No | Dockerfile | Yes |
+| **dclint** | Yes — schema/structure only | Style/formatting only | Docker Compose | Yes |
+| **Trivy** | No — image/CVE + IaC misconfig scanning, no dedicated Compose ruleset | No | Dockerfiles, images, IaC | Yes |
+| **Checkov** | No — no dedicated Compose ruleset | No | Broad IaC (Terraform, K8s, ...) | No |
+
+*Competitor capabilities verified July 2026.*
 
 If you need broad IaC coverage across Terraform, Kubernetes, and more, KICS covers Docker Compose and is worth evaluating. If you want a lightweight, focused tool with zero config and actionable fix guidance for Compose files specifically, this is it.
 
@@ -241,8 +250,9 @@ init options:
 ## Fixing findings
 
 `compose-lint fix` auto-remediates the findings that have a safe, unambiguous
-edit — adding `read_only: true`, `no-new-privileges:true`, dropping a bare
-`latest` tag, binding a published port to `127.0.0.1`, and similar. It is
+edit — adding `read_only: true` or `no-new-privileges:true`, binding a
+published port to `127.0.0.1`, restoring a disabled logging driver, seccomp
+profile, or healthcheck, and similar. It is
 **dry-run by default**: it prints a unified diff and writes nothing.
 
 ```bash
@@ -331,7 +341,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: tmatens/compose-lint@76a831a46ae7165a57c7ff4a8b9e08f7b9a63e6c # v0.13.0
+      - uses: tmatens/compose-lint@67ce85772f5631a53a616d294c1b3dc654dd2c40 # v0.14.0
         with:
           sarif-file: results.sarif
 ```
@@ -367,7 +377,7 @@ jobs:
         run: |
           apt-get update -qq
           apt-get install -yqq --no-install-recommends python3-pip
-          pip3 install --break-system-packages --no-cache-dir compose-lint==0.13.0
+          pip3 install --break-system-packages --no-cache-dir compose-lint==0.14.0
       - name: Run compose-lint
         run: compose-lint --fail-on high
 ```
@@ -386,7 +396,7 @@ compose-lint --format sarif docker-compose.yml > results.sarif
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/tmatens/compose-lint
-    rev: v0.13.0
+    rev: v0.14.0
     hooks:
       - id: compose-lint
 ```

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -179,17 +179,18 @@ four before opening the bump PR.
 
 - [ ] `pyproject.toml` — `version = "X.Y.Z"` under `[project]`
 - [ ] `src/compose_lint/__init__.py` — `__version__ = "X.Y.Z"`
-- [ ] `README.md` — version references in copy-paste integration
-      snippets. All need bumping each release; otherwise users land
-      on a stale version. Four forms exist:
-      - `tmatens/compose-lint@<sha> # v0.X.Y` (GitHub Action snippet)
-      - `rev: v0.X.Y` (pre-commit snippet)
-      - `compose-lint==0.X.Y` (Forgejo Actions snippet — pip pin)
-      - `composelint/compose-lint:0.X.Y` (hardened `docker run` snippet
-        and the digest-lookup hint immediately below it)
+- [ ] `README.md` + `docs/hardening.md` — version references in
+      copy-paste integration snippets. All need bumping each release;
+      otherwise users land on a stale version (v0.14.0 shipped with all
+      of them stale — this step was skipped). Four forms exist:
+      - `tmatens/compose-lint@<sha> # v0.X.Y` (README — GitHub Action snippet)
+      - `rev: v0.X.Y` (README — pre-commit snippet)
+      - `compose-lint==0.X.Y` (README — Forgejo Actions snippet, pip pin)
+      - `:0.X.Y` image tags (docs/hardening.md — hardened `docker run`
+        snippet, plus the digest-lookup prose below it; NOT in README)
 
       Verify all four with:
-      `grep -nE 'v0\.[0-9]+\.[0-9]+|compose-lint==0\.[0-9]+\.[0-9]+|composelint/compose-lint:0\.[0-9]+\.[0-9]+' README.md`.
+      `grep -nE 'v0\.[0-9]+\.[0-9]+|compose-lint==0\.[0-9]+\.[0-9]+|:0\.[0-9]+\.[0-9]+' README.md docs/hardening.md`.
 - [ ] `.github/workflows/marketplace-smoke.yml` — two
       `uses: tmatens/compose-lint@<sha> # vX.Y.Z` lines. Update both
       the full commit SHA and the trailing `# vX.Y.Z` comment. Get

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-As of v0.13.0, compose-lint ships 22 security rules, PyPI distribution, a published GitHub Action and Docker image, SARIF/JSON/text output, pre-commit support, per-service rule overrides, and `--explain`. The foundation is solid; the next milestone is the 1.0 stability commitment. Remaining investments make the tool more useful to the users already running it, not chase speculative distribution channels.
+compose-lint today ships 22 security rules, PyPI distribution, a published GitHub Action and Docker image, SARIF/JSON/text output, pre-commit support, per-service rule overrides, and `--explain`. The foundation is solid; the next milestone is the 1.0 stability commitment. Remaining investments make the tool more useful to the users already running it, not chase speculative distribution channels.
 
 ## Strategic framing
 

--- a/docs/hardening.md
+++ b/docs/hardening.md
@@ -13,7 +13,7 @@ docker run --rm \
   --user 65532:65532 \
   --pids-limit 256 \
   -v "$(pwd):/src:ro" \
-  composelint/compose-lint:0.13.0
+  composelint/compose-lint:0.14.0
 ```
 
 | Flag | Rule satisfied |
@@ -26,6 +26,6 @@ docker run --rm \
 
 `--network none` and `:ro` on the bind mount are extra hardening — compose-lint never reaches the network and only reads its inputs.
 
-For full supply-chain reproducibility (and to satisfy CL-0004 / CL-0019), replace the `:0.13.0` tag with a digest pin: `composelint/compose-lint@sha256:<digest>`. Get the current digest from [Docker Hub](https://hub.docker.com/r/composelint/compose-lint/tags) or with `docker buildx imagetools inspect composelint/compose-lint:0.13.0 --format '{{json .Manifest}}' | jq -r '.digest'`.
+For full supply-chain reproducibility (and to satisfy CL-0004 / CL-0019), replace the `:0.14.0` tag with a digest pin: `composelint/compose-lint@sha256:<digest>`. Get the current digest from [Docker Hub](https://hub.docker.com/r/composelint/compose-lint/tags) or with `docker buildx imagetools inspect composelint/compose-lint:0.14.0 --format '{{json .Manifest}}' | jq -r '.digest'`.
 
 A Compose-form equivalent that lints clean across every rule lives in [`tests/compose_files/safe_self_hosted.yml`](https://github.com/tmatens/compose-lint/blob/main/tests/compose_files/safe_self_hosted.yml).


### PR DESCRIPTION
Content fixes from the README product review, unblocked by #441 (README is no longer byte-capped). Every claim verified before editing:

**Correctness**
- The "Fixing findings" section claimed `fix` drops a bare `latest` tag — no CL-0004 fixer exists (fixer set: CL-0003/0005/0007/0009/0014/0015). Replaced with real examples.
- All six stale `0.13.0` pins bumped to `0.14.0`: three in README, three in `docs/hardening.md`. The v0.14.0 release skipped the RELEASING checklist step, and its grep only covered README.md while the docker-tag form lives in hardening.md — checklist + grep now cover both files.

**Positioning**
- Auto-fix surfaced where evaluation happens: hero clause, `fix` dry-run/apply pair in Quick Start, and an **Auto-fix** column in the comparison table. Competitor cells verified against their docs: KICS has a `remediate` command (honest "Yes"), dclint `--fix` is style-only. Footnote: capabilities verified July 2026.
- ROADMAP intro de-versioned so it stops going stale each release.

**AGENTS.md**
- Lint commands scoped to `src/ tests/` as CI runs them (bare `ruff check` fails on accepted `scripts/` violations).
- New "Docs surfaces" note: the 25,000-byte cap + version-free rule live on `docs/dockerhub-overview.md`; README is uncapped but pin-bearing.

Follow-up on the `version-reference-gate` branch CI-enforces the pins so the 0.14.0-style miss can't recur.