### PR TITLE
Bump marketplace-smoke pin to v0.14.1

### DIFF
--- a/.github/workflows/marketplace-smoke.yml
+++ b/.github/workflows/marketplace-smoke.yml
@@ -52,7 +52,7 @@ jobs:
           persist-credentials: false
 
       - name: Clean fixture should pass
-        uses: tmatens/compose-lint@67ce85772f5631a53a616d294c1b3dc654dd2c40 # v0.14.0
+        uses: tmatens/compose-lint@5a26e30c78a3c093a7955de26f0a1b12b26aabb0 # v0.14.1
         with:
           files: tests/smoke/clean.yml
           fail-on: high
@@ -60,7 +60,7 @@ jobs:
       - name: Insecure fixture should fail
         id: insecure
         continue-on-error: true
-        uses: tmatens/compose-lint@67ce85772f5631a53a616d294c1b3dc654dd2c40 # v0.14.0
+        uses: tmatens/compose-lint@5a26e30c78a3c093a7955de26f0a1b12b26aabb0 # v0.14.1
         with:
           files: tests/smoke/insecure.yml
           fail-on: high


### PR DESCRIPTION
**Post-tag follow-up.** This PR was opened automatically by `publish.yml` *after*:

- Tag `v0.14.1` was pushed and triggered the Publish workflow
- TestPyPI + Docker smoke tests passed
- The `release-gate` environment was approved
- `publish` (PyPI) and `docker-publish` (Docker Hub) both succeeded
- `create-release` created the GitHub Release `v0.14.1`

So the pinned SHA `5a26e30c78a3c093a7955de26f0a1b12b26aabb0` is guaranteed to correspond to a release that actually shipped through every channel.

**After merging this PR**, trigger **Actions → Marketplace smoke test → Run workflow** to verify the published Action end-to-end against the new tag.
