### PR TITLE
Resolve in-file extends before linting

### DIFF
--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -517,6 +517,75 @@ def _validate_compose(data: Any) -> dict[str, Any]:
     return data
 
 
+def _merge_extends(base: Any, over: Any) -> Any:
+    """Merge a resolved ``extends`` base under an overriding child value.
+
+    Follows Compose's ``extends`` semantics: child scalars win, mappings merge
+    (child wins per key), sequences concatenate with the base first (Docker
+    append-merges the base's list into every service that extends it).
+    """
+    if isinstance(base, dict) and isinstance(over, dict):
+        merged = dict(base)
+        for key, value in over.items():
+            merged[key] = _merge_extends(base[key], value) if key in base else value
+        return merged
+    if isinstance(base, list) and isinstance(over, list):
+        return [*base, *over]
+    return over
+
+
+def _resolve_in_file_extends(data: dict[str, Any]) -> None:
+    """Merge in-file ``extends`` targets into each service, in place.
+
+    A service can inherit another's config via ``extends``. compose-lint reads
+    files only, so it resolves the *in-file* forms — ``extends: <name>`` and
+    ``extends: {service: <name>}`` — by merging the recursively-resolved target
+    into the child. Without this, a child inheriting hardening is flagged for
+    missing it and one inheriting a dangerous key is not flagged at all (issue
+    #517). Cross-file ``extends: {file: ...}`` needs I/O we do not do and is
+    left unresolved.
+
+    The child's ``extends`` key is intentionally *kept* after merging: the
+    fixers refuse to edit either side of an ``extends`` relationship (a text
+    edit could create a post-merge duplicate Docker rejects), and that refusal
+    keys on the ``extends`` marker still being present.
+    """
+    services = data.get("services")
+    if not isinstance(services, dict):
+        return
+    resolved: dict[str, Any] = {}
+
+    def _resolve(name: str, stack: tuple[str, ...]) -> Any:
+        if name in resolved:
+            return resolved[name]
+        cfg = services[name]
+        if not isinstance(cfg, dict):
+            return cfg
+        ext = cfg.get("extends")
+        target: str | None = None
+        if isinstance(ext, str):
+            target = ext
+        elif isinstance(ext, dict) and "file" not in ext:
+            service = ext.get("service")
+            if isinstance(service, str):
+                target = service
+        if (
+            target is None
+            or target not in services
+            or not isinstance(services[target], dict)
+            or name in stack  # cycle — stop rather than recurse forever
+        ):
+            resolved[name] = cfg
+            return cfg
+        parent = _resolve(target, (*stack, name))
+        merged = _merge_extends(parent, cfg)  # keeps child's `extends` marker
+        resolved[name] = merged
+        return merged
+
+    for name in list(services):
+        services[name] = _resolve(name, ())
+
+
 def load_compose(
     path: str | Path,
 ) -> tuple[dict[str, Any], dict[str, int]]:
@@ -589,5 +658,6 @@ def loads(content: str) -> tuple[dict[str, Any], dict[str, int]]:
 
     lines = _collect_lines(raw, seq_lines)
     data = _strip_lines(raw)
+    _resolve_in_file_extends(data)
 
     return data, lines

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -498,3 +498,81 @@ h: {p: *g, q: *g, r: *g, s: *g, t: *g, u: *g, v: *g, w: *g, x: *g}
         assert len(result) < 1000
         # The legitimate `services.s.image` lookup still resolves.
         assert "services.s" in result
