### PR TITLE
Coerce quoted string booleans in boolean-typed fields

### DIFF
--- a/src/compose_lint/rules/CL0002_privileged_mode.py
+++ b/src/compose_lint/rules/CL0002_privileged_mode.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from compose_lint.models import Finding, RuleMetadata, Severity
 from compose_lint.rules import BaseRule, register_rule
+from compose_lint.rules._bool import as_bool
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -44,7 +45,7 @@ class PrivilegedModeRule(BaseRule):
         global_config: dict[str, Any],
         lines: dict[str, int],
     ) -> Iterator[Finding]:
-        if service_config.get("privileged") is True:
+        if as_bool(service_config.get("privileged")) is True:
             yield Finding(
                 rule_id="CL-0002",
                 severity=Severity.CRITICAL,

--- a/src/compose_lint/rules/CL0007_read_only.py
+++ b/src/compose_lint/rules/CL0007_read_only.py
@@ -10,6 +10,7 @@ from compose_lint._yaml_edit import (
 )
 from compose_lint.models import Finding, RuleMetadata, Severity, TextEdit
 from compose_lint.rules import BaseRule, register_rule
+from compose_lint.rules._bool import as_bool
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -54,7 +55,7 @@ class ReadOnlyFilesystemRule(BaseRule):
         global_config: dict[str, Any],
         lines: dict[str, int],
     ) -> Iterator[Finding]:
-        if service_config.get("read_only") is not True:
+        if as_bool(service_config.get("read_only")) is not True:
             yield Finding(
                 rule_id="CL-0007",
                 severity=Severity.MEDIUM,

--- a/src/compose_lint/rules/CL0013_sensitive_mount.py
+++ b/src/compose_lint/rules/CL0013_sensitive_mount.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from compose_lint.models import Finding, RuleMetadata, Severity
 from compose_lint.rules import BaseRule, register_rule
+from compose_lint.rules._bool import as_bool
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -128,7 +129,7 @@ class SensitiveMountRule(BaseRule):
                     vtype == "bind" or source.startswith("/")
                 ):
                     host_path = source
-                    is_readonly = volume.get("read_only") is True
+                    is_readonly = as_bool(volume.get("read_only")) is True
                 else:
                     continue
             else:

--- a/src/compose_lint/rules/CL0015_healthcheck_disabled.py
+++ b/src/compose_lint/rules/CL0015_healthcheck_disabled.py
@@ -12,6 +12,7 @@ from compose_lint._yaml_edit import (
 )
 from compose_lint.models import Finding, RuleMetadata, Severity
 from compose_lint.rules import BaseRule, register_rule
+from compose_lint.rules._bool import as_bool
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -61,7 +62,7 @@ class HealthcheckDisabledRule(BaseRule):
         if not isinstance(healthcheck, dict):
             return
 
-        disable = healthcheck.get("disable")
+        disable = as_bool(healthcheck.get("disable"))
         test = healthcheck.get("test")
         disabled_via_test = test == ["NONE"] or test == "NONE"
 
@@ -118,7 +119,7 @@ class HealthcheckDisabledRule(BaseRule):
         if not isinstance(healthcheck, dict):
             return None
 
-        disable = healthcheck.get("disable")
+        disable = as_bool(healthcheck.get("disable"))
         test = healthcheck.get("test")
         if not (disable is True or test == ["NONE"] or test == "NONE"):
             return None

--- a/src/compose_lint/rules/_bool.py
+++ b/src/compose_lint/rules/_bool.py
@@ -1,0 +1,29 @@
+"""Boolean coercion matching Docker's compose-file compatibility.
+
+Compose boolean-typed fields accept the YAML 1.1 boolean spellings and their
+quoted string forms; ``docker compose config`` coerces ``privileged: "true"``
+and ``privileged: yes`` alike to a real boolean. The parser keeps *unquoted*
+spellings as bools, but a quoted ``"true"``/``"yes"`` reaches a rule as a
+string, so a rule that tests ``is True`` misreads it. Use ``as_bool`` for every
+boolean-typed field so string and native forms are treated identically.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_TRUE = frozenset({"true", "yes", "on"})
+_FALSE = frozenset({"false", "no", "off"})
+
+
+def as_bool(value: Any) -> bool | None:
+    """Return True/False for a bool or a YAML boolean spelling, else None."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        low = value.strip().lower()
+        if low in _TRUE:
+            return True
+        if low in _FALSE:
+            return False
+    return None

--- a/tests/test_CL0002.py
+++ b/tests/test_CL0002.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from compose_lint.parser import load_compose
+from compose_lint.parser import load_compose, loads
 from compose_lint.rules.CL0002_privileged_mode import PrivilegedModeRule
 
 FIXTURES = Path(__file__).parent / "compose_files"
@@ -56,3 +56,26 @@ class TestPrivilegedModeRule:
     def test_has_references(self) -> None:
         assert len(self.rule.metadata.references) > 0
         assert "owasp" in self.rule.metadata.references[0].lower()
