### PR TITLE
Add Google Search Console site-verification file

### DIFF
--- a/docs/google0319e25860b14c3a.html
+++ b/docs/google0319e25860b14c3a.html
@@ -1,0 +1,1 @@
+google-site-verification: google0319e25860b14c3a.html


### PR DESCRIPTION
One file: `docs/google0319e25860b14c3a.html` → served at `https://tmatens.github.io/compose-lint/google0319e25860b14c3a.html` (verified present in a local mkdocs build). Enables Search Console ownership verification for the docs site; sitemap submission follows in the Search Console UI. The file must remain in place permanently — Google re-checks it periodically.