### PR TITLE
Stop passing include-only files clean; warn on unresolved include

### DIFF
--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -10,7 +10,7 @@ import stat
 import sys
 import tempfile
 from pathlib import Path
-from typing import NoReturn
+from typing import Any, NoReturn
 
 from compose_lint import __version__
 from compose_lint.config import ConfigError, load_config
@@ -334,6 +334,23 @@ def main(argv: list[str] | None = None) -> NoReturn:
     _run_check(args)
 
 
+def _warn_unresolved_include(filepath: str, data: dict[str, Any]) -> None:
+    """Warn that `include:` brings in services compose-lint does not lint.
+
+    An include-*only* file is rejected at parse (ComposeError); here `include`
+    coexists with `services`, so the local services lint normally but services
+    from the included files are invisible. Surface the coverage gap (issue
+    #516) rather than reporting a clean pass over a partial view.
+    """
+    if "include" in data:
+        print(
+            f"Warning: {filepath}: 'include:' is not resolved; services from "
+            "included files are not linted. Lint the merged output "
+            "(docker compose config) to cover them.",
+            file=sys.stderr,
+        )
+
+
 def _run_check(args: argparse.Namespace) -> NoReturn:
     """Run the `check` operation: lint files and exit with the verdict code."""
     if args.explain is not None:
@@ -419,6 +436,7 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
             parse_errors.append((filepath, _report_parse_error(filepath, e)))
             continue
 
+        _warn_unresolved_include(filepath, data)
         seen_services.update(data.get("services", {}).keys())
 
         def _record_rule_error(
@@ -581,6 +599,8 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
             _report_parse_error(filepath, e)
             had_error = True
             continue
+
+        _warn_unresolved_include(filepath, data)
 
         try:
             # newline="" preserves the file's original line endings: read_text's

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -96,6 +96,18 @@ def _classify_missing_services(data: dict[str, Any]) -> ComposeError:
     is not recognisable as Compose at all). See ADR-013 for the heuristic.
     """
 
+    # `include` pulls services in from other files. compose-lint reads files
+    # only and does not resolve it, so an include-only file is NOT a harmless
+    # fragment — treating it as one produces a reassuring clean pass on a
+    # deployable stack (issue #516). Refuse honestly instead.
+    if "include" in data:
+        return ComposeError(
+            "Not a lintable target: this file uses 'include:', which pulls in "
+            "services from other files. compose-lint reads files only and does "
+            "not resolve include. Lint the merged output instead: "
+            "docker compose config > merged.yml && compose-lint merged.yml"
+        )
+
     def _is_meta(k: Any) -> bool:
         if k is _LINES:
             return True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -129,6 +129,29 @@ class TestCLI:
         assert "compose v1" in result.stderr.lower()
         assert "2023" in result.stderr
 
+    def test_include_only_file_errors_not_clean_pass(self, tmp_path: Path) -> None:
+        # Issue #516: an include-only file used to be skipped with a reassuring
+        # "no services to lint" and exit 0 — a false all-clear on a deployable
+        # stack. It must now be an honest usage error (exit 2).
+        f = tmp_path / "docker-compose.yml"
+        f.write_text("include:\n  - base.yml\n")
+        result = run_cli(str(f))
+        assert result.returncode == 2
+        assert "include" in result.stderr.lower()
+
+    def test_include_with_services_warns_and_still_lints(self, tmp_path: Path) -> None:
+        # When include coexists with services, the local services lint normally
+        # but a warning flags that the included files are not covered.
+        f = tmp_path / "docker-compose.yml"
+        f.write_text(
+            "include:\n  - base.yml\n"
+            "services:\n  web:\n    image: nginx:1.27\n    privileged: true\n"
+        )
+        result = run_cli(str(f))
+        assert result.returncode == 1
+        assert "CL-0002" in result.stdout
+        assert "include" in result.stderr.lower()
+
     def test_own_config_skipped_with_exit_zero(self) -> None:
         # ADR-013 / issue #499: handing the linter its own config is a skip,
         # not a failure.

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -43,6 +43,15 @@ class TestLoads:
         with pytest.raises(ComposeError, match="file is empty"):
             loads("")
 
+    def test_include_only_file_is_a_hard_error_not_a_skip(self) -> None:
+        # `include:` pulls services in from other files; compose-lint reads
+        # files only and can't resolve it, so an include-only file must be an
+        # honest error (exit 2), not a reassuring clean pass (issue #516). It
+        # must NOT be a ComposeNotApplicableError (which the CLI skips at exit 0).
+        with pytest.raises(ComposeError, match="include") as exc:
+            loads("include:\n  - base.yml\n")
+        assert not isinstance(exc.value, ComposeNotApplicableError)
+
 
 class TestDuplicateKeys:
     """Duplicate mapping keys are rejected, matching Docker (#277 P2)."""


### PR DESCRIPTION
## What

A file whose only top-level key is `include:` was classified as a harmless *fragment* and skipped with "no services to lint" at **exit 0** — a false all-clear, since `include:` pulls services in from other files and can produce a deployable, privileged stack. compose-lint reads files only and cannot resolve `include`.

## Fix

- **include-only file** → honest usage error (exit 2) pointing at the merged-output workaround (`docker compose config > merged.yml && compose-lint merged.yml`), instead of a reassuring clean pass.
- **include + services** → lint the local services normally, but warn on stderr that the included files are not covered (a coverage gap, not a false pass).

## Verification

`test_include_only_file_is_a_hard_error_not_a_skip` (parser: raises `ComposeError`, not the skip-at-0 `ComposeNotApplicableError`), `test_include_only_file_errors_not_clean_pass` and `test_include_with_services_warns_and_still_lints` (CLI). Full suite 1112 passed, 6 skipped; ruff/mypy clean.

Closes #516
