### PR TITLE
Preserve line endings and skip read-only files in fix --apply

### DIFF
--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -583,7 +583,12 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
             continue
 
         try:
-            text = Path(filepath).read_text(encoding="utf-8")
+            # newline="" preserves the file's original line endings: read_text's
+            # universal-newline translation would turn a CRLF file into LF and
+            # _atomic_write would then persist the LF verbatim, so `fix --apply`
+            # would rewrite every line's ending though the diff showed only one.
+            with Path(filepath).open(encoding="utf-8", newline="") as fh:
+                text = fh.read()
         except OSError as e:
             # Parsed above, but unreadable now (deleted, unmounted, permission
             # change) — record and continue so the rest of the batch still runs.
@@ -659,6 +664,17 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
             continue
 
         if args.apply:
+            if not os.access(filepath, os.W_OK):
+                # A read-only file (e.g. chmod 444) is an explicit "do not
+                # modify" signal; os.replace would still swap it in via the
+                # writable parent directory. Warn and skip rather than override
+                # the user's intent silently.
+                print(
+                    f"Warning: {filepath}: file is not writable; skipping "
+                    "(make it writable to allow `fix --apply` to modify it)",
+                    file=sys.stderr,
+                )
+                continue
             _atomic_write(Path(filepath), patched)
             # The behavior-changing caveats must surface here too, not only on
             # the dry run — nothing forces a dry run first, so a one-shot

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -476,6 +476,36 @@ class TestFixSubcommand:
         assert stat.S_IMODE(f.stat().st_mode) == 0o640
         assert "read_only: true" in f.read_text()
 
+    def test_apply_preserves_crlf_line_endings(self, tmp_path: Path) -> None:
+        # Regression (#515): --apply must not rewrite CRLF to LF file-wide. The
+        # read used universal-newline translation, so a one-line edit persisted
+        # the whole file as LF though the diff showed only that line.
+        f = tmp_path / "docker-compose.yml"
+        f.write_bytes(
+            b"services:\r\n  web:\r\n    image: nginx:1.27\r\n"
+            b'    ports:\r\n      - "8080:80"\r\n'
+        )
+        result = run_cli("fix", "--apply", "--only", "CL-0005", str(f))
+        assert result.returncode == 0
+        raw = f.read_bytes()
+        assert b"127.0.0.1:8080:80" in raw  # the fix applied
+        assert b"\r\n" in raw  # endings preserved
+        assert b"\n" not in raw.replace(b"\r\n", b"")  # no lone LF introduced
+
+    def test_apply_skips_read_only_file_with_warning(self, tmp_path: Path) -> None:
+        # Regression (#515): a chmod 444 file is an explicit "do not modify"
+        # signal; os.replace would still swap it in via the writable directory.
+        f = tmp_path / "docker-compose.yml"
+        f.write_text(_BARE_SERVICE)
+        f.chmod(0o444)
+        try:
+            result = run_cli("fix", "--apply", "--only", "CL-0007", str(f))
+            assert result.returncode == 0
+            assert "not writable" in result.stderr
+            assert f.read_text() == _BARE_SERVICE  # unchanged
+        finally:
+            f.chmod(0o644)
+
     def test_apply_prints_behavior_changing_caveats(self, tmp_path: Path) -> None:
         # Regression (#428): the caveat banner must surface on the apply path
         # too, not only in the dry-run diff — nothing forces a dry run first,
@@ -633,7 +663,7 @@ class TestFixSubcommand:
             def __init__(self, *a: object, **k: object) -> None:
                 self._p = Path(*a, **k)
 
-            def read_text(self, *a: object, **k: object) -> str:
+            def open(self, *a: object, **k: object) -> object:
                 raise OSError("simulated: file became unreadable")
 
             def __getattr__(self, name: str) -> object:


### PR DESCRIPTION
## What

Two defects in `fix --apply` where the written change differed from the diff shown:

1. **CRLF → LF file-wide rewrite.** The apply path read with `Path.read_text` (universal-newline translation), so a CRLF file was persisted as LF though the diff showed only one edited line. (CL-0005's CRLF-preservation branch was dead code as a result.)
2. **Wrote files the user marked read-only.** `--apply` on a `chmod 444` file succeeded via the atomic `os.replace` and carried the 444 mode over, no warning.

## Fix

Read the file with `newline=""` so original endings survive; skip a non-writable target with a warning instead of silently overriding the "do not modify" signal.

## Verification

`test_apply_preserves_crlf_line_endings` (all endings stay CRLF, fix still applied) and `test_apply_skips_read_only_file_with_warning` (file unchanged, warning emitted). Updated the existing second-read-failure test to mock `open` (the apply path now reads via `open`); the SARIF/check-path test is unchanged. Full suite 1111 passed, 6 skipped; ruff/mypy clean.

Closes #515
