### PR TITLE
Bump doc version pins in release-prep and the README action pin at publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -876,20 +876,28 @@ jobs:
             echo "succeeded, so the pinned SHA points at a release that actually"
             echo "shipped to PyPI, Docker Hub, and GitHub Releases."
           } >> "$GITHUB_STEP_SUMMARY"
-      - name: Update .github/workflows/marketplace-smoke.yml
+      # README.md carries the same `uses: tmatens/compose-lint@<sha> # vX.Y.Z`
+      # form in its copy-paste GitHub Action snippet. It is the one
+      # self-referencing pin CI cannot enforce (the tag's SHA does not exist
+      # until the tag is pushed), so it is bumped here alongside the smoke
+      # workflow. Without this it silently stayed a release behind — v0.14.1
+      # shipped with the README snippet still pinned to v0.14.0.
+      - name: Update marketplace-smoke.yml and the README action pin
         env:
           TAG: ${{ github.ref_name }}
           SHA: ${{ steps.sha.outputs.sha }}
         run: |
           version="${TAG#v}"
+          targets=(.github/workflows/marketplace-smoke.yml README.md)
           sed -i -E \
             "s|uses: tmatens/compose-lint@[0-9a-f]+ # v[0-9.]+|uses: tmatens/compose-lint@${SHA} # v${version}|g" \
-            .github/workflows/marketplace-smoke.yml
-          if git diff --quiet .github/workflows/marketplace-smoke.yml; then
+            "${targets[@]}"
+          if git diff --quiet "${targets[@]}"; then
             echo "no_changes=1" >> "$GITHUB_ENV"
-            echo "::notice::marketplace-smoke.yml already points at ${SHA}; nothing to do."
+            echo "::notice::action pins already point at ${SHA}; nothing to do."
           else
-            echo "marketplace-smoke.yml updated to ${SHA} (${TAG})."
+            echo "action pins updated to ${SHA} (${TAG}):"
+            git diff --name-only "${targets[@]}"
           fi
       - name: Commit, push, open PR
         if: env.no_changes != '1'
@@ -909,7 +917,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "${branch}"
-          git add .github/workflows/marketplace-smoke.yml
+          # Subject and PR title below are kept verbatim across releases: the
+          # release skill locates this PR by searching that exact string.
+          git add .github/workflows/marketplace-smoke.yml README.md
           git commit -m "Bump marketplace-smoke pin to ${TAG}"
           git push -u origin "${branch}"
           cat > /tmp/pr-body.md <<EOF
@@ -922,6 +932,8 @@ jobs:
           - \`create-release\` created the GitHub Release \`${TAG}\`
 
           So the pinned SHA \`${SHA}\` is guaranteed to correspond to a release that actually shipped through every channel.
+
+          Bumps the pin in \`.github/workflows/marketplace-smoke.yml\` **and** the copy-paste GitHub Action snippet in \`README.md\` — both use the \`@<sha> # vX.Y.Z\` form that CI cannot check pre-tag.
 
           **After merging this PR**, trigger **Actions → Marketplace smoke test → Run workflow** to verify the published Action end-to-end against the new tag.
           EOF

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -1,9 +1,11 @@
 name: Release prep
 
 # Maintainer-triggered. Opens the "Prepare X.Y.Z release" PR for you:
-# bumps pyproject.toml + src/compose_lint/__init__.py, renames the
-# CHANGELOG [Unreleased] section to [X.Y.Z] - <today>, inserts a fresh
-# empty [Unreleased] above it, updates the CHANGELOG compare-link footer,
+# bumps pyproject.toml + src/compose_lint/__init__.py, bumps the
+# self-referencing version pins in README.md + docs/ that the
+# version-consistency job enforces (#443), renames the CHANGELOG
+# [Unreleased] section to [X.Y.Z] - <today>, inserts a fresh empty
+# [Unreleased] above it, updates the CHANGELOG compare-link footer,
 # commits on a release/X.Y.Z branch, and opens a PR against main.
 #
 # The signed annotated tag is NOT created here. After the PR merges,
@@ -73,6 +75,66 @@ jobs:
         run: |
           sed -i -E "s/^__version__ = \"[^\"]+\"/__version__ = \"${VERSION}\"/" src/compose_lint/__init__.py
           grep '__version__' src/compose_lint/__init__.py
+
+      # The version-consistency job's "self-referencing version pins" step
+      # (#443) requires every `compose-lint==X.Y.Z`,
+      # `composelint/compose-lint:X.Y.Z`, and `rev: vX.Y.Z` pin in README.md
+      # and docs/ to equal pyproject's version. Bumping only pyproject +
+      # __init__ therefore opened a PR that failed its own required check on
+      # every release — 0.14.1 had to have the bump pushed by hand. Rewrite
+      # the same three forms here, over the same file set and exclusions, so
+      # the prep PR is green by construction.
+      #
+      # The `tmatens/compose-lint@<sha> # vX.Y.Z` action-pin form is
+      # deliberately NOT handled here: the new tag's commit SHA does not exist
+      # until the tag is pushed, so publish.yml's bump-marketplace-smoke-pin
+      # job owns that one post-release.
+      - name: Bump self-referencing version pins in README and docs
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          python - <<'PY'
+          import os, pathlib, re, sys
+
+          version = os.environ["VERSION"]
+          # Keep these patterns and exclusions in lockstep with the
+          # "self-referencing version pins" step in .github/workflows/ci.yml.
+          patterns = [
+              re.compile(r"(compose-lint==)(\d+\.\d+\.\d+)"),
+              re.compile(r"(composelint/compose-lint:)(\d+\.\d+\.\d+)"),
+              re.compile(r"(rev: v)(\d+\.\d+\.\d+)"),
+          ]
+          exclude = ("docs/adr/", "docs/publishing/", "docs/state-of-compose.md")
+
+          def targets():
+              for f in [pathlib.Path("README.md"), *sorted(pathlib.Path("docs").rglob("*.md"))]:
+                  if not f.as_posix().startswith(exclude):
+                      yield f
+
+          changed = []
+          for f in targets():
+              original = f.read_text()
+              updated = original
+              for pat in patterns:
+                  updated = pat.sub(rf"\g<1>{version}", updated)
+              if updated != original:
+                  f.write_text(updated)
+                  changed.append(f.as_posix())
+          print("bumped:", ", ".join(changed) if changed else "nothing (already current)")
+
+          # Re-scan so this workflow fails loudly here rather than as a red
+          # required check on the PR it just opened.
+          stale = [
+              f"{f.as_posix()}:{i}: {m.group(0)}"
+              for f in targets()
+              for i, line in enumerate(f.read_text().splitlines(), 1)
+              for pat in patterns
+              for m in pat.finditer(line)
+              if m.group(2) != version
+          ]
+          if stale:
+              sys.exit("::error::pins still stale after bump: " + "; ".join(stale))
+          PY
 
       - name: Rename CHANGELOG [Unreleased] and insert fresh header
         env:
