### PR TITLE
Retire the DAC_OVERRIDE waiver from the read-only multi-service example

### DIFF
--- a/docs/examples/read-only-multi-service/.compose-lint.yml
+++ b/docs/examples/read-only-multi-service/.compose-lint.yml
@@ -1,23 +1,19 @@
 # One waiver for a four-service stack.
 #
-# There used to be a second, for CL-0007, saying the server, worker and database
-# "write to data and cache volumes so cannot be fully read_only". It was deleted
-# rather than reworded — see the page. Volumes stay writable under read_only.
+# There used to be two others, and both are gone for different reasons.
+#
+# A CL-0007 waiver said the server, worker and database "write to data and cache
+# volumes so cannot be fully read_only". It was deleted rather than reworded —
+# see the page. Volumes stay writable under read_only.
+#
+# A CL-0011 waiver covered the database's DAC_OVERRIDE. It is gone because the
+# rule stopped flagging it: DAC_OVERRIDE is one of Docker's 14 default
+# capabilities, so the container holds it whether or not the file names it, and
+# flagging it scored the declaration rather than the runtime state (issue #492).
+# The capability is still required, and why is recorded next to the cap_add in
+# docker-compose.yml. Nothing about the deployment changed — the tool did.
 
 rules:
-  CL-0011:
-    exclude_services:
-      database: >-
-        DAC_OVERRIDE is required and was confirmed in the DEPLOYED posture, not
-        inferred from upstream guidance. The data directory is a host bind owned
-        by the database uid with mode 700, so the entrypoint — which starts as
-        root — cannot traverse it without the capability; dropping it fails at
-        "find: /var/lib/postgresql/data: Permission denied". Note that testing
-        this against a NAMED VOLUME instead of a bind reports the capability as
-        removable, which is a false negative: the mount type is the whole
-        difference. CHOWN, SETUID and SETGID complete the set the official
-        Postgres entrypoint needs to initialise and drop to its own user.
-
   CL-0019:
     exclude_services:
       server: >-

--- a/docs/examples/read-only-multi-service/index.md
+++ b/docs/examples/read-only-multi-service/index.md
@@ -1,6 +1,6 @@
 # A true premise and a false conclusion
 
-**Verified against:** compose-lint 0.15.1, 2026-08-08
+**Verified against:** compose-lint 0.15.2 plus the CL-0011 fix from issue #492, 2026-08-09
 
 A four-service stack — application server, database, cache, machine-learning worker — where every service runs with a read-only root filesystem. For a long time its config said that was impossible:
 
@@ -58,7 +58,7 @@ All six data directories created, the asset written and readable. That is the ev
 
 The database was checked the same way: inserts, all three vector extensions available, and a successful `CHECKPOINT` to force a real write through to the volume.
 
-## The waiver that nearly got deleted by a bad test
+## The capability that nearly got dropped by a bad test
 
 The database keeps `DAC_OVERRIDE`, and the honest version of how that was confirmed is more useful than the conclusion.
 
@@ -73,21 +73,25 @@ without DAC_OVERRIDE  FAILED — find: '/var/lib/postgresql/data': Permission de
 
 The entrypoint starts as root, and root without `DAC_OVERRIDE` cannot traverse a directory it does not own with mode 700. Docker creates named volumes with ownership that makes the problem disappear, so the wrong mount type produces a clean, confident, wrong answer.
 
-The suppression records that, so the next person to re-derive it does not repeat the shortcut.
+The compose file records that next to the `cap_add`, so the next person to re-derive it does not repeat the shortcut.
 
-## When the number and the posture disagree
+## A warning this page used to carry
 
-Worth knowing before hardening a service that currently has no `cap_drop` at all: dropping capabilities can make the linter's output *worse*.
+Until recently this section said that dropping capabilities could make the linter's output *worse*, and it was right.
 
-A service with no `cap_drop` holds roughly fourteen default capabilities, several of them dangerous, and reports a single CL-0006 **medium**. Convert it to `cap_drop: ALL` plus explicit add-backs and any dangerous capability you keep becomes a CL-0011 **high** — a strictly smaller set of privileges, reported more severely, because the implicit ones were never visible and the explicit one is.
+A service with no `cap_drop` holds roughly fourteen default capabilities, several of them dangerous, and reports a single CL-0006 **medium**. Converting it to `cap_drop: ALL` plus explicit add-backs turned `DAC_OVERRIDE` — one of those same fourteen — into a CL-0011 **high**. A strictly smaller set of privileges, reported more severely, because the implicit ones were never visible and the explicit one was.
 
