### PR TITLE
Hoist the NET_BIND_SERVICE probe script out of its list literal

### DIFF
--- a/scripts/validate_rule_premises.py
+++ b/scripts/validate_rule_premises.py
@@ -304,13 +304,12 @@ def _t_net_bind_service() -> tuple[bool, str]:
     # Poll for the listening socket instead of a fixed sleep — on a loaded
     # runner the fork-to-bind can exceed any single guess, and nc's own exit
     # status is swallowed by the backgrounding.
-    bind = [
-        "sh",
-        "-c",
+    bind_script = (
         "nc -l -p 80 -w 3 & i=0; while [ $i -lt 20 ]; do "
         "netstat -tln | grep -q ':80 ' && exit 0; "
-        "i=$((i+1)); sleep 0.1; done; exit 1",
-    ]
+        "i=$((i+1)); sleep 0.1; done; exit 1"
+    )
+    bind = ["sh", "-c", bind_script]
     hard = ["--sysctl", "net.ipv4.ip_unprivileged_port_start=1024"]
     rc_loose, _ = _run_err(["--cap-drop", "ALL"], bind)
     rc_deny, err = _run_err(["--cap-drop", "ALL", *hard], bind)


### PR DESCRIPTION
Closes CodeQL alert [#99](https://github.com/tmatens/compose-lint/security/code-scanning/99) (`py/implicit-string-concatenation-in-list`, `scripts/validate_rule_premises.py:310`).

The `sh -c` argument in `_t_net_bind_service` is one shell one-liner written as three adjacent string literals inside the argv list. The concatenation is deliberate — there is no missing comma — but inside a list literal that is precisely the shape the query exists to catch, so silencing it by construction is cheaper than carrying a permanent dismissal.

Bind the script to a local before building argv. Verified the resulting command string is byte-identical to the previous concatenation, so the premise check itself is unchanged.

Cutting 0.15.1 behind this.