### PR TITLE
Add a real-world examples library: CL-0001 as four escalating remediations

### DIFF
--- a/docs/examples/ci-runner-suppression/.compose-lint.yml
+++ b/docs/examples/ci-runner-suppression/.compose-lint.yml
@@ -1,0 +1,62 @@
+# A suppression written as a dated exception rather than a permanent silence.
+#
+# Three things distinguish it from the one in the portainer example:
+#
+#   1. It is scoped to the one service that needs it. CL-0001 stays enabled for
+#      the forge itself, so if the socket ever appears there it is a finding.
+#   2. It states the residual risk in the same breath as the justification, so
+#      a reader is not left thinking the suppression made the risk go away.
+#   3. It carries a review date. That is the part that is easy to skip and the
+#      part that decides whether this is an exception or an expiry-free waiver.
+#
+# Review date: 2027-02-08. On that date the question to answer is whether a
+# rootless or socket-proxy-backed runner has become viable for this workload,
+# not whether the requirement still exists — it will.
+
+rules:
+  CL-0001:
+    exclude_services:
+      forge-runner: >-
+        The runner creates a container per CI job, which requires the Docker
+        API; there is no filtered subset that permits container creation while
+        withholding host compromise, so a GET-only proxy cannot help here.
+        RESIDUAL RISK, ACCEPTED, NOT MITIGATED: anyone who can run CI on this
+        instance can reach the daemon and is effectively root on the host. This
+        is contained by restricting who can push to it, not by anything in this
+        file. Review 2027-02-08.
+
+  CL-0013:
+    exclude_services:
+      forge-runner: >-
+        The /var/run/docker.sock mount reported by the host-path rule is the
+        same finding as CL-0001 above.
+      forge: >-
+        /etc/timezone and /etc/localtime are read-only single files, mounted so
+        that timestamps in the UI and in commit metadata match the host.
+
+  CL-0018:
+    exclude_services:
+      forge-runner: >-
+        Runs as root plus the host docker group in order to open the socket.
+        Note that this is a consequence of the CL-0001 suppression above, not
+        an independent decision: fixing that one removes this one.
+
+  CL-0005:
+    exclude_services:
+      forge: >-
+        Git over SSH has to be reachable from every machine that pushes to this
+        forge, so the listener is deliberately not bound to loopback. Exposure
+        is bounded at the network edge instead — the port is not forwarded from
+        outside, and the forge's own SSH authentication is the access control.
+
+# Deliberately NOT suppressed: CL-0006 (cap_drop) and CL-0007 (read_only), which
+# both remain open as medium findings on both services.
+#
+# The honest reason is that neither fix has been tested against the forge's
+# first-boot behaviour or its backup path, and a suppression saying "pending
+# live-test" would be the same expiry-free waiver the portainer example in this
+# ladder exists to criticise. An open finding that is visible in every CI run is
+# a more accurate record of the state than a waiver that says the same thing
+# while turning the output green.
+#
+# Not every finding needs a suppression. Leaving one open is a valid answer.

--- a/docs/examples/ci-runner-suppression/docker-compose.yml
+++ b/docs/examples/ci-runner-suppression/docker-compose.yml
@@ -1,0 +1,72 @@
+name: forge
+
+# A self-hosted Git forge with a CI runner attached.
+#
+# The runner mounts the Docker socket because that is how it starts job
+# containers: each CI job runs in its own container, and creating containers
+# means calling the Docker API. Unlike the other examples in this ladder, there
+# is no version of this that removes the requirement — it is what the runner
+# does.
+#
+# So this is the honest case: the finding stays, the suppression is written
+# down with a date and a plan, and the residual risk is stated rather than
+# argued away.
+
+services:
+  forge:
+    image: codeberg.org/forgejo/forgejo:15@sha256:db04c7114b656f896e206ba3873fe8d3a7adf2daa44907037f0274f4ba653fb9
+    container_name: forge
+    volumes:
+      - forge-data:/data
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    environment:
+      - USER_UID=1000
+      - USER_GID=1000
+      - FORGEJO__server__DOMAIN=git.example.com
+      - FORGEJO__server__ROOT_URL=https://git.example.com/
+      - FORGEJO__service__DISABLE_REGISTRATION=true
+      # Block webhooks aimed at private and loopback addresses, so a repo
+      # webhook cannot be used to probe internal hosts from this container.
+      - FORGEJO__webhook__ALLOWED_HOST_LIST=external
+    ports:
+      - '2222:22'
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    healthcheck:
+      test: curl -sf http://localhost:3000/api/v1/version || exit 1
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  forge-runner:
+    image: code.forgejo.org/forgejo/runner:12.9.0@sha256:2860af6a7fa5521b2cdb26a14545c083ffd06b2528dbfc470cfec39a0b6bde39
+    container_name: forge-runner
+    depends_on:
+      - forge
+    volumes:
+      - forge-runner-data:/data
+      # The finding. Not fixable while this runner spawns job containers.
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - DOCKER_HOST=unix:///var/run/docker.sock
+    command: >-
+      sh -c '
+        if [ ! -f /data/.runner ]; then
+          forgejo-runner register --instance http://forge:3000 --token "$RUNNER_TOKEN" --no-interactive;
+        fi &&
+        forgejo-runner daemon
+      '
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    # Root, plus the host docker group, to open the socket. Worth being precise
+    # about what this does and does not buy: no-new-privileges above does not
+    # contain a process that can ask the daemon to start a privileged container
+    # for it. The user directive is not the boundary here — there isn't one.
+    user: "0:${DOCKER_GID}"
+
+volumes:
+  forge-data:
+  forge-runner-data:

