### PR TITLE
Smoke-test the pre-commit hook with the real tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,11 @@ jobs:
           # Python sources, tests, helper scripts, the package manifest,
           # hash-pinned lockfiles, and the action contract all warrant the
           # full lint/type/test/coverage/security/smoke suite.
-          if match '^(src/|tests/|scripts/|pyproject\.toml$|requirements[.-].*lock$|action\.yml$)'; then
+          # `.pre-commit-hooks.yaml` is in here on purpose: it is the hook
+          # contract, and `precommit-smoke` (gated on this filter) is what
+          # guards it. Leaving it out meant a manifest-only edit — exactly
+          # the shape of issue #465 — skipped its own smoke test.
+          if match '^(src/|tests/|scripts/|pyproject\.toml$|requirements[.-].*lock$|action\.yml$|\.pre-commit-hooks\.yaml$)'; then
             code=true
           fi
           if match '^(Dockerfile$|\.dockerignore$|requirements\.lock$|requirements-build\.lock$|pyproject\.toml$|src/)'; then
@@ -762,6 +766,85 @@ jobs:
           echo "::error::Expected action to fail on insecure fixture, got '${{ steps.insecure.outcome }}'"
           exit 1
 
+  # The pre-commit arm of the integration-surface smoke set. `action-smoke`
+  # covers action.yml, `docker-smoke` the image, publish.yml's `testpypi-smoke`
+  # the wheel — `.pre-commit-hooks.yaml` had nothing, and issue #465 (a broken
+  # `files` pattern that made the hook unable to pass) reached a user because
+  # of it. tests/test_precommit.py asserts the patterns in isolation; this job
+  # runs the real tool so `entry`, `language`, and hook installation are
+  # exercised too. `try-repo` reads the manifest from the working tree, so a
+  # regression is caught on the PR that introduces it rather than after release.
+  precommit-smoke:
+    name: Smoke test .pre-commit-hooks.yaml
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements-dev.lock
+      - name: Install pinned dev env
+        run: pip install --require-hashes -r requirements-dev.lock
+
+      # `try-repo` runs against the *current* directory's git repo, so each
+      # case builds a throwaway repo whose filenames match the hook's `files`
+      # pattern. Reusing tests/smoke/ fixtures keeps one source of truth for
+      # what "clean" and "insecure" mean across every smoke job.
+      - name: Clean stack with a config present should pass
+        env:
+          SMOKE: ${{ runner.temp }}/hook-pass
+        run: |
+          set -euo pipefail
+          mkdir -p "$SMOKE"
+          cp tests/smoke/clean.yml "$SMOKE/docker-compose.yml"
+          # A config in the tree is the issue #465 reproducer: the hook used
+          # to hand it to the linter, which exited 2 and could never pass.
+          printf 'rules:\n  CL-0004:\n    enabled: false\n    reason: "smoke"\n' \
+            > "$SMOKE/.compose-lint.yml"
+          git -C "$SMOKE" init -q
+          git -C "$SMOKE" add -A
+          cd "$SMOKE"
+          pre-commit try-repo "$GITHUB_WORKSPACE" compose-lint --all-files \
+            --verbose 2>&1 | tee out.txt
+          # A hook that matched no files "passes" trivially. Assert it ran.
+          if grep -q "no files to check" out.txt; then
+            echo "::error::Hook selected no files — the smoke test proved nothing."
+            exit 1
+          fi
+          grep -q "docker-compose.yml" out.txt \
+            || { echo "::error::Hook did not receive docker-compose.yml"; exit 1; }
+          # Not a bare grep for the config filename: the banner legitimately
+          # prints `config: .compose-lint.yml` when the linter *reads* it.
+          # Assert the symptom of it being *linted* instead — either the
+          # pre-#500 parse failure or the post-#500 skip line.
+          if grep -qE "appears to be a compose-lint config|could not be parsed" out.txt; then
+            echo "::error::Hook passed its own config to the linter (issue #465)."
+            exit 1
+          fi
+
+      - name: Insecure stack should fail the hook
+        env:
+          SMOKE: ${{ runner.temp }}/hook-fail
+        run: |
+          set -euo pipefail
+          mkdir -p "$SMOKE"
+          cp tests/smoke/insecure.yml "$SMOKE/docker-compose.yml"
+          git -C "$SMOKE" init -q
+          git -C "$SMOKE" add -A
+          cd "$SMOKE"
+          if pre-commit try-repo "$GITHUB_WORKSPACE" compose-lint --all-files; then
+            echo "::error::Expected the hook to fail on the insecure fixture."
+            exit 1
+          fi
+
   # Runtime arm of the rule-grounding bar: every rule that describes container
   # runtime state must demonstrate its premise against a live container (the
   # insecure state is the Docker default, or the flagged config produces the
@@ -814,6 +897,7 @@ jobs:
       - lockfiles
       - docker-smoke
       - action-smoke
+      - precommit-smoke
       - rule-premises
     if: always()
     runs-on: ubuntu-24.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- CI now smoke-tests `.pre-commit-hooks.yaml` with the real tool
