### PR TITLE
Build the sdist from an allowlist and gate its contents in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -124,6 +124,22 @@ jobs:
             echo "::error::Wheel contains forbidden files"
             exit 1
           fi
+          # The sdist needs its own check: `twine check` only validates
+          # metadata, and the wheel guard above cannot see the sdist. The
+          # sdist allowlist in pyproject.toml is the primary defence; this
+          # is the gate that proves it held. A virtualenv swept in from a
+          # maintainer's working tree is the motivating case — it is
+          # invisible to `git status` (venvs write their own `.gitignore`)
+          # and its absolute `bin/python` symlink makes the archive
+          # unusable, so fail closed on symlinks and venv markers.
+          if tar tzvf dist/*.tar.gz | grep -E ' -> '; then
+            echo "::error::sdist contains symlinks"
+            exit 1
+          fi
+          if tar tzf dist/*.tar.gz | grep -E '(pyvenv\.cfg|AGENTS\.md|CLAUDE\.md|/\.env$|/\.git/|/\.claude/|site-packages/)'; then
+            echo "::error::sdist contains forbidden files"
+            exit 1
+          fi
       # Sign dists with Sigstore so we can attach .sigstore bundles to the
       # GitHub Release. PyPI gets its own PEP 740 attestations via the
       # trusted-publisher flow in the `publish` job — this is an independent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `pyproject.toml`, `__init__.py`, and `CHANGELOG.md` — so the release PR it
   opened failed its own required check on every release and needed a
   hand-pushed fixup commit.
+- The sdist no longer ships whatever happens to sit in the maintainer's
+  working tree. `[tool.hatch.build.targets.sdist]` was a denylist of nine
+  known paths, but hatchling ships everything the *root* `.gitignore` does
+  not exclude and does not read nested `.gitignore` files — so a local
+  virtualenv, which writes its own `.gitignore: *` and is therefore
+  invisible to `git status`, was swept in: 158 of 445 entries, 35% of a
+  3.5 MB archive, including `bin/python` as an absolute symlink into the
+  build machine's filesystem. Such an archive is not merely untidy but
+  unusable — uv rejects it as an invalid tar — and nothing caught it:
+  `twine check` validates metadata, not contents, and `publish.yml`'s
+  content guard inspects the wheel alone. The sdist target is now a
+  root-anchored allowlist, and `publish.yml` gates the sdist on symlinks
+  and virtualenv markers. Published artifacts were never affected: release
+  builds run from a clean checkout, and the wheel packages `src/` only.
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,7 +165,45 @@ select = [
     "TCH", # flake8-type-checking
 ]
 
+# The sdist is built from an ALLOWLIST because a denylist cannot defend
+# against a path nobody anticipated. Hatchling ships everything the *root*
+# .gitignore does not exclude, and it does not read nested .gitignore files
+# — so a stray directory in a maintainer's working tree is invisible to
+# `git status` yet still lands in the archive. A virtualenv is the case that
+# bites: uv writes `.gitignore: *` inside the venv, which silences git but
+# not the build, and the venv's `bin/python` is an absolute symlink into the
+# build machine's filesystem. An sdist carrying those is not merely untidy,
+# it is unusable — uv rejects it outright as an invalid tar, and neither
+# `twine check` (metadata only) nor the wheel guard in publish.yml looks at
+# sdist contents. `exclude` below is kept as defence in depth for paths that
+# would otherwise match an `include` entry.
 [tool.hatch.build.targets.sdist]
+# Every pattern is root-anchored with a leading slash. These are
+# gitignore-style patterns, so an unanchored `LICENSE` matches a file of
+# that name at ANY depth — which silently re-admits
+# `.demo-venv/lib/python3.13/site-packages/*/licenses/LICENSE` and defeats
+# the allowlist. Anchor anything added here.
+include = [
+    "/src/",
+    "/tests/",
+    "/docs/",
+    "/scripts/",
+    "/.github/",
+    "/.githooks/",
+    "/.vex/",
+    "/action.yml",
+    "/pyproject.toml",
+    "/README.md",
+    "/CHANGELOG.md",
+    "/CONTRIBUTING.md",
+    "/GOVERNANCE.md",
+    "/MAINTAINERS.md",
+    "/LICENSE",
+    "/LICENSE-corpus.md",
+    "/requirements-build.lock",
+    "/.pre-commit-hooks.yaml",
+    "/.gitignore",
+]
 exclude = [
     "AGENTS.md",
     "CLAUDE.md",


### PR DESCRIPTION
## What

The sdist target in `pyproject.toml` was a **denylist** of nine known paths. Hatchling ships everything the *root* `.gitignore` does not exclude, and it does not read nested `.gitignore` files — so a denylist cannot defend against a path nobody anticipated.

A local virtualenv is exactly that path. `uv` writes `.gitignore: *` inside every venv, which keeps it out of `git status` while the build still sweeps it in.

## Evidence

Building `v0.14.1` from a working tree containing `.demo-venv/` and `.venv-lint/`:

- **158 of 445 entries** (35%) of a **3.5 MB** archive came from the two venvs
- including absolute symlinks into the build machine's filesystem:
  ```
  .demo-venv/bin/python -> /opt/uv/python/cpython-3.13-linux-x86_64-gnu/bin/python3.13
  ```
- `uv build` **refuses the result**: `Invalid tar file … symlink path is absolute, but external symlinks are not allowed`

So the archive is unusable, not merely untidy. Nothing caught it:

| gate | why it missed |
|---|---|
| `git status` | clean — the venv's own `.gitignore: *` hides it |
| `twine check` | validates metadata and README rendering, not archive contents |
| `publish.yml` content guard | reads `dist/*.whl` only |

The root `.gitignore` lists `.venv/` but not `.demo-venv`/`.venv-lint`, which is precisely why `.venv/` was excluded and the other two were not — confirming the inclusion rule.

## Change

1. **`pyproject.toml`** — `[tool.hatch.build.targets.sdist]` becomes an allowlist. Every pattern is **root-anchored**: these are gitignore-style patterns, so a bare `LICENSE` matches at *any* depth and silently re-admits `.demo-venv/lib/python3.13/site-packages/*/licenses/LICENSE`. The first draft of this PR had that bug and the new CI gate caught it. `exclude` is kept as defence in depth.
2. **`publish.yml`** — the release gate now checks the sdist too, failing on symlinks and virtualenv markers.

## Verification

- `uv build` now succeeds end-to-end (sdist → wheel); previously it failed outright
- sdist: 445 → **287 entries**, 3.5 MB → **1.9 MB**
- set-diff old vs new: **zero legitimate files dropped, zero added** — the delta is exactly the 158 venv entries
- wheel **unchanged** (73 entries, identical listing)
- both new guards pass against the rebuilt sdist
- `actionlint` clean, `shellcheck` clean on the new run block
- `ruff check` / `ruff format --check` clean, **1154 passed, 6 skipped**

## Impact

**Published artifacts were never affected** — release builds run from a clean checkout, nothing in the repo creates these directories, and the wheel packages `src/` only. This closes a latent path where a maintainer's local `python -m build` would publish a broken sdist with every existing gate green.