### PR TITLE
Fix pre-commit files regex

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,4 +4,5 @@
   entry: compose-lint
   language: python
   types: [yaml]
-  files: (^|/)docker-compose[^/]*\.ya?ml$|compose[^/]*\.ya?ml$
+  files: (^|/)(docker-)?compose[^/]*\.ya?ml$
+  exclude: (^|/)\.?compose-lint\.ya?ml$

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   flag. The doc and fix text are rewritten around the verified semantics,
   and a CI premise check now pins the drop-unaffected fact so the wrong
   claim cannot silently return.
+- Fixed file matching in `.pre-commit-hooks.yaml` that was incorrectly including
+  `.compose-lint.yml` if present in the commits. This generated errors
+  meaning pre-commit will always fail (issue #465). **Note** this now only
+  matches compose files starting with `compose` and `docker-compose` but still
+  matches environment specific files, e.g. `compose-dev.yml`, but no longer
+  matches files with prefixes, e.g. `dev-compose.yml`.
 
 ### Changed
 

--- a/tests/test_precommit.py
+++ b/tests/test_precommit.py
@@ -1,0 +1,64 @@
+"""Tests that the 'files' regex in .pre-commit-hooks.yaml does not match
+.compose-lint.yml (#465).
+
+Errors if file a .pre-commit-hooks.yaml file is not found in the root of
+the repository.
+
+Checks that there at least one hook present in the config file. Allowing
+for additional to be added, e.g. using docker in the future.
+
+Reads the configured regexes and checks then against list of file paths that
+should/shouldn't match.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+import yaml
+
+TEST_DATA = [
+    # (string, expected)
+    (".compose-lint.yml", False),
+    (".compose-lint.yaml", False),
+    ("foo/.compose-lint.yml", False),
+    ("dev-compose.yml", False),
+    ("docker-compose.yaml", True),
+    ("compose.yaml", True),
+    ("docker-compose.yml", True),
+    ("compose.yml", True),
+    ("foo/docker-compose.yml", True),
+    ("foo/bar/compose.yml", True),
+    ("foo/bar/baz/compose-test.yml", True),
+    ("foo/bar/baz/docker-compose-test.yaml", True),
+]
+
+
+@pytest.fixture(scope="module")
+def _load_patterns_from_config(pytestconfig):
+    precommit_file = pytestconfig.rootpath / ".pre-commit-hooks.yaml"
+    with open(precommit_file) as f:
+        config = yaml.safe_load(f)
+        return {item["id"]: re.compile(item["files"]) for item in config}
+
+
+def test_precommit_config_has_at_least_one_entry(_load_patterns_from_config):
+    # Verifies that at least one hook is configured.
+    assert len(_load_patterns_from_config) > 0
+
+
+@pytest.mark.parametrize("string, expected", TEST_DATA)
+def test_regex_only_match_valid_compose_files(
+    _load_patterns_from_config, string, expected
+):
+    # Verifies the extracted pre-commit regex against target file paths.
+    # Iterates over multiple hooks if more than one is configured.
+    for id, pattern in _load_patterns_from_config.items():
+        match = pattern.search(string)
+        is_match = match is not None
+
+        assert is_match == expected, (
+            f"Linter '{id}' failed for path '{string}'. "
+            f"Expected match to be {expected}."
+        )


### PR DESCRIPTION
Previously this was matching .compose-lint.yml which causes errors preventing the hook from passing.

## Summary

- Updates the file matching regex in `pre-commit-hooks.yaml`  this was previously matching `.compose-lint.yml`. If the config file is included in the evaluation it causes errors to be thrown preventing the hook passing.
- Adds new pre-commit tests that:
  - Load the config from `.pre-commit-hooks.yaml` in the repo root.
  - Validate at lease one hook is configured with a `files` regex.
  - Tests multiple hook configs if more are added in the future
  - Validates a list of strings representing compose file paths against all configs found.

## Why

Without this fix the pre-commit check will never pass is a `.compose-lint.yml` file has been added to the code base.

Closes #465 

## Type of change

- [ ] New rule (`CL-XXXX`)
- [X] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / CI / release tooling
- [ ] Other:

## Checklist

- [X] Commits are signed (GitHub shows **Verified**)
- [X] One logical change per commit; no unrelated changes bundled in
- [X] `ruff check`, `ruff format --check`, `mypy src/`, and `pytest` all pass locally
- [X] New/changed behavior has tests (positive **and** negative cases for rules)
- [X] Docs updated where behavior changed (`README.md`, `docs/rules/CL-XXXX.md`, `CHANGELOG.md`)
- [X] No AI attribution anywhere (commits, comments, docs)

## Breaking changes

None
