### PR TITLE
Parse non-string scalar mapping keys as their source text

### DIFF
--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -158,6 +158,24 @@ class LineLoader(yaml.SafeLoader):
         self._seq_lines: dict[int, dict[int, int]] = {}
 
 
+def _mapping_key(loader: LineLoader, key_node: yaml.Node) -> Any:
+    """Construct a mapping key, keeping non-string scalar keys as source text.
+
+    Compose mapping keys (service names and every other key) are always strings;
+    ``docker compose config`` keeps a key like ``yes`` or ``123`` verbatim while
+    coercing only boolean-typed *values*. The retained YAML 1.1 resolvers (see
+    ``_install_scalar_resolvers``) would otherwise turn a service named
+    ``yes``/``on``/``123``/``null`` into ``True``/``int``/``None`` — which gets
+    no line-map entry (line 218's ``isinstance(key, str)`` guard) and later
+    crashes the formatters on the non-string ``Finding.service``. Using the
+    source text matches Docker and keeps keys hashable strings.
+    """
+    key = loader.construct_object(key_node)
+    if not isinstance(key, str) and isinstance(key_node, yaml.ScalarNode):
+        return key_node.value
+    return key
+
+
 def _reject_duplicate_keys(loader: LineLoader, node: yaml.MappingNode) -> None:
     """Raise if a mapping declares the same key twice (issue #277 P2).
 
@@ -176,7 +194,7 @@ def _reject_duplicate_keys(loader: LineLoader, node: yaml.MappingNode) -> None:
     for key_node, _value_node in node.value:
         if key_node.tag == "tag:yaml.org,2002:merge":
             continue  # the `<<` merge directive, not a data key
-        key = loader.construct_object(key_node)
+        key = _mapping_key(loader, key_node)
         try:
             duplicate = key in seen
         except TypeError:
@@ -197,7 +215,7 @@ def _construct_mapping(loader: LineLoader, node: yaml.MappingNode) -> dict[Any, 
     mapping: dict[Any, Any] = {}
     line_map: dict[str, int] = {}
     for key_node, value_node in node.value:
-        key = loader.construct_object(key_node)
+        key = _mapping_key(loader, key_node)
         try:
             hash(key)
         except TypeError as e:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -78,6 +78,35 @@ class TestDuplicateKeys:
         assert data["services"]["web"]["image"] == "nginx"
 
 
+class TestNonStringScalarKeys:
+    """Service names that look like YAML 1.1 literals stay strings (#507).
+
+    Docker/compose-go keeps a key like ``yes`` or ``123`` verbatim and coerces
+    only boolean-typed *values*; the retained YAML 1.1 resolvers otherwise
+    turned a service named ``yes``/``on``/``123``/``null`` into True/int/None,
+    which had no line-map entry and crashed the formatters on a non-string
+    ``Finding.service``.
+    """
+
+    def test_boolean_literal_service_name_stays_string(self) -> None:
+        data, lines = loads("services:\n  yes:\n    image: nginx\n")
+        assert "yes" in data["services"]
+        assert all(isinstance(name, str) for name in data["services"])
+        assert lines["services.yes"] == 2
+
+    def test_numeric_and_null_service_names_stay_strings(self) -> None:
+        data, lines = loads("services:\n  123:\n    image: a\n  null:\n    image: b\n")
+        assert set(data["services"]) == {"123", "null"}
+        assert lines["services.123"] == 2
+        assert lines["services.null"] == 4
+
+    def test_distinct_boolean_names_are_not_duplicates(self) -> None:
+        # ``yes`` and ``on`` both resolved to True and tripped the duplicate
+        # check, dying with a misleading "duplicate key True".
+        data, _lines = loads("services:\n  yes:\n    image: a\n  on:\n    image: b\n")
+        assert set(data["services"]) == {"yes", "on"}
+
+
 class TestOverrideTags:
     """Compose override-file tags (`!reset` / `!override`) parse, not crash."""
 


### PR DESCRIPTION
## What

A service whose **name** is a YAML 1.1 boolean/number/null literal (`yes`, `on`, `123`, `null`) crashed the linter or degraded its output: the mapping key was resolved through the value resolvers into `True`/`int`/`None`, which had no line-map entry and then crashed the text formatter (`TypeError`, **exit 1** instead of the contractual **exit 2**). JSON/SARIF degraded to `"service": "True"` with a null line, and two boolean-shaped names collided into a misleading `found duplicate key True`.

## Fix

`docker compose config` keeps such keys verbatim and coerces only boolean-typed *values*, so Compose mapping keys are always strings. `_construct_mapping` and `_reject_duplicate_keys` now construct scalar keys from their source text (`key_node.value`) when the resolved key isn't already a string. Value-side coercion (`privileged: yes` → `True`) is unchanged.

## Verification

New `TestNonStringScalarKeys` covers boolean/numeric/null service names staying strings with correct line numbers, and distinct boolean-shaped names not being treated as duplicates. Full suite: 1103 passed, 6 skipped; `ruff check`, `ruff format --check`, `mypy src/` clean.

Closes #507