@@ -149,7 +211,12 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "${branch}"
-          git add pyproject.toml src/compose_lint/__init__.py CHANGELOG.md
+          # `-u` stages every tracked file the steps above modified — the two
+          # version files, CHANGELOG.md, and whichever README/docs carried a
+          # self-referencing pin. Listing paths explicitly would silently drop
+          # a pin in a doc added later, which is the failure #443 guards
+          # against. `-u` cannot add untracked files, so nothing stray is swept in.
+          git add -u
           git commit -m "Prepare ${VERSION} release"
           git push -u origin "${branch}"
           cat > /tmp/pr-body.md <<EOF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The GitHub Action snippet in `README.md` now pins the current release.
+  `publish.yml`'s `bump-marketplace-smoke-pin` job rewrote the
+  `tmatens/compose-lint@<sha> # vX.Y.Z` pin only in
+  `.github/workflows/marketplace-smoke.yml`, so the copy-paste snippet users
+  actually take from the README stayed a release behind every time — it was
+  still on v0.14.0 after v0.14.1 shipped. The job now rewrites both files,
+  and the stale pin is corrected.
+- `release-prep.yml` now bumps the self-referencing version pins in
+  `README.md` and `docs/` as part of the version-bump commit. The
+  `version-consistency` job has required those pins to match
+  `pyproject.toml` since #443, but release-prep only touched
+  `pyproject.toml`, `__init__.py`, and `CHANGELOG.md` — so the release PR it
+  opened failed its own required check on every release and needed a
+  hand-pushed fixup commit.
+
 ## [0.14.1] - 2026-07-31
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: tmatens/compose-lint@67ce85772f5631a53a616d294c1b3dc654dd2c40 # v0.14.0
+      - uses: tmatens/compose-lint@5a26e30c78a3c093a7955de26f0a1b12b26aabb0 # v0.14.1
         with:
           sarif-file: results.sarif
 ```

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -182,28 +182,39 @@ four before opening the bump PR.
 - [ ] `README.md` + `docs/hardening.md` — version references in
       copy-paste integration snippets. All need bumping each release;
       otherwise users land on a stale version (v0.14.0 shipped with all
-      of them stale — this step was skipped). Four forms exist:
+      of them stale). Four forms exist:
       - `tmatens/compose-lint@<sha> # v0.X.Y` (README — GitHub Action snippet)
       - `rev: v0.X.Y` (README — pre-commit snippet)
       - `compose-lint==0.X.Y` (README — Forgejo Actions snippet, pip pin)
       - `:0.X.Y` image tags (docs/hardening.md — hardened `docker run`
         snippet, plus the digest-lookup prose below it; NOT in README)
 