+
+
+class TestExtendsResolution:
+    """In-file `extends` is merged into the child before rules run (#517)."""
+
+    def test_mapping_form_inherits_keys(self) -> None:
+        data, _lines = loads(
+            "services:\n"
+            "  base:\n"
+            "    image: nginx\n"
+            "    privileged: true\n"
+            "    read_only: true\n"
+            "  child:\n"
+            "    extends:\n      service: base\n"
+        )
+        child = data["services"]["child"]
+        assert child["privileged"] is True
+        assert child["read_only"] is True
+        assert child["image"] == "nginx"
+
+    def test_shorthand_form_inherits_keys(self) -> None:
+        data, _lines = loads(
+            "services:\n"
+            "  base:\n    image: nginx\n    privileged: true\n"
+            "  child:\n    extends: base\n"
+        )
+        assert data["services"]["child"]["privileged"] is True
+
+    def test_child_keys_win_over_base(self) -> None:
+        data, _lines = loads(
+            "services:\n"
+            "  base:\n    image: nginx\n    privileged: true\n"
+            "  child:\n    extends: base\n    privileged: false\n"
+        )
+        assert data["services"]["child"]["privileged"] is False
+
+    def test_sequences_concatenate(self) -> None:
+        # Docker append-merges the base's list into the child.
+        data, _lines = loads(
+            "services:\n"
+            "  base:\n    image: nginx\n"
+            "    security_opt:\n      - seccomp:unconfined\n"
+            "  child:\n    extends: base\n"
+            "    security_opt:\n      - no-new-privileges:true\n"
+        )
+        assert data["services"]["child"]["security_opt"] == [
+            "seccomp:unconfined",
+            "no-new-privileges:true",
+        ]
+
+    def test_extends_marker_kept_for_fixer_safety(self) -> None:
+        # The child keeps its `extends` key so the fixers still refuse to edit
+        # either side of the merge (a text edit could create a post-merge dup).
+        data, _lines = loads(
+            "services:\n  base:\n    image: nginx\n  child:\n    extends: base\n"
+        )
+        assert "extends" in data["services"]["child"]
+
+    def test_cross_file_extends_left_unresolved(self) -> None:
+        # extends: {file: ...} needs I/O; the child is not merged.
+        data, _lines = loads(
+            "services:\n"
+            "  child:\n    image: nginx\n"
+            "    extends:\n      file: base.yml\n      service: base\n"
+        )
+        assert data["services"]["child"]["extends"] == {
+            "file": "base.yml",
+            "service": "base",
+        }
+
+    def test_extends_cycle_does_not_hang(self) -> None:
+        data, _lines = loads(
+            "services:\n"
+            "  a:\n    image: nginx\n    extends: b\n"
+            "  b:\n    image: redis\n    extends: a\n"
+        )
+        assert "extends" in data["services"]["a"]
+        assert "extends" in data["services"]["b"]


### PR DESCRIPTION
## What

`extends` was not resolved, so a service inheriting config was linted with only its own keys — producing, in a single self-contained file, three false positives and a missed CRITICAL:

```yaml
services:
  base:  { image: x, privileged: true, cap_drop: [ALL], read_only: true,
           security_opt: [no-new-privileges:true] }
  child: { extends: { service: base } }
```

`child` was flagged for CL-0003/0006/0007 (hardening it inherits) and **not** flagged for CL-0002 (the inherited `privileged: true`).

## Fix

Resolve **in-file** `extends` (mapping `{service: X}` and shorthand `extends: X`) in the parser by merging the recursively-resolved target into the child, following Compose semantics: child scalars win, mappings merge per key, sequences concatenate (base first). Cross-file `extends: {file: ...}` needs I/O compose-lint does not do and is left unresolved.

The child's `extends` marker is **kept** after merging: the fixers (`fix.py`, CL-0003) refuse to edit either side of an `extends` relationship because a text edit could create a post-merge duplicate Docker rejects, and that refusal keys on the marker being present. Verified the fixer still refuses.

## Verification

`TestExtendsResolution` (7 cases: mapping/shorthand inherit, child-wins, sequence concat, marker kept, cross-file left unresolved, cycle doesn't hang). On the repro, CL-0002 now fires on the child and the three FPs are gone. Full suite 1116 passed, 6 skipped; ruff/mypy clean.

Closes #517
