### PR TITLE
Extend symptom-table treatment to CL-0012, CL-0018, and CL-0022

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- CL-0012, CL-0018, and CL-0022 get the symptom → remedy treatment
+  (issue #479, same pattern as CL-0006/CL-0007): each rule doc gains a
+  "Reading the failure" table quoting verbatim, live-captured error messages.
+  CL-0012 maps the fork-failure wordings (chronically misattributed to
+  `ulimit -u`) to the pids cgroup with a `pids.max`/`pids.current`
+  confirmation step; CL-0018 maps non-root `Permission denied` writes by
+  mount type, backed by two CI-proven facts — a tmpfs over an existing image
+  directory inherits its root ownership (use `uid=`/`gid=`), and named-volume
+  initial ownership follows Docker's copy-up rules; CL-0022 frames the
+  `noexec` exec failure as relocate-first, `:exec`-with-documented-reason
+  last, since the naive fix is the finding. Six new CI premise checks prove
+  the busybox rows live. CL-0002's fix text now points at CL-0006's
+  capability-determination guide instead of stopping at `<SPECIFIC_CAP>`.
+
 ## [0.15.1] - 2026-08-08
 
 ### Added

--- a/docs/rules/CL-0012.md
+++ b/docs/rules/CL-0012.md
@@ -34,3 +34,19 @@ services:
 ```
 
 Typical web applications need 100–500 PIDs. Start with a conservative limit and increase if the container hits it during normal operation.
+
+## Reading the failure
+
+When a container *hits* its PIDs limit, the symptom is a fork failure that is chronically misattributed to `ulimit`/`RLIMIT_NPROC`. The busybox wording below is re-proven against a live container on every CI run (`scripts/validate_rule_premises.py`); the bash variant was captured live but is not CI-asserted.
+
+| Symptom in logs (verbatim) | What it means | Action |
+|---|---|---|
+| `sh: line 0: can't fork: Resource temporarily unavailable` (busybox) · `bash: fork: retry: Resource temporarily unavailable` (bash/glibc) | under Docker's defaults, the pids cgroup at its limit — containers ship with `ulimit -u` **unlimited** (live-verified), so the common `RLIMIT_NPROC` diagnosis only applies if you set `--ulimit nproc` yourself (same errno) | confirm below, then raise `pids_limit` to a sane explicit value — not `-1` (that re-opens the fork-bomb exposure this rule exists to prevent) |
+
+Confirm it's the cgroup before changing anything:
+
+```
+docker exec <container> cat /sys/fs/cgroup/pids.max /sys/fs/cgroup/pids.current
+```
+
+If `pids.current` is pinned at `pids.max`, the limit is the cause; size the new limit from the observed steady-state `pids.current` plus headroom. Note the failure can also be *silent degradation*: worker pools that fail to spawn threads shrink quietly (every thread counts against the pids cgroup), so a service can look healthy while running under-provisioned — check `pids.current` against `pids.max` during load, not just at startup.

--- a/docs/rules/CL-0018.md
+++ b/docs/rules/CL-0018.md
@@ -52,6 +52,25 @@ services:
     user: "1000:1000"
 ```
 
+## Reading the failure (after switching to non-root)
+
+The flip side of this rule: once a service runs as a non-root `user:`, writes to root-owned paths fail with `Permission denied` (EACCES). The remedy depends on the **mount type** of the failing path. Busybox wordings are re-proven against a live container on every CI run (`scripts/validate_rule_premises.py`); coreutils variants were captured live but are not CI-asserted.
+
+| Symptom in logs (verbatim) | Failing path is… | Remedy |
+|---|---|---|
+| `touch: /etc/app.lock: Permission denied` (busybox) · `touch: cannot touch '/etc/app.lock': Permission denied` (coreutils) | a root-owned path in the image's filesystem | a `tmpfs:` entry with `uid=`/`gid=` options — see the tmpfs gotcha below |
+| same, under a bind mount | a host directory owned by another uid | `chown` the host directory to the container uid (the PUID/PGID convention exists for exactly this) |
+| same, under a named volume at a path that does **not** exist in the image | a fresh volume — Docker creates it root-owned | pre-create and pre-own the directory in the image build, or chown it once from a root one-shot container |
+| works on first deploy, fails after moving the volume | volume initialized from a *different* image's ownership | same remedies; volume ownership is set at first mount, not per-run |
+| `permission denied` binding a port below 1024 as non-root | not a filesystem problem | see [CL-0006](CL-0006.md)'s NET_BIND_SERVICE row — under default per-container network namespaces low ports need no privilege (Docker 20.10+); under `network_mode: host` grant the capability |
+
+Two facts behind those rows, both CI-proven:
+
+- **The tmpfs gotcha:** a tmpfs mounted over a directory that *exists in the image* inherits that directory's ownership and mode — so a bare `tmpfs:` entry over a root-owned dir is still unwritable for a non-root user. Give it `uid=`/`gid=` options (`/run:uid=1000,gid=1000`). A tmpfs at a path *absent* from the image defaults to mode `1777` and just works.
+- **Named-volume initial ownership:** a fresh volume mounted at a path absent from the image is root-owned; mounted over an existing image directory, Docker copies that directory's contents *and ownership* into the volume on first use. Where the image prepares the directory for its runtime uid, the copy-up does the right thing — otherwise you own the fixup.
+
+As with every hardening step here: after switching to non-root, **verify function, not just startup** — applications catch EACCES and quietly continue with uploads, caches, or state persistence disabled.
+
 ## See also
 
 - [CL-0010](CL-0010.md) — `userns_mode: host` (disables daemon-level userns-remap, related to the caveat above)

--- a/docs/rules/CL-0022.md
+++ b/docs/rules/CL-0022.md
@@ -51,3 +51,13 @@ tmpfs:
 ```
 
 There is no auto-fix: the option is set deliberately when present, so reverting it (which would break a workload that genuinely executes from the mount) is left to manual review.
+
+## Reading the failure
+
+If you arrived here from an error, it is probably this one — a binary or script refusing to run from a tmpfs. The busybox wording is re-proven against a live container on every CI run (`scripts/validate_rule_premises.py`); the exact prefix varies by shell.
+
+| Symptom in logs (verbatim) | What it means | Action — in this order |
+|---|---|---|
+| `sh: line 0: /scratch/busybox: Permission denied` executing a file that *is* executable (`x` bit set) from a tmpfs | the mount's default `noexec` blocked the exec — not a file-permission problem | **1.** relocate the executable into the image (bake it in at build time) or onto a named volume; **2.** only if the workload genuinely must write-then-execute on that path, add `:exec` — which is exactly what this rule flags, so pair it with a suppression carrying a documented reason |
+
+The trap is that the obvious fix (`:exec`) is the finding: a writable, executable, in-memory mount is the classic staging ground for a dropped payload, and doubly so under `read_only: true` (CL-0007), where tmpfs is often the only writable path. Treat `:exec` as a justified exception, not a fix. A related red herring: `chmod +x` appears to succeed on the tmpfs file and changes nothing — `noexec` is a property of the mount, not the file.

--- a/scripts/validate_rule_premises.py
+++ b/scripts/validate_rule_premises.py
@@ -554,6 +554,91 @@ def _t7_volume_writable() -> tuple[bool, str]:
     return ok, f"volume write rc={rc_vol}; rootfs write rc={rc_root} msg={err!r}"
 
 
+# --- CL-0012 / CL-0018 / CL-0022 symptom-table mappings (#479) --------------
+#
+# Same contract as the CL-0006/CL-0007 mapping checks (ADR-016 amendment).
+
+
+def _t12_fork_limit() -> tuple[bool, str]:
+    # 40 background forks against a pids limit of 10 must fail; the same storm
+    # under a sane limit must not. The busybox wording is the doc's quoted row.
+    fork_script = "for i in $(seq 1 40); do sleep 2 & done"
+    return _remedy(
+        ["--pids-limit", "10"],
+        ["--pids-limit", "100"],
+        ["sh", "-c", fork_script],
+        "can't fork: Resource temporarily unavailable",
+    )
+
+
+def _t22_exec_tmpfs() -> tuple[bool, str]:
+    # Exec from a default (noexec) tmpfs fails even though the file has the x
+    # bit; :exec permits it — which is exactly the option CL-0022 flags, so
+    # the doc frames the remedy as relocate-first, :exec-with-reason last.
+    exec_script = "cp /bin/busybox /scratch/busybox && /scratch/busybox true"
+    return _remedy(
+        ["--tmpfs", "/scratch"],
+        ["--tmpfs", "/scratch:exec"],
+        ["sh", "-c", exec_script],
+        "/scratch/busybox: Permission denied",
+    )
+
+
+def _t18_rootfs_write() -> tuple[bool, str]:
+    # Non-root write to a root-owned image path fails EACCES; the remedy row
+    # is a tmpfs with uid= — see _t18_tmpfs_inherits for why bare tmpfs isn't
+    # enough here.
+    return _remedy(
+        ["--user", "1000"],
+        ["--user", "1000", "--tmpfs", "/etc:uid=1000"],
+        ["touch", "/etc/app.lock"],
+        "touch: /etc/app.lock: Permission denied",
+    )
+
+
+def _t18_tmpfs_inherits() -> tuple[bool, str]:
+    # The doc's tmpfs gotcha, both halves: a tmpfs over an EXISTING image dir
+    # inherits that dir's root ownership (still unwritable for uid 1000),
+    # while a tmpfs at a path ABSENT from the image defaults to mode 1777.
+    rc_inherit, err = _run_err(
+        ["--user", "1000", "--tmpfs", "/etc"], ["touch", "/etc/app.lock"]
+    )
+    rc_fresh, _ = _run_err(
+        ["--user", "1000", "--tmpfs", "/newpath"], ["touch", "/newpath/x"]
+    )
+    ok = rc_inherit != 0 and "Permission denied" in err and rc_fresh == 0
+    return ok, (
+        f"tmpfs over /etc rc={rc_inherit} msg={err!r}; tmpfs at absent path "
+        f"rc={rc_fresh}"
+    )
+
+
+def _t18_volume_ownership() -> tuple[bool, str]:
+    # The doc's named-volume rows: a fresh volume at a path absent from the
+    # image is root-owned (non-root write fails), while a volume mounted over
+    # an existing image dir copies that dir's contents AND ownership on first
+    # use (busybox's /tmp is 1777, so the copy-up makes it writable).
+    def attempt(vol: str, mountpoint: str, path: str) -> tuple[int, str]:
+        subprocess.run(
+            ["docker", "volume", "create", vol], capture_output=True, timeout=90
+        )
+        try:
+            return _run_err(
+                ["--user", "1000", "-v", f"{vol}:{mountpoint}"], ["touch", path]
+            )
+        finally:
+            subprocess.run(
+                ["docker", "volume", "rm", vol], capture_output=True, timeout=90
+            )
+
+    rc_fresh, err = attempt("clpremise-cl0018-fresh", "/data", "/data/x")
+    rc_copyup, _ = attempt("clpremise-cl0018-copyup", "/tmp", "/tmp/x")
+    ok = rc_fresh != 0 and "Permission denied" in err and rc_copyup == 0
+    return ok, (
+        f"fresh volume rc={rc_fresh} msg={err!r}; copy-up volume rc={rc_copyup}"
+    )
+
+
 CHECKS: list[tuple[str, str, Callable[[], tuple[bool, str]]]] = [
     ("CL-0001", "docker socket mount is root-equivalent", _cl0001),
     ("CL-0002", "privileged grants full caps", _cl0002),
@@ -588,6 +673,12 @@ CHECKS: list[tuple[str, str, Callable[[], tuple[bool, str]]]] = [
     ("CL-0007", "map: mkdir EROFS -> tmpfs", _t7_mkdir_tmpfs),
     ("CL-0007", "map: masked ENOENT -> tmpfs mountpoint", _t7_tmpfs_creates_mountpoint),
     ("CL-0007", "premise: named volume writable under read_only", _t7_volume_writable),
+    # CL-0012 / CL-0018 / CL-0022 symptom-table mappings (#479).
+    ("CL-0012", "map: fork failure at pids limit", _t12_fork_limit),
+    ("CL-0022", "map: exec from noexec tmpfs", _t22_exec_tmpfs),
+    ("CL-0018", "map: non-root write to root-owned path", _t18_rootfs_write),
+    ("CL-0018", "premise: tmpfs inherits image-dir ownership", _t18_tmpfs_inherits),
+    ("CL-0018", "premise: named-volume initial ownership", _t18_volume_ownership),
 ]
 
 

--- a/src/compose_lint/rules/CL0002_privileged_mode.py
+++ b/src/compose_lint/rules/CL0002_privileged_mode.py
@@ -62,7 +62,9 @@ class PrivilegedModeRule(BaseRule):
                     "  cap_drop:\n"
                     "    - ALL\n"
                     "  cap_add:\n"
-                    "    - <SPECIFIC_CAP>"
+                    "    - <SPECIFIC_CAP>\n"
+                    "Devices need explicit devices: entries; to determine the\n"
+                    "capability set, see: compose-lint --explain CL-0006"
                 ),
                 references=[OWASP_REF, CIS_REF],
             )


