### PR TITLE
Phrase rule-doc headings for the queries users search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,36 @@ CONTRIBUTING.md is the source of truth for commits, signing, and PRs. Key points
 - All changes go through a PR, squash-merge to main
 - Releases: follow `docs/RELEASING.md` checklist — version lives in both `pyproject.toml` and `src/compose_lint/__init__.py`
 
+## Rule docs (docs/rules/)
+
+- H1 format: `# CL-XXXX: <directive> — <symptom phrasing>` (query-phrased, id first).
+  The docs-site `<title>` comes from the matching nav label in `mkdocs.yml` — keep
+  both in sync. `tests/test_cli.py` pins CL-0003's H1; update it if that changes.
+- "Reading the failure" symptom tables quote **verbatim, live-captured** error
+  strings. Busybox wordings must be re-proven by a mapping check in
+  `scripts/validate_rule_premises.py` (see the ADR-016 amendment); other wordings
+  (coreutils/bash/application) are captured-but-not-asserted and labeled as such.
+  Mechanism claims are observed against a live container, never reasoned from docs.
+- **Never add front matter** to any `docs/*.md` — `--explain` prints files raw.
+- The docs site builds from `docs/` on every main push (`docs` workflow →
+  GitHub Pages). `docs/google*.html` is the Search Console verification file and
+  must stay in place permanently.
+
+## Rule docs (docs/rules/)
+
+- H1 format: `# CL-XXXX: <directive> — <symptom phrasing>` (query-phrased, id first).
+  The docs-site `<title>` comes from the matching nav label in `mkdocs.yml` — keep
+  both in sync. `tests/test_cli.py` pins CL-0003's H1; update it if that changes.
+- "Reading the failure" symptom tables quote **verbatim, live-captured** error
+  strings. Busybox wordings must be re-proven by a mapping check in
+  `scripts/validate_rule_premises.py` (see the ADR-016 amendment); other wordings
+  (coreutils/bash/application) are captured-but-not-asserted and labeled as such.
+  Mechanism claims are observed against a live container, never reasoned from docs.
+- **Never add front matter** to any `docs/*.md` — `--explain` prints files raw.
+- The docs site builds from `docs/` on every main push (`docs` workflow →
+  GitHub Pages). `docs/google*.html` is the Search Console verification file and
+  must stay in place permanently.
+
 ## Dependency pinning
 
 Pin everything to an immutable ref. Renovate bumps the pins.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Rule-doc headings are now phrased for the queries users actually search
