### PR TITLE
Treat Compose's $$ escape as a literal dollar in CL-0020/CL-0021

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- CL-0020 and CL-0021 no longer skip credentials containing `$$`, Compose's
+  escape for a literal dollar (issue #502). CL-0020's variable-reference
+  regex read the second dollar of `pa$$w0rd` as starting a `$w0rd`
+  substitution, and CL-0021 exempted any value containing `$` at all — so
+  exactly the passwords a careful user escaped correctly went unchecked,
+  and the two rules disagreed on values like `hunter2$` (flagged as an env
+  key, silent in a connection string). Both rules now share one classifier
+  that consumes `$$` escapes left-to-right, as Compose does, before testing
+  for a `${VAR}`/`$VAR` reference.
+
 - Handing compose-lint its own config file no longer fails the run
   (issue #499). `.compose-lint.yml` parses as YAML but has no `services:`
   key, and its shape matched neither of ADR-013's not-applicable buckets,

--- a/docs/rules/CL-0020.md
+++ b/docs/rules/CL-0020.md
@@ -26,7 +26,7 @@ Exemptions (key matches a credential pattern but the rule does **not** fire):
 - Keys containing `ALLOW_EMPTY_` or `RANDOM_` — image-startup boolean toggles (`MYSQL_ALLOW_EMPTY_PASSWORD: "yes"`, `MYSQL_RANDOM_ROOT_PASSWORD: "yes"`).
 - Values that are exactly `yes`, `no`, `true`, `false`, `on`, `off`, `0`, or `1` (case-insensitive) — boolean flags.
 - Empty values (`PASSWORD: ""` — env unset, not a credential).
-- Pure or partial `${VAR}` substitutions — the credential is parameterized and sourced from process env, which is the documented secure-ish pattern.
+- Pure or partial `${VAR}` substitutions — the credential is parameterized and sourced from process env, which is the documented secure-ish pattern. Compose's escaped literal dollar (`$$`) does not count: `DB_PASSWORD: "pa$$w0rd"` is a literal credential containing `$`, so it fires.
 
 This rule is a **naming-convention check, not a content scanner**. It does not inspect the value for entropy, length, or provider-specific formats. A value of `changeme` fires, a 40-character production credential under `BILLING_ENDPOINT` does not. For value-side detection of credentials in URL-shaped env vars, see [CL-0021](CL-0021.md).
 

--- a/docs/rules/CL-0021.md
+++ b/docs/rules/CL-0021.md
@@ -20,11 +20,11 @@ services:
       AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow  # fires
 ```
 
-The value-side regex matches any URI scheme (`[a-zA-Z][a-zA-Z0-9+.\-]*`) followed by `://user:password@`, where the password half is non-empty and contains no `$` (variable substitution). The username half may be empty: RFC 3986 §3.2.1 permits it, and `redis://:password@host` — the standard Redis URL form — still leaks the password, so it fires.
+The value-side regex matches any URI scheme (`[a-zA-Z][a-zA-Z0-9+.\-]*`) followed by `://user:password@`, where the password half is non-empty and contains no `${VAR}`/`$VAR` variable substitution (Compose's escaped literal dollar, `$$`, is data, not a substitution — `pa$$w0rd` fires). The username half may be empty: RFC 3986 §3.2.1 permits it, and `redis://:password@host` — the standard Redis URL form — still leaks the password, so it fires.
 
 Skipped:
 
-- Password half contains `${VAR}` or `$VAR` — the credential is parameterized. (A `$`-valued *username* with a literal password still fires: the password leaks regardless.)
+- Password half contains `${VAR}` or `$VAR` — the credential is parameterized. (A `$`-valued *username* with a literal password still fires: the password leaks regardless. A password whose only dollars are `$$` escapes also fires — that is a literal `$` in the credential, not a substitution.)
 - Userinfo password is empty (`scheme://user:@host`) — no credential to leak.
 - No userinfo at all (`scheme://host/path`) — nothing to flag.
 - Empty or non-string value.

--- a/src/compose_lint/rules/CL0020_credential_env_keys.py
+++ b/src/compose_lint/rules/CL0020_credential_env_keys.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING, Any
 
 from compose_lint.models import Finding, RuleMetadata, Severity
 from compose_lint.rules import BaseRule, register_rule
+from compose_lint.rules._interpolation import contains_var_ref
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -63,11 +63,6 @@ _FLAG_KEY_FRAGMENTS = (
 # Compared case-insensitively against the trimmed value.
 _FLAG_VALUES = frozenset({"yes", "no", "true", "false", "0", "1", "on", "off"})
 
-# A pure variable substitution ("${VAR}", "${VAR:-default}", "$VAR").
-# Used to skip parameterized values entirely; the credential is sourced
-# from process env, which is the documented secure-ish pattern.
-_VAR_REF_RE = re.compile(r"\$\{[^}]+\}|\$[A-Za-z_][A-Za-z0-9_]*")
-
 
 def _matches_credential_pattern(key_upper: str) -> bool:
     """Return True if the key name matches a credential-shaped pattern."""
@@ -90,7 +85,10 @@ def _is_literal_credential_value(raw: Any) -> bool:
     - Booleans (a YAML `yes`/`no`/`true`/`false` toggle, not a credential)
     - Non-string, non-numeric, and empty-string values (env unset)
     - Boolean / numeric toggles like "yes", "true", "1"
-    - Any value containing a ${VAR} substitution (parameterized)
+    - Any value containing a ${VAR} substitution (parameterized); the
+      credential is sourced from process env, which is the documented
+      secure-ish pattern. Compose's escaped literal dollar (`$$`) is not
+      a substitution, so `pa$$w0rd` still counts as literal (issue #502).
 
     An unquoted numeric value (`DB_PASSWORD: 12345678`) decodes to a Python
     int/float; it is coerced to its string form so a numeric literal secret is
@@ -107,7 +105,7 @@ def _is_literal_credential_value(raw: Any) -> bool:
         return False
     if raw.strip().lower() in _FLAG_VALUES:
         return False
-    return not _VAR_REF_RE.search(raw)
+    return not contains_var_ref(raw)
 
 
 def _iter_env(env_block: Any) -> Iterator[tuple[str, Any, int | None]]:

--- a/src/compose_lint/rules/CL0021_connection_string_credentials.py
+++ b/src/compose_lint/rules/CL0021_connection_string_credentials.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from compose_lint.models import Finding, RuleMetadata, Severity
 from compose_lint.rules import BaseRule, register_rule
+from compose_lint.rules._interpolation import contains_var_ref
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -25,18 +26,13 @@ RFC3986_REF = "https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.1"
 # the structural separators (':', '/', '@', whitespace). The user half is
 # optional (`*`, not `+`): RFC 3986 §3.2.1 permits an empty username, and
 # `redis://:password@host` — the standard Redis URL form — must still fire
-# (issue #279 R2). The '$' guard below filters out variable substitutions in
-# the password half.
+# (issue #279 R2). The var-ref guard below filters out variable substitutions
+# in the password half.
 _URI_USERINFO_RE = re.compile(
     r"(?P<scheme>[a-zA-Z][a-zA-Z0-9+.\-]*)://"
     r"(?P<user>[^:/@\s]*):"
     r"(?P<password>[^@/\s]+)@"
 )
-
-
-def _is_var_ref(s: str) -> bool:
-    """True if s contains a $VAR or ${VAR} substitution."""
-    return "$" in s
 
 
 def _iter_env(env_block: Any) -> Iterator[tuple[str, Any, int | None]]:
@@ -65,7 +61,10 @@ def _find_inline_credential(value: str) -> tuple[str, str, str] | None:
     password being a `${VAR}` substitution means the secret is parameterized;
     a substituted username with a literal password (e.g.
     `postgres://${DB_USER}:secret@db`) still leaks the credential, so it must
-    not suppress the finding (issue #277 F6).
+    not suppress the finding (issue #277 F6). The var-ref test is shared with
+    CL-0020 so both rules classify a password identically — in particular,
+    Compose's escaped literal dollar (`$$`) is data, not a substitution, so
+    `pa$$w0rd` still fires (issue #502).
     """
     # The pattern requires a terminating '@', so a value without one can never
     # match. Bail before `finditer` runs: without this guard a value shaped like
@@ -77,7 +76,7 @@ def _find_inline_credential(value: str) -> tuple[str, str, str] | None:
     for m in _URI_USERINFO_RE.finditer(value):
         user = m.group("user")
         password = m.group("password")
-        if _is_var_ref(password):
+        if contains_var_ref(password):
             continue
         return m.group("scheme"), user, password
     return None

--- a/src/compose_lint/rules/_interpolation.py
+++ b/src/compose_lint/rules/_interpolation.py
@@ -1,0 +1,21 @@
+"""Shared classification of Compose variable substitution in env values."""
+
+from __future__ import annotations
+
+import re
+
+# An active variable substitution ("${VAR}", "${VAR:-default}", "$VAR").
+_VAR_REF_RE = re.compile(r"\$\{[^}]+\}|\$[A-Za-z_][A-Za-z0-9_]*")
+
+
+def contains_var_ref(value: str) -> bool:
+    """Return True if ``value`` contains a ``$VAR``/``${VAR}`` substitution.
+
+    Compose writes a literal dollar as ``$$`` and consumes those escapes
+    left-to-right before interpolation, so ``pa$$w0rd`` is a literal
+    credential, not a reference to ``$w0rd`` (issue #502). ``str.replace``
+    removes non-overlapping ``$$`` pairs in the same left-to-right order,
+    so exactly the dollars Compose would treat as syntax remain to be
+    tested against the reference pattern.
+    """
+    return _VAR_REF_RE.search(value.replace("$$", "")) is not None

--- a/tests/test_CL0020.py
+++ b/tests/test_CL0020.py
@@ -209,6 +209,25 @@ class TestCredentialEnvKeysRule:
         findings = self._check("skip_mixed_var_reference")
         assert findings == []
 
+    # ---- $$ escape: a literal dollar is not a substitution (issue #502) ----
+
+    def test_detects_dollar_escaped_password(self) -> None:
+        # `$$` is Compose's escape for a literal `$`; the `$w0rd` tail must
+        # not be read as a `$VAR` reference.
+        findings = self._check_key("DB_PASSWORD", '"pa$$w0rd"')
+        assert len(findings) == 1
+
+    def test_detects_trailing_dollar_password(self) -> None:
+        # A trailing `$` cannot begin a substitution — still a literal.
+        findings = self._check_key("DB_PASSWORD", '"hunter2$"')
+        assert len(findings) == 1
+
+    def test_skip_var_ref_following_escaped_dollar(self) -> None:
+        # Compose consumes escapes left-to-right: `$$` is a literal `$`, the
+        # `${VAR}` after it is a real substitution — still parameterized.
+        findings = self._check_key("DB_PASSWORD", '"$$${DB_PASSWORD}"')
+        assert findings == []
+
     # ---- Negative cases ----
 
     def test_skip_empty_string(self) -> None:

--- a/tests/test_CL0021.py
+++ b/tests/test_CL0021.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from compose_lint.models import Finding, Severity
 from compose_lint.parser import load_compose, loads
+from compose_lint.rules.CL0020_credential_env_keys import CredentialEnvKeysRule
 from compose_lint.rules.CL0021_connection_string_credentials import (
     ConnectionStringCredentialsRule,
 )
@@ -113,6 +114,43 @@ class TestConnectionStringCredentialsRule:
     def test_skip_list_form_with_var(self) -> None:
         findings = self._check("list_form_skipped_when_var")
         assert findings == []
+
+    # ---- $$ escape: a literal dollar is not a substitution (issue #502) ----
+
+    def test_detect_dollar_escaped_password_in_url(self) -> None:
+        # `$$` is Compose's escape for a literal `$` — the password is a
+        # literal credential, not parameterized.
+        findings = self._check_inline('"postgres://app:pa$$w0rd@db/app"')
+        assert len(findings) == 1
+
+    def test_detect_trailing_dollar_password_in_url(self) -> None:
+        # A trailing `$` cannot begin a substitution — still a literal.
+        findings = self._check_inline('"postgres://u:hunter2$@db/x"')
+        assert len(findings) == 1
+
+    def test_skip_password_var_after_escaped_dollar(self) -> None:
+        # `$$` is a literal `$`; the `${VAR}` after it is a real substitution,
+        # so the password is still parameterized.
+        findings = self._check_inline('"postgres://u:$$${DB_PASSWORD}@db/x"')
+        assert findings == []
+
+    def test_agrees_with_cl0020_on_dollar_passwords(self) -> None:
+        # The same password must classify identically as an env-key value
+        # (CL-0020) and inside a connection string (CL-0021) (issue #502).
+        for password in ("pa$$w0rd", "hunter2$"):
+            data, lines = loads(
+                "services:\n"
+                "  app:\n"
+                "    image: nginx\n"
+                "    environment:\n"
+                f'      DB_PASSWORD: "{password}"\n'
+                f'      DATABASE_URL: "postgres://app:{password}@db/app"\n'
+            )
+            svc = data["services"]["app"]
+            key_findings = list(CredentialEnvKeysRule().check("app", svc, data, lines))
+            url_findings = list(self.rule.check("app", svc, data, lines))
+            assert [f.rule_id for f in key_findings] == ["CL-0020"], password
+            assert [f.rule_id for f in url_findings] == ["CL-0021"], password
 
     # ---- Skips: structural ----
 


### PR DESCRIPTION
Fixes #502.

Compose writes a literal dollar as `$$`, so a password like `pa$$w0rd` is literal credential data — but CL-0020's variable-reference regex read the second dollar as starting a `$w0rd` substitution, and CL-0021 exempted any value containing `$` at all. Exactly the passwords a careful user escaped correctly were silently skipped, and the two rules disagreed on values like a trailing-dollar password (flagged as an env key, silent inside a connection string).

## Change

- New shared classifier `rules/_interpolation.py`: `contains_var_ref()` removes `$$` escapes left-to-right — mirroring Compose's tokenization, so `$$${VAR}` still counts as parameterized — before testing for a `${VAR}`/`$VAR` reference.
- CL-0020 drops its local `_VAR_REF_RE`, CL-0021 drops its `"$" in s` substring test; both now classify a value identically.
- Tests per the issue's suggested shape: `pa$$w0rd`, trailing `$`, and `$$${VAR}` cases in both suites, plus a cross-rule agreement test asserting both rules fire on the same password as an env key and inside a connection string.
- Rule docs and CHANGELOG updated.

## Verification

The issue's repro now yields all five expected findings (both `pa$$w0rd` values, both connection strings, the control). `ruff check`, `ruff format --check`, strict `mypy`, and pytest (1100 passed, 6 skipped) all green.