### PR TITLE
Give CL-0007 the symptom-table treatment: EROFS errors mapped by path type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- CL-0007's guidance gets the same symptom → remedy treatment as CL-0006
+  (issue #474): the rule doc gains a "Reading the failure" table mapping
+  verbatim `Read-only file system` errors to remedies **by path type** —
+  ephemeral paths to `tmpfs:`, persistent data to a named volume (never
+  `tmpfs`, which silently erases it on restart), plus the masked
+  `No such file or directory` symptom when the image lacks the directory.
+  The finding's `fix` text carries the path-type rule and points at
+  `--explain CL-0007`. Four new CI premise checks prove the busybox rows
+  live, including that named volumes stay writable under `read_only`.
+
 - The CL-0006 symptom → capability table now covers 11 mappings — added
   `NET_ADMIN`, `SYS_NICE`, `SYS_TIME`, `FOWNER`, `KILL`, and `IPC_LOCK` — and
   quotes the verbatim error messages real tools emit, captured from live

--- a/docs/rules/CL-0007.md
+++ b/docs/rules/CL-0007.md
@@ -54,17 +54,32 @@ Observed failure modes:
 
 ### Writable-path discovery
 
-1. Run the service **without** `read_only` and let it reach a steady state.
+1. Run the service **without** `read_only` and let it reach a steady state — exercise its real functionality, not just startup.
 2. Inspect what was written:
 
    ```
    docker diff <container>
    ```
 
-3. Add each writable path as a `tmpfs` entry (for ephemeral data) or a named volume (for persistent data). Named volumes remain writable regardless of `read_only`.
-4. Enable `read_only: true` and restart.
+   `read_only` blocks exactly the writable-layer writes `docker diff` records, so the diff is a near-complete preview of what will break. (Volume paths don't appear in it — they stay writable under `read_only` anyway.)
+3. Add each written path as a `tmpfs` entry (ephemeral data) or a named volume (persistent data) using the table below.
+4. Enable `read_only: true`, restart, and re-verify **function, not just startup**: applications routinely catch a write failure and continue with the feature silently disabled (caching off, uploads rejected, temp exports failing), so read the logs and exercise the service before calling it done.
 
 If the entrypoint runs `chown`, either pre-own the mount as the target UID:GID in the image build, or drop that specific service from the rule scope.
+
+### Reading the failure
+
+A blocked write surfaces as `Read-only file system` (EROFS) in the container logs, naming the path — the remedy follows from what *kind* of path it is. The busybox wordings below are re-proven against a live container on every CI run (`scripts/validate_rule_premises.py`: the write must fail under `read_only: true` with this message and succeed with the mapped remedy); coreutils variants were captured live from a Debian container but are not CI-asserted.
+
+| Symptom in logs (verbatim) | Path type | Remedy |
+|---|---|---|
+| `touch: /tmp/scratch: Read-only file system` (busybox) · `touch: cannot touch '/run/app.pid': Read-only file system` (coreutils) | ephemeral runtime state: PID files, sockets, scratch space | `tmpfs:` entry for the directory |
+| `mkdir: can't create directory '/var/cache/': Read-only file system` (busybox) · `mkdir: cannot create directory '/var/cache/app': Read-only file system` (coreutils) | caches | `tmpfs:`, or a named volume if a warm cache across restarts matters |
+| `can't create /etc/…: Read-only file system` from the entrypoint shell | config rewritten at startup | named volume for that path, pre-render the config in the image build, or accept that `read_only` doesn't fit this image and suppress with a documented reason |
+| any EROFS under a data directory (database files, uploads) | **persistent application data** | **named volume — never `tmpfs`.** Named volumes stay writable under `read_only` (CI-proven). A `tmpfs` here runs green until the first restart, then silently erases the data |
+| `No such file or directory` on a path the app would normally create at startup | directory absent from the image *and* rootfs unwritable — the EROFS is masked by the failed `mkdir` | a `tmpfs:` entry both creates the mount point and makes it writable |
+
+The last two rows are the traps: the naive fix — "add whatever path the error names as `tmpfs`" — is exactly wrong for persistent data, and its failure mode is invisible until a restart; and a missing-directory error under `read_only` is usually this rule's breakage wearing a different message.
 
 ### Hardened non-root images
 

--- a/scripts/validate_rule_premises.py
+++ b/scripts/validate_rule_premises.py
@@ -475,6 +475,86 @@ def _t_ipc_lock() -> tuple[bool, str]:
     )
 
 
+# --- CL-0007 symptom-table mappings (docs/rules/CL-0007.md) -----------------
+#
+# Same contract as the CL-0006 mapping checks (ADR-016 amendment): each row of
+# the rule doc's "Reading the failure" table is proven live — the write fails
+# under ``--read-only`` emitting the quoted busybox message, and succeeds with
+# the mapped remedy applied.
+
+
+def _remedy(
+    deny_args: list[str],
+    allow_args: list[str],
+    cmd: list[str],
+    msg: str,
+) -> tuple[bool, str]:
+    """Prove one symptom→remedy row (fails under ``deny_args`` with ``msg``;
+    works under ``allow_args``)."""
+    rc_deny, err = _run_err(deny_args, cmd)
+    rc_allow, _ = _run_err(allow_args, cmd)
+    ok = rc_deny != 0 and msg in err and rc_allow == 0
+    return ok, f"denied rc={rc_deny} msg={err!r}; remedied rc={rc_allow}"
+
+
+def _t7_touch_tmpfs() -> tuple[bool, str]:
+    return _remedy(
+        ["--read-only"],
+        ["--read-only", "--tmpfs", "/tmp"],
+        ["touch", "/tmp/scratch"],
+        "touch: /tmp/scratch: Read-only file system",
+    )
+
+
+def _t7_mkdir_tmpfs() -> tuple[bool, str]:
+    # busybox mkdir -p reports the first missing parent it fails to create.
+    return _remedy(
+        ["--read-only"],
+        ["--read-only", "--tmpfs", "/var/cache"],
+        ["mkdir", "-p", "/var/cache/app"],
+        "mkdir: can't create directory '/var/cache/': Read-only file system",
+    )
+
+
+def _t7_tmpfs_creates_mountpoint() -> tuple[bool, str]:
+    # The doc's masked-symptom row: /run is absent from the busybox image, so
+    # under read_only the write fails ENOENT (not EROFS) — and a tmpfs entry
+    # both creates the mount point and makes it writable.
+    return _remedy(
+        ["--read-only"],
+        ["--read-only", "--tmpfs", "/run"],
+        ["touch", "/run/app.pid"],
+        "touch: /run/app.pid: No such file or directory",
+    )
+
+
+def _t7_volume_writable() -> tuple[bool, str]:
+    # The doc's persistent-data row: a named volume stays writable under
+    # read_only while the rootfs is locked — the load-bearing fact behind
+    # "persistent data -> named volume, never tmpfs".
+    vol = "clpremise-cl0007-vol"
+    subprocess.run(["docker", "volume", "create", vol], capture_output=True, timeout=90)
+    try:
+        rc_vol, _ = _run_err(
+            ["--read-only", "-v", f"{vol}:/data"],
+            [
+                "touch",
+                "/data/persist",
+            ],
+        )
+        rc_root, err = _run_err(
+            ["--read-only", "-v", f"{vol}:/data"],
+            [
+                "touch",
+                "/tmp/x",
+            ],
+        )
+    finally:
+        subprocess.run(["docker", "volume", "rm", vol], capture_output=True, timeout=90)
+    ok = rc_vol == 0 and rc_root != 0 and "Read-only file system" in err
+    return ok, f"volume write rc={rc_vol}; rootfs write rc={rc_root} msg={err!r}"
+
+
 CHECKS: list[tuple[str, str, Callable[[], tuple[bool, str]]]] = [
     ("CL-0001", "docker socket mount is root-equivalent", _cl0001),
     ("CL-0002", "privileged grants full caps", _cl0002),
@@ -504,6 +584,11 @@ CHECKS: list[tuple[str, str, Callable[[], tuple[bool, str]]]] = [
     ("CL-0006", "map: set clock -> SYS_TIME", _t_sys_time),
     ("CL-0006", "map: cross-uid signal -> KILL", _t_kill),
     ("CL-0006", "map: mlockall -> IPC_LOCK", _t_ipc_lock),
+    # CL-0007 symptom-table mappings — one per row of the rule doc's table.
+    ("CL-0007", "map: touch EROFS -> tmpfs", _t7_touch_tmpfs),
+    ("CL-0007", "map: mkdir EROFS -> tmpfs", _t7_mkdir_tmpfs),
+    ("CL-0007", "map: masked ENOENT -> tmpfs mountpoint", _t7_tmpfs_creates_mountpoint),
+    ("CL-0007", "premise: named volume writable under read_only", _t7_volume_writable),
 ]
 
 

--- a/src/compose_lint/rules/CL0007_read_only.py
+++ b/src/compose_lint/rules/CL0007_read_only.py
@@ -71,8 +71,12 @@ class ReadOnlyFilesystemRule(BaseRule):
                     "  tmpfs:\n"
                     "    - /tmp\n"
                     "    - /run\n"
-                    "Note: run once without read_only and check "
-                    "`docker diff` first."
+                    "To find the paths, run once without read_only and check\n"
+                    "`docker diff`; then map each 'Read-only file system'\n"
+                    "error by path type: ephemeral (PID files, sockets,\n"
+                    "caches, /tmp) -> a tmpfs entry; persistent data -> a\n"
+                    "named volume, NEVER tmpfs (erased on every restart).\n"
+                    "Full guide: compose-lint --explain CL-0007"
                 ),
                 references=[OWASP_REF, CIS_REF],
             )


