### PR TITLE
Stop flagging DAC_OVERRIDE, a Docker default, in CL-0011

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- CL-0011 no longer flags `DAC_OVERRIDE`, which inverted the default gate
+  (issue #492). `DAC_OVERRIDE` is one of Docker's 14 default capabilities,
+  so a container holds it whether or not the file names it — flagging it on
+  `cap_add` scored the declaration rather than the runtime state. The effect
+  was that hardening a service made it fail: `cap_drop: [ALL]` plus
+  `cap_add: [DAC_OVERRIDE]` — one capability — exited 1 at the default
+  `--fail-on high`, while the same service with no `cap_drop` at all —
+  fourteen capabilities, `DAC_OVERRIDE` among them — exited 0. The fastest
+  way back to green was to delete the hardening. CL-0011 already excluded
+  `MKNOD` and `SYS_CHROOT` for exactly this reason; `DAC_OVERRIDE` was the
+  one default capability the list still carried, and so was the whole of the
+  inversion. CL-0006 now names it among the retained defaults, so both rules
+  describe the same capability the same way.
+
 - CL-0020 and CL-0021 no longer skip credentials containing `$$`, Compose's
   escape for a literal dollar (issue #502). CL-0020's variable-reference
   regex read the second dollar of `pa$$w0rd` as starting a `$w0rd`

--- a/docs/rules/CL-0011.md
+++ b/docs/rules/CL-0011.md
@@ -21,11 +21,12 @@ Services that add dangerous Linux capabilities via `cap_add`:
 | `SYS_TIME` | HIGH | Change system clock, affecting all containers and the host |
 | `SYS_BOOT` | HIGH | Reboot the host or load a new kernel via kexec |
 | `DAC_READ_SEARCH` | HIGH | Bypass file read permission checks on the host |
-| `DAC_OVERRIDE` | HIGH | Bypass all file read, write, and execute permission checks |
 | `BPF` | HIGH | Load BPF programs — arbitrary kernel read/write on modern kernels |
 | `PERFMON` | HIGH | Performance-monitoring access (`perf_event_open`) — enables timing/side-channel attacks and kernel info disclosure |
 
-Safe capabilities like `NET_BIND_SERVICE` or `CHOWN` are not flagged. `BPF` and `PERFMON` were split out of `SYS_ADMIN` in Linux 5.8 and are flagged in their own right. `MKNOD` and `SYS_CHROOT` are intentionally not flagged here because the `cap_drop: [ALL]` baseline (CL-0006) already covers them; adding them back is not on its own a HIGH-severity escape path.
+Safe capabilities like `NET_BIND_SERVICE` or `CHOWN` are not flagged. `BPF` and `PERFMON` were split out of `SYS_ADMIN` in Linux 5.8 and are flagged in their own right. `MKNOD`, `SYS_CHROOT`, and `DAC_OVERRIDE` are intentionally not flagged here because the `cap_drop: [ALL]` baseline (CL-0006) already covers them; adding them back is not on its own a HIGH-severity escape path.
+
+All three are members of Docker's default capability set, so a container holds them unless they are dropped. Flagging one of them on `cap_add` scored the *declaration* rather than the runtime state, and inverted the gate: `cap_drop: [ALL]` plus `cap_add: [DAC_OVERRIDE]` — one capability — failed at the default `--fail-on high`, while a service with no `cap_drop` at all — fourteen capabilities, `DAC_OVERRIDE` among them — passed. `DAC_OVERRIDE` is the only capability in both Docker's defaults and this rule's list, so it was the whole of that inversion (issue #492).
 
 ## Why it matters
 

--- a/src/compose_lint/rules/CL0006_cap_drop.py
+++ b/src/compose_lint/rules/CL0006_cap_drop.py
@@ -33,8 +33,9 @@ class CapDropRule(BaseRule):
             name="No capability restrictions",
             description=(
                 "Containers retain ~14 default Linux capabilities unless explicitly "
-                "dropped. These include NET_RAW (ARP spoofing), SYS_CHROOT, and "
-                "MKNOD, which are unnecessary for most workloads."
+                "dropped. These include NET_RAW (ARP spoofing), DAC_OVERRIDE "
+                "(bypass file permission checks), SYS_CHROOT, and MKNOD, which are "
+                "unnecessary for most workloads."
             ),
             severity=Severity.MEDIUM,
             references=[OWASP_REF, CIS_REF],
@@ -61,8 +62,8 @@ class CapDropRule(BaseRule):
                 service=service_name,
                 message=(
                     "Service does not drop all capabilities. Containers retain "
-                    "~14 default capabilities including NET_RAW, SYS_CHROOT, "
-                    "and MKNOD."
+                    "~14 default capabilities including NET_RAW, DAC_OVERRIDE, "
+                    "SYS_CHROOT, and MKNOD."
                 ),
                 line=lines.get(f"services.{service_name}"),
                 fix=(

--- a/src/compose_lint/rules/CL0011_dangerous_cap_add.py
+++ b/src/compose_lint/rules/CL0011_dangerous_cap_add.py
@@ -34,7 +34,6 @@ DANGEROUS_CAPS: dict[str, str] = {
     "SYS_TIME": "change system clock, affecting all containers and the host",
     "SYS_BOOT": "reboot the host or load a new kernel via kexec",
     "DAC_READ_SEARCH": "bypass file read permission checks on the host",
-    "DAC_OVERRIDE": "bypass all file read, write, and execute permission checks",
     "BPF": "load BPF programs — arbitrary kernel read/write on modern kernels",
     "PERFMON": (
         "performance-monitoring access (perf_event_open) — enables timing and "

--- a/tests/test_CL0011.py
+++ b/tests/test_CL0011.py
@@ -42,10 +42,15 @@ class TestDangerousCapAddRule:
         assert findings[0].severity == Severity.HIGH
         assert "SYS_BOOT" in findings[0].message
 
-    def test_detects_dac_override(self) -> None:
-        findings = self._check_cap("DAC_OVERRIDE")
-        assert len(findings) == 1
-        assert "DAC_OVERRIDE" in findings[0].message
+    def test_ignores_dac_override(self) -> None:
+        # DAC_OVERRIDE is one of Docker's 14 default capabilities, so adding it
+        # back after cap_drop: [ALL] is not an escalation above the baseline —
+        # the container holds it either way. Flagging it inverted the gate:
+        # `cap_drop: [ALL]` + `cap_add: [DAC_OVERRIDE]` (one capability) failed
+        # at --fail-on high while no cap_drop at all (fourteen, DAC_OVERRIDE
+        # among them) passed. Same reasoning already excludes MKNOD and
+        # SYS_CHROOT; DAC_OVERRIDE was missed (issue #492).
+        assert self._check_cap("DAC_OVERRIDE") == []
 
     def test_detects_bpf(self) -> None:
         findings = self._check_cap("BPF")


### PR DESCRIPTION
Closes #492.

## The problem

`DAC_OVERRIDE` is one of Docker's 14 default capabilities, so a container holds it whether or not the compose file names it. CL-0011 flagged it on `cap_add` anyway, which scored the *declaration* rather than the runtime state — and inverted the default gate.

Two files, identical except for the capability configuration:

```yaml
# a-implicit.yml — no cap_drop. Holds all 14 defaults, DAC_OVERRIDE among them.
services:
  app:
    image: nginx:1.29.4@sha256:...
    read_only: true
    security_opt: [no-new-privileges:true]
```

```yaml
# b-hardened.yml — holds exactly one capability, a strict subset of the above.
services:
  app:
    image: nginx:1.29.4@sha256:...
    read_only: true
    security_opt: [no-new-privileges:true]
    cap_drop: [ALL]
    cap_add: [DAC_OVERRIDE]
```

Before this change:

```
a-implicit.yml    1 medium (CL-0006)   ✓ PASS   exit 0
b-hardened.yml    1 high   (CL-0011)   ✗ FAIL   exit 1
```

The more constrained file failed. The fastest route back to green was to delete the `cap_drop`/`cap_add` block and go back to holding every default capability.

## Why it was exactly one entry

Intersecting `DANGEROUS_CAPS` with Docker's default set leaves exactly one capability: `DAC_OVERRIDE`. Every other member — `SYS_ADMIN`, `NET_ADMIN`, `BPF`, `PERFMON`, and the rest — is a genuine escalation above the default baseline, so the gate never inverts for them. That one dict entry was the entire inversion surface.

The default set was verified rather than assumed: moby `daemon/pkg/oci/caps/defaults.go` grants the 14 including `CAP_NET_RAW`, and the only commits touching that file since 2019-11-14 are a comment cleanup and a package move. A live capture on Docker 29.1.3 (`alpine:3`, no flags) gives `CapEff = 00000000a80425fb`, which decodes to exactly those 14. `dockerd` exposes no flag to alter the set.

## Why removal rather than a lower severity

CL-0011 already had a documented policy covering this case, in `docs/rules/CL-0011.md`:

> `MKNOD` and `SYS_CHROOT` are intentionally not flagged here because the `cap_drop: [ALL]` baseline (CL-0006) already covers them; adding them back is not on its own a HIGH-severity escape path.

`DAC_OVERRIDE` is the same category — a Docker default re-granted after a full drop — and appears to have been missed rather than deliberately included. Removing it applies the rule's existing policy consistently; demoting it would have introduced an exception to that sentence instead.

The issue deliberately left the resolution open, and demotion to LOW was the other candidate. Removal was chosen because it matches the `MKNOD`/`SYS_CHROOT` precedent, needs no new branch, and makes the hardened file score *strictly better* rather than merely equal.

## After

```
a-implicit.yml    1 medium (CL-0006)   ✓ PASS   exit 0
b-hardened.yml    no findings          ✓ PASS   exit 0
```

Hardening can no longer score worse than not hardening.

## Changes

- `CL0011_dangerous_cap_add.py` — remove the `DAC_OVERRIDE` entry from `DANGEROUS_CAPS`
- `tests/test_CL0011.py` — `test_detects_dac_override` becomes `test_ignores_dac_override`, with the reasoning recorded in the test
- `docs/rules/CL-0011.md` — drop the table row; add `DAC_OVERRIDE` to the `MKNOD`/`SYS_CHROOT` exclusion sentence and explain the inversion it caused
- `CL0006_cap_drop.py` — name `DAC_OVERRIDE` among the retained defaults in both the rule description and the finding message, so CL-0006 and CL-0011 describe the same capability the same way
- `CHANGELOG.md`

## Verification

`ruff check src/ tests/`, `ruff format --check src/ tests/`, `mypy src/` (strict), and `pytest` all pass. The before/after output above was captured from this branch.

## Not addressed here

Whether CL-0006's MEDIUM is itself correct, given that the default set includes `NET_RAW` and its ARP-spoofing reach is cross-container rather than single-container, is a separate question and deliberately out of scope for this fix.