+
+
+class TestStringBoolean:
+    """Quoted string booleans are coerced like Docker does (issue #514)."""
+
+    def setup_method(self) -> None:
+        self.rule = PrivilegedModeRule()
+
+    def _check(self, content: str, service: str = "a") -> list:
+        data, lines = loads(content)
+        return list(self.rule.check(service, data["services"][service], data, lines))
+
+    def test_quoted_true_fires(self) -> None:
+        content = 'services:\n  a:\n    image: nginx\n    privileged: "true"\n'
+        assert len(self._check(content)) == 1
+
+    def test_quoted_yes_fires(self) -> None:
+        content = 'services:\n  a:\n    image: nginx\n    privileged: "yes"\n'
+        assert len(self._check(content)) == 1
+
+    def test_quoted_false_does_not_fire(self) -> None:
+        content = 'services:\n  a:\n    image: nginx\n    privileged: "false"\n'
+        assert self._check(content) == []

--- a/tests/test_CL0007.py
+++ b/tests/test_CL0007.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from compose_lint.fix import apply_edits
-from compose_lint.parser import load_compose
+from compose_lint.parser import load_compose, loads
 from compose_lint.rules.CL0007_read_only import ReadOnlyFilesystemRule
 
 if TYPE_CHECKING:
@@ -188,3 +188,26 @@ class TestReadOnlyFix:
     def test_refuses_explicit_read_only_value(self, tmp_path: Path) -> None:
         content = "services:\n  web:\n    read_only: false\n    image: nginx\n"
         assert self._fix(tmp_path, content) is None
+
+
+class TestStringBoolean:
+    """`read_only: "true"` (quoted) must not be misread as writable (issue #514)."""
+
+    def setup_method(self) -> None:
+        self.rule = ReadOnlyFilesystemRule()
+
+    def _check(self, content: str, service: str = "a") -> list:
+        data, lines = loads(content)
+        return list(self.rule.check(service, data["services"][service], data, lines))
+
+    def test_quoted_true_does_not_fire(self) -> None:
+        content = 'services:\n  a:\n    image: nginx\n    read_only: "true"\n'
+        assert self._check(content) == []
+
+    def test_quoted_false_fires(self) -> None:
+        content = 'services:\n  a:\n    image: nginx\n    read_only: "false"\n'
+        assert len(self._check(content)) == 1
+
+    def test_absent_fires(self) -> None:
+        content = "services:\n  a:\n    image: nginx\n"
+        assert len(self._check(content)) == 1

--- a/tests/test_CL0013.py
+++ b/tests/test_CL0013.py
@@ -194,6 +194,15 @@ class TestTimezoneExemption:
         )
         assert len(self._check(content)) == 1
 
+    def test_long_syntax_quoted_readonly_localtime_exempt(self) -> None:
+        # A quoted `read_only: "true"` is coerced like Docker does (issue #514).
+        content = (
+            "services:\n  a:\n    image: nginx\n    volumes:\n"
+            "      - type: bind\n        source: /etc/localtime\n"
+            '        target: /etc/localtime\n        read_only: "true"\n'
+        )
+        assert self._check(content) == []
+
 
 class TestRunMount:
     """Bare /run is sensitive: it holds both daemon sockets (issue #513)."""

--- a/tests/test_CL0015.py
+++ b/tests/test_CL0015.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from compose_lint.fix import apply_edits
-from compose_lint.parser import load_compose
+from compose_lint.parser import load_compose, loads
 from compose_lint.rules.CL0015_healthcheck_disabled import HealthcheckDisabledRule
 
 if TYPE_CHECKING:
@@ -202,3 +202,28 @@ class TestHealthcheckDisabledFix:
             "      disable: true\n"
         )
         assert self._fix(tmp_path, content) is None
+
+
+class TestStringBoolean:
+    """`disable: "true"` (quoted) is coerced like Docker does (issue #514)."""
+
+    def setup_method(self) -> None:
+        self.rule = HealthcheckDisabledRule()
+
+    def _check(self, content: str, service: str = "a") -> list:
+        data, lines = loads(content)
+        return list(self.rule.check(service, data["services"][service], data, lines))
+
+    def test_quoted_true_fires(self) -> None:
+        content = (
+            "services:\n  a:\n    image: nginx\n"
+            '    healthcheck:\n      disable: "true"\n'
+        )
+        assert len(self._check(content)) == 1
+
+    def test_quoted_false_does_not_fire(self) -> None:
+        content = (
+            "services:\n  a:\n    image: nginx\n"
+            '    healthcheck:\n      disable: "false"\n      test: ["CMD", "true"]\n'
+        )
+        assert self._check(content) == []


### PR DESCRIPTION
## What

`docker compose config` coerces quoted string booleans (`privileged: "true"`, `read_only: "true"`) to real booleans for boolean-typed fields — VERIFIED. The rules tested `is True`, so:

- **CL-0002** missed `privileged: "true"` (false negative — a privileged container passed clean)
- **CL-0007** misread `read_only: "true"` as *not* read-only → **false positive** on a hardened service
- **CL-0013** (long-syntax volume `read_only`) and **CL-0015** (`disable`) misread the string form too

## Fix

New shared `as_bool()` helper (`rules/_bool.py`) maps bool and the YAML boolean spellings (`true/false/yes/no/on/off`, any case, quoted or not) to `True`/`False`/`None`; applied in CL-0002, CL-0007, CL-0013, CL-0015. Unquoted spellings were already coerced by the parser; this closes the quoted-string gap.

## Verification

`TestStringBoolean` added to each rule's tests (fires on quoted true/yes, not on false/absent; CL-0007 no longer fires on `read_only: "true"`). Full suite 1118 passed, 6 skipped; ruff/mypy clean.

Closes #514
