### PR TITLE
Teach CL-0006 to determine required capabilities, not just name a placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- CL-0006's fix guidance now teaches how to *determine* an image's required
+  capability set instead of stopping at a `<SPECIFIC_CAP>` placeholder
+  (issue #4). The finding's `fix` text gains the drop-and-observe method and
+  the common `Operation not permitted` → capability mappings, and
+  `docs/rules/CL-0006.md` (also served by `--explain CL-0006`) gains a full
+  "Determining required capabilities" section covering the symptom→capability
+  table, the `capable` BPF tool, `docker diff`, and entrypoint inspection.
+  Both stress verifying *function*, not just startup: capability failures are
+  often non-fatal, silently degrading a feature (e.g. DHCP device discovery
+  under a dropped `NET_RAW`) while the container stays "healthy" — so review
+  logs and exercise background behaviors after every change.
+  Guidance-only per [ADR-019](docs/adr/019-withdraw-security-profile-catalog.md):
+  no per-image capability data is bundled.
+
 ## [0.15.0] - 2026-08-07
 
 ### Removed

--- a/docs/rules/CL-0006.md
+++ b/docs/rules/CL-0006.md
@@ -38,13 +38,13 @@ services:
     cap_drop:
       - ALL
     cap_add:
-      - NET_BIND_SERVICE  # only if binding to ports < 1024
+      - NET_BIND_SERVICE  # only for ports < 1024 under network_mode: host
 ```
 
 Common capabilities that specific workloads may need:
-- `NET_BIND_SERVICE` — binding to privileged ports (< 1024)
+- `NET_BIND_SERVICE` — binding to privileged ports (< 1024) under `network_mode: host`; with Docker's default per-container network namespaces, low ports need no capability since Docker 20.10 (`ip_unprivileged_port_start=0`)
 - `CHOWN` / `DAC_OVERRIDE` / `FOWNER` / `SETUID` / `SETGID` — entrypoints that switch users (`gosu`, `su-exec`) or fix volume ownership at startup (postgres, redis)
-- `NET_RAW` — `ping` / ICMP from inside the container
+- `NET_RAW` — raw/`AF_PACKET` sockets: packet capture, ARP/DHCP watching, and `ping` binaries that don't use ICMP datagram sockets (tool-dependent — busybox's needs it, others don't)
 
 ## Compatibility
 
@@ -54,9 +54,33 @@ Common capabilities that specific workloads may need:
 - `tini` / dumb-init wrappers running as PID 1 with signal forwarding — usually fine, but check.
 - Init-style processes that fork helpers (cron, sendmail) — typically need `SETUID` + `SETGID`.
 
-### How to test
+## Determining required capabilities
 
-Apply `cap_drop: [ALL]`, then `docker compose up`. If the container exits with `Operation not permitted` around `chown`, `setuid`, `setgid`, or `mknod`, add the relevant capability back. As a rule of thumb, an entrypoint that switches users (`su-exec`, `gosu`) typically needs `SETUID` and `SETGID`. Better guidance on determining an image's required set is tracked in [#4](https://github.com/tmatens/compose-lint/issues/4).
+There is no trustworthy registry mapping images to required capabilities — the required set depends on the image's entrypoint *and* your configuration (bind-mount ownership, `user:` overrides, network mode), so it has to be determined per service. The reliable method is drop-and-observe:
+
+1. **Start from nothing.** Apply `cap_drop: [ALL]` with no `cap_add`, then `docker compose up`. Many services — static binaries, images that already run as a non-root user — work with no capabilities at all.
+2. **Verify function, not just startup.** A running, "healthy" container is not proof the required set is complete: applications routinely catch a capability failure and continue with that feature disabled, so the damage shows up only in the logs or as a feature quietly not working. (Real example: a home-automation stack under `cap_drop: [ALL]` booted clean and served its UI, while its DHCP device-discovery integration died silently — the only trace was `Cannot watch for dhcp packets: [Errno 1] Operation not permitted` in the logs, until `NET_RAW` was restored.) After startup, read the full container logs for `Operation not permitted` / `permission denied`, then exercise the service's actual functionality — background behaviors included (device discovery, scheduled jobs, notifications, transcoding), not just the landing page. Healthchecks and orchestrator rollback gates won't catch healthy-but-degraded: a monitoring agent that loses a collector to a missing capability (e.g. per-process metrics without `SYS_PTRACE`) keeps serving its dashboard while an entire metrics family quietly disappears.
+3. **Read the failure.** A missing capability almost always surfaces as `Operation not permitted` (EPERM) in the container logs, naming the operation that failed. Map the operation back to a capability:
+
+   | Symptom in logs | Capability to add |
+   |---|---|
+   | `chown: … Operation not permitted` (volume/ownership fixup at startup) | `CHOWN`, often plus `DAC_OVERRIDE` + `FOWNER` |
+   | `su-exec`/`gosu`/`setuid`/`setgid` failure (entrypoint switches users) | `SETUID` + `SETGID` |
+   | `permission denied` binding a port below 1024 — in practice only under `network_mode: host`; in a container's own network namespace low ports need no capability (Docker 20.10+) | `NET_BIND_SERVICE` |
+   | `ping`, DHCP/ARP watching, or other raw-socket failure | `NET_RAW` |
+   | `mknod: … Operation not permitted` | `MKNOD` |
+
+4. **Add back only the capability implicated, then repeat** — including the functional verification in step 2, not just the boot — until the service is fully working. Add one at a time — adding a batch hides which ones were actually needed. Never "fix" a failure with `privileged: true` or by skipping `cap_drop: [ALL]` entirely; that trades one MEDIUM finding for a worse posture ([CL-0002](CL-0002.md)).
+
+The result is configuration-specific: changing a bind mount's ownership, the `user:` directive, or the image major version can change the required set, so re-verify after those changes.
+
+### Auditing tools
+
+When log messages are too vague to map, observe the container directly:
+
+- **`capable`** (from [BCC](https://github.com/iovisor/bcc/blob/master/tools/capable_example.txt); bpftrace ships an equivalent `capable.bt`) traces `cap_capable()` checks kernel-wide, printing which process checked which capability. Run it on the host while exercising the container's startup and main workflows. It shows *checks*, not verdicts — there is no granted/denied column, and the kernel checks some capabilities speculatively for operations the application tolerates failing — so treat its output as candidates and confirm each one with a drop-and-observe run rather than adding everything it prints.
+- **`docker diff <container>`** lists files created or changed *in the container's writable layer* — volumes and bind mounts never appear in it. Run it against the service before hardening: ownership or permission churn on non-volume paths reveals startup fixups that will need `CHOWN`/`FOWNER` once capabilities are dropped. The common fixup that targets a *volume* is exactly what it cannot see; for that, read the entrypoint or the logs (steps 2–3).
+- **Read the entrypoint.** Most official images publish their entrypoint script; a `gosu`/`su-exec` invocation or an explicit `chown` there tells you the required set before you ever start the container.
 
 ## See also
 

--- a/src/compose_lint/rules/CL0006_cap_drop.py
+++ b/src/compose_lint/rules/CL0006_cap_drop.py
@@ -70,7 +70,16 @@ class CapDropRule(BaseRule):
                     "  cap_drop:\n"
                     "    - ALL\n"
                     "  cap_add:\n"
-                    "    - <SPECIFIC_CAP>"
+                    "    - <SPECIFIC_CAP>\n"
+                    "To find the required set, start with cap_drop: [ALL] and\n"
+                    "no cap_add — many services need none — then review the\n"
+                    "logs and test all functionality, background features\n"
+                    "included: capability failures are often non-fatal and\n"
+                    "degrade a feature silently. Map each 'Operation not\n"
+                    "permitted' to a capability: chown -> CHOWN, su-exec/gosu\n"
+                    "user switch -> SETUID + SETGID, port < 1024 under host\n"
+                    "networking -> NET_BIND_SERVICE.\n"
+                    "Full guide: compose-lint --explain CL-0006"
                 ),
                 references=[OWASP_REF, CIS_REF],
             )


### PR DESCRIPTION
Closes #4.

## What

Makes CL-0006's `<SPECIFIC_CAP>` placeholder actionable by teaching users how to **determine** an image's required capability set — the guidance-only remaining path after the derived-profile catalog was withdrawn in ADR-019 (#461). Per that ADR and the ROADMAP entry, no per-image capability data is bundled.

- **Fix text** (`CL0006_cap_drop.py`): gains the drop-and-observe method, the common `Operation not permitted` → capability mappings, a warning that capability failures are often non-fatal and degrade features silently, and a pointer to `compose-lint --explain CL-0006`.
- **`docs/rules/CL-0006.md`** (served by `--explain`): new *Determining required capabilities* section — symptom→capability table; an explicit **verify function, not just startup** step (real case: an app under `cap_drop: [ALL]` booted healthy and served its UI while DHCP device discovery died silently, its only trace a `Cannot watch for dhcp packets: [Errno 1] Operation not permitted` log line, until `NET_RAW` was restored); one-capability-at-a-time re-add discipline; config-specificity caveat; and auditing tools (`capable` BPF tool, `docker diff`, entrypoint inspection).
- **CHANGELOG**: Unreleased → Changed entry.

## Notes

- Docs + rule-data only; no engine/predicate/severity/line changes, so the corpus snapshot is unaffected (fix text is not in the snapshot schema).
- Tests: existing CL-0006 tests assert fix presence, not exact text — all pass. `ruff check`, `ruff format --check`, `mypy --strict`, and `pytest` (1068 passed) are green locally.
- ROADMAP's *CL-0006 capability guidance* entry is left for the usual shipped-in-release retitle at release time.