### PR TITLE
Refuse to auto-fix a multi-line security_opt item in CL-0009

### DIFF
--- a/src/compose_lint/rules/CL0009_security_profile.py
+++ b/src/compose_lint/rules/CL0009_security_profile.py
@@ -8,6 +8,7 @@ from compose_lint._yaml_edit import (
     DISABLED_SECURITY_PROFILES,
     delete_lines,
     is_anchored_or_merged,
+    line_indent,
     normalize_security_opt,
     opens_block_body,
 )
@@ -24,6 +25,27 @@ _CAVEAT = (
     "profile; a workload that relies on a syscall the default profile blocks "
     "may fail."
 )
+
+
+def _item_is_multiline(source_lines: list[str], item_line: int) -> bool:
+    """True if the sequence item at ``item_line`` continues onto later lines.
+
+    A list item's continuation — a ``>-``/``|-`` block-scalar body or a wrapped
+    plain scalar — is indented deeper than the ``- `` marker, while a sibling
+    ``- ...`` sits at the marker's own indent and the next key/dedent sits
+    shallower. So a strictly deeper following non-blank line means the item is
+    multi-line, and deleting only its first line would orphan the continuation
+    into the previous entry (issue #508).
+    """
+    marker_indent = line_indent(source_lines[item_line - 1])
+    nxt = item_line  # 0-based index of the line after the 1-based item_line
+    if nxt >= len(source_lines):
+        return False
+    following = source_lines[nxt]
+    if not following.strip():
+        return False
+    return line_indent(following) > marker_indent
+
 
 OWASP_REF = (
     "https://cheatsheetseries.owasp.org/cheatsheets/"
@@ -175,6 +197,12 @@ class SecurityProfileRule(BaseRule):
             # A legitimate entry survives, so the list stays non-empty: remove
             # only this item's line.
             if not source_lines[item_line - 1].lstrip().startswith("- "):
+                return None
+            # A single-line delete is only safe when the item is one line. A
+            # multi-line item (`- >-` / `- |-` block scalar, or a wrapped value)
+            # would leave an orphaned continuation that silently merges into the
+            # previous entry (issue #508); refuse and leave it for the user.
+            if _item_is_multiline(source_lines, item_line):
                 return None
             return [delete_lines(source_lines, item_line, item_line, caveat=_CAVEAT)]
         # legit_remaining == 0: emptying the block would leave CL-0003 to

--- a/tests/test_CL0009.py
+++ b/tests/test_CL0009.py
@@ -304,6 +304,22 @@ class TestSecurityProfileFix:
         )
         assert self._fix(tmp_path, content) is None
 
+    def test_refuses_block_scalar_item(self, tmp_path: Path) -> None:
+        # A `>-` block-scalar list item spans two lines; a single-line delete
+        # would orphan the continuation into the previous entry, destroying it
+        # and leaving seccomp:unconfined in place (issue #508). Refuse instead.
+        content = (
+            "services:\n"
+            "  web:\n"
+            "    image: nginx\n"
+            "    security_opt:\n"
+            "      - no-new-privileges:true\n"
+            "      - label:user:USER\n"
+            "      - >-\n"
+            "        seccomp:unconfined\n"
+        )
+        assert self._fix(tmp_path, content) is None
+
     def test_refuses_merge_key_service(self, tmp_path: Path) -> None:
         content = (
             "x-base: &base\n"


### PR DESCRIPTION
## What

`fix --apply --only CL-0009` silently corrupted a neighbouring `security_opt` entry when the flagged unconfined item was a multi-line block scalar (`- >-` / `- |-`). The single-line delete removed only the item's first line, orphaning the continuation into the previous entry:

```yaml
      - label:user:USER
        seccomp:unconfined      # orphaned — re-parses as one merged string
```

That destroyed the SELinux option **and** left `seccomp:unconfined` in place, while reporting `applied 1 fix(es)` and passing all four verify nets.

## Fix

Refuse the fix (return `None` → manual review, matching the existing `legit_remaining == 0` branch and ADR-014 "refuse, never guess") when the flagged item continues onto a deeper-indented following line. Single-line items fix exactly as before.

## Verification

New `test_refuses_block_scalar_item`; the corruption repro now leaves the file byte-for-byte unchanged and reports `1 finding(s) need manual review`, while a plain single-line item still has `seccomp:unconfined` removed with `label:user:USER` preserved. Full suite 1101 passed, 6 skipped; `ruff`, `mypy` clean.

Closes #508