### PR DESCRIPTION
Closes #474. Applies the #468/#469 pattern to `read_only: true` — the highest-volume error family of the candidates surveyed.

## What

- **`docs/rules/CL-0007.md`**: new *Reading the failure* table — verbatim EROFS wordings (busybox CI-asserted; coreutils captured live from Debian, not asserted, same convention as CL-0006) mapped to remedies **by path type**. The two traps get called out explicitly: persistent data must be a **named volume, never `tmpfs`** (the naive fix runs green until the first restart, then silently erases the data), and a masked `No such file or directory` under `read_only` is usually this rule's breakage wearing a different message (the image lacks the dir; a `tmpfs:` entry both creates the mount point and makes it writable — found empirically: busybox has no `/run`).
- **Discovery procedure**: notes `docker diff` is a near-complete preview *here* (read-only blocks exactly the rw-layer writes it records — contrast with its volume blind spot documented in CL-0006), and adds the verify-function-not-just-startup step.
- **Fix text**: path-type rule inline + `--explain CL-0007` pointer (tests assert substring presence only — unaffected).
- **Four premise checks** via a new `_remedy` helper (same ADR-016 amendment contract): touch-EROFS→tmpfs, mkdir-EROFS→tmpfs, masked-ENOENT→tmpfs-mountpoint, and named-volume-writable-under-`read_only` — the load-bearing fact behind the persistent-data row.

## Verification

Full premise suite live against Docker 29.1.3: `PASS (31 premises validated)` (27 prior + 4 new). Scoped gate green (`ruff`/`mypy --strict`/`pytest` 1068 passed). No engine/predicate changes; corpus snapshot unaffected. The docs site redeploys itself on merge (docs/** path trigger).