### PR TITLE
Exempt the read-only timezone pattern from CL-0013

### DIFF
--- a/src/compose_lint/rules/CL0013_sensitive_mount.py
+++ b/src/compose_lint/rules/CL0013_sensitive_mount.py
@@ -38,17 +38,27 @@ _SENSITIVE_PATHS = (
 
 # Matches host:container or host:container:mode in short syntax.
 # Host group allows a bare "/" (root mount) by using `*` instead of `+`.
-_SHORT_VOLUME_RE = re.compile(r"^(?P<host>/[^:]*):(?P<container>[^:]+)")
+_SHORT_VOLUME_RE = re.compile(
+    r"^(?P<host>/[^:]*):(?P<container>[^:]+)(?::(?P<mode>[^:]+))?"
+)
+
+# The timezone-config pattern `- /etc/localtime:/etc/localtime:ro` (and
+# /etc/timezone) is near-universal and, read-only, exposes only the host's UTC
+# offset — not host configuration. A read-only mount of exactly these files is
+# exempt; /etc itself, /etc/shadow, or a read-write timezone mount still fire.
+_BENIGN_READONLY_FILES = frozenset({"/etc/localtime", "/etc/timezone"})
 
 
-def _extract_host_path(volume: Any) -> str | None:
-    """Extract the host path from a short-syntax volume string."""
+def _extract_short_mount(volume: Any) -> tuple[str, bool] | None:
+    """Return (host_path, is_readonly) for a short-syntax bind, else None."""
     if not isinstance(volume, str):
         return None
     m = _SHORT_VOLUME_RE.match(volume)
-    if m:
-        return m.group("host")
-    return None
+    if not m:
+        return None
+    mode = m.group("mode")
+    is_readonly = bool(mode) and "ro" in (part.strip() for part in mode.split(","))
+    return m.group("host"), is_readonly
 
 
 def _is_sensitive(host_path: str) -> str | None:
@@ -99,8 +109,10 @@ class SensitiveMountRule(BaseRule):
 
         for i, volume in enumerate(volumes):
             # Short syntax: /host/path:/container/path[:mode]
-            host_path = _extract_host_path(volume)
-            if host_path is None and isinstance(volume, dict):
+            short = _extract_short_mount(volume)
+            if short is not None:
+                host_path, is_readonly = short
+            elif isinstance(volume, dict):
                 # Long syntax: dict with 'source' key.
                 # Treat as a bind when type == "bind" OR when source is an
                 # absolute path (Compose infers bind from absolute paths even
@@ -111,12 +123,18 @@ class SensitiveMountRule(BaseRule):
                     vtype == "bind" or source.startswith("/")
                 ):
                     host_path = source
-
-            if host_path is None:
+                    is_readonly = volume.get("read_only") is True
+                else:
+                    continue
+            else:
                 continue
 
             sensitive = _is_sensitive(host_path)
             if sensitive is None:
+                continue
+
+            # Exempt the read-only timezone-config pattern (issue #509).
+            if is_readonly and host_path.rstrip("/") in _BENIGN_READONLY_FILES:
                 continue
 
             is_root_mount = sensitive == "/"

--- a/tests/test_CL0013.py
+++ b/tests/test_CL0013.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from compose_lint.models import Severity
-from compose_lint.parser import load_compose
+from compose_lint.parser import load_compose, loads
 from compose_lint.rules.CL0013_sensitive_mount import SensitiveMountRule
 
 FIXTURES = Path(__file__).parent / "compose_files"
@@ -137,3 +137,59 @@ class TestSensitiveMountRule:
         meta = self.rule.metadata
         assert meta.id == "CL-0013"
         assert meta.severity.value == "high"
+
+
+class TestTimezoneExemption:
+    """Read-only /etc/localtime and /etc/timezone are exempt (issue #509).
+
+    The near-universal `- /etc/localtime:/etc/localtime:ro` pattern exposes only
+    the host's UTC offset. Flagging it HIGH failed the default gate on otherwise
+    fully-hardened services. /etc itself, other /etc files, and read-write
+    timezone mounts still fire.
+    """
+
+    def setup_method(self) -> None:
+        self.rule = SensitiveMountRule()
+
+    def _check(self, content: str, service: str = "a") -> list:
+        data, lines = loads(content)
+        return list(self.rule.check(service, data["services"][service], data, lines))
+
+    def test_readonly_localtime_and_timezone_exempt(self) -> None:
+        content = (
+            "services:\n  a:\n    image: nginx\n    volumes:\n"
+            "      - /etc/localtime:/etc/localtime:ro\n"
+            "      - /etc/timezone:/etc/timezone:ro\n"
+        )
+        assert self._check(content) == []
+
+    def test_long_syntax_readonly_localtime_exempt(self) -> None:
+        content = (
+            "services:\n  a:\n    image: nginx\n    volumes:\n"
+            "      - type: bind\n        source: /etc/localtime\n"
+            "        target: /etc/localtime\n        read_only: true\n"
+        )
+        assert self._check(content) == []
+
+    def test_readwrite_localtime_still_fires(self) -> None:
+        content = (
+            "services:\n  a:\n    image: nginx\n    volumes:\n"
+            "      - /etc/localtime:/etc/localtime\n"
+        )
+        findings = self._check(content)
+        assert len(findings) == 1
+        assert findings[0].severity == Severity.HIGH
+
+    def test_etc_directory_still_fires_readonly(self) -> None:
+        content = (
+            "services:\n  a:\n    image: nginx\n    volumes:\n"
+            "      - /etc:/host/etc:ro\n"
+        )
+        assert len(self._check(content)) == 1
+
+    def test_other_etc_file_still_fires_readonly(self) -> None:
+        content = (
+            "services:\n  a:\n    image: nginx\n    volumes:\n"
+            "      - /etc/shadow:/etc/shadow:ro\n"
+        )
+        assert len(self._check(content)) == 1


### PR DESCRIPTION
## What

CL-0013 flagged the near-universal timezone-config pattern `- /etc/localtime:/etc/localtime:ro` (and `/etc/timezone`) at **HIGH**, via a bare `/etc` prefix match that ignored the mount mode. Because HIGH fails the default `--fail-on high` gate, an otherwise maximally-hardened service (read_only, cap_drop ALL, no-new-privileges, non-root, digest-pinned, …) was reported **failing solely because of a timezone mount** — the scenario that makes operators disable a linter. A read-only bind of these two files exposes only the host's UTC offset.

## Fix

Parse the short-syntax mode and the long-syntax `read_only` flag, and exempt a read-only mount of exactly `/etc/localtime` or `/etc/timezone`. Everything else is unchanged: `/etc` itself, other `/etc` files (e.g. `/etc/shadow`), a read-write timezone mount, and the root `:ro` mount all still fire.

## Verification

New `TestTimezoneExemption` (short + long syntax exempt; read-write tz, `/etc` dir, and `/etc/shadow` still fire). Full suite 1105 passed, 6 skipped; `ruff`, `mypy` clean. Rebased onto main after #510.

## Related (not in this PR)

- CL-0013 double-flags `docker.sock` paths CL-0001 already owns (redundant HIGH + a "copy into the image" fix nonsensical for a socket).
- The `/:/rootfs:ro` message claims "full read/write access … one-line container escape" — wrong for a `:ro` mount.

Closes #509