### PR DESCRIPTION
Closes #479. One PR for the three rules (plus the CL-0002 rider) since they share `scripts/validate_rule_premises.py` and the CHANGELOG — same pattern as #469/#475.

## Highlights

- **CL-0012**: the fork-failure table row targets the chronic misdiagnosis — `bash: fork: retry: Resource temporarily unavailable` gets blamed on `ulimit -u` when it's the pids cgroup. Confirmation step (`pids.max` vs `pids.current`), sizing guidance, silent-degradation note (worker pools shrink quietly — threads count against the cgroup), and an explicit warning that `-1` re-opens the exposure the rule exists to prevent.
- **CL-0018**: `Permission denied` mapped **by mount type**, backed by two facts found empirically during probing and now CI-proven:
  - a tmpfs over an existing image dir **inherits that dir's root ownership** — bare `tmpfs:` doesn't help a non-root user; `uid=`/`gid=` does (a tmpfs at an absent path defaults `1777`);
  - named-volume initial ownership follows copy-up — fresh path ⇒ root-owned, over an image dir ⇒ ownership copied on first use.
- **CL-0022**: the naive fix (`:exec`) *is* the finding, so the action column is ordered: relocate the executable first; `:exec` only with a documented suppression reason. Plus the `chmod +x` red herring (noexec is a mount property, not a file bit).
- **CL-0002**: fix text now points at `--explain CL-0006` for determining the capability set (tests assert substrings only — unaffected).

## Verification

Full premise suite live against Docker 29.1.3: `PASS (36 premises validated)` (31 prior + 6 new — the `_t18_tmpfs_inherits` check proves both halves of the tmpfs gotcha in one row). Scoped gate green (`ruff`/`mypy --strict`/`pytest`). Busybox wordings CI-asserted; bash/coreutils variants captured live, not asserted (established convention). Multi-part `sh -c` scripts hoisted to locals per #476's CodeQL convention. Docs site redeploys on merge.