### PR TITLE
Rebase the fix-dedup rationale off the withdrawn profile catalog

### DIFF
--- a/src/compose_lint/formatters/text.py
+++ b/src/compose_lint/formatters/text.py
@@ -257,9 +257,10 @@ def format_findings(
     The fix block and reference URL are printed only on the first occurrence
     of each *distinct* fix within a file; subsequent occurrences with the same
     fix get a brief `(see fix above)` marker. The dedup key includes the fix
-    text, not just the rule id, so profile enrichment — which makes a rule's fix
-    image-specific (e.g. postgres vs caddy get different `cap_add` hints) — is
-    never collapsed into another service's recommendation. ``verbose=True``
+    text, not just the rule id, because one rule's fix can differ per service —
+    CL-0009 names the particular profile a service disables, CL-0011 the
+    particular capability it adds — so one service's guidance is never collapsed
+    into another's. ``verbose=True``
     restores per-finding fix
     repetition for IDE tooling or local fix-it-now workflows. ``quiet=True``
     does the opposite — one line per finding, dropping the fix block,
@@ -283,11 +284,12 @@ def format_findings(
     out.append(_colorize(_sanitize(filepath), _BOLD))
     out.append("")
 
-    # Dedup on (rule_id, fix, references), not rule_id alone: profile enrichment
-    # makes a rule's fix image-specific, so two services flagged by the same rule
+    # Dedup on (rule_id, fix, references), not rule_id alone: one rule's fix can
+    # differ per service (CL-0009 names the profile that service disables,
+    # CL-0011 the capability it adds), so two services flagged by the same rule
     # can carry genuinely different guidance. Keying on rule_id alone would mark
-    # the second "(see fix above)" and point it at the first service's (wrong-
-    # image) recommendation.
+    # the second "(see fix above)" and point it at the first service's
+    # recommendation, which may not apply.
     seen_fixes: set[tuple[str, str, tuple[str, ...]]] = set()
 
     for service, group in services_in_order:

--- a/tests/test_text_formatter.py
+++ b/tests/test_text_formatter.py
@@ -446,36 +446,36 @@ def test_format_summary_escapes_bidi_in_path() -> None:
 
 
 def test_fix_dedup_keys_on_fix_not_rule_id() -> None:
-    # Profile enrichment makes a rule's fix image-specific, so two services
-    # flagged by the same rule can carry genuinely different guidance. The dedup
-    # must not collapse the second into "(see fix above)" pointing at the first
-    # service's (wrong-image) fix.
+    # One rule's fix can differ per service: CL-0009 names the specific profile
+    # that service disables, so two services flagged by it carry genuinely
+    # different guidance. The dedup must not collapse the second into
+    # "(see fix above)" pointing at the first service's inapplicable fix.
     findings = [
         Finding(
-            "CL-0006",
-            Severity.MEDIUM,
+            "CL-0009",
+            Severity.HIGH,
             "db",
-            "caps not dropped",
+            "security profile disabled",
             line=2,
-            fix="cap_drop: [ALL]\nhint: cap_add: [CHOWN, DAC_OVERRIDE, SETGID, SETUID]",
+            fix="Remove `seccomp:unconfined` from security_opt.",
         ),
         Finding(
-            "CL-0006",
-            Severity.MEDIUM,
+            "CL-0009",
+            Severity.HIGH,
             "proxy",
-            "caps not dropped",
+            "security profile disabled",
             line=6,
-            fix="cap_drop: [ALL]\nprofile hint: cap_add: [NET_BIND_SERVICE]",
+            fix="Remove `apparmor:unconfined` from security_opt.",
         ),
     ]
     out = format_findings(findings, "compose.yml")
-    assert "CHOWN" in out
-    assert "NET_BIND_SERVICE" in out  # the second, distinct hint is not collapsed
+    assert "seccomp:unconfined" in out
+    assert "apparmor:unconfined" in out  # the second, distinct fix is not collapsed
     assert "(see fix above)" not in out
 
 
 def test_fix_dedup_collapses_identical_fixes() -> None:
-    # Same rule + identical fix (no enrichment) still dedups to a single block.
+    # Same rule + identical fix still dedups to a single block.
     findings = [
         Finding(
             "CL-0003",


### PR DESCRIPTION
Follow-up to #461. Comments and test data only — **no behaviour change**.

## What

`format_findings` dedups fix blocks on `(rule_id, fix, references)` rather than `rule_id` alone. Two comments explaining why (docstring + inline) and the test guarding it all justified that **solely** by profile enrichment making a rule's fix image-specific. That feature was withdrawn in #461, so the stated reason no longer exists — while the behaviour is still correct and still load-bearing.

## Why the behaviour stays

One rule's fix genuinely can differ per service, for a reason that predates enrichment and outlives it:

- **CL-0009** names the particular profile a service disables (`seccomp:unconfined` vs `apparmor:unconfined`)
- **CL-0011** names the particular capability a service adds

Keying on `rule_id` alone would mark the second occurrence `(see fix above)` and point it at a fix that does not apply to that service.

## Change

- Restate both comments in those terms.
- Rewrite `test_fix_dedup_keys_on_fix_not_rule_id` to use two services disabling **different** security profiles, instead of two synthetic `profile hint:` fix strings that no code path can produce any more. The old test still passed — it builds `Finding` objects directly — but it was guarding the behaviour via a scenario that can no longer occur, which is a trap for the next reader.

No CHANGELOG entry: the gate fires on `pyproject.toml` changes, and this is internal comments plus test data.

## Verification

- **1068 passed, 6 skipped**; `ruff` + `ruff format` clean; `actionlint` clean; `mypy` zero new errors
- End-to-end smoke on a multi-service file: `text` / `json` / `sarif` all valid (12 findings, SARIF parses), `--explain` and `fix` dry-run both work
- Confirmed the dedup still renders both distinct CL-0009 fixes rather than collapsing them