### PR TITLE
Parenthesize wrapped strings flagged by CodeQL in vuln_report

### DIFF
--- a/scripts/vuln_report.py
+++ b/scripts/vuln_report.py
@@ -152,10 +152,12 @@ def build_body(
         MARKER,
         f"**{total} fixable {noun}**{tail}",
         "",
-        "This issue is maintained automatically: the body is rewritten on "
-        "each run and the issue **closes itself** when the fixable list is "
-        "empty. An open issue therefore means there is something to fix "
-        "right now.",
+        (
+            "This issue is maintained automatically: the body is rewritten on "
+            "each run and the issue **closes itself** when the fixable list is "
+            "empty. An open issue therefore means there is something to fix "
+            "right now."
+        ),
         "",
     ]
 
@@ -218,12 +220,14 @@ def build_body(
     parts += [
         "---",
         "",
-        "This report applies **no `--ignore-vuln` suppressions**, so an "
-        "advisory suppressed in `ci.yml` or `publish.yml` still appears "
-        "here. That is deliberate — a suppression whose justification has "
-        "gone stale is otherwise invisible to pip-audit (it is filtered by "
-        "ID) *and* to Renovate (the pin is already satisfiable) at the same "
-        "time.",
+        (
+            "This report applies **no `--ignore-vuln` suppressions**, so an "
+            "advisory suppressed in `ci.yml` or `publish.yml` still appears "
+            "here. That is deliberate — a suppression whose justification has "
+            "gone stale is otherwise invisible to pip-audit (it is filtered by "
+            "ID) *and* to Renovate (the pin is already satisfiable) at the same "
+            "time."
+        ),
         "",
         f"[Workflow run]({run_url})" if run_url else "",
     ]


### PR DESCRIPTION
Resolves the last two open code-scanning alerts (#97, #98 — `py/implicit-string-concatenation-in-list`).

The two prose paragraphs in `build_body`'s `parts` list are wrapped across lines as adjacent string literals, which CodeQL can't distinguish from a forgotten comma. This wraps each group in parentheses — the same pattern the `tail` expression at the top of the function already uses — to mark the concatenation as deliberate.

No behavior change: verified the rendered issue body is byte-identical before/after for both the empty and populated cases. `ruff check` and `ruff format --check` pass on the file.