-That happened on a different stack in this library and is being tracked upstream. It does not apply to this example — the database's `DAC_OVERRIDE` was always explicit — but it is the reason to read a suppression file for what it *permits* rather than counting entries.
+That was a defect in the linter rather than a fact about capabilities, and it is fixed (issue #492). CL-0011 no longer flags Docker's default capabilities, on the same reasoning that already excluded `MKNOD` and `SYS_CHROOT`: the container holds them either way, so flagging them scored the declaration rather than the runtime state. The waiver this stack needed for `DAC_OVERRIDE` is gone from its config as a result — nothing about the deployment changed.
 
-## Two waivers that survived
+Adding back a capability that is **not** a default — `SYS_ADMIN`, `NET_ADMIN`, `SYS_MODULE` — is a genuine escalation above Docker's baseline and still reports HIGH. That is a different situation and the severity is correct there.
+
+The habit is worth keeping even though the bug is gone: read a suppression file for what it *permits*, not for how many entries it has.
+
+## A waiver that survived
 
 Not every waiver on this page was wrong, and it would be a poor lesson if they all were.
 
-`DAC_OVERRIDE` above is real, once tested properly. The **CL-0019** digest-pinning waiver is real too: these images are tracked by an automated update tool through a custom matcher whose pattern ends in a version-tag capture, so appending a digest would silently stop version tracking rather than improve it. That is a genuine tooling constraint, and the correct answer is a documented waiver rather than a pinned digest that quietly freezes updates.
+The **CL-0019** digest-pinning waiver is real: these images are tracked by an automated update tool through a custom matcher whose pattern ends in a version-tag capture, so appending a digest would silently stop version tracking rather than improve it. That is a genuine tooling constraint, and the correct answer is a documented waiver rather than a pinned digest that quietly freezes updates. The `DAC_OVERRIDE` claim above was sound too, once tested properly — it simply no longer needs a waiver to sit behind.
 
 The useful ratio is not "waivers are usually wrong". It is that a waiver nobody has re-tested is *unverified*, and unverified claims fail at whatever rate the original reasoning fails.
 


### PR DESCRIPTION
Follow-up to #505, which stopped CL-0011 flagging `DAC_OVERRIDE`. That left this example carrying a waiver for a finding that no longer exists, and a section teaching the inversion as current behaviour.

## The dead waiver

`.compose-lint.yml` suppressed CL-0011 for the `database` service, entirely for `DAC_OVERRIDE`. Verified against `main`: CL-0011 no longer fires on this stack, so the entry suppressed nothing.

Removed — but with a note recording why it went. A waiver that disappears because the tool got better is a different thing from the CL-0007 waiver above it, which was deleted because it was wrong, and on a page whose whole subject is how to read a waiver, that distinction is the point.

The capability is unchanged and still required. Why it is required already lives next to the `cap_add` in `docker-compose.yml`, so nothing was lost.

## The stale section

`index.md` carried "When the number and the posture disagree", which told readers that dropping capabilities could make their lint output worse, and pointed at the inversion as being tracked upstream. That is #492, now fixed.

Rewritten as history rather than deleted, because it keeps a distinction worth having: adding back a capability that is **not** a Docker default — `SYS_ADMIN`, `NET_ADMIN`, `SYS_MODULE` — is a real escalation above the baseline and still reports HIGH. Only the default capabilities were ever mis-scored.

Also in this file:

- "The waiver that nearly got deleted by a bad test" → "The capability that nearly got dropped by a bad test". It is not a waiver any more.
- "Two waivers that survived" → "A waiver that survived". CL-0019 is the one left; the `DAC_OVERRIDE` claim was sound too, it just no longer needs a waiver behind it.
- The drop-test story and the named-volume false negative are untouched. That is the useful lesson on the page and none of it depended on the suppression.

## Verification

With the waiver removed, on `main` plus this change:

```
docker-compose.yml: 0 issues  ·  2 suppressed (not counted)
✓ PASS  ·  threshold: high    exit 0
```

Both remaining suppressions are CL-0019, which confirms the removed entry was inert.

## One thing to decide

The `**Verified against:**` line now reads `compose-lint 0.15.2 plus the CL-0011 fix from issue #492`, which breaks the format the other six example pages use. The fix is unreleased, so naming a bare version would claim behaviour 0.15.2 does not have. Worth normalising to a plain version number at release time.

## Not in scope

Two other examples also carry `DAC_OVERRIDE` waivers. `read-only-in-tension`'s is likewise dead; `netdata-socket-proxy`'s is still required for `SYS_PTRACE` and only its justification text is stale. Both are held deliberately — proposed rule splits (#503) would change CL-0011's rule ID, and those files suppress by ID, so touching them now means touching them twice.

Separately: nothing in `tests/` or CI lints `docs/examples/`, which is why two dead waivers could sit unnoticed. A job that lints each example with its own config and asserts the documented result would catch this class.