+  (`precommit-smoke`). `action.yml`, the image, and the wheel each had an
+  end-to-end smoke job; the pre-commit hook had none, which is how issue
+  #465 — a `files` pattern that made the hook unable to pass — reached a
+  user. `pre-commit try-repo` runs the manifest from the working tree, so
+  `entry`, `language`, and hook installation are exercised on the PR that
+  changes them. Covers both directions (a clean stack passes, an insecure
+  one fails), asserts the hook actually matched files rather than passing
+  trivially on an empty set, and pins the #465 case directly by keeping a
+  config file in the test tree. `.pre-commit-hooks.yaml` was also missing
+  from the `code` path filter, so a manifest-only edit previously skipped
+  the very jobs that check it.
+
 ### Fixed
 
 - Handing compose-lint its own config file no longer fails the run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,10 @@ dev = [
     "check-jsonschema==0.37.4",
     "mutmut==3.7.0",
     "mypy==2.3.0",
+    # Drives the `precommit-smoke` job: `pre-commit try-repo` runs
+    # .pre-commit-hooks.yaml from the working tree, so a broken `entry` or
+    # `language` is caught here rather than by a user (issue #465).
+    "pre-commit==4.6.1",
     "pytest==9.1.1",
     # Statement coverage gate (>=80%) is enforced by the `coverage` CI job.
     # Threshold lives in [tool.coverage.report] below.

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -195,6 +195,10 @@ cffi==2.1.1 ; platform_python_implementation != 'PyPy' \
     --hash=sha256:fb92203a88b3d3053034db775110081c49d28be6551923805e039924093761e4 \
     --hash=sha256:fcd22650c908d7b7da162bbfaab594a1227a15d1643a98c68b122ac642fa2264
     # via cryptography
+cfgv==3.5.0 \
+    --hash=sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0 \
+    --hash=sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132
+    # via pre-commit
 charset-normalizer==3.4.9 \
     --hash=sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380 \
     --hash=sha256:03d07803992c6c7bbc976327f34b18b6160327fc81cb82c9d504720ac0be3b62 \
@@ -493,6 +497,10 @@ defusedxml==0.7.1 \
     --hash=sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69 \
     --hash=sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61
     # via py-serializable
+distlib==0.4.3 \
+    --hash=sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b \
+    --hash=sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed
+    # via virtualenv
 dnspython==2.8.0 \
     --hash=sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af \
     --hash=sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f
@@ -512,13 +520,20 @@ exceptiongroup==1.3.1 ; python_full_version < '3.11' \
 filelock==3.32.2 \
     --hash=sha256:87dd94cf281e586d135fa51132b8e3d9a598b316e90377a288663c9321036c82 \
     --hash=sha256:c33351e1f49cae33414acbc6d56784e6ecee82514ec90795da1161fc4836b5b8
-    # via cachecontrol
+    # via
+    #   cachecontrol
+    #   python-discovery
+    #   virtualenv
 id==1.6.1 \
     --hash=sha256:d0732d624fb46fd4e7bc4e5152f00214450953b9e772c182c1c22964def1a069 \
     --hash=sha256:f5ec41ed2629a508f5d0988eda142e190c9c6da971100612c4de9ad9f9b237ca
     # via
     #   sigstore
     #   twine
+identify==2.6.19 \
+    --hash=sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a \
+    --hash=sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842
+    # via pre-commit
 idna==3.18 \
     --hash=sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2 \
     --hash=sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848
@@ -923,6 +938,10 @@ nh3==0.3.6 \
     --hash=sha256:f3736c9dd3d1856f80cd031715b84ca75cda2bbb1ac802c3da26bfce590838d7 \
     --hash=sha256:f5ed5fe84aee7f39db95c214a7421bf0499fbf500fec6d86a4e29bfc37971438
     # via readme-renderer
+nodeenv==1.10.0 \
+    --hash=sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827 \
+    --hash=sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb
+    # via pre-commit
 packageurl-python==0.17.6 \
     --hash=sha256:1252ce3a102372ca6f86eb968e16f9014c4ba511c5c37d95a7f023e2ca6e5c25 \
     --hash=sha256:31a85c2717bc41dd818f3c62908685ff9eebcb68588213745b14a6ee9e7df7c9
@@ -963,12 +982,17 @@ platformdirs==4.11.0 \
     #   pip-audit
     #   sigstore
     #   textual
+    #   virtualenv
 pluggy==1.6.0 \
     --hash=sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3 \
     --hash=sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
     # via
     #   pytest
     #   pytest-cov
+pre-commit==4.6.1 \
+    --hash=sha256:03e809865c7d178b9979d06c761fcbfe6808fdaded8581a745bb110e52050421 \
+    --hash=sha256:0e3b2942510d1fb34eec167a3ec57331bf8442122f1153a9fb8b58f5c49b2717
+    # via compose-lint (pyproject.toml)
 py-serializable==2.1.0 \
     --hash=sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103 \
     --hash=sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304
@@ -1145,6 +1169,10 @@ pytest-cov==7.1.0 \
     --hash=sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2 \
     --hash=sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678
     # via compose-lint (pyproject.toml)
+python-discovery==1.5.1 \
+    --hash=sha256:ac07f44cade589d954e9d6a1e1468539fdddd2cf676beb51da73e0f156b7c932 \
+    --hash=sha256:e2ea8b884cd1701f386eda8cf327b87743f1dc21b7f784470799537d95635384
+    # via virtualenv
 pywin32-ctypes==0.2.3 ; platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'win32' \
     --hash=sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8 \
     --hash=sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755
@@ -1227,6 +1255,7 @@ pyyaml==6.0.3 \
     #   compose-lint (pyproject.toml)
     #   bandit
     #   libcst
+    #   pre-commit
 pyyaml-ft==8.0.0 ; python_full_version == '3.13.*' \
     --hash=sha256:052561b89d5b2a8e1289f326d060e794c21fa068aa11255fe71d65baf18a632e \
     --hash=sha256:06237267dbcab70d4c0e9436d8f719f04a51123f0ca2694c00dd4b68c338e40b \
@@ -1912,6 +1941,7 @@ typing-extensions==4.16.0 \
     #   sigstore-models
     #   textual
     #   typing-inspection
+    #   virtualenv
 typing-inspection==0.4.2 \
     --hash=sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7 \
     --hash=sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464
@@ -1928,6 +1958,10 @@ urllib3==2.7.0 \
     #   requests
     #   tuf
     #   twine
+virtualenv==21.7.3 \
+    --hash=sha256:26dfda3c34f29bf1a3ca167426a67658d59979b9954e705aef60a5f724ce1773 \
+    --hash=sha256:5e9e287f5c808070eea3b40403d3368248e64b24f1b60bd9a36e85ac841d2c3e
+    # via pre-commit
 zipp==4.1.0 ; (python_full_version < '3.10.2' and platform_machine == 'ppc64le') or (python_full_version < '3.10.2' and platform_machine == 's390x') or (python_full_version < '3.12' and platform_machine != 'ppc64le' and platform_machine != 's390x') \
     --hash=sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f \
     --hash=sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602


### PR DESCRIPTION
Closes the pre-commit gap from the integration-surface audit.

## Why

Every other integration surface has an end-to-end smoke job — `action-smoke` for `action.yml`, `docker-smoke` for the image, `testpypi-smoke` for the wheel. `.pre-commit-hooks.yaml` had none. That asymmetry is how #465 (a `files` pattern that made the hook unable to pass on any repo that had run `compose-lint init`) reached a user rather than CI.

`tests/test_precommit.py` asserts the patterns in isolation and stays — it is the right guard for that half, and cheaper than pre-commit could be. What it cannot catch is a broken `entry`, a wrong `language`, or a manifest that fails to install, because it never runs pre-commit.

## What

`precommit-smoke` runs `pre-commit try-repo`, which reads the manifest from the **working tree** rather than a released `rev:`, so a regression fails the PR that introduces it. Both directions, reusing `tests/smoke/` so "clean" and "insecure" mean the same thing across every smoke job.

Two guards a naive version would miss, both found by rehearsing the job locally before pushing:

1. **A hook that matches no files reports success.** The run is asserted to have actually received the compose file, so an over-narrowed pattern cannot pass trivially on an empty set — which is #465 inverted, and the more likely direction for a future regression.
2. **The assertion is on the symptom, not the filename.** The test tree keeps a `.compose-lint.yml` to pin #465 directly, but the banner legitimately prints `config: .compose-lint.yml` when the linter *reads* it. A bare grep for the filename fails on a healthy run — my first draft did exactly that. It now greps for the two ways the config being *linted* would surface (the pre-#500 parse failure, the post-#500 skip line), verified against a synthetic regressed run.

`.pre-commit-hooks.yaml` was also missing from the `code` path filter, so a manifest-only edit — the exact shape of the #465 change — skipped the jobs that check it. Added, and `precommit-smoke` wired into `ci-ok` so it gates rather than merely reports.

## Verification

Rehearsed locally end to end against this branch's manifest:

```
compose-lint.............................................................Passed
  ok: hook ran on files
  ok: received docker-compose.yml
  ok: config not linted
insecure fixture -> hook failed (as required)
guard fires on a synthetic regressed run
```

`actionlint` clean. `ruff check`, `ruff format --check`, `mypy src/`, `pytest` (1093 passed, 6 skipped) all green. Recompiling `requirements-dev.lock` onto itself is a no-op, so the `lockfiles` job reproduces byte-for-byte.

## Dependency note

`pre-commit==4.6.1` pinned in the `dev` extra and hash-locked, per the repo's "no ad-hoc `pip install pkg==X.Y.Z` in workflows" rule. It adds 6 transitive deps (`cfgv`, `distlib`, `identify`, `nodeenv`, `python-discovery`, `virtualenv`) to the dev environment; no unrelated pins moved. Runtime deps are untouched — the wheel stays PyYAML-only.

## Type of change

- [ ] New rule (`CL-XXXX`)
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [X] Build / CI / release tooling
- [ ] Other:

## Breaking changes

None. CI-only; no change to the linter, the hook manifest, or the published package.