+  (issue #471): every `docs/rules/` H1 leads with the rule id then names the
+  directive and the symptom it produces (e.g. "CL-0007: read_only — fixing
+  'Read-only file system' errors"), and the docs-site nav labels — which set
+  each page's `<title>` — are synced to match. Affects the site, the GitHub
+  view, and `--explain` output; rule ids and content are unchanged.
+
 ### Fixed
 
 - CL-0003's compatibility guidance claimed root-dropping entrypoints

--- a/docs/rules/CL-0001.md
+++ b/docs/rules/CL-0001.md
@@ -1,4 +1,4 @@
-# CL-0001: Container Runtime Socket Mounted
+# CL-0001: Mounting the Docker socket (docker.sock) — root-equivalent access
 
 **Severity:** CRITICAL
 

--- a/docs/rules/CL-0002.md
+++ b/docs/rules/CL-0002.md
@@ -1,4 +1,4 @@
-# CL-0002: Privileged Mode Enabled
+# CL-0002: privileged: true — what it grants and how to replace it
 
 **Severity:** CRITICAL
 

--- a/docs/rules/CL-0004.md
+++ b/docs/rules/CL-0004.md
@@ -1,4 +1,4 @@
-# CL-0004: Image Not Pinned to Version
+# CL-0004: Unpinned image tags (implicit :latest)
 
 **Severity:** MEDIUM
 

--- a/docs/rules/CL-0005.md
+++ b/docs/rules/CL-0005.md
@@ -1,4 +1,4 @@
-# CL-0005: Ports Bound to All Interfaces
+# CL-0005: Ports published on 0.0.0.0 (all interfaces)
 
 **Severity:** HIGH
 

--- a/docs/rules/CL-0006.md
+++ b/docs/rules/CL-0006.md
@@ -1,4 +1,4 @@
-# CL-0006: No Capability Restrictions
+# CL-0006: cap_drop ALL — mapping “Operation not permitted” to capabilities
 
 **Severity:** MEDIUM
 

--- a/docs/rules/CL-0007.md
+++ b/docs/rules/CL-0007.md
@@ -1,4 +1,4 @@
-# CL-0007: Filesystem Not Read-Only
+# CL-0007: read_only — fixing “Read-only file system” errors
 
 **Severity:** MEDIUM
 

--- a/docs/rules/CL-0008.md
+++ b/docs/rules/CL-0008.md
@@ -1,4 +1,4 @@
-# CL-0008: Host Network Mode
+# CL-0008: network_mode: host — risks and alternatives
 
 **Severity:** HIGH
 

--- a/docs/rules/CL-0009.md
+++ b/docs/rules/CL-0009.md
@@ -1,4 +1,4 @@
-# CL-0009: Security Profile Disabled
+# CL-0009: Disabled seccomp and AppArmor profiles
 
 **Severity:** HIGH
 

--- a/docs/rules/CL-0010.md
+++ b/docs/rules/CL-0010.md
@@ -1,4 +1,4 @@
-# CL-0010: Host Namespace Sharing
+# CL-0010: Host PID, IPC, and UTS namespace sharing
 
 **Severity:** HIGH
 

--- a/docs/rules/CL-0011.md
+++ b/docs/rules/CL-0011.md
@@ -1,4 +1,4 @@
-# CL-0011: Dangerous Capabilities Added
+# CL-0011: Dangerous cap_add capabilities (SYS_ADMIN, SYS_PTRACE, NET_ADMIN)
 
 **Severity:** HIGH (CRITICAL when `cap_add: ALL` is used)
 

--- a/docs/rules/CL-0012.md
+++ b/docs/rules/CL-0012.md
@@ -1,4 +1,4 @@
-# CL-0012: PIDs Cgroup Limit Disabled
+# CL-0012: pids_limit disabled — fork bombs and “can't fork” errors
 
 **Severity:** MEDIUM
 

--- a/docs/rules/CL-0013.md
+++ b/docs/rules/CL-0013.md
@@ -1,4 +1,4 @@
-# CL-0013: Sensitive Host Path Mounted
+# CL-0013: Sensitive host paths bind-mounted into the container
 
 **Severity:** HIGH (CRITICAL when the entire host root filesystem is mounted)
 

--- a/docs/rules/CL-0014.md
+++ b/docs/rules/CL-0014.md
@@ -1,4 +1,4 @@
-# CL-0014: Logging Driver Disabled
+# CL-0014: Logging driver set to none
 
 **Severity:** MEDIUM
 

--- a/docs/rules/CL-0015.md
+++ b/docs/rules/CL-0015.md
@@ -1,4 +1,4 @@
-# CL-0015: Healthcheck Disabled
+# CL-0015: Healthcheck explicitly disabled
 
 **Severity:** LOW
 

--- a/docs/rules/CL-0016.md
+++ b/docs/rules/CL-0016.md
@@ -1,4 +1,4 @@
-# CL-0016: Dangerous Host Device Exposed
+# CL-0016: Dangerous host devices exposed via devices:
 
 **Severity:** HIGH
 

--- a/docs/rules/CL-0017.md
+++ b/docs/rules/CL-0017.md
@@ -1,4 +1,4 @@
-# CL-0017: Shared Mount Propagation
+# CL-0017: Shared bind-mount propagation
 
 **Severity:** MEDIUM
 

--- a/docs/rules/CL-0018.md
+++ b/docs/rules/CL-0018.md
@@ -1,4 +1,4 @@
-# CL-0018: Explicit Root User
+# CL-0018: user: root — and non-root “Permission denied” fixes
 
 **Severity:** MEDIUM
 

--- a/docs/rules/CL-0019.md
+++ b/docs/rules/CL-0019.md
@@ -1,4 +1,4 @@
-# CL-0019: Image Tag Without Digest
+# CL-0019: Image tags without digest pins (@sha256)
 
 **Severity:** MEDIUM
 

--- a/docs/rules/CL-0020.md
+++ b/docs/rules/CL-0020.md
@@ -1,4 +1,4 @@
-# CL-0020: Credential-Shaped Env Key With Literal Value
+# CL-0020: Credential-shaped environment keys with literal values
 
 **Severity:** HIGH
 

--- a/docs/rules/CL-0021.md
+++ b/docs/rules/CL-0021.md
@@ -1,4 +1,4 @@
-# CL-0021: Credential Embedded in Connection-String Env Value
+# CL-0021: Credentials embedded in connection-string values
 
 **Severity:** HIGH
 

--- a/docs/rules/CL-0022.md
+++ b/docs/rules/CL-0022.md
@@ -1,4 +1,4 @@
-# CL-0022: tmpfs mount re-enables exec/suid/dev
+# CL-0022: tmpfs exec — “Permission denied” running from tmpfs
 
 **Severity:** LOW
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,28 +40,28 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Rules:
-      - CL-0001 Container runtime socket mounted: rules/CL-0001.md
-      - CL-0002 Privileged mode enabled: rules/CL-0002.md
-      - CL-0003 no-new-privileges privilege escalation: rules/CL-0003.md
-      - CL-0004 Image not pinned to version: rules/CL-0004.md
-      - CL-0005 Ports bound to all interfaces: rules/CL-0005.md
-      - CL-0006 No capability restrictions: rules/CL-0006.md
-      - CL-0007 Filesystem not read-only: rules/CL-0007.md
-      - CL-0008 Host network mode: rules/CL-0008.md
-      - CL-0009 Security profile disabled: rules/CL-0009.md
-      - CL-0010 Host namespace sharing: rules/CL-0010.md
-      - CL-0011 Dangerous capabilities added: rules/CL-0011.md
-      - CL-0012 PIDs cgroup limit disabled: rules/CL-0012.md
-      - CL-0013 Sensitive host path mounted: rules/CL-0013.md
-      - CL-0014 Logging driver disabled: rules/CL-0014.md
-      - CL-0015 Healthcheck disabled: rules/CL-0015.md
-      - CL-0016 Dangerous host device exposed: rules/CL-0016.md
-      - CL-0017 Shared mount propagation: rules/CL-0017.md
-      - CL-0018 Explicit root user: rules/CL-0018.md
-      - CL-0019 Image tag without digest: rules/CL-0019.md
-      - CL-0020 Credential-shaped env key: rules/CL-0020.md
-      - CL-0021 Credential in connection string: rules/CL-0021.md
-      - CL-0022 tmpfs re-enables exec/suid/dev: rules/CL-0022.md
+      - "CL-0001 Docker socket (docker.sock) mounts": rules/CL-0001.md
+      - "CL-0002 privileged: true — grants and replacement": rules/CL-0002.md
+      - "CL-0003 no-new-privileges — privilege escalation": rules/CL-0003.md
+      - "CL-0004 Unpinned image tags (:latest)": rules/CL-0004.md
+      - "CL-0005 Ports published on 0.0.0.0": rules/CL-0005.md
+      - "CL-0006 cap_drop — Operation not permitted to capabilities": rules/CL-0006.md
+      - "CL-0007 read_only — Read-only file system errors": rules/CL-0007.md
+      - "CL-0008 network_mode: host": rules/CL-0008.md
+      - "CL-0009 Disabled seccomp / AppArmor profiles": rules/CL-0009.md
+      - "CL-0010 Host PID / IPC / UTS namespaces": rules/CL-0010.md
+      - "CL-0011 Dangerous cap_add capabilities": rules/CL-0011.md
+      - "CL-0012 pids_limit — fork failures": rules/CL-0012.md
+      - "CL-0013 Sensitive host bind mounts": rules/CL-0013.md
+      - "CL-0014 Logging driver none": rules/CL-0014.md
+      - "CL-0015 Healthcheck disabled": rules/CL-0015.md
+      - "CL-0016 Dangerous host devices": rules/CL-0016.md
+      - "CL-0017 Shared mount propagation": rules/CL-0017.md
+      - "CL-0018 user: root and non-root permission fixes": rules/CL-0018.md
+      - "CL-0019 Digest pinning (@sha256)": rules/CL-0019.md
+      - "CL-0020 Credential-shaped env keys": rules/CL-0020.md
+      - "CL-0021 Credentials in connection strings": rules/CL-0021.md
+      - "CL-0022 tmpfs exec — running from tmpfs": rules/CL-0022.md
   - Guides:
       - Configuration: configuration.md
       - Severity levels: severity.md


### PR DESCRIPTION
Closes #471 — the last piece of the docs/SEO arc.

## What

- All 21 remaining `docs/rules/` H1s retitled (CL-0003's shipped in #481): keep the `CL-XXXX:` prefix, then name the **directive + the symptom it produces** — e.g. `CL-0007: read_only — fixing \"Read-only file system\" errors`, `CL-0012: pids_limit disabled — fork bombs and \"can't fork\" errors`, `CL-0018: user: root — and non-root \"Permission denied\" fixes`. Headings carry the most ranking weight, and the symptom-table series' verbatim strings are the long-tail hooks these now match.
- `mkdocs.yml` nav labels synced to compact versions — they set each page's `<title>` (verified in a local build: `CL-0007 read_only — Read-only file system errors - compose-lint`).
- CHANGELOG entry. No rule ids, content, or metadata names changed; no code changes.

## Verification

- Local mkdocs build clean (only the pre-existing out-of-nav maintainer-doc warnings); spot-checked rendered `<title>`s.
- Full test suite green — the one H1-pinning test (`test_cli.py`, CL-0003) was already updated in #481; grep confirms no other file outside `docs/rules/` + CHANGELOG references the old titles.
- Docs site redeploys on merge.