### PR TITLE
Stop calling auto-fixable findings safe in the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   opened failed its own required check on every release and needed a
   hand-pushed fixup commit.
 
+### Changed
+
+- Documentation no longer describes auto-fixable findings as "safe". `README.md`,
+  `docs/dockerhub-overview.md`, and `docs/SECURITY-EXPECTATIONS.md` said `fix`
+  applies "safe, mechanical edits", which invites the reading that applying them
+  is harmless. Per ADR-014 the guarantee is a property of the *edit* — one
+  unambiguous value, no collateral change, still-valid YAML — not of the
+  outcome: `read_only: true` and the `127.0.0.1` port rebind both change runtime
+  behavior by design, and are surfaced with a `⚠ behavior-changing` caveat
+  rather than withheld. The docs now say "mechanically unambiguous", state the
+  edit/outcome distinction explicitly, and show the caveat line a user will see.
+
 ## [0.14.1] - 2026-07-31
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # compose-lint
 
-**Security-focused linter for Docker Compose files.** Catches dangerous misconfigurations before they reach production — and auto-fixes the safe ones, dry-run first. Grounded in OWASP and the CIS Docker Benchmark.
+**Security-focused linter for Docker Compose files.** Catches dangerous misconfigurations before they reach production — and auto-fixes the unambiguous ones, dry-run first. Grounded in OWASP and the CIS Docker Benchmark.
 
 [![CI](https://github.com/tmatens/compose-lint/actions/workflows/ci.yml/badge.svg)](https://github.com/tmatens/compose-lint/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/compose-lint)](https://pypi.org/project/compose-lint/)
@@ -68,7 +68,7 @@ Or pass files explicitly:
 compose-lint docker-compose.yml docker-compose.prod.yml
 ```
 
-Preview the safe auto-fixes as a unified diff, then apply them (see [Fixing findings](#fixing-findings)):
+Preview the auto-fixable findings as a unified diff, then apply them — reading the `⚠ behavior-changing` labels first (see [Fixing findings](#fixing-findings)):
 
 ```bash
 compose-lint fix              # dry-run diff, writes nothing
@@ -221,7 +221,7 @@ See [docs/configuration.md](https://github.com/tmatens/compose-lint/blob/main/do
 
 ```
 compose-lint [check] [OPTIONS] [FILE ...]   Lint files (default; bare invocation works)
-compose-lint fix [OPTIONS] [FILE ...]       Auto-remediate safe findings
+compose-lint fix [OPTIONS] [FILE ...]       Auto-remediate auto-fixable findings
 compose-lint init [OPTIONS] FILE            Generate a starter .compose-lint.yml
 
 check options:
@@ -249,11 +249,29 @@ init options:
 
 ## Fixing findings
 
-`compose-lint fix` auto-remediates the findings that have a safe, unambiguous
-edit — adding `read_only: true` or `no-new-privileges:true`, binding a
-published port to `127.0.0.1`, restoring a disabled logging driver, seccomp
-profile, or healthcheck, and similar. It is
-**dry-run by default**: it prints a unified diff and writes nothing.
+`compose-lint fix` auto-remediates the findings whose edit is **mechanically
+unambiguous** — one correct value, in one place, with no collateral change to
+the rest of the file: adding `read_only: true` or `no-new-privileges:true`,
+binding a published port to `127.0.0.1`, restoring a disabled logging driver,
+seccomp profile, or healthcheck, and similar. It is **dry-run by default**: it
+prints a unified diff and writes nothing.
+
+> **Auto-fixable does not mean harmless.** The guarantee is about the *edit*,
+> not the *outcome*. `fix` will not corrupt your file, reflow it, or guess at a
+> value it cannot derive — but it will happily change how your stack behaves.
+> `read_only: true` breaks a container that writes to its root filesystem;
+> rebinding a published port to `127.0.0.1` cuts off every client outside the
+> host. Those edits are still offered, because withholding them would hide a
+> real finding. Instead each one is labelled `⚠ behavior-changing` in the diff
+> with the specific breakage named:
+>
+> ```
+> ⚠ behavior-changing · CL-0007: read_only: true breaks the container if it
+>   writes to its root filesystem; declare writable paths via tmpfs/volumes first.
+> ```
+>
+> Read those lines before you `--apply`, and roll the result out to a staging
+> stack before production. Treat `fix` as a patch author, not an approver.
 
 ```bash
 compose-lint fix docker-compose.yml            # preview the diff, write nothing
@@ -264,12 +282,18 @@ compose-lint fix --only CL-0007 --apply .      # restrict to one rule
 - **Dry-run by default; `--apply` writes in place** via an atomic swap that
   preserves the file's permission bits — an interrupted write never corrupts the
   Compose file.
-- **Only safe, mechanical fixes are applied.** Findings whose remediation is
-  context-dependent (e.g. CL-0006 capability lists, CL-0001 socket mounts) are
-  reported as needing manual review, never auto-edited.
+- **Only mechanically unambiguous fixes are applied.** Findings whose
+  remediation is context-dependent (e.g. CL-0006 capability lists, CL-0001
+  socket mounts) are reported as needing manual review, never auto-edited — the
+  tool refuses rather than guess at a value only you can choose.
+- **Behavior-changing edits are labelled, not withheld.** Every edit that alters
+  runtime behavior emits a `⚠ behavior-changing` line naming what breaks, on the
+  dry-run *and* on `--apply`, so the warning reaches you on whichever path you
+  took. The label is the mitigation; there is no severity gate that quietly
+  drops risky fixes.
 - **Suppressed findings are never touched** — `.compose-lint.yml` disables and
   per-service excludes are honored.
-- **Refuses unsafe edits.** Files using YAML anchors, merge keys, or `${VAR}`
+- **Refuses rather than risk a wrong rewrite.** Files using YAML anchors, merge keys, or `${VAR}`
   interpolation in the affected region are skipped rather than risk a wrong
   rewrite, and every apply is re-parsed and re-linted before it is written —
   anything that wouldn't round-trip clean is refused with the diff surfaced for

--- a/docs/SECURITY-EXPECTATIONS.md
+++ b/docs/SECURITY-EXPECTATIONS.md
@@ -28,10 +28,13 @@ pipeline, this is the page to read.
    (the default command) only reads its inputs. The `fix` command is
    dry-run by default — it prints a unified diff and writes nothing;
    only `fix --apply` rewrites in place, via an atomic swap that
-   preserves permission bits. It applies only safe, mechanical edits,
-   never touches suppressed findings, and re-parses and re-lints every
-   change before writing — see [docs/ROADMAP.md](ROADMAP.md) and the
-   Fixing findings section of the README.
+   preserves permission bits. It applies only mechanically unambiguous
+   edits, never touches suppressed findings, and re-parses and re-lints
+   every change before writing. That guarantee covers the *edit*, not
+   the *outcome*: a fix can still change how your stack behaves, and
+   every such edit is labelled `⚠ behavior-changing` in the diff rather
+   than withheld — see [docs/ROADMAP.md](ROADMAP.md) and the Fixing
+   findings section of the README.
 
 4. **Released artifacts are signed.** Every release ships:
    - PyPI wheel + sdist with PEP 740 trusted-publisher attestations and

--- a/docs/dockerhub-overview.md
+++ b/docs/dockerhub-overview.md
@@ -1,6 +1,6 @@
 # compose-lint
 
-**Security-focused linter for Docker Compose files.** Catches dangerous misconfigurations before they reach production — and auto-fixes the safe ones, dry-run first. Grounded in the [OWASP Docker Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html) and [CIS Docker Benchmark](https://www.cisecurity.org/benchmark/docker).
+**Security-focused linter for Docker Compose files.** Catches dangerous misconfigurations before they reach production — and auto-fixes the unambiguous ones, dry-run first. Grounded in the [OWASP Docker Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html) and [CIS Docker Benchmark](https://www.cisecurity.org/benchmark/docker).
 
 In a scan of 6,444 public Docker Compose files on GitHub, **91% of those that parse had at least one security finding** — 68% had a finding rated HIGH or CRITICAL. [Read the full *State of Docker Compose Security* report →](https://github.com/tmatens/compose-lint/blob/main/docs/state-of-compose.md)
 
@@ -21,7 +21,7 @@ docker run --rm -v "$(pwd):/src" composelint/compose-lint fix        # preview a
 docker run --rm -v "$(pwd):/src" composelint/compose-lint --explain CL-0001
 ```
 
-Auto-detects `compose.yml` / `docker-compose.yml` variants; pass filenames to lint specific files. `fix --apply` writes the safe, mechanical fixes in place (atomic, re-parsed and re-linted before writing); context-dependent findings are reported for manual review, never auto-edited. Also on PyPI: `pip install compose-lint` (Python 3.10+).
+Auto-detects `compose.yml` / `docker-compose.yml` variants; pass filenames to lint specific files. `fix --apply` writes the mechanically unambiguous fixes in place (atomic, re-parsed and re-linted before writing); context-dependent findings are reported for manual review, never auto-edited. Unambiguous is not harmless — the guarantee is about the edit, not the outcome, so edits that change runtime behavior (e.g. `read_only: true`) are labelled `⚠ behavior-changing` in the diff. Read those before `--apply`. Also on PyPI: `pip install compose-lint` (Python 3.10+).
 
 ## Exit codes
 


### PR DESCRIPTION
Per ADR-014, "mechanically safe" is a property of the **edit**, not the **risk** — yet the docs shortened it to "safe", which reads as "harmless". That is exactly wrong for the two fixes most likely to bite: `read_only: true` breaks a container that writes to its rootfs, and the `127.0.0.1` port rebind cuts off every remote client. Both are in the auto-fix set by design; the mitigation is the `⚠ behavior-changing` caveat, not exclusion.

This is the doc-side counterpart to the 0.14.1 fix that made those caveats reach the `--apply` path — no point routing the warning correctly if the surrounding prose has already told the reader there is nothing to warn about.

**Changes** — no code, docs only:
- `README.md` — "safe, unambiguous edit" → "mechanically unambiguous"; new callout stating the edit/outcome distinction and showing a real caveat line; "Only safe, mechanical fixes" → "Only mechanically unambiguous fixes", plus a new bullet on labelled-not-withheld; "Refuses unsafe edits" → "Refuses rather than risk a wrong rewrite" (the old phrasing implied the applied ones were the "safe" ones); tagline and quickstart de-safed; CLI reference line realigned with the actual `--help` text, which already said "auto-fixable".
- `docs/dockerhub-overview.md` — same two claims, on the public Docker Hub description. 4146 bytes, well under the 25000 cap.
- `docs/SECURITY-EXPECTATIONS.md` — item 3 is a security *promise*; it now scopes the guarantee to the edit and names the caveat mechanism.

**Verification** — `ruff check`, `ruff format --check`, `mypy src/` clean. The quoted caveat text is copied from live `compose-lint fix` output, not paraphrased. Signed + DCO.