### PR TITLE
Bump marketplace-smoke pin to v0.15.1

### DIFF
--- a/.github/workflows/marketplace-smoke.yml
+++ b/.github/workflows/marketplace-smoke.yml
@@ -52,7 +52,7 @@ jobs:
           persist-credentials: false
 
       - name: Clean fixture should pass
-        uses: tmatens/compose-lint@eb301fff39926309c04ba7beb52ce89c400ccfa9 # v0.15.0
+        uses: tmatens/compose-lint@ce3e745de877bf46e014be3da5555c0ca037578b # v0.15.1
         with:
           files: tests/smoke/clean.yml
           fail-on: high
@@ -60,7 +60,7 @@ jobs:
       - name: Insecure fixture should fail
         id: insecure
         continue-on-error: true
-        uses: tmatens/compose-lint@eb301fff39926309c04ba7beb52ce89c400ccfa9 # v0.15.0
+        uses: tmatens/compose-lint@ce3e745de877bf46e014be3da5555c0ca037578b # v0.15.1
         with:
           files: tests/smoke/insecure.yml
           fail-on: high

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: tmatens/compose-lint@eb301fff39926309c04ba7beb52ce89c400ccfa9 # v0.15.0
+      - uses: tmatens/compose-lint@ce3e745de877bf46e014be3da5555c0ca037578b # v0.15.1
         with:
           sarif-file: results.sarif
 ```


### PR DESCRIPTION
**Post-tag follow-up.** This PR was opened automatically by `publish.yml` *after*:

- Tag `v0.15.1` was pushed and triggered the Publish workflow
- TestPyPI + Docker smoke tests passed
- The `release-gate` environment was approved
- `publish` (PyPI) and `docker-publish` (Docker Hub) both succeeded
- `create-release` created the GitHub Release `v0.15.1`

So the pinned SHA `ce3e745de877bf46e014be3da5555c0ca037578b` is guaranteed to correspond to a release that actually shipped through every channel.

Bumps the pin in `.github/workflows/marketplace-smoke.yml` **and** the copy-paste GitHub Action snippet in `README.md` — both use the `@<sha> # vX.Y.Z` form that CI cannot check pre-tag.

**After merging this PR**, trigger **Actions → Marketplace smoke test → Run workflow** to verify the published Action end-to-end against the new tag.
