### PR TITLE
Add three examples beyond the CL-0001 ladder

### DIFF
--- a/docs/examples/clean-edge-proxy/.compose-lint.yml
+++ b/docs/examples/clean-edge-proxy/.compose-lint.yml
@@ -1,0 +1,20 @@
+# One rule, one service. The auth service is not listed anywhere in this file,
+# because it needs nothing waived.
+
+rules:
+  CL-0005:
+    exclude_services:
+      proxy: >-
+        Public ingress has to accept connections from the network, so 80 and 443
+        are published. Re-examined rather than assumed, because "must bind all
+        interfaces" is imprecise — it could bind a single address; the question
+        is whether that would close anything. On this host it would not. There
+        is exactly one routable interface, so 0.0.0.0 adds only loopback and the
+        docker bridge gateways over a specific bind, and both were probed from
+        containers: 443 is already unreachable via the host address, via a
+        bridge gateway, and from a fully isolated network, while 80 answers only
+        a redirect to HTTPS. Narrowing the bind would delete this finding
+        without closing a reachable path, while risking ingress for every
+        service behind the proxy. Certificates use the DNS-01 challenge, so port
+        80 is not needed for issuance either — it exists solely for the redirect
+        and is the thing to drop if this finding ever needs closing outright.

--- a/docs/examples/clean-edge-proxy/docker-compose.yml
+++ b/docs/examples/clean-edge-proxy/docker-compose.yml
@@ -1,0 +1,95 @@
+name: edge
+
+# The public entry point: a reverse proxy terminating TLS for every service
+# behind it, plus the forward-auth service that gates the private ones.
+#
+# This is the example with almost nothing to suppress. It is here because a
+# library of hardening stories is misleading if every entry needs six waivers.
+#
+# Excerpted: the proxy attaches to one docker network per backend stack; the
+# list is trimmed here to two for readability.
+
+services:
+  proxy:
+    build: .
+    container_name: proxy
+    cap_drop:
+      - ALL
+    cap_add:
+      # The only capability it needs, and only because it binds 80 and 443.
+      - NET_BIND_SERVICE
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp
+      - /run
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - proxy_data:/data
+      - proxy_config:/config
+    environment:
+      # Certificates are issued over the DNS-01 challenge, so this token is the
+      # only inbound-facing credential and port 80 is never used for issuance.
+      - DNS_API_TOKEN=${DNS_API_TOKEN}
+    ports:
+      - '80:80'
+      - '443:443'
+    networks:
+      - backend_a
+      - backend_b
+      - auth-net
+    restart: unless-stopped
+    healthcheck:
+      test: curl -sf http://localhost:2019/config/ || exit 1
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  auth:
+    image: authelia/authelia:4@sha256:1b363e9279e742397966333f364e0876ae02bf5c876de73e83af6d48c57ff51b
+    container_name: auth
+    # The image entrypoint chowns /config and drops privileges with su-exec,
+    # which needs CHOWN, SETUID and SETGID. Rather than grant those back, the
+    # binary is invoked directly: the process stays root but holds NO
+    # capabilities at all, under a read-only root. See the page.
+    entrypoint: ['authelia', '--config', '/config/configuration.yml']
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp
+    volumes:
+      - ./auth/configuration.yml:/config/configuration.yml:ro
+      - ./auth/users_database.yml:/config/users_database.yml:ro
+      - auth_data:/data
+    environment:
+      - AUTHELIA_IDENTITY_VALIDATION_RESET_PASSWORD_JWT_SECRET=${AUTH_JWT_SECRET}
+      - AUTHELIA_SESSION_SECRET=${AUTH_SESSION_SECRET}
+      - AUTHELIA_STORAGE_ENCRYPTION_KEY=${AUTH_STORAGE_KEY}
+    networks:
+      # Only the proxy needs to reach it, so it joins one internal network and
+      # publishes no ports at all.
+      - auth-net
+    restart: unless-stopped
+    healthcheck:
+      test: ['CMD', 'wget', '-q', '--tries=1', '--spider', 'http://localhost:9091/api/health']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+networks:
+  backend_a:
+    external: true
+  backend_b:
+    external: true
+  auth-net:
+    driver: bridge
+
+volumes:
+  proxy_data:
+  proxy_config:
+  auth_data:

--- a/docs/examples/clean-edge-proxy/index.md
+++ b/docs/examples/clean-edge-proxy/index.md
@@ -1,0 +1,85 @@
+# The clean one
+
+**Verified against:** compose-lint 0.15.1, 2026-08-08
+
+Every other example in this library is a story about a finding. This one is here because a library made only of those teaches the wrong lesson — that real infrastructure inevitably needs a pile of waivers, and that a suppression file with six entries is just how it goes.
+
+It isn't. This is the public entry point for every service in the deployment, and its entire suppression file covers **one rule on one service**:
+
+```
+docker-compose.yml: 0 issues  ·  2 suppressed (not counted)
+```
+
+The two suppressed findings are ports 80 and 443 on the proxy. The forward-auth service alongside it produces **no findings at all** and appears nowhere in the config.
+
+## What a zero-finding service looks like
+
+```yaml
+  auth:
+    entrypoint: ['authelia', '--config', '/config/configuration.yml']
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp
+    networks:
+      - auth-net        # reachable only by the proxy; publishes nothing
+```
+
+No capabilities at all — not `cap_drop: ALL` with add-backs, but `cap_drop: ALL` full stop. Read-only root, no published ports, one internal network, secrets by environment reference, image pinned by digest.
+
+## The trick worth stealing
+
+That `entrypoint:` line is doing the work, and it is the most transferable thing on this page.
+
+The stock image entrypoint chowns `/config` and drops privileges using `su-exec`. That sequence needs `CHOWN`, `SETUID` and `SETGID`. With those dropped, the container crash-loops before the application starts — and the obvious response is to add the three capabilities back, which is what most hardening guides end up doing.
+
+The alternative is to skip the entrypoint and exec the binary directly. The process then runs as root **with no capabilities**, under a read-only root filesystem, and never needs to drop privileges because it never gains any.
+
+That trade is worth being precise about, because "runs as root" sounds worse than "drops to an unprivileged user":
+
+| | stock entrypoint | direct exec |
+|---|---|---|
+| final user | unprivileged | root |
+| capabilities held | whatever was granted to enable the drop | **none** |
+| `CHOWN`/`SETUID`/`SETGID` | required | not granted |
+| root filesystem | writable for the chown | read-only |
+
+Root without capabilities is a much weaker position than the name suggests. Nearly everything root can normally do — bind low ports, override file permissions, change ownership, signal other processes, load modules — *is* a capability, and this process has none of them. Meanwhile the privilege-dropping path requires handing the container three capabilities during the window when it is still root, one of which (`SETUID`) is exactly what an attacker wants.
+
+This only works when the image's setup step is unnecessary in your deployment. Here it is: the config files are read-only bind mounts owned correctly on the host, so nothing needs chowning. Check that before copying — if the entrypoint is doing real initialisation, skipping it will fail in a less obvious way than a crash loop.
+
+## The one waiver, and why it stays
+
+Ports 80 and 443 bind all interfaces. The original reason said they "must" — which is imprecise, since they could bind a single address. The right question is whether narrowing would close anything.
+
+Probed from containers, rather than assumed:
+
+```
+container -> host address:443       unreachable
+container -> bridge gateway:443     unreachable      already blocked at the firewall
+isolated container -> gateway:443   unreachable
+container -> bridge gateway:80      HTTP 308         the HTTPS redirect, nothing else
+```
+
+The host has exactly one routable interface, so `0.0.0.0` adds only loopback and the docker bridge gateways over a specific bind — and 443 is already unreachable by every container path tested, while 80 serves only a redirect.
+
+So narrowing the bind would **remove the finding without closing a reachable path**, while putting ingress for every service behind this proxy at risk. The waiver stays, and now says that instead of asserting necessity.
+
+This is the mirror of a problem described in the [multi-service example](../read-only-multi-service/index.md#when-the-number-and-the-posture-disagree): there, hardening made the linter's output worse. Here, improving the linter's output would not harden anything. Both are cases where the count and the posture point different directions, and the count is the one that deserves less trust.
+
+Also recorded in the suppression: certificates are issued over the DNS-01 challenge, so port 80 is not needed for issuance. It exists purely for the HTTP-to-HTTPS redirect. That is the lever if this finding ever has to be closed outright — drop the port, lose the redirect.
+
+## What made this one easy
+
+Nothing here was hard-won. The proxy needs one capability because it binds low ports, and it needs open ports because it is the front door. Everything else — read-only roots, no extra capabilities, no host mounts, digest pins, an internal-only network for the auth service — was available from the start.
+
+The contrast with the rest of this library is the point. The stacks that needed waivers needed them because of what the software does: an agent that reads host processes, a runner that creates containers, an init system that writes to its own directory. Where the software has no such requirement, the hardened configuration is not a compromise and the suppression file stays nearly empty.
+
+If your edge proxy has six waivers, that is worth a look. This one manages with one, and the one is a deliberate decision with the evidence written down.
+
+## Scope note
+
+Sanitized: hostnames, domains, addresses and credential names are replaced, and the proxy's per-backend network list is trimmed to two entries for readability. Capabilities, `read_only`, the entrypoint override and the port configuration are as deployed; both containers were running in that configuration and healthy when the reachability probes above were taken.

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,8 +1,8 @@
 # Real-world examples
 
-Four Compose files that all trip the same rule — [CL-0001](../rules/CL-0001.md), the Docker socket mount — and four different correct answers.
+Compose files from stacks that are actually deployed and continuously linted, so the hardened versions are what runs rather than what a documentation author wished were running.
 
-The rule text can tell you that mounting `/var/run/docker.sock` is root-equivalent. What it cannot tell you is which of these you are allowed to do about it, because that depends on what the service is for. These examples are drawn from stacks that are actually deployed and continuously linted, so the hardened files are what runs, not what a documentation author wished were running.
+The library is in two parts. **The ladder** is four files that all trip the same rule — [CL-0001](../rules/CL-0001.md), the Docker socket mount — and four different correct answers to it, because the rule text can tell you a socket mount is root-equivalent but not which remediation your service is allowed. **Beyond the ladder** is three stacks chosen for lessons the ladder doesn't reach: two rules that cannot both be satisfied, a waiver whose premise was true and whose conclusion wasn't, and one stack that needed almost nothing waived at all.
 
 ## The ladder
 
@@ -15,6 +15,16 @@ The rule text can tell you that mounting `/var/run/docker.sock` is root-equivale
 
 Read in order, they answer a question the rule docs cannot: the first question is never "how do I silence this", it is "which rung am I on".
 
+## Beyond the ladder
+
+Three more stacks, each carrying a lesson the ladder doesn't.
+
+| Example | The lesson |
+|---|---|
+| [Two rules in tension](read-only-in-tension/index.md) | Satisfying one rule means violating another. Buying a read-only root by accepting a CL-0022 — a medium traded for a low. |
+| [A true premise and a false conclusion](read-only-multi-service/index.md) | A four-service stack whose waiver said read-only was impossible because the services write to volumes. True, and it doesn't follow: volumes stay writable. |
+| [The clean one](clean-edge-proxy/index.md) | The public entry point, with one waiver for the whole stack and a forward-auth service that holds *no capabilities at all*. |
+
 ## What the linter says about each
 
 Every example ships the Compose file and the `.compose-lint.yml` that goes with it, so you can reproduce these numbers:
@@ -24,6 +34,9 @@ portainer-removed            exit=1   2 high            1 suppressed
 logging-without-the-socket   exit=0   0 issues          1 suppressed
 netdata-socket-proxy         exit=0   0 issues         14 suppressed
 ci-runner-suppression        exit=0   4 medium          6 suppressed
+read-only-in-tension         exit=0   0 issues          2 suppressed
+read-only-multi-service      exit=0   0 issues          3 suppressed
+clean-edge-proxy             exit=0   0 issues          2 suppressed
 ```
 
 Two of these deserve comment, because they are the opposite of what a "findings went down" summary would suggest.

--- a/docs/examples/read-only-in-tension/.compose-lint.yml
+++ b/docs/examples/read-only-in-tension/.compose-lint.yml
@@ -1,0 +1,24 @@
+# Two waivers, and the first one exists *because* of a hardening decision rather
+# than in spite of one. That is the whole subject of this example.
+
+rules:
+  CL-0022:
+    exclude_services:
+      homeassistant: >-
+        Deliberate, and the price of read_only. s6-overlay execs its init from
+        /run, so under a read-only root that mount must permit execution; with
+        Docker's default noexec the container dies at
+        "/run/s6/basedir/bin/init: Permission denied" before the application
+        starts. Only /run carries :exec — /tmp is a plain tmpfs and keeps
+        noexec. This waiver REPLACED a CL-0007 one: a low finding in exchange
+        for a read-only root filesystem.
+
+  CL-0011:
+    exclude_services:
+      homeassistant: >-
+        Two capabilities added back after cap_drop ALL, both confirmed by
+        removing them and observing the failure. DAC_OVERRIDE: the application
+        runs as root with no privilege drop and writes into a bind mount owned
+        by another user. NET_RAW: required by the DHCP discovery integration,
+        which opens an AF_PACKET socket. The other twelve Docker defaults stay
+        dropped.

--- a/docs/examples/read-only-in-tension/docker-compose.yml
+++ b/docs/examples/read-only-in-tension/docker-compose.yml
@@ -1,0 +1,54 @@
+name: home_assistant
+
+# A home-automation server behind a reverse proxy. It runs its own s6 init as root
+# and cannot be pinned to a non-root user, so the hardening available here is
+# capabilities, no-new-privileges, a read-only root, and tight resource limits.
+#
+# The interesting line is the tmpfs. See the page.
+
+services:
+  homeassistant:
+    image: ghcr.io/home-assistant/home-assistant:stable@sha256:adb3341e31e03e0048e60d8c1cf952e118a381ae258bb921d3da12a3b27bf0c2
+    container_name: homeassistant
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      # The only capability the application core needs. It runs as root under s6
+      # with no privilege drop, and writes its database, .storage and logs into a
+      # bind mount owned by a different user, so it needs to bypass that
+      # directory's permission bits.
+      - DAC_OVERRIDE
+      # Required by the DHCP discovery integration, which opens an AF_PACKET
+      # socket. Without it the log shows "Cannot watch for dhcp packets:
+      # [Errno 1] Operation not permitted". Enabled because this install uses
+      # that integration — a different install would not need it.
+      - NET_RAW
+    read_only: true
+    # /run must permit execution. s6-overlay execs its init from there, and with
+    # Docker's default noexec the container dies before the application starts.
+    # /tmp is a plain tmpfs and keeps the secure default — only /run needs the
+    # exception, and narrowing it to one mount is the point.
+    tmpfs:
+      - "/run:exec"
+      - /tmp
+    volumes:
+      - ./config:/config
+    environment:
+      # Timezone by environment variable rather than a host bind of
+      # /etc/localtime — one fewer host path in the container.
+      - TZ=America/Chicago
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8123/manifest.json').status==200 else 1)"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 90s
+    deploy:
+      resources:
+        limits:
+          memory: 1g
+          cpus: '1.50'
+          pids: 512

--- a/docs/examples/read-only-in-tension/index.md
+++ b/docs/examples/read-only-in-tension/index.md
@@ -1,0 +1,82 @@
+# Two rules in tension — buying `read_only` with a CL-0022
+
+**Verified against:** compose-lint 0.15.1, 2026-08-08
+
+Most hardening advice reads as though the rules point the same direction. Sometimes satisfying one means violating another, and the useful skill is deciding which finding you would rather have.
+
+This service runs its own s6 init as root and cannot be pinned to a non-root user, so a read-only root filesystem is one of the few controls genuinely available to it. Applying it requires accepting a different finding.
+
+## The failure that looks like a dead end
+
+Adding `read_only: true` with an ordinary tmpfs for `/run` kills the container before the application starts:
+
+```
+/package/admin/s6-overlay/libexec/stage0: exec: line 83: /run/s6/basedir/bin/init: Permission denied
+```
+
+The chain is worth following, because every step is correct:
+
+1. s6-overlay execs its init from `/run`.
+2. Under a read-only root, `/run` has to be a tmpfs to be writable at all.
+3. Docker mounts every tmpfs `noexec` by default — see [CL-0022](../../rules/CL-0022.md).
+4. So the init binary is present, executable, owned correctly, and refused.
+
+This is the exact trap CL-0022's own docs describe: a file with the execute bit set, refused by the *mount*, where `chmod +x` changes nothing because the restriction is not on the file.
+
+## Where the reasoning usually goes wrong
+
+It is easy to stop here and record "`read_only` is impractical for this image". That conclusion was, in fact, recorded for this stack for months, on the strength of a real boot test that produced exactly the error above.
+
+The step that does not hold is the assumption that Compose cannot ask for anything else. It can:
+
+```yaml
+    tmpfs:
+      - "/run:exec"
+      - /tmp
+```
+
+The list form takes mount options and passes them through. Verified against a running container:
+
+```
+tmpfs: ["/run:exec"]  ->  /run rw,nosuid,nodev,relatime          noexec absent
+tmpfs: [/tmp]         ->  /tmp rw,nosuid,nodev,noexec,relatime   noexec present
+```
+
+The size-and-mode-only limitation that the old note relied on is real, but it belongs to the **long** `volumes: [{type: tmpfs}]` form, which is a different syntax. With `:exec` on `/run`, the container boots normally.
+
+A sound observation, a correct mechanism, and a conclusion that reached one step too far. That combination is far more common than a careless waiver, and much harder to notice.
+
+## What it costs, stated honestly
+
+`:exec` re-enables execution on a writable in-memory filesystem. That is a genuine weakening and CL-0022 exists to flag it. The finding does not go away — it is traded:
+
+```
+before:  CL-0007  medium   writable root filesystem
+after:   CL-0022  low      /run permits execution
+```
+
+Both files also carry an unrelated CL-0011 for the capability add-backs, unchanged by any of this.
+
+The trade is worth taking. Before, the *entire* root filesystem was writable, and a tmpfs at `/run` was writable and executable anyway once the container booted. After, exactly one mount is writable-and-executable and everything else is read-only. The attack surface strictly shrinks, and this time the linter agrees — a medium becomes a low.
+
+That agreement is not guaranteed. Hardening can move the output the wrong way; there is [an example of that](../read-only-multi-service/index.md#when-the-number-and-the-posture-disagree) elsewhere in this library. Here the number and the posture move together, which is the easy case.
+
+## Scoping the exception
+
+Only `/run` gets `:exec`. `/tmp` is listed as a plain tmpfs and keeps `noexec`, `nosuid` and `nodev`:
+
+```yaml
+    tmpfs:
+      - "/run:exec"     # s6 execs its init from here
+      - /tmp            # secure defaults, nothing runs from here
+```
+
+This matters more than it looks. The reflex when hitting the error is to make the whole thing permissive, or to drop `read_only` entirely and move on. Neither is necessary. The exception is one mount wide, and the suppression says which one and why — so a reviewer can see the scope of what was given up rather than inferring it.
+
+## When to reach for this
+
+Ask whether the finding you are about to accept is *smaller* than the one you are closing. Here a low replaces a medium and the writable surface shrinks from a whole filesystem to one directory, so the answer is clear. If accepting CL-0022 had meant `:exec` on a mount that untrusted input can write to, the answer would be the opposite — and the right move would have been to leave `read_only` off and say so.
+
+## Scope note
+
+Sanitized: hostnames, domains and paths are replaced. The boot behaviour, capability set and tmpfs configuration are as deployed, and all three states in this page — as-deployed, `read_only` with a plain tmpfs, and `read_only` with `/run:exec` — were boot-tested against the pinned digest above rather than reasoned about.

--- a/docs/examples/read-only-multi-service/.compose-lint.yml
+++ b/docs/examples/read-only-multi-service/.compose-lint.yml
@@ -1,0 +1,32 @@
+# One waiver for a four-service stack.
+#
+# There used to be a second, for CL-0007, saying the server, worker and database
+# "write to data and cache volumes so cannot be fully read_only". It was deleted
+# rather than reworded — see the page. Volumes stay writable under read_only.
+
+rules:
+  CL-0011:
+    exclude_services:
+      database: >-
+        DAC_OVERRIDE is required and was confirmed in the DEPLOYED posture, not
+        inferred from upstream guidance. The data directory is a host bind owned
+        by the database uid with mode 700, so the entrypoint — which starts as
+        root — cannot traverse it without the capability; dropping it fails at
+        "find: /var/lib/postgresql/data: Permission denied". Note that testing
+        this against a NAMED VOLUME instead of a bind reports the capability as
+        removable, which is a false negative: the mount type is the whole
+        difference. CHOWN, SETUID and SETGID complete the set the official
+        Postgres entrypoint needs to initialise and drop to its own user.
+
+  CL-0019:
+    exclude_services:
+      server: >-
+        A waiver that survived scrutiny, recorded here because not every one
+        does. These two images are tracked by an automated update tool through a
+        custom matcher whose pattern ends in a version-tag capture — appending a
+        digest stops that pattern matching, so pinning by digest would silently
+        end version tracking rather than add to it. The tool is also configured
+        with digest pinning explicitly disabled, to match how this upstream
+        publishes releases. Real tooling constraint, not a preference.
+      machine-learning: >-
+        Same matcher and the same constraint as the server above.

--- a/docs/examples/read-only-multi-service/docker-compose.yml
+++ b/docs/examples/read-only-multi-service/docker-compose.yml
@@ -1,0 +1,132 @@
+name: photos
+
+# A self-hosted photo library: application server, database, cache, and a
+# machine-learning worker. Every one of the four runs with a read-only root
+# filesystem. The data they write lives in volumes, which stay writable.
+#
+# Excerpted from a deployed stack; a tailnet sidecar unrelated to the story has
+# been left out.
+
+services:
+  database:
+    image: ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0@sha256:bcf63357191b76a916ae5eb93464d65c07511da41e3bf7a8416db519b40b1c23
+    container_name: photos_db
+    cap_drop:
+      - ALL
+    cap_add:
+      # The data directory is a host bind owned by the database uid with mode
+      # 700. The entrypoint starts as root and cannot traverse it without this.
+      # Confirmed by removing it — see the page for why the obvious test of
+      # that claim gives the wrong answer.
+      - DAC_OVERRIDE
+      - CHOWN
+      - SETUID
+      - SETGID
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    # /etc/postgresql ships EMPTY in this image — the entrypoint copies a config
+    # template in at runtime — so a tmpfs here masks nothing.
+    tmpfs:
+      - /run
+      - /tmp
+      - /etc/postgresql
+    volumes:
+      - ${DB_DATA_LOCATION}:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_USER: ${DB_USERNAME}
+      POSTGRES_DB: ${DB_DATABASE_NAME}
+      POSTGRES_INITDB_ARGS: '--data-checksums'
+    healthcheck:
+      test: pg_isready -d ${DB_DATABASE_NAME} -U ${DB_USERNAME}
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: always
+
+  cache:
+    image: docker.io/valkey/valkey:9@sha256:4963247afc4cd33c7d3b2d2816b9f7f8eeebab148d29056c2ca4d7cbc966f2d9
+    container_name: photos_cache
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETUID
+      - SETGID
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    # Cache data is ephemeral by design, so it lives on a tmpfs rather than a
+    # volume — the strongest form of "this container writes nothing durable".
+    tmpfs:
+      - /data
+    # Requires a password: an unauthenticated co-tenant on the shared network
+    # otherwise had zero-auth reach to the cache's admin commands.
+    command: ["valkey-server", "--requirepass", "${CACHE_PASSWORD}"]
+    healthcheck:
+      # Auth-agnostic: a NOAUTH reply still proves the server is accepting
+      # connections, so the check works without putting the password in argv.
+      test: ["CMD-SHELL", "redis-cli ping 2>&1 | grep -qE 'PONG|NOAUTH'"]
+    restart: always
+
+  server:
+    image: ghcr.io/immich-app/immich-server:v3.1.0
+    container_name: photos_server
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp
+      - /run
+    depends_on:
+      database:
+        condition: service_healthy
+      cache:
+        condition: service_healthy
+    volumes:
+      # Uploads, thumbnails and transcodes all land here. A volume, so it stays
+      # writable under read_only — which is the whole point of this example.
+      - ${UPLOAD_LOCATION}:/data
+    env_file:
+      - .env
+    restart: always
+    healthcheck:
+      disable: false
+
+  machine-learning:
+    image: ghcr.io/immich-app/immich-machine-learning:v3.1.0-openvino
+    container_name: photos_ml
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp
+      - /run
+    volumes:
+      - model-cache:/cache
+    env_file:
+      - .env
+    environment:
+      # Under read_only a plotting library in the dependency tree cannot create
+      # its cache in the home directory and warns on every start before falling
+      # back to a random /tmp path. Pointing it at the tmpfs makes that explicit
+      # and keeps a recurring warning out of the logs.
+      MPLCONFIGDIR: /tmp/matplotlib
+    devices:
+      - /dev/dri:/dev/dri
+    restart: always
+    healthcheck:
+      disable: false
+    deploy:
+      resources:
+        limits:
+          memory: 4g
+          cpus: '2.0'
+
+volumes:
+  model-cache:

--- a/docs/examples/read-only-multi-service/index.md
+++ b/docs/examples/read-only-multi-service/index.md
@@ -1,0 +1,96 @@
+# A true premise and a false conclusion
+
+**Verified against:** compose-lint 0.15.1, 2026-08-08
+
+A four-service stack — application server, database, cache, machine-learning worker — where every service runs with a read-only root filesystem. For a long time its config said that was impossible:
+
+> Server/ML/db write to named data/cache volumes so cannot be fully read_only
+
+The first half is true. All three write constantly: uploads, thumbnails, transcodes, database pages, model caches. The second half does not follow from it, because **`read_only` does not affect volumes.** It makes the container's own image layer read-only. Every volume and bind mount stays exactly as writable as it was.
+
+The waiver was deleted rather than reworded. All four services were already able to do this.
+
+## Why this kind of error survives
+
+Nothing about the stack looked wrong. The reason was written by someone who knew what the services do, it named a real behaviour, and every run linted clean. A reader checking it would think about whether those services write data — they obviously do — and move on.
+
+The failure is one step upstream of the evidence: it is a claim about what `read_only` *means*, and no amount of looking at the application tells you that. This is the same shape as the [rules-in-tension example](../read-only-in-tension/index.md), where a correct boot test carried a conclusion one step too far.
+
+## What each service actually needed
+
+Three of the four needed nothing beyond `read_only` and a tmpfs for scratch space. The database needed one more thing:
+
+```yaml
+    read_only: true
+    tmpfs:
+      - /run
+      - /tmp
+      - /etc/postgresql      # ships EMPTY; the entrypoint copies a template in at runtime
+```
+
+That third entry is worth checking before copying. A tmpfs over a directory **masks whatever the image ships there** — the mistake that broke an earlier attempt at this on a different service, where a tmpfs over an init system's directory hid the service definitions and produced a container that ran and served nothing. Here the directory is genuinely empty in the image and populated at runtime, so a tmpfs is exactly right. Verify that before assuming.
+
+The cache service goes further and puts its *data* on a tmpfs, since it holds nothing durable:
+
+```yaml
+    read_only: true
+    tmpfs:
+      - /data
+```
+
+That is the strongest available statement of "this container writes nothing that outlives it".
+
+## Testing a photo library means uploading a photo
+
+`read_only` on an application server is exactly the kind of change that starts cleanly and fails on the first real write. A container that boots and answers its health endpoint proves very little — several examples in this library exist because a green container was hiding missing functionality.
+
+So the verification was an actual upload against a scratch instance:
+
+```
+login:          OK
+upload:         {"id":"f10b3bed-...","status":"created"}
+asset on disk:  /data/upload/9a8bdd45-.../8cbbd832-....jpg
+dirs created:   backups encoded-video library profile thumbs upload
+read-only fs errors: 0
+```
+
+All six data directories created, the asset written and readable. That is the evidence that `read_only` is safe here — not the health check.
+
+The database was checked the same way: inserts, all three vector extensions available, and a successful `CHECKPOINT` to force a real write through to the volume.
+
+## The waiver that nearly got deleted by a bad test
+
+The database keeps `DAC_OVERRIDE`, and the honest version of how that was confirmed is more useful than the conclusion.
+
+The first test dropped the capability against a scratch instance with a **named volume**. It started fine, so the capability looked removable — a finding that would have been written up confidently.
+
+Production does not use a named volume. It binds a host directory owned by the database uid with mode `700`. Re-run that way:
+
+```
+with DAC_OVERRIDE     READY
+without DAC_OVERRIDE  FAILED — find: '/var/lib/postgresql/data': Permission denied
+```
+
+The entrypoint starts as root, and root without `DAC_OVERRIDE` cannot traverse a directory it does not own with mode 700. Docker creates named volumes with ownership that makes the problem disappear, so the wrong mount type produces a clean, confident, wrong answer.
+
+The suppression records that, so the next person to re-derive it does not repeat the shortcut.
+
+## When the number and the posture disagree
+
+Worth knowing before hardening a service that currently has no `cap_drop` at all: dropping capabilities can make the linter's output *worse*.
+
+A service with no `cap_drop` holds roughly fourteen default capabilities, several of them dangerous, and reports a single CL-0006 **medium**. Convert it to `cap_drop: ALL` plus explicit add-backs and any dangerous capability you keep becomes a CL-0011 **high** — a strictly smaller set of privileges, reported more severely, because the implicit ones were never visible and the explicit one is.
+
+That happened on a different stack in this library and is being tracked upstream. It does not apply to this example — the database's `DAC_OVERRIDE` was always explicit — but it is the reason to read a suppression file for what it *permits* rather than counting entries.
+
+## Two waivers that survived
+
+Not every waiver on this page was wrong, and it would be a poor lesson if they all were.
+
+`DAC_OVERRIDE` above is real, once tested properly. The **CL-0019** digest-pinning waiver is real too: these images are tracked by an automated update tool through a custom matcher whose pattern ends in a version-tag capture, so appending a digest would silently stop version tracking rather than improve it. That is a genuine tooling constraint, and the correct answer is a documented waiver rather than a pinned digest that quietly freezes updates.
+
+The useful ratio is not "waivers are usually wrong". It is that a waiver nobody has re-tested is *unverified*, and unverified claims fail at whatever rate the original reasoning fails.
+
+## Scope note
+
+Sanitized: hostnames, domains, addresses and paths are replaced, and a tailnet sidecar unrelated to the story is omitted. Capability, mount and `read_only` behaviour are as deployed, and every claim here was tested against the pinned digests above on scratch instances — the production database was never touched.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,9 @@ nav:
       - "2 — Re-architect so the socket isn't needed": examples/logging-without-the-socket/index.md
       - "3 — Constrain it when the need is real": examples/netdata-socket-proxy/index.md
       - "4 — Suppress it, with the risk written down": examples/ci-runner-suppression/index.md
+      - "Two rules in tension": examples/read-only-in-tension/index.md
+      - "A true premise and a false conclusion": examples/read-only-multi-service/index.md
+      - "The clean one": examples/clean-edge-proxy/index.md
   - Guides:
       - Configuration: configuration.md
       - Severity levels: severity.md


### PR DESCRIPTION
Completes the examples library for #111. The ladder covers one question — which remediation a socket mount allows. These three carry lessons it can't reach, and each came out of pressure-testing suppressions on a real stack rather than from picking illustrative software.

| Example | Lesson | Result |
|---|---|---|
| [Two rules in tension](docs/examples/read-only-in-tension/) | Satisfying one rule violates another | `exit=0`, 2 suppressed |
| [A true premise and a false conclusion](docs/examples/read-only-multi-service/) | Premise true, conclusion doesn't follow | `exit=0`, 3 suppressed |
| [The clean one](docs/examples/clean-edge-proxy/) | Almost nothing to waive | `exit=0`, 2 suppressed |

**Two rules in tension.** A read-only root bought by accepting CL-0022 — s6-overlay execs its init from `/run`, and Docker mounts every tmpfs `noexec`. The finding is traded, not removed: a medium for a low, exception scoped to one mount. The page also dissects where the reasoning normally fails — a correct boot test whose conclusion went one step too far, resting on the false belief that compose can't express `tmpfs: ["/run:exec"]`.

**A true premise and a false conclusion.** A waiver claiming read-only was impossible because the services write to volumes. True, and irrelevant: `read_only` doesn't affect volumes. Verified by uploading an actual photo, not by a health check — several examples in this library exist because a green container hid missing functionality. It also documents the capability waiver that nearly got deleted by a bad test: dropping `DAC_OVERRIDE` against a *named volume* passes and fails against the *bind mount* production uses.

**The clean one.** One waiver for the whole stack, and a forward-auth service with **no capabilities at all** — by skipping an image entrypoint whose only job was a chown and a privilege drop that would have required `CHOWN`, `SETUID`, `SETGID` back. Root-without-capabilities is a weaker position than dropping to a user you had to grant setuid to reach, and the page includes the table making that case. It exists to contradict the impression a library of hard cases would otherwise give.

The two "number vs posture disagree" cases now cross-reference each other: hardening that made the lint output worse (tracked in #492), and lint improvement that would harden nothing.

Verified: all seven examples lint as documented, mkdocs build clean with no new link warnings, leak scan clean, `ruff` clean, 1070 passed / 6 skipped. Docs only.