### PR TITLE
CI-gate self-referencing version pins in README and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,6 +330,45 @@ jobs:
           if pyproject != init:
               sys.exit(f"::error::Version drift: pyproject.toml ({pyproject}) vs src/compose_lint/__init__.py ({init})")
           PY
+      # Self-referencing version pins in living docs (README integration
+      # snippets, docs/hardening.md) must equal the current version. A
+      # hand-maintained checklist can't self-discover new references — v0.14.0
+      # shipped with every doc pin stale despite RELEASING.md listing them —
+      # so any new doc that pins our own artifacts is covered from its first
+      # commit. Historical records (ADRs, CHANGELOG-adjacent reports) are
+      # excluded. The `tmatens/compose-lint@<sha>` action-pin form is also
+      # excluded: the new tag's SHA exists only after the release, so it is
+      # structurally a post-release follow-up (RELEASING.md pairs it with the
+      # marketplace-smoke bump, and the smoke test exercises it end-to-end).
+      - name: Check self-referencing version pins in docs
+        run: |
+          python - <<'PY'
+          import pathlib, re, sys, tomllib
+
+          version = tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"]
+
+          patterns = [
+              re.compile(r"compose-lint==(\d+\.\d+\.\d+)"),
+              re.compile(r"composelint/compose-lint:(\d+\.\d+\.\d+)"),
+              re.compile(r"rev: v(\d+\.\d+\.\d+)"),
+          ]
+          exclude = ("docs/adr/", "docs/publishing/", "docs/state-of-compose.md")
+          stale = []
+          for f in [pathlib.Path("README.md"), *sorted(pathlib.Path("docs").rglob("*.md"))]:
+              p = f.as_posix()
+              if p.startswith(exclude):
+                  continue
+              for i, line in enumerate(f.read_text().splitlines(), 1):
+                  for pat in patterns:
+                      for m in pat.finditer(line):
+                          if m.group(1) != version:
+                              stale.append(f"{p}:{i}: {m.group(0)} (current: {version})")
+          print(f"current version: {version}")
+          if stale:
+              print("\n".join(stale))
+              sys.exit(f"::error::{len(stale)} stale self-referencing version pin(s) — bump to {version} (docs/RELEASING.md, 'version references' item)")
+          print("all self-referencing version pins in README/docs match")
+          PY
 
   # Docker Hub's repository API rejects a `full_description` over 25000 bytes
   # with HTTP 400, which is what docs/dockerhub-overview.md is synced into by

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -189,8 +189,15 @@ four before opening the bump PR.
       - `:0.X.Y` image tags (docs/hardening.md — hardened `docker run`
         snippet, plus the digest-lookup prose below it; NOT in README)
 
-      Verify all four with:
-      `grep -nE 'v0\.[0-9]+\.[0-9]+|compose-lint==0\.[0-9]+\.[0-9]+|:0\.[0-9]+\.[0-9]+' README.md docs/hardening.md`.
+      CI enforces the first three forms (`version-consistency` job,
+      "self-referencing version pins" step): any `compose-lint==X.Y.Z`,
+      `composelint/compose-lint:X.Y.Z`, or `rev: vX.Y.Z` anywhere in
+      `README.md` or `docs/` (historical files excluded) must equal
+      `pyproject.toml`'s version, so the bump PR fails CI until they all
+      move together — including pins in docs this list doesn't know
+      about yet. The action-SHA form is the exception (the new tag's
+      SHA exists only post-release; bump it in the marketplace-smoke
+      follow-up PR).
 - [ ] `.github/workflows/marketplace-smoke.yml` — two
       `uses: tmatens/compose-lint@<sha> # vX.Y.Z` lines. Update both
       the full commit SHA and the trailing `# vX.Y.Z` comment. Get

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -40,7 +40,7 @@ ShellCheck, and ruff. A file that is clean on `1.2.0` may report new findings on
 
 Two escape hatches keep a pipeline deterministic:
 
-- **Pin the version** (`compose-lint==1.2.0`, or the digest-pinned Action /
+- **Pin the version** (`==1.2.0` in this example, or the digest-pinned Action /
   image) for identical results across runs.
 - **Use `--fail-on`** to gate CI on a severity threshold, so new lower-severity
   findings surface without failing the build.

--- a/docs/hardening.md
+++ b/docs/hardening.md
@@ -26,6 +26,6 @@ docker run --rm \
 
 `--network none` and `:ro` on the bind mount are extra hardening — compose-lint never reaches the network and only reads its inputs.
 
-For full supply-chain reproducibility (and to satisfy CL-0004 / CL-0019), replace the `:0.14.0` tag with a digest pin: `composelint/compose-lint@sha256:<digest>`. Get the current digest from [Docker Hub](https://hub.docker.com/r/composelint/compose-lint/tags) or with `docker buildx imagetools inspect composelint/compose-lint:0.14.0 --format '{{json .Manifest}}' | jq -r '.digest'`.
+For full supply-chain reproducibility (and to satisfy CL-0004 / CL-0019), replace the version tag with a digest pin: `composelint/compose-lint@sha256:<digest>`. Get the current digest from [Docker Hub](https://hub.docker.com/r/composelint/compose-lint/tags) or with `docker buildx imagetools inspect composelint/compose-lint:0.14.0 --format '{{json .Manifest}}' | jq -r '.digest'`.
 
 A Compose-form equivalent that lints clean across every rule lives in [`tests/compose_files/safe_self_hosted.yml`](https://github.com/tmatens/compose-lint/blob/main/tests/compose_files/safe_self_hosted.yml).


### PR DESCRIPTION
Completes the pin-staleness fix from #442. The RELEASING checklist grep is a hand-maintained file list — it can't self-discover a pin added in a new doc, which is exactly how the `hardening.md` pins rotted, and v0.14.0 shipped with every doc pin stale despite the checklist naming all of them.

New step in the existing `version-consistency` job: every `compose-lint==X.Y.Z`, `composelint/compose-lint:X.Y.Z`, and `rev: vX.Y.Z` in `README.md` or `docs/` must equal `pyproject.toml`'s version. Properties:

- a new doc with a pin is covered **from its first commit**, no RELEASING edit needed
- a version-bump PR fails CI until every pin moves in lockstep
- historical records excluded (`docs/adr/`, `docs/publishing/`, `state-of-compose.md` — old versions are *correct* there)
- the `tmatens/compose-lint@<sha>` action-pin form stays checklist-managed: the new tag's SHA exists only post-release (marketplace-smoke follow-up PR, exercised by the smoke test)

Tested both directions: current tree passes (4 pins, 0 stale); simulating version 0.15.0 correctly flags all 4 with file:line.

Two docs adjust to fit the gate: `hardening.md` prose drops its redundant second copy of the version (bare `:X.Y.Z` can't be gated without false-positiving on third-party image tags), and `compatibility.md`'s deliberately-hypothetical `==1.2.0` example drops the package name so an illustration never has to track the real version — the dry run caught it as the one would-be false positive.