### PR TITLE
Correct CL-0003's compatibility claims and add its symptom guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- CL-0003's compatibility guidance claimed root-dropping entrypoints
+  (`gosu`/`su-exec`: postgres, redis, mysql, …) crash-loop under
+  `no-new-privileges` — **live-verified false**: nnp blocks privilege *gain*
+  at `execve` (sudo, setuid bits, file capabilities), not a root process's
+  downward `setuid()`, and a su-exec image (valkey) runs healthy under the
+  flag. The doc and fix text are rewritten around the verified semantics,
+  and a CI premise check now pins the drop-unaffected fact so the wrong
+  claim cannot silently return.
+
+### Changed
+
+- CL-0003 gains the "Reading the failure" treatment (the last rule from the
+  symptom-table survey): sudo's explicit nnp message (captured live), the
+  silent case — a setuid `execve` under nnp *succeeds* with privileges
+  unchanged (CI-proven: exit 0, euid intact), so failures surface later as
+  ordinary permission errors — the `NoNewPrivs` `/proc` confirmation step,
+  and an explicit warning not to confuse the crash-looping `cap_drop`
+  symptom (CL-0006's `SETUID` row) with this setting.
+
 ### Changed
 
 - CL-0012, CL-0018, and CL-0022 get the symptom → remedy treatment

--- a/docs/rules/CL-0003.md
+++ b/docs/rules/CL-0003.md
@@ -1,4 +1,4 @@
-# CL-0003: Privilege Escalation Not Blocked
+# CL-0003: no-new-privileges — blocking setuid/sudo privilege escalation
 
 **Severity:** MEDIUM
 
@@ -25,24 +25,27 @@ security_opt:
 
 ## Compatibility
 
-`no-new-privileges` blocks any privilege gain through `execve`, including the user-switching that many official images perform at startup. Applying it to those services will crash-loop the container.
+`no-new-privileges` blocks privilege **gain** at `execve()` — it does **not** block privilege *drop*. The distinction decides what breaks:
 
-Known-incompatible patterns:
+- **Unaffected: entrypoints that drop from `root` to an unprivileged user** via `gosu`/`su-exec` (official `postgres`, `redis`, `mysql`, `valkey`, …). A root process calling `setuid()` downward needs no `execve`-time gain, so `no_new_privs` never engages. Live-verified on both `valkey` and `postgres` (su-exec entrypoints): each runs healthy under `no-new-privileges` with its server processes as the unprivileged user and clean logs, and the drop path is re-proven against a live container on every CI run (`scripts/validate_rule_premises.py`). An earlier revision of this page claimed these images crash-loop — that was wrong.
+- **Affected: anything that needs to *gain* privilege after starting unprivileged** — `sudo`/`su` invoked by a non-root user, setuid-root helper binaries, and binaries carrying file capabilities (`setcap` xattrs; live-verified — the exec succeeds and the capability is silently not granted). The monitoring-agent case is the subtle one: netdata's `apps.plugin` is setuid root in its container image (live-verified on a running deployment), so under nnp the agent stays healthy while that collector quietly runs unprivileged.
+- Services that already run as a non-root user and never invoke a privilege-gaining helper are safe by construction.
 
-- Entrypoints that drop from `root` to an unprivileged user via `gosu` or `su-exec` — e.g. the official `postgres`, `redis`, and `mysql` images, `itzg/minecraft-server`, `itzg/mc-backup`.
-- Plugins or agents that rely on capability inheritance across `execve` — e.g. `netdata/netdata`.
+### Reading the failure
 
-Services that already start as a non-root user (`USER` in the Dockerfile, or `user:` in compose) and do not fork privileged helpers are safe.
+The trap is that **nnp rarely announces itself**: the `execve` of a setuid binary *succeeds* — the kernel just ignores the setuid bit and file capabilities, so the process runs with unchanged privileges and fails later with ordinary permission errors. CI re-proves this silence live (the setuid exec returns exit 0 with euid unchanged); the sudo wording below was captured from a live container but is not CI-asserted.
+
+| Symptom in logs (verbatim) | What happened | Action |
+|---|---|---|
+| `sudo: The "no new privileges" flag is set, which prevents sudo from running as root.` (newer sudo versions add: `If sudo is running in a container, you may need to adjust the container configuration to disable the flag.`) | sudo detects nnp explicitly — the friendly case | in-container `sudo` is a design smell: run the step as root before dropping privileges, or bake the permission in; remove nnp only with a documented suppression reason |
+| ordinary `Permission denied` / `Operation not permitted` from a helper that "should" be root, with **no** nnp mention | a setuid binary or `setcap`'d file executed fine but ran **unprivileged** — the silent case | confirm with `grep NoNewPrivs /proc/<pid>/status` (`1` = flag set), then redesign as above |
+| a monitoring agent runs "healthy" while privileged collectors report nothing | its setuid or `setcap`'d helpers silently ran unprivileged (both variants verified live; the setuid one is CI-proven) | same confirmation; grant the specific capability to the *container* (see [CL-0006](CL-0006.md)) instead of relying on in-image helpers, or accept the reduced collector set |
+
+Do **not** map a crash-looping `setuid: Operation not permitted` entrypoint failure to this setting — that is the `cap_drop: [ALL]` symptom ([CL-0006](CL-0006.md)'s `SETUID`+`SETGID` row); nnp leaves root's downward `setuid()` alone.
 
 ### How to test
 
-Add the setting, then run:
-
-```
-docker compose up
-```
-
-If the container exits immediately with a message like `operation not permitted` around `setuid`, `setgid`, or `execve`, the image is incompatible. Either remove the setting for that service or rebuild the image to start directly as the target user.
+Add the setting, `docker compose up`, and — because the failure mode is silent — **verify function, not just startup**: read the logs and exercise the service's privileged behaviors. A service that breaks is *gaining* privilege somewhere; find the helper, redesign it, and only suppress with a documented reason if the gain is genuinely required.
 
 ### Per-service handling
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,7 +42,7 @@ nav:
   - Rules:
       - CL-0001 Container runtime socket mounted: rules/CL-0001.md
       - CL-0002 Privileged mode enabled: rules/CL-0002.md
-      - CL-0003 Privilege escalation not blocked: rules/CL-0003.md
+      - CL-0003 no-new-privileges privilege escalation: rules/CL-0003.md
       - CL-0004 Image not pinned to version: rules/CL-0004.md
       - CL-0005 Ports bound to all interfaces: rules/CL-0005.md
       - CL-0006 No capability restrictions: rules/CL-0006.md

--- a/scripts/validate_rule_premises.py
+++ b/scripts/validate_rule_premises.py
@@ -39,8 +39,9 @@ if TYPE_CHECKING:
 IMAGE = (
     "busybox@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d"
 )
-# python:3.13-alpine — used only by the IPC_LOCK mapping check: proving the
-# mlockall(2) -> CAP_IPC_LOCK mapping needs a libc caller busybox doesn't ship.
+# python:3.13-alpine — for checks busybox can't express: syscalls needing a
+# libc caller (mlockall, clock_settime) and the CL-0003 setuid-interpreter
+# staging (python keeps its effective uid; busybox re-drops it).
 PY_IMAGE = (
     "python@sha256:399babc8b49529dabfd9c922f2b5eea81d611e4512e3ed250d75bd2e7683f4b0"
 )
@@ -48,15 +49,15 @@ PY_IMAGE = (
 _NON_RUNTIME = ["CL-0004", "CL-0014", "CL-0015", "CL-0019", "CL-0020", "CL-0021"]
 
 
-def _run(args: list[str], cmd: list[str]) -> tuple[int, str]:
-    """``docker run --rm <args> IMAGE <cmd>`` → (returncode, stdout).
+def _run(args: list[str], cmd: list[str], image: str = IMAGE) -> tuple[int, str]:
+    """``docker run --rm <args> <image> <cmd>`` → (returncode, stdout).
 
     Returns *stdout only*: the container echoes the value each check inspects,
     and ``docker`` itself writes warnings to stderr — folding stderr in here
     corrupted exact/suffix matches (e.g. a stderr warning after ``SOCKET``).
     """
     proc = subprocess.run(
-        ["docker", "run", "--rm", *args, IMAGE, *cmd],
+        ["docker", "run", "--rm", *args, image, *cmd],
         capture_output=True,
         text=True,
         timeout=90,
@@ -639,6 +640,55 @@ def _t18_volume_ownership() -> tuple[bool, str]:
     )
 
 
+# --- CL-0003 symptom mappings (#471 follow-on) ------------------------------
+#
+# Both checks use PY_IMAGE: staging a setuid interpreter needs a real ELF that
+# keeps its effective uid (python does; busybox re-drops for non-suid applets),
+# and alpine's su provides the root->nobody drop.
+
+_SUID_GAIN_SCRIPT = (
+    "PY=$(readlink -f $(command -v python3)); cp $PY /tmp/suidpy && "
+    "chmod u+s /tmp/suidpy && "
+    "su nobody -s /bin/sh -c '/tmp/suidpy -c \"import os;print(os.geteuid())\"'"
+)
+
+
+def _t3_setuid_inert() -> tuple[bool, str]:
+    # The doc's silent-failure claim: without nnp the staged setuid python
+    # gives nobody euid 0; WITH nnp the same execve SUCCEEDS (rc 0) but the
+    # setuid bit is ignored — euid stays 65534, and nothing errors.
+    rc_gain, out_gain = _run([], ["sh", "-c", _SUID_GAIN_SCRIPT], image=PY_IMAGE)
+    rc_nnp, out_nnp = _run(
+        ["--security-opt", "no-new-privileges"],
+        ["sh", "-c", _SUID_GAIN_SCRIPT],
+        image=PY_IMAGE,
+    )
+    ok = (
+        rc_gain == 0
+        and out_gain.strip() == "0"
+        and rc_nnp == 0
+        and out_nnp.strip() == "65534"
+    )
+    return ok, (
+        f"without nnp euid={out_gain!r} rc={rc_gain}; "
+        f"with nnp euid={out_nnp!r} rc={rc_nnp} (exec still succeeds)"
+    )
+
+
+def _t3_drop_unaffected() -> tuple[bool, str]:
+    # The compatibility claim this page once got wrong: a root entrypoint
+    # dropping to an unprivileged user (the gosu/su-exec pattern) works fine
+    # under no-new-privileges — nnp blocks execve-time GAIN, not setuid()
+    # drops. This check exists so that claim can never silently regress.
+    rc, out = _run(
+        ["--security-opt", "no-new-privileges"],
+        ["su", "nobody", "-s", "/bin/sh", "-c", "id -u"],
+        image=PY_IMAGE,
+    )
+    ok = rc == 0 and out.strip() == "65534"
+    return ok, f"root->nobody drop under nnp rc={rc} uid={out!r}"
+
+
 CHECKS: list[tuple[str, str, Callable[[], tuple[bool, str]]]] = [
     ("CL-0001", "docker socket mount is root-equivalent", _cl0001),
     ("CL-0002", "privileged grants full caps", _cl0002),
@@ -679,6 +729,9 @@ CHECKS: list[tuple[str, str, Callable[[], tuple[bool, str]]]] = [
     ("CL-0018", "map: non-root write to root-owned path", _t18_rootfs_write),
     ("CL-0018", "premise: tmpfs inherits image-dir ownership", _t18_tmpfs_inherits),
     ("CL-0018", "premise: named-volume initial ownership", _t18_volume_ownership),
+    # CL-0003 symptom mappings.
+    ("CL-0003", "map: setuid bit inert (and silent) under nnp", _t3_setuid_inert),
+    ("CL-0003", "premise: root privilege-drop unaffected by nnp", _t3_drop_unaffected),
 ]
 
 

--- a/src/compose_lint/rules/CL0003_no_new_privileges.py
+++ b/src/compose_lint/rules/CL0003_no_new_privileges.py
@@ -80,8 +80,10 @@ class NoNewPrivilegesRule(BaseRule):
                     "Add to your service:\n"
                     "  security_opt:\n"
                     "    - no-new-privileges:true\n"
-                    "Note: breaks images that switch users via "
-                    "gosu/su-exec — test first."
+                    "Blocks privilege GAIN at execve (sudo, setuid binaries,\n"
+                    "file capabilities) - failures are often silent. Root\n"
+                    "entrypoints that DROP to a user (gosu/su-exec) are\n"
+                    "unaffected. Details: compose-lint --explain CL-0003"
                 ),
                 references=[OWASP_REF, CIS_REF],
             )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -230,7 +230,10 @@ class TestCLI:
     def test_explain_prints_rule_doc(self) -> None:
         result = run_cli("--explain", "CL-0003")
         assert result.returncode == 0
-        assert "CL-0003: Privilege Escalation Not Blocked" in result.stdout
+        assert (
+            "CL-0003: no-new-privileges — blocking setuid/sudo privilege escalation"
+            in result.stdout
+        )
         assert "no-new-privileges:true" in result.stdout
 
     def test_explain_is_case_insensitive(self) -> None:


### PR DESCRIPTION
The last rule from the symptom-table survey — and it turned into a correction: **the existing doc's central compatibility claim was false.**

## The correction

The doc said gosu/su-exec entrypoints (postgres, redis, mysql, …) "will crash-loop" under `no-new-privileges`, and the fix text repeated it ("breaks images that switch users via gosu/su-exec"). Live evidence says otherwise: **nnp blocks privilege *gain* at `execve` — not a root process's downward `setuid()`**. Verified two ways:
- `valkey/valkey:8-alpine` (su-exec entrypoint) runs healthy under the flag, server process as the `valkey` user, clean logs;
- a minimal root→nobody drop under nnp succeeds (now a CI premise check, pinned so the wrong claim can't silently return).

The old "How to test" symptom (`operation not permitted` around `setuid` ⇒ incompatible) was CL-0006's `cap_drop` failure mode, not nnp's — the rewrite says so explicitly.

## What's new

- **Reading the failure table**: sudo's explicit message (`sudo: The \"no new privileges\" flag is set…` — captured live, with its container-hint second line), and the sharp case: **nnp failures are usually silent** — a setuid `execve` *succeeds* with privileges unchanged (CI-proven: exit 0, euid intact), so breakage surfaces later as ordinary permission errors. Confirmation step: `grep NoNewPrivs /proc/<pid>/status`. File-caps row covers the silent-collector-loss case (netdata-style), pointing at container-level `cap_add` (CL-0006) as the honest alternative.
- **Two premise checks** (38 total): setuid-inert-and-silent (three assertions: gain works without nnp, exec still rc 0 with nnp, euid unchanged), and drop-unaffected. `_run` gains an `image` param — PY_IMAGE stages the setuid interpreter since busybox re-drops effective uid for non-suid applets.
- **Fix text corrected** + `--explain CL-0003` pointer; H1 retitled as this rule's #471 slice, mkdocs nav label synced.
- CHANGELOG: the false-claim correction under **Fixed**, the new guidance under **Changed**.

## Verification

Full premise suite live against Docker 29.1.3: `PASS (38 premises validated)`. Scoped gate green. Doc site redeploys on merge.