### PR TITLE
Prepare 0.15.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-08-07
+
 ### Removed
 
 - **Profile enrichment has been withdrawn** ([ADR-019](docs/adr/019-withdraw-security-profile-catalog.md),
@@ -1242,7 +1244,8 @@ First public release.
   inputs through `env:` rather than direct `${{ }}` interpolation to prevent
   shell injection.
 
-[Unreleased]: https://github.com/tmatens/compose-lint/compare/v0.14.1...HEAD
+[Unreleased]: https://github.com/tmatens/compose-lint/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/tmatens/compose-lint/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/tmatens/compose-lint/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/tmatens/compose-lint/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/tmatens/compose-lint/compare/v0.12.2...v0.13.0

--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ jobs:
         run: |
           apt-get update -qq
           apt-get install -yqq --no-install-recommends python3-pip
-          pip3 install --break-system-packages --no-cache-dir compose-lint==0.14.1
+          pip3 install --break-system-packages --no-cache-dir compose-lint==0.15.0
       - name: Run compose-lint
         run: compose-lint --fail-on high
 ```
@@ -420,7 +420,7 @@ compose-lint --format sarif docker-compose.yml > results.sarif
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/tmatens/compose-lint
-    rev: v0.14.1
+    rev: v0.15.0
     hooks:
       - id: compose-lint
 ```

--- a/docs/hardening.md
+++ b/docs/hardening.md
@@ -13,7 +13,7 @@ docker run --rm \
   --user 65532:65532 \
   --pids-limit 256 \
   -v "$(pwd):/src:ro" \
-  composelint/compose-lint:0.14.1
+  composelint/compose-lint:0.15.0
 ```
 
 | Flag | Rule satisfied |
@@ -26,6 +26,6 @@ docker run --rm \
 
 `--network none` and `:ro` on the bind mount are extra hardening — compose-lint never reaches the network and only reads its inputs.
 
-For full supply-chain reproducibility (and to satisfy CL-0004 / CL-0019), replace the version tag with a digest pin: `composelint/compose-lint@sha256:<digest>`. Get the current digest from [Docker Hub](https://hub.docker.com/r/composelint/compose-lint/tags) or with `docker buildx imagetools inspect composelint/compose-lint:0.14.1 --format '{{json .Manifest}}' | jq -r '.digest'`.
+For full supply-chain reproducibility (and to satisfy CL-0004 / CL-0019), replace the version tag with a digest pin: `composelint/compose-lint@sha256:<digest>`. Get the current digest from [Docker Hub](https://hub.docker.com/r/composelint/compose-lint/tags) or with `docker buildx imagetools inspect composelint/compose-lint:0.15.0 --format '{{json .Manifest}}' | jq -r '.digest'`.
 
 A Compose-form equivalent that lints clean across every rule lives in [`tests/compose_files/safe_self_hosted.yml`](https://github.com/tmatens/compose-lint/blob/main/tests/compose_files/safe_self_hosted.yml).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "compose-lint"
-version = "0.14.1"
+version = "0.15.0"
 description = "Security-focused linter for Docker Compose files. Catches dangerous misconfigurations before they reach production — grounded in OWASP and the CIS Docker Benchmark; emits SARIF for GitHub Code Scanning."
 readme = "README.md"
 license = "MIT"

--- a/src/compose_lint/__init__.py
+++ b/src/compose_lint/__init__.py
@@ -1,3 +1,3 @@
 """A security-focused linter for Docker Compose files."""
 
-__version__ = "0.14.1"
+__version__ = "0.15.0"


### PR DESCRIPTION
Automated release prep for `0.15.0`. Review the CHANGELOG entry and version bumps, then squash-merge.

**After this PR merges**, create and push a signed annotated tag from your workstation:

```
git checkout main && git pull --ff-only
git tag -s v0.15.0 -m "compose-lint 0.15.0"
git push origin v0.15.0
```

The tag push triggers `publish.yml`, which runs TestPyPI/Docker smoke tests, waits for your approval on the `release` environment, then publishes PyPI + Docker Hub, creates the GitHub Release, and opens a follow-up PR to bump the `marketplace-smoke` pin.
