### PR TITLE
Flag bare /run as a sensitive mount in CL-0013

### DIFF
--- a/src/compose_lint/rules/CL0013_sensitive_mount.py
+++ b/src/compose_lint/rules/CL0013_sensitive_mount.py
@@ -33,6 +33,11 @@ _SENSITIVE_PATHS = (
     "/var/run",
     "/run/containerd",
     "/run/systemd",
+    # Bare /run must follow the more specific /run/* entries so those keep
+    # their own messages. On a systemd host /run holds both /run/docker.sock
+    # and /run/containerd.sock (and /var/run is a symlink to it), so mounting
+    # it is root-equivalent daemon control that was previously a clean pass.
+    "/run",
     "/home",
 )
 

--- a/tests/test_CL0013.py
+++ b/tests/test_CL0013.py
@@ -193,3 +193,33 @@ class TestTimezoneExemption:
             "      - /etc/shadow:/etc/shadow:ro\n"
         )
         assert len(self._check(content)) == 1
+
+
+class TestRunMount:
+    """Bare /run is sensitive: it holds both daemon sockets (issue #513)."""
+
+    def setup_method(self) -> None:
+        self.rule = SensitiveMountRule()
+
+    def _check(self, content: str, service: str = "a") -> list:
+        data, lines = loads(content)
+        return list(self.rule.check(service, data["services"][service], data, lines))
+
+    def test_bare_run_flagged(self) -> None:
+        content = (
+            "services:\n  a:\n    image: nginx\n    volumes:\n      - /run:/hostrun\n"
+        )
+        findings = self._check(content)
+        assert len(findings) == 1
+        assert findings[0].severity == Severity.HIGH
+        assert "/run" in findings[0].message
+
+    def test_run_subpaths_keep_specific_message(self) -> None:
+        # /run/containerd must still report as itself, not as bare /run.
+        content = (
+            "services:\n  a:\n    image: nginx\n    volumes:\n"
+            "      - /run/containerd:/x\n"
+        )
+        findings = self._check(content)
+        assert len(findings) == 1
+        assert "/run/containerd" in findings[0].message


### PR DESCRIPTION
## What

`- /run:/hostrun` produced **zero findings, exit 0** — a clean pass on a fully hardened service — even though on every systemd host `/run` holds both `/run/docker.sock` and `/run/containerd.sock` (`/var/run` is a symlink to it). Mounting it is root-equivalent daemon control. `_SENSITIVE_PATHS` listed the children (`/var/run`, `/run/containerd`, `/run/systemd`) but not the parent.

## Fix

Add `/run` to `_SENSITIVE_PATHS`, ordered after the specific `/run/*` entries so those keep their own messages (verified: `/run/containerd` still reports as itself).

## Verification

New `TestRunMount`; `/run:/hostrun` now fires HIGH, `/run/containerd` keeps its specific message. Full suite 1111 passed, 6 skipped; ruff/mypy clean.

Closes #513