--- a/docs/examples/ci-runner-suppression/index.md
+++ b/docs/examples/ci-runner-suppression/index.md
@@ -1,0 +1,74 @@
+# Rung 4 — Suppress it, with the risk written down
+
+**Verified against:** compose-lint 0.15.1, 2026-08-08
+
+A CI runner starts a container per job. Starting containers means calling `POST /containers/create` and `POST /containers/<id>/start`. There is no filtered subset of the Docker API that permits creating containers while withholding host compromise — the two are the same capability. `POST /containers/create` with a bind mount of `/` is the whole exploit, and it is also just how the runner does its job.
+
+So the [rung 3](../netdata-socket-proxy/index.md) proxy does not help here. This is the case where the finding is correct, unfixable in place, and gets suppressed. What separates a defensible suppression from the one in [rung 1](../portainer-removed/index.md) is entirely in how it is written.
+
+## The suppression
+
+```yaml
+rules:
+  CL-0001:
+    exclude_services:
+      forge-runner: >-
+        The runner creates a container per CI job, which requires the Docker
+        API; there is no filtered subset that permits container creation while
+        withholding host compromise, so a GET-only proxy cannot help here.
+        RESIDUAL RISK, ACCEPTED, NOT MITIGATED: anyone who can run CI on this
+        instance can reach the daemon and is effectively root on the host. This
+        is contained by restricting who can push to it, not by anything in this
+        file. Review 2027-02-08.
+```
+
+Three properties, against the rung-1 version:
+
+- **Scoped, not global.** CL-0001 stays enabled for the forge itself. If a socket mount ever appears there it is a finding, not a silence inherited from this entry.
+- **States the residual risk in the same breath.** Not "this is required, therefore fine" but "this is required, and here is what remains true afterwards". A reader who only reads the reason still learns that CI access equals host root here.
+- **Carries a review date.** Not a promise to migrate — rung 1 shows what those are worth — but a date on which someone is obliged to look again. The question on that date is whether a rootless runner has become viable for this workload, not whether the requirement still exists. It will.
+
+Note also that the control that actually bounds this risk is named, and it is not in the Compose file. It is who can push to the repository. A suppression that implies the risk is handled by configuration, when it is really handled by access policy somewhere else, is worse than no suppression at all.
+
+## The dependent finding
+
+```yaml
+  CL-0018:
+    exclude_services:
+      forge-runner: >-
+        Runs as root plus the host docker group in order to open the socket.
+        Note that this is a consequence of the CL-0001 suppression above, not
+        an independent decision: fixing that one removes this one.
+```
+
+Worth flagging as dependent rather than justifying separately. `user: "0:${DOCKER_GID}"` looks like its own decision and is not — it is downstream of the socket requirement. Suppressions that each look locally reasonable are how a file ends up with six of them and no one able to say which is load-bearing.
+
+The same goes for `no-new-privileges: true` on that service: it is set, it is not useless, and it does not contain a process that can ask the daemon to start a privileged container on its behalf. Controls that do not apply to the actual threat are worth being explicit about, or someone will read the file and conclude the runner is contained.
+
+## Four findings are left open on purpose
+
+```
+docker-compose.yml: 4 medium  ·  6 suppressed (not counted)
+```
+
+The open ones are CL-0006 (`cap_drop`) and CL-0007 (`read_only`), on both services. They are not suppressed, and the reason is written in the config:
+
+> The honest reason is that neither fix has been tested against the forge's first-boot behaviour or its backup path, and a suppression saying "pending live-test" would be the same expiry-free waiver the portainer example in this ladder exists to criticise. An open finding that is visible in every CI run is a more accurate record of the state than a waiver that says the same thing while turning the output green.
+
+This is the part most easily lost: **not every finding needs a suppression.** A waiver is a claim that you have considered the finding and decided. If you have not decided yet, an open medium finding is the truthful output, and it costs nothing as long as the failure threshold is set where you want it — here the gate is `--fail-on high`, so these four are visible without blocking.
+
+The failure mode a suppression file drifts into is one entry per finding, each individually defensible, collectively meaning the tool reports nothing. Leaving things open is the pressure valve against that.
+
+## Reading the ladder backwards
+
+If you arrived here because you have a socket mount and want to know what to write in your config, the honest advice is to check the three rungs above first:
+
+1. Is anything still using this service? ([rung 1](../portainer-removed/index.md))
+2. Does it need the API, or does it need *data* the runtime already publishes elsewhere? ([rung 2](../logging-without-the-socket/index.md))
+3. Does it need to read, or does it need to write? Read-only needs can be filtered down to a fraction of the API. ([rung 3](../netdata-socket-proxy/index.md))
+
+Rung 4 is for when all three answers are the wrong ones. It is a legitimate place to end up, and it should be the smallest category in your infrastructure rather than the default.
+
+## Scope note
+
+This example is de-identified: it is a representative self-hosted forge and runner pairing, with domains, addresses, network topology and identifiers replaced, and services unrelated to the CI path removed. The socket requirement, the root-plus-docker-group user and the suppression structure are as deployed.

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,0 +1,47 @@
+# Real-world examples
+
+Four Compose files that all trip the same rule — [CL-0001](../rules/CL-0001.md), the Docker socket mount — and four different correct answers.
+
+The rule text can tell you that mounting `/var/run/docker.sock` is root-equivalent. What it cannot tell you is which of these you are allowed to do about it, because that depends on what the service is for. These examples are drawn from stacks that are actually deployed and continuously linted, so the hardened files are what runs, not what a documentation author wished were running.
+
+## The ladder
+
+| | Example | Remediation | Result |
+|---|---|---|---|
+| 1 | [Delete the service](portainer-removed/index.md) | The socket was mounted for a management UI nobody was managing anything with | Finding gone, no suppression |
+| 2 | [Re-architect so the socket isn't needed](logging-without-the-socket/index.md) | Same job — reading container logs — done from the systemd journal instead of the Docker API | Finding gone, no suppression |
+| 3 | [Constrain it when the need is real](netdata-socket-proxy/index.md) | Container metrics genuinely require the Docker API, so a GET-only filtering proxy holds the socket | Suppressed for the proxy, still enforced everywhere else |
+| 4 | [Suppress it, with the risk written down](ci-runner-suppression/index.md) | A CI runner creates job containers; nothing removes that requirement | Suppressed with a review date and a stated residual risk |
+
+Read in order, they answer a question the rule docs cannot: the first question is never "how do I silence this", it is "which rung am I on".
+
+## What the linter says about each
+
+Every example ships the Compose file and the `.compose-lint.yml` that goes with it, so you can reproduce these numbers:
+
+```
+portainer-removed            exit=1   2 high            1 suppressed
+logging-without-the-socket   exit=0   0 issues          1 suppressed
+netdata-socket-proxy         exit=0   0 issues         14 suppressed
+ci-runner-suppression        exit=0   4 medium          6 suppressed
+```
+
+Two of these deserve comment, because they are the opposite of what a "findings went down" summary would suggest.
+
+**The socket-proxy example did not reduce its finding count.** Before hardening it reported 14 findings; after hardening it reports 14 findings. What changed is that the critical one moved from a container with host networking, the host PID namespace and an unconfined AppArmor profile, onto a scratch-image container that is read-only, capability-less and answers `403` to every API path it does not need. The number is identical and the blast radius is not. Counting findings is a bad proxy for security, and this is the clearest example of it we have.
+
+**The CI-runner example still has four open medium findings.** They are not suppressed, on purpose — see [that page](ci-runner-suppression/index.md). Leaving a finding open is a valid state, and often a more honest one than a waiver that says "pending investigation" and then does not expire.
+
+## How suppressions are written here
+
+Every suppression in these examples uses per-service `exclude_services` ([ADR-010](../adr/010-per-service-rule-overrides.md)) rather than a global `enabled: false`, including the cases where only one service exists today.
+
+A global disable switches the rule off for the whole file. In the socket-proxy example that would mean a later edit re-adding a direct socket mount to the metrics agent would lint clean — the exact regression the architecture was built to prevent, made invisible by the config that documents it. Scoping the suppression to the service that is supposed to hold the socket keeps the rule live for everything else.
+
+Suppressed findings still appear in the output, marked `SUPPRESSED` and carrying their reason, so what was waived stays auditable rather than disappearing.
+
+## On staleness
+
+Each page carries a "verified against" stamp naming the compose-lint version and the date its output was captured. The files come from deployed stacks, so they are re-linted whenever those stacks change, but the narrative around them is maintained by hand — if a stamp is old, treat the prose as older than the rule.
+
+Identifiers have been sanitized: hostnames, domains, addresses and paths are replaced. Sanitizing is done carefully, because it can change findings — replacing a `/home/...` bind mount with `/opt/...` silently removes a CL-0013 finding, which happened once while these examples were being written and was caught by re-linting the scrubbed file against the original.

--- a/docs/examples/logging-without-the-socket/.compose-lint.yml
+++ b/docs/examples/logging-without-the-socket/.compose-lint.yml
@@ -1,0 +1,15 @@
+# One suppression for the whole stack, and it is not CL-0001 — because after
+# the re-architecture there is no socket mount left to suppress.
+#
+# Scoped to the one service it applies to, so the rule stays live for loki and
+# grafana. Neither of them mounts a host path today, and if one starts, this
+# config will not hide it.
+
+rules:
+  CL-0013:
+    exclude_services:
+      alloy: >-
+        The two host mounts are the log source itself and are both read-only:
+        /var/log/journal is the systemd journal this collector exists to read,
+        and /etc/machine-id is the single file journal entries need in order to
+        resolve which host they came from. No writable host path is exposed.

--- a/docs/examples/logging-without-the-socket/docker-compose.yml
+++ b/docs/examples/logging-without-the-socket/docker-compose.yml
@@ -1,0 +1,115 @@
+name: observability
+
+# The stack that took over the job the socket-mounting management UI had been
+# doing: reading container logs and showing service status.
+#
+# Nothing here mounts /var/run/docker.sock. That is the entire point. Container
+# logs are read off the systemd journal, read-only, because the Docker daemon
+# is configured with the journald log driver — so the log data arrives without
+# anything having to speak to the Docker API at all.
+#
+# Excerpted from a deployed stack: services unrelated to the logging path have
+# been left out.
+
+services:
+  loki:
+    image: grafana/loki:3.7.2@sha256:191d4fdfb7264f16989f0a57f320872620a5a7c2ceeec6229212c4190ec49b86
+    container_name: loki
+    # Isolated off the default network so co-tenant containers cannot reach
+    # its query, push and delete APIs. Only its real clients join this network.
+    networks:
+      - loki_internal
+    command: -config.file=/etc/loki/config.yml -log.level=warn
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp
+    volumes:
+      - ./loki-config.yml:/etc/loki/config.yml:ro
+      - loki-data:/loki
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:13.0.2@sha256:5dad0df181cb644a14e13617b913b261a54f7d4fd4510721dba420929f35bea2
+    container_name: grafana
+    networks:
+      - default
+      - loki_internal
+    depends_on:
+      - loki
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - grafana-data:/var/lib/grafana
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
+      - GF_SERVER_ROOT_URL=https://grafana.example.com
+      - GF_AUTH_ANONYMOUS_ENABLED=false
+      - GF_SECURITY_COOKIE_SECURE=true
+      - GF_SECURITY_CONTENT_SECURITY_POLICY=true
+      - GF_USERS_ALLOW_SIGN_UP=false
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  alloy:
+    image: grafana/alloy:v1.16.2@sha256:32913cbfac652d15fa84d256a74e5ee3f71575961bb19d34796ce3838bfba693
+    container_name: alloy
+    networks:
+      - default
+      - loki_internal
+    # Non-root: the image's own alloy user, with the host's systemd-journal
+    # group as a supplementary group. The journal files are root:systemd-journal
+    # mode 0640, so group read is the entire access requirement — no capability
+    # and no root needed to collect every container's logs.
+    user: "473:473"
+    group_add:
+      - "999"
+    command:
+      - run
+      - /etc/alloy/config.alloy
+      - --storage.path=/tmp/alloy
+    depends_on:
+      - loki
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy:ro
+      # The read-only systemd journal. This is what replaces the Docker socket.
+      - /var/log/journal:/var/log/journal:ro
+      - /etc/machine-id:/etc/machine-id:ro
+    ports:
+      # Syslog listener for external network devices. Bound to one specific
+      # host interface, not 0.0.0.0: Docker's port publishing inserts DNAT
+      # rules that bypass host firewall rules, so the bind address is the
+      # control that actually holds here.
+      - "10.10.20.5:1514:1514/udp"
+    restart: unless-stopped
+
+networks:
+  default:
+    name: observability_default
+  loki_internal:
+    name: loki_internal
+
+volumes:
+  loki-data:
+  grafana-data:

--- a/docs/examples/logging-without-the-socket/index.md
+++ b/docs/examples/logging-without-the-socket/index.md
@@ -1,0 +1,78 @@
+# Rung 2 — Re-architect so the socket isn't needed
+
+**Verified against:** compose-lint 0.15.1, 2026-08-08
+
+The management UI in [rung 1](../portainer-removed/index.md) was mounting the Docker socket, but almost all of what it was used for was reading container logs and checking whether services were up. That is a data problem, not a control problem — and the data is available without the Docker API.
+
+This stack does the same job with no socket anywhere in it.
+
+## How
+
+Container logs reach this stack because the Docker daemon is configured to use the `journald` log driver, so every container's stdout is already in the systemd journal, tagged with the container name and its Compose project and service. A collector reads the journal off disk, read-only, and ships it to a log database that a dashboard queries.
+
+The Docker API is never involved. Nothing here needs to ask the daemon anything, because the daemon already wrote the data down.
+
+```yaml
+    # The read-only systemd journal. This is what replaces the Docker socket.
+    volumes:
+      - /var/log/journal:/var/log/journal:ro
+      - /etc/machine-id:/etc/machine-id:ro
+```
+
+The access requirement collapses to something very small. Journal files are `root:systemd-journal` mode `0640`, so *group read* is the entire permission needed to collect every container's logs. The collector therefore runs as the image's own unprivileged user with the host's `systemd-journal` group added:
+
+```yaml
+    user: "473:473"
+    group_add:
+      - "999"
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+```
+
+No capability, no root, no socket — to do the job that a moment ago justified root-equivalent access to the host.
+
+## What the linter says
+
+```
+docker-compose.yml: 0 issues  ·  1 suppressed (not counted)
+✓ PASS  ·  threshold: high
+```
+
+One finding, on the collector, for its two host mounts:
+
+```yaml
+rules:
+  CL-0013:
+    exclude_services:
+      alloy: >-
+        The two host mounts are the log source itself and are both read-only:
+        /var/log/journal is the systemd journal this collector exists to read,
+        and /etc/machine-id is the single file journal entries need in order to
+        resolve which host they came from. No writable host path is exposed.
+```
+
+Note what this suppression does *not* have to say. There is no residual risk paragraph, because there is no residual risk to state: the mount is read-only, it contains log data, and a compromise of this container yields the logs it was already reading. Compare that with the suppression in [rung 4](../ci-runner-suppression/index.md), which has to be explicit that the risk is accepted rather than mitigated. The difference in how those two reasons read is a decent smell test for which rung you are actually on.
+
+## Two details that are easy to get wrong
+
+**The port bind is doing real work.** The collector publishes a syslog listener for network devices, bound to one specific host address rather than `0.0.0.0`:
+
+```yaml
+    ports:
+      - "10.10.20.5:1514:1514/udp"
+```
+
+This is not cosmetic. Docker's port publishing inserts DNAT rules that are evaluated before host firewall rules, so a host firewall will not save a `0.0.0.0` publish. The bind address is the control that actually holds. See [CL-0005](../../rules/CL-0005.md).
+
+**The log database is on its own network.** It is reachable only by its actual clients, not by every co-tenant on the default network — an unauthenticated internal API is still an API.
+
+## When this rung applies
+
+Ask what the socket is being used to *learn*, and whether that information exists anywhere else. Logs, resource usage and container state are all published by the runtime through channels that are not the control API. If the answer is that the service needs to *do* something — create, start, stop, exec — no amount of re-architecting removes the requirement, and you are on [rung 3](../netdata-socket-proxy/index.md) or [rung 4](../ci-runner-suppression/index.md).
+
+## Scope note
+
+This file is excerpted from a larger deployed stack; services unrelated to the logging path have been left out, and identifiers are sanitized. The claim that nothing here mounts the socket was verified against the running containers, not just the file.

--- a/docs/examples/netdata-socket-proxy/.compose-lint.yml
+++ b/docs/examples/netdata-socket-proxy/.compose-lint.yml
@@ -1,0 +1,68 @@
+# Suppressions for the hardened stack.
+#
+# Every entry uses `exclude_services` (ADR-010) rather than a global
+# `enabled: false`. That distinction is the point of this file: a global
+# disable would switch CL-0001 off for the whole stack, so a future edit that
+# bind-mounts the Docker socket straight into netdata again would lint clean.
+# Scoping the suppression to the one service that is *supposed* to hold the
+# socket keeps the rule live everywhere else.
+#
+# Suppressed findings still appear in output, marked SUPPRESSED and carrying
+# the reason below, so a reviewer can see what was waived and why.
+
+rules:
+  CL-0001:
+    exclude_services:
+      docker-socket-proxy: >-
+        This service exists to hold the socket. It is the mitigation, not the
+        risk: scratch image, read_only, cap_drop ALL, no-new-privileges, runs
+        as nobody, and exposes only a GET-filtered subset of the API. Netdata
+        itself no longer mounts the socket, so CL-0001 stays enabled for it.
+
+  CL-0013:
+    exclude_services:
+      netdata: >-
+        Read-only mounts of /proc, /sys, /etc/os-release, /etc/passwd and
+        /etc/group are what a host-metrics agent is for — they are how process
+        metrics get attributed to real users and host processes.
+      docker-socket-proxy: >-
+        The /var/run/docker.sock mount is the same finding as CL-0001 above,
+        reported by the path rule. Same justification.
+
+  CL-0008:
+    exclude_services:
+      netdata: >-
+        Host network mode is required to see host interface metrics. Without
+        it the agent reports only its own veth pair.
+
+  CL-0010:
+    exclude_services:
+      netdata: >-
+        Host PID namespace is required to attribute metrics to host processes
+        rather than only container-internal ones.
+
+  CL-0009:
+    exclude_services:
+      netdata: >-
+        AppArmor unconfined is required for the /proc and /sys read access the
+        agent depends on under the host's default profile.
+
+  CL-0011:
+    exclude_services:
+      netdata: >-
+        DAC_OVERRIDE and SYS_PTRACE are both load-bearing and both were
+        confirmed by drop-testing. SYS_PTRACE in particular is needed to read
+        /proc/<pid>/io for setuid and non-dumpable processes. SYS_ADMIN was
+        dropped and is deliberately absent.
+
+  CL-0003:
+    exclude_services:
+      netdata: >-
+        The agent's plugins rely on capability inheritance across the
+        privilege drop at startup, which no-new-privileges prevents.
+
+  CL-0007:
+    exclude_services:
+      netdata: >-
+        The agent writes to /etc/netdata and /var/lib/netdata during startup.
+        The socket proxy, which has no such requirement, does set read_only.

--- a/docs/examples/netdata-socket-proxy/docker-compose.hardened.yml
+++ b/docs/examples/netdata-socket-proxy/docker-compose.hardened.yml
@@ -1,0 +1,90 @@
+name: netdata
+
+# AFTER — netdata no longer holds the Docker socket. A path-filtered, GET-only
+# socket proxy holds it and publishes a restricted unix socket that netdata
+# consumes over DOCKER_HOST.
+#
+# Every capability and mount below is annotated with why it survived. The
+# capability set was reduced by drop-testing against this image on a host with
+# a matching configuration — remove one, restart, look for the failure.
+
+services:
+  netdata:
+    image: netdata/netdata:v2.10.3@sha256:bcc822ec685dd7ee488e9f99b957f479b66301be04f13f346df692ad7de94151
+    container_name: netdata
+    volumes:
+      - ./netdata.conf:/etc/netdata/netdata.conf:ro
+      - netdata_lib:/var/lib/netdata
+      - netdata_cache:/var/cache/netdata
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /etc/os-release:/host/etc/os-release:ro
+      - /var/log:/host/var/log:ro
+      - /etc/group:/host/etc/group:ro
+      - /etc/passwd:/host/etc/passwd:ro
+      # NO /var/run/docker.sock. Netdata reads the filtered socket the proxy
+      # publishes into this directory instead.
+      - ./sockets:/sock
+    environment:
+      # Puts netdata's user in the host docker group — here that is only what
+      # lets it connect to the proxy's socket (mode 0660, group docker), not
+      # to the real Docker socket, which this container can no longer reach.
+      - PGID=${DOCKER_GID}
+      # Netdata's collectors honour DOCKER_HOST; for a socket path they issue
+      # requests over that unix socket, and only ever GET.
+      - DOCKER_HOST=unix:///sock/docker.sock
+    depends_on:
+      - docker-socket-proxy
+    network_mode: host
+    restart: unless-stopped
+    cap_drop:
+      - ALL
+    cap_add:
+      # Container exits without it.
+      - DAC_OVERRIDE
+      # Used once at startup to drop from root to the netdata user. Drop these
+      # and the agent silently keeps running as root — and the healthcheck
+      # still reports healthy, so nothing catches it.
+      - SETUID
+      - SETGID
+      # Per-process metrics read /proc/<pid>/io and /proc/<pid>/fd. Reading
+      # those for setuid or non-dumpable processes needs this capability even
+      # as root. Dropping it produced a silent partial failure — see the page.
+      - SYS_PTRACE
+      # NOT granted: SYS_ADMIN. This image ships no eBPF plugin, so the config
+      # option that appears to require it is a no-op and the capability gates
+      # nothing.
+    pid: host
+    security_opt:
+      - apparmor:unconfined
+
+  # The only container in this stack that touches the real Docker socket.
+  docker-socket-proxy:
+    image: wollomatic/socket-proxy:1@sha256:74e770f5ed3cfc9ecb6350e177d2aa55873568c85bc953079834e68607dbf71b
+    container_name: netdata-socket-proxy
+    # nobody, plus the host docker gid — needed only to open the real socket.
+    user: "65534:${DOCKER_GID}"
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./sockets:/sock
+    command:
+      - -loglevel=info
+      - -proxysocketendpoint=/sock/docker.sock
+      # 432 decimal = 0660 octal. The default (384 = 0600) leaves the socket
+      # owner-only and the consumer cannot connect.
+      - -proxysocketendpointfilemode=432
+      # Exactly the endpoints the consumer calls, and nothing else. Every other
+      # path answers 403; every write method answers 405.
+      - -allowGET=^(/v[0-9]+\.[0-9]+)?/(_ping|version|info|images/json(\?.*)?|containers/json(\?.*)?|containers/[a-zA-Z0-9_.-]+/json(\?.*)?)$$
+    restart: unless-stopped
+    # No healthcheck: this is a scratch image with no shell or HTTP client to
+    # run one with. Suppressed in .compose-lint.yml with that reason.
+
+volumes:
+  netdata_lib:
+  netdata_cache:

--- a/docs/examples/netdata-socket-proxy/docker-compose.yml
+++ b/docs/examples/netdata-socket-proxy/docker-compose.yml
@@ -1,0 +1,41 @@
+name: netdata
+
+# BEFORE — the arrangement this example replaces. Netdata mounts the Docker
+# socket directly, read-only, to collect container metrics.
+#
+# This file is here to be linted, not to be copied.
+
+services:
+  netdata:
+    image: netdata/netdata:v2.10.3@sha256:bcc822ec685dd7ee488e9f99b957f479b66301be04f13f346df692ad7de94151
+    container_name: netdata
+    volumes:
+      - ./netdata.conf:/etc/netdata/netdata.conf:ro
+      - netdata_lib:/var/lib/netdata
+      - netdata_cache:/var/cache/netdata
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /etc/os-release:/host/etc/os-release:ro
+      - /var/log:/host/var/log:ro
+      - /etc/group:/host/etc/group:ro
+      - /etc/passwd:/host/etc/passwd:ro
+      # The finding. `:ro` looks like it contains the risk. It does not.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      - PGID=${DOCKER_GID}
+    network_mode: host
+    restart: unless-stopped
+    cap_drop:
+      - ALL
+    cap_add:
+      - DAC_OVERRIDE
+      - SETUID
+      - SETGID
+      - SYS_PTRACE
+    pid: host
+    security_opt:
+      - apparmor:unconfined
+
+volumes:
+  netdata_lib:
+  netdata_cache:

--- a/docs/examples/netdata-socket-proxy/index.md
+++ b/docs/examples/netdata-socket-proxy/index.md
@@ -1,0 +1,121 @@
+# Rung 3 — Constrain it when the need is real
+
+**Verified against:** compose-lint 0.15.1, 2026-08-08
+
+A host-metrics agent needs the Docker API. Not log data, not "container state" in the abstract — it calls `/containers/json` to enumerate containers and `/containers/<id>/json` to map a cgroup back to a container name. There is no journal file that answers those, so [rung 2](../logging-without-the-socket/index.md) does not apply.
+
+The requirement is real and the remediation is still not "suppress it". It is to make the socket the agent can reach a strictly smaller thing than the socket.
+
+## `:ro` on a socket does not do what it looks like
+
+The starting file mounted the socket read-only, which reads as a mitigation and is not one:
+
+```yaml
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+```
+
+`:ro` applies to the socket *file*. It makes the inode non-writable. The Docker API is a request/response protocol over an open connection, and the daemon accepts `POST` regardless of the mount flag — `POST /containers/create` with a host bind mount and `POST /containers/<id>/start` is a two-call path to root on the host, and neither call writes to the socket file. This is covered in [CL-0001](../../rules/CL-0001.md); it is repeated here because it is the single most common misreading of this finding.
+
+## The architecture
+
+A filtering proxy holds the real socket and publishes a restricted one:
+
+```yaml
+  docker-socket-proxy:
+    user: "65534:${DOCKER_GID}"      # nobody, plus the docker group to open the socket
+    read_only: true
+    cap_drop: [ALL]
+    security_opt: [no-new-privileges:true]
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./sockets:/sock
+    command:
+      - -proxysocketendpoint=/sock/docker.sock
+      - -proxysocketendpointfilemode=432   # 0660; the 0600 default leaves the consumer unable to connect
+      - -allowGET=^(/v[0-9]+\.[0-9]+)?/(_ping|version|info|images/json(\?.*)?|containers/json(\?.*)?|containers/[a-zA-Z0-9_.-]+/json(\?.*)?)$$
+```
+
+and the agent consumes it by pointing `DOCKER_HOST` at the published socket instead of mounting the real one.
+
+### Why a unix socket rather than a loopback TCP port
+
+A TCP proxy would be simpler to wire up, and it is the wrong choice here. The agent runs with host networking, so a proxy on a bridge network would have to publish a host port — and `GET /containers/<id>/json`, which is on the allow-list because the agent genuinely needs it, returns `.Config.Env`: every container's environment variables, which is where secrets live.
+
+A `127.0.0.1:2375` listener would therefore expose every container's secrets to any local uid and any host-network container. The real socket is `root:docker` mode `0660`; a loopback port is a strictly wider audience than that. The unix socket keeps the audience identical to what it was.
+
+This is also the honest limit of this rung: the filtering converts "can take over the host" into "can read container names and environments". That is a large reduction and it is not zero.
+
+### The filter, verified
+
+Probed against the running proxy — status codes only, since some of these responses carry environment variables:
+
+```
+ALLOWED (what the agent actually calls):
+  GET    /_ping                                -> 200
+  GET    /version                              -> 200
+  GET    /info                                 -> 200
+  GET    /containers/json                      -> 200
+  GET    /images/json                          -> 200
+
+BLOCKED paths:
+  GET    /volumes                              -> 403
+  GET    /networks                             -> 403
+  GET    /secrets                              -> 403
+  GET    /containers/json/../../secrets        -> 403
+
+BLOCKED methods:
+  POST   /_ping                                -> 405
+  DELETE /_ping                                -> 405
+```
+
+The proxy logs each rejection, so attempts show up in the same log pipeline as everything else rather than failing silently.
+
+## The finding count did not go down
+
+Before: 14 findings. After: 14 findings.
+
+The critical one moved from the metrics agent — host network, host PID namespace, unconfined AppArmor, several sensitive host mounts — to a scratch-image container that is read-only, has no capabilities, runs as `nobody` and answers `403` to everything it does not need. Same number, different blast radius.
+
+If you are tracking a finding count as a security metric, this refactor is invisible to you. That is a problem with the metric.
+
+## Capabilities, and a failure the healthcheck did not catch
+
+The capability set was reduced by drop-testing: remove one, restart, see what breaks. Two results are worth writing down because in both cases *the container stayed healthy while being wrong*.
+
+**`SYS_PTRACE`.** An earlier, more aggressive reduction dropped it. Per-process metrics then failed for privileged processes — reading `/proc/<pid>/io` for a setuid or non-dumpable process requires the capability even as root — and the agent logged a flood of permission errors while its healthcheck continued to report healthy. The drop-test that approved the change had only verified reading the agent's *own* processes, which are dumpable and need no capability. The test was passing on an unrepresentative case.
+
+**`SETUID` / `SETGID`.** These are used exactly once, at startup, to drop from root to the agent's user. Drop them and the agent silently continues as root — still healthy, still collecting metrics, no longer dropping privileges. A hardening change that quietly *removes* the privilege drop is the worst possible outcome, and nothing in the container's own status reports it.
+
+The signature to alert on is not the message, it is the errno. Over the last 30 days of logs from the current configuration:
+
+```
+     0  Cannot process /host/proc/<pid>/... + errno 13 (Permission denied)   <- the regression
+  2549  Cannot process /host/proc/<pid>/... + errno  3 (No such process)     <- benign race
+```
+
+Same message text. The benign one fires thousands of times a month because processes exit between enumeration and read. Anyone grepping for the message string rather than the errno would drown in false positives and conclude the alert was useless.
+
+`SYS_ADMIN` was also dropped and deliberately stays absent: the image ships no eBPF plugin, so the config option that appears to require it is a no-op and the capability gated nothing.
+
+## The suppressions
+
+Every entry is scoped with `exclude_services` rather than globally disabled — including CL-0001, which is suppressed **only** for the proxy:
+
+```yaml
+rules:
+  CL-0001:
+    exclude_services:
+      docker-socket-proxy: >-
+        This service exists to hold the socket. It is the mitigation, not the
+        risk: scratch image, read_only, cap_drop ALL, no-new-privileges, runs
+        as nobody, and exposes only a GET-filtered subset of the API. Netdata
+        itself no longer mounts the socket, so CL-0001 stays enabled for it.
+```
+
+A global `enabled: false` would have been shorter and would have quietly re-permitted the exact thing this architecture exists to prevent: a later edit re-adding a direct socket mount to the agent would lint clean. The scoped form keeps the rule live for every other service in the file. See [ADR-010](../../adr/010-per-service-rule-overrides.md).
+
+The remaining suppressions cover what a host-metrics agent inherently needs — host networking for interface metrics, host PID for process attribution, read-only `/proc`, `/sys`, `/etc/passwd` and `/etc/group` to attribute metrics to real users, and an unconfined AppArmor profile for that access. Each is scoped to the agent, so the proxy is still held to the default standard, which it meets.
+
+## Scope note
+
+Files are sanitized: hostnames, paths and the docker group id are replaced. The finding set of the sanitized file was compared against the deployed original and is identical — 14 findings, same rules, same services. Capability and mount claims were verified against the running containers.

--- a/docs/examples/portainer-removed/.compose-lint.yml
+++ b/docs/examples/portainer-removed/.compose-lint.yml
@@ -1,0 +1,16 @@
+# The suppression that used to live alongside the service above.
+#
+# Kept here deliberately, as an artifact rather than a recommendation. It is a
+# realistic example of the most common way a CL-0001 suppression goes wrong:
+# it is not false, and it is not lazy — it names the requirement and commits to
+# a fix. It just has no date, no owner, and nothing that ever reopens it. A
+# suppression like this is indistinguishable from a permanent one after a few
+# months, because in practice that is what it is.
+#
+# The rule was eventually resolved by deleting the service, not by the migration
+# this file promised.
+
+rules:
+  CL-0001:
+    enabled: false
+    reason: "Portainer requires Docker socket to manage containers — socket proxy migration planned"

--- a/docs/examples/portainer-removed/docker-compose.yml
+++ b/docs/examples/portainer-removed/docker-compose.yml
@@ -1,0 +1,37 @@
+name: portainer
+
+# The service this example is about — a container-management UI holding the
+# Docker socket. It is reproduced here as it actually ran, hardened in every
+# way except the one that mattered, so that the finding can be read against a
+# realistic file rather than a strawman.
+#
+# It is no longer deployed. See the page for what replaced it.
+
+services:
+  portainer:
+    image: portainer/portainer-ce:lts@sha256:1ae8e65d50ca5498cb2c33e617495a1e3ef245b0d2392b4a44c70ae09b822891
+    container_name: portainer
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp
+    volumes:
+      # cap_drop ALL, no-new-privileges and read_only above are all real
+      # hardening, and none of them constrain this line at all.
+      - /var/run/docker.sock:/var/run/docker.sock
+      - portainer_data:/data
+      - /home/deploy/.local/bin/curl-static:/curl:ro
+    command: --trusted-origins portainer.example.com
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "/curl", "-sfk", "https://localhost:9443"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+volumes:
+  portainer_data:

--- a/docs/examples/portainer-removed/index.md
+++ b/docs/examples/portainer-removed/index.md
@@ -1,0 +1,54 @@
+# Rung 1 — Delete the service
+
+**Verified against:** compose-lint 0.15.1, 2026-08-08
+
+The cheapest fix for a critical finding is the one nobody proposes: stop running the thing.
+
+This example is a container-management UI that mounted the Docker socket. It was hardened in every way its own documentation suggests — `cap_drop: ALL`, `no-new-privileges`, `read_only: true`, a tmpfs for `/tmp`, an image pinned by digest — and every one of those controls is irrelevant to the finding, because none of them constrain what a process can ask the Docker daemon to do once it can reach the socket.
+
+## What the linter says
+
+```
+  service: portainer  (line 24)
+    line  severity    rule     message
+      24  CRITICAL    CL-0001  Docker runtime socket mounted via
+                               '/var/run/docker.sock:/var/run/docker.sock'. This gives the
+                               container full control over the Docker runtime — equivalent
+                               to root on the host.
+      24  HIGH        CL-0013  Service mounts sensitive host path '/var/run/docker.sock'
+                               (under /var/run). This exposes host system files to the
+                               container.
+      26  HIGH        CL-0013  Service mounts sensitive host path
+                               '/home/deploy/.local/bin/curl-static' (under /home).
+```
+
+The third finding is worth a moment. A static `curl` binary was bind-mounted from the host purely so the healthcheck had something to run, because the image ships no shell. It is unrelated to the socket, and it is the kind of thing that accumulates around a service you are keeping alive.
+
+## The suppression that was there
+
+```yaml
+rules:
+  CL-0001:
+    enabled: false
+    reason: "Portainer requires Docker socket to manage containers — socket proxy migration planned"
+```
+
+This is not a lazy suppression. It is accurate — the tool genuinely does require the socket — and it commits to a fix. It is still the failure mode to learn from, for three reasons:
+
+- **It is global.** `enabled: false` disables CL-0001 for the entire file, not just this service.
+- **It has no date and no owner.** "Planned" is not a state anything can transition out of.
+- **Nothing ever reopened it.** The migration it promised was never done. What actually resolved the finding was noticing, much later, that the service had not been used to manage anything in months.
+
+A suppression with an indefinite promise in it is indistinguishable from a permanent one after a few months, because that is what it has become.
+
+## The fix
+
+The service was removed. The log- and status-viewing that it was genuinely still used for moved to a stack that does not need the Docker API at all — that is [rung 2](../logging-without-the-socket/index.md).
+
+There is no hardened file in this directory, because the hardened version of this service is its absence.
+
+## The question to ask first
+
+Before asking how to constrain a socket mount, it is worth asking what the service is still doing for you. Management UIs, one-off debugging tools and "we set this up to try it" containers are heavily represented among socket mounts, and they are the population where the answer is most often "nothing, any more".
+
+Rungs 2 through 4 are for when the answer is not "nothing".

--- a/docs/rules/CL-0001.md
+++ b/docs/rules/CL-0001.md
@@ -64,5 +64,6 @@ This is the fix recommended in canonical Traefik / portainer-with-proxy guides. 
 
 ## See also
 
+- [Real-world examples](../examples/index.md) — four deployed stacks that trip this rule and the four different correct answers: delete the service, re-architect so the socket isn't needed, constrain it behind a GET-only proxy, or suppress it with the residual risk written down
 - [CL-0013](CL-0013.md) — `/var/run` host mount (parent directory of the socket)
 - [CL-0011](CL-0011.md) — `cap_add: ALL` is functionally similar in blast radius

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,12 @@ nav:
       - "CL-0020 Credential-shaped env keys": rules/CL-0020.md
       - "CL-0021 Credentials in connection strings": rules/CL-0021.md
       - "CL-0022 tmpfs exec — running from tmpfs": rules/CL-0022.md
+  - Examples:
+      - "Real-world examples": examples/index.md
+      - "1 — Delete the service": examples/portainer-removed/index.md
+      - "2 — Re-architect so the socket isn't needed": examples/logging-without-the-socket/index.md
+      - "3 — Constrain it when the need is real": examples/netdata-socket-proxy/index.md
+      - "4 — Suppress it, with the risk written down": examples/ci-runner-suppression/index.md
   - Guides:
       - Configuration: configuration.md
       - Severity levels: severity.md


### PR DESCRIPTION
Builds the first tranche of the real-world examples library. Refs #111.

Four deployed stacks that all trip [CL-0001](https://github.com/tmatens/compose-lint/blob/main/docs/rules/CL-0001.md), and the four different correct answers:

| | Example | Remediation | Linter result |
|---|---|---|---|
| 1 | Delete the service | A management UI nobody was managing anything with | `exit=1`, 2 high — the unfixed state, kept as the "before" |
| 2 | Re-architect | Same job (reading container logs) done from the systemd journal | `exit=0`, 1 suppressed |
| 3 | Constrain | Metrics genuinely need the Docker API → GET-only filtering proxy | `exit=0`, 14 suppressed |
| 4 | Suppress | A CI runner creates job containers; nothing removes that | `exit=0`, 6 suppressed, **4 left open on purpose** |

### Why this shape

The original issue framed the library as a teaching surface for suppression semantics. Showing the same rule at four remediation levels turns out to teach more, because the reader's real question is not *what* CL-0001 flags — it is *which of these four am I allowed to do*. Rung 4 is deliberately the last resort rather than the default.

Three things the rule docs cannot show, which only fell out of using real files:

- **The socket-proxy refactor did not reduce the finding count** — 14 before, 14 after. What changed is that the critical finding moved off a host-network, host-PID, AppArmor-unconfined container and onto a read-only scratch container with no capabilities. If you track finding counts as a security metric, this refactor is invisible to you.
- **Two capability drops produce a silently healthy container.** Dropping `SYS_PTRACE` breaks per-process metrics for privileged processes while the healthcheck still passes; dropping `SETUID`/`SETGID` means the agent silently keeps running as root, also healthy. The alertable signature is the errno, not the message — over 30 days of the current config: 0 occurrences of the regression signature (errno 13) against 2549 of the benign race (errno 3) sharing the same message text.
- **Not every finding needs a suppression.** Rung 4 leaves CL-0006 and CL-0007 open rather than waiving them "pending live-test", because that is the same expiry-free waiver rung 1 exists to criticise.

### Verification

- **Sanitization**: every sanitized file was re-linted against its deployed original and the finding sets compared on (rule, severity, service). Both comparable pairs are identical. This check earned its keep immediately — an early scrub relocating a bind mount from `/home/...` to `/opt/...` silently deleted a CL-0013 finding, since the rule treats `/home` as sensitive and `/opt` as not.
- **Live state**: capability sets, `read_only`, mounts and network/PID modes were checked against the running containers rather than inferred from the files (projected fields only — never a raw `docker inspect`, which would dump environment variables).
- **The proxy's filter was probed live**, status codes only since some of those responses carry `.Config.Env`: allowed endpoints 200, `/volumes` `/networks` `/secrets` and a path-traversal attempt 403, `POST`/`DELETE` 405. That table is in the page.
- **Docs build**: local `mkdocs build` with the hash-pinned toolchain. Each page publishes to `/examples/<name>/` with its Compose files copied alongside; no new link warnings. `.compose-lint.yml` files are dotfiles and mkdocs skips them, so every page also shows its config inline.
- `ruff check src/ tests/` clean, 1070 passed / 6 skipped.

Docs only — no engine, rule, or CI changes.