-      CI enforces the first three forms (`version-consistency` job,
-      "self-referencing version pins" step): any `compose-lint==X.Y.Z`,
+      **All four are automated — nothing to do by hand here.** The first
+      three are rewritten by `release-prep.yml` in the bump commit itself,
+      and CI enforces them (`version-consistency` job, "self-referencing
+      version pins" step): any `compose-lint==X.Y.Z`,
       `composelint/compose-lint:X.Y.Z`, or `rev: vX.Y.Z` anywhere in
       `README.md` or `docs/` (historical files excluded) must equal
-      `pyproject.toml`'s version, so the bump PR fails CI until they all
-      move together — including pins in docs this list doesn't know
-      about yet. The action-SHA form is the exception (the new tag's
-      SHA exists only post-release; bump it in the marketplace-smoke
-      follow-up PR).
+      `pyproject.toml`'s version, so the prep PR fails CI if the rewrite
+      ever misses one — including pins in docs this list doesn't know
+      about yet. The action-SHA form cannot be checked pre-tag (the new
+      tag's SHA exists only post-release), so `publish.yml`'s
+      `bump-marketplace-smoke-pin` job rewrites it in both
+      `marketplace-smoke.yml` and `README.md` in the post-release
+      follow-up PR.
+
+      This used to be manual, and drifted: the prep PR failed its own
+      required check on every release after #443 added the gate (0.14.1
+      needed a hand-pushed pin-bump commit), and the README action pin
+      stayed a release behind because only `marketplace-smoke.yml` was
+      rewritten. Verify rather than re-do — if the prep PR is green and
+      the follow-up PR touches `README.md`, this item is satisfied.
 - [ ] `.github/workflows/marketplace-smoke.yml` — two
-      `uses: tmatens/compose-lint@<sha> # vX.Y.Z` lines. Update both
-      the full commit SHA and the trailing `# vX.Y.Z` comment. Get
-      the new SHA with `git rev-parse vX.Y.Z^{commit}` **after** you
-      push the signed tag in a later step, then open a follow-up PR
-      to bump the pin.
+      `uses: tmatens/compose-lint@<sha> # vX.Y.Z` lines. Automated by
+      the same `bump-marketplace-smoke-pin` job as the README pin above:
+      it resolves `git rev-parse vX.Y.Z^{commit}` **after** the signed
+      tag is pushed and opens the follow-up PR for you. Review and merge
+      that PR; only bump by hand if the job failed.
 
 Verify the first two match:
 


### PR DESCRIPTION
Closes two automation gaps found driving the v0.14.1 release.

### 1. `release-prep.yml` did not bump the doc pins its own CI gate requires

#443 added the `version-consistency` job's *self-referencing version pins* step: every `compose-lint==X.Y.Z`, `composelint/compose-lint:X.Y.Z`, and `rev: vX.Y.Z` pin in `README.md` / `docs/` must equal `pyproject.toml`'s version. But `release-prep.yml` only bumped `pyproject.toml`, `__init__.py`, and `CHANGELOG.md` — so **the release PR it opens failed its own required check on every release**. v0.14.1 (#445) needed a hand-pushed fixup commit.

release-prep now rewrites those three forms itself, using the same patterns and the same exclusion list as the CI check, then re-scans and fails loudly if anything is still stale. Staging switched to `git add -u` so a pin in a doc added later is picked up automatically rather than silently dropped by a hardcoded path list.

### 2. The README action pin stayed a release behind

`bump-marketplace-smoke-pin` rewrote `uses: tmatens/compose-lint@<sha> # vX.Y.Z` only in `.github/workflows/marketplace-smoke.yml`. The README carries the identical form in the copy-paste GitHub Action snippet — the one users actually take — and nothing ever bumped it. It was still on `v0.14.0` after v0.14.1 shipped. The job now rewrites both, and this PR corrects the currently-stale pin to `5a26e30` (v0.14.1).

This is the one pin CI cannot enforce pre-tag: the tag's SHA does not exist until the tag is pushed, which is why it stays a post-release step rather than moving into release-prep.

### Verification

- `actionlint` clean.
- Bump logic dry-run against a scratch copy at a fake `0.99.0`: rewrote all four pins (README ×2, `docs/hardening.md` ×2, including the digest-lookup prose), re-scan reported no stale pins, and correctly left the action-SHA pin alone.
- `sed` change dry-run: rewrote all three action pins (README ×1, marketplace-smoke ×2).

The PR title and commit subject of the generated follow-up PR are deliberately unchanged — the release skill locates that PR by searching the exact string.

`docs/RELEASING.md` is updated to say these are automated (verify, don't re-do).