### PR TITLE
Match an interpolated bind source on the default it ships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A bind source written as `${VAR:-/some/path}` is now matched on its
+  default.** With no `.env` and no exported variable, Compose substitutes the
+  default, so the default *is* the configuration the file ships — what a fresh
+  clone, a reviewer and a CI gate all get. compose-lint matched the string as
+  written, so `${DOCKER_SOCKET_PATH:-/var/run/docker.sock}` mounted the live
+  control socket and reported nothing: measured over a 5,417-file corpus, 14
+  CRITICAL findings were missing on that spelling alone, plus writable `/etc`
+  paths and `~/.ssh` reached the same way. A reference with **no** default
+  (`${VAR}`, `${VAR:?err}`, `$VAR`) is still left alone — the host path is not
+  knowable from the file, and guessing one would invent a finding. **New
+  findings**, up to CRITICAL, on files using an interpolated bind source with a
+  default that names a flagged host path.
+
 ### Added
 
 - **CL-0028: host-reaching capabilities (`PERFMON`, `SYS_TIME`), HIGH.** Split

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -10,6 +10,7 @@ from typing import Any
 import yaml
 
 from compose_lint.config import KNOWN_TOP_LEVEL_KEYS
+from compose_lint.rules._interpolation import substitute_defaults
 
 
 class _LinesKey:
@@ -609,6 +610,17 @@ def _resolved_bind_source(source: str, base_dir: Path) -> str | None:
     Anything else — an absolute path, a named volume, an unresolved
     ``${VAR}`` — is returned as ``None`` and left exactly as written.
     """
+    # Resolve "${VAR:-default}" first, so the shapes below see the path the
+    # file actually ships. The two compose: "${DATA:-./data}" is a relative
+    # source, "${SOCK:-/var/run/docker.sock}" an absolute one.
+    substituted = substitute_defaults(source)
+    if substituted is None:
+        return None  # a reference with no default -- not knowable from this file
+    if substituted != source:
+        resolved = _resolved_bind_source(substituted, base_dir)
+        # An absolute default resolves to itself, which the recursion reports as
+        # None (nothing to rewrite); the substitution still has to be applied.
+        return resolved if resolved is not None else substituted
     if source.startswith("~"):
         if source == "~" or source.startswith("~/"):
             return os.path.normpath(os.path.expanduser(source))
@@ -616,6 +628,29 @@ def _resolved_bind_source(source: str, base_dir: Path) -> str | None:
     if source in {".", ".."} or source.startswith(("./", "../")):
         return os.path.normpath(os.path.join(base_dir, source))
     return None
+
+
+def _split_short_volume(volume: str) -> tuple[str, str, str]:
+    """Split ``source:target[:mode]`` at the separator, ignoring ``${...}``.
+
+    A plain ``partition(":")`` splits inside the substitution:
+    ``${DOCKER_SOCKET_PATH:-/var/run/docker.sock}:/s`` has its first colon in
+    the ``:-``, yielding a source of ``${DOCKER_SOCKET_PATH``. That silently
+    skipped every ``:-`` default -- the commonest spelling by far -- while the
+    ``-`` form worked, which is exactly the sort of near-miss that looks
+    correct in a test written around one example.
+
+    Returns the same 3-tuple shape as :meth:`str.partition`.
+    """
+    depth = 0
+    for i, ch in enumerate(volume):
+        if ch == "{" and i and volume[i - 1] == "$":
+            depth += 1
+        elif ch == "}" and depth:
+            depth -= 1
+        elif ch == ":" and not depth:
+            return volume[:i], ":", volume[i + 1 :]
+    return volume, "", ""
 
 
 def _resolve_bind_sources(data: dict[str, Any], base_dir: Path) -> None:
@@ -644,7 +679,7 @@ def _resolve_bind_sources(data: dict[str, Any], base_dir: Path) -> None:
             continue
         for i, volume in enumerate(volumes):
             if isinstance(volume, str):
-                source, sep, rest = volume.partition(":")
+                source, sep, rest = _split_short_volume(volume)
                 if not sep:
                     continue  # a lone name is an anonymous volume, not a bind
                 resolved = _resolved_bind_source(source, base_dir)

--- a/src/compose_lint/rules/_interpolation.py
+++ b/src/compose_lint/rules/_interpolation.py
@@ -19,3 +19,41 @@ def contains_var_ref(value: str) -> bool:
     tested against the reference pattern.
     """
     return _VAR_REF_RE.search(value.replace("$$", "")) is not None
+
+
+# "${VAR:-default}" and "${VAR-default}". Compose distinguishes them -- ":-"
+# substitutes when unset *or empty*, "-" only when unset -- but both yield the
+# same default for a file carrying no .env, which is the case being resolved.
+# Non-greedy up to the first "}", so a trailing literal survives:
+# "${DIR:-/srv}/data" -> "/srv/data".
+_VAR_DEFAULT_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*):?-([^}]*)\}")
+
+# A reference with no default: "${VAR}", "$VAR", "${VAR:?err}". Nothing to
+# resolve to, so a value containing one is left exactly as written.
+_VAR_NO_DEFAULT_RE = re.compile(
+    r"\$\{[A-Za-z_][A-Za-z0-9_]*(:?[?+][^}]*)?\}|\$[A-Za-z_][A-Za-z0-9_]*"
+)
+
+
+def substitute_defaults(value: str) -> str | None:
+    """Resolve ``${VAR:-default}`` to its default, or ``None`` if unresolvable.
+
+    With no ``.env`` and no exported variable, Compose substitutes the default,
+    so the default *is* the configuration the file ships: it is what a fresh
+    clone, a reviewer and a CI gate all get. Leaving it unresolved hid real
+    findings -- ``${DOCKER_SOCKET_PATH:-/var/run/docker.sock}`` mounts the live
+    control socket and was reported clean, 13 times over the corpus.
+
+    Returns ``None`` when any reference in the value has no default, because
+    then the host path genuinely is not knowable from this file and guessing
+    one would invent a finding. Deliberately narrow: it answers "what does this
+    file do on its own", not "what will it do in your deployment", and a
+    deployment that sets the variable is the case suppressions exist for.
+    """
+    escaped = value.replace("$$", "")
+    if not _VAR_REF_RE.search(escaped):
+        return value  # nothing to substitute
+    resolved = _VAR_DEFAULT_RE.sub(lambda m: m.group(2), value)
+    if _VAR_NO_DEFAULT_RE.search(resolved.replace("$$", "")):
+        return None  # a reference without a default remains -- not knowable
+    return resolved

--- a/tests/test_bind_source_resolution.py
+++ b/tests/test_bind_source_resolution.py
@@ -214,3 +214,73 @@ def test_loads_without_a_base_dir_leaves_sources_as_written() -> None:
         'services:\n  svc:\n    image: nginx\n    volumes: ["../../x:/x"]\n'
     )
     assert data["services"]["svc"]["volumes"] == ["../../x:/x"]
+
+
+def test_an_interpolated_default_resolves_to_its_default(base_dir: Path) -> None:
+    # With no .env and no exported variable, Compose substitutes the default,
+    # so the default is the configuration the file ships. Verified against
+    # Compose 29.4.3. Both spellings: ":-" (unset or empty) and "-" (unset).
+    for source in (
+        "${DOCKER_SOCKET_PATH:-/var/run/docker.sock}",
+        "${DOCKER_SOCKET_PATH-/var/run/docker.sock}",
+    ):
+        path = _write(
+            base_dir / source.replace("$", "").replace("{", "").replace("}", "")[:20],
+            f'services:\n  svc:\n    image: nginx\n    volumes: ["{source}:/s"]\n',
+        )
+        assert _mount_findings(path).get("svc") == {"CL-0001"}, source
+
+
+def test_a_default_is_resolved_before_the_relative_and_tilde_shapes(
+    base_dir: Path,
+) -> None:
+    # The two compose: a default may itself be relative, or carry a literal
+    # suffix. "${DIR:-/srv}/data" must become "/srv/data", not stay as written.
+    path = _write(
+        base_dir,
+        "services:\n  svc:\n    image: nginx\n"
+        '    volumes: ["${DIR:-/srv}/data:/d", "${DATA:-./local}:/l"]\n',
+    )
+    data, _ = load_compose(path)
+    volumes = data["services"]["svc"]["volumes"]
+    assert volumes[0] == "/srv/data:/d"
+    assert volumes[1].endswith("/local:/l")
+    assert volumes[1].startswith("/")  # the relative default was resolved too
+
+
+def test_a_reference_without_a_default_is_still_left_alone(base_dir: Path) -> None:
+    # Nothing to resolve to: the host path is genuinely not knowable from this
+    # file, and guessing one would invent a finding.
+    for source in ("${UNSET}", "${REQUIRED:?boom}", "$BARE"):
+        path = _write(
+            base_dir / source.replace("$", "").replace("{", "").replace("}", "")[:16],
+            f'services:\n  svc:\n    image: nginx\n    volumes: ["{source}:/s"]\n',
+        )
+        data, _ = load_compose(path)
+        assert data["services"]["svc"]["volumes"] == [f"{source}:/s"], source
+
+
+def test_the_separator_split_ignores_a_colon_inside_a_substitution() -> None:
+    # A plain partition(":") splits inside "${VAR:-...}", yielding a source of
+    # "${VAR" -- which silently skipped the commonest spelling while the "-"
+    # form worked.
+    from compose_lint.parser import _split_short_volume
+
+    assert _split_short_volume("${SOCK:-/var/run/docker.sock}:/s") == (
+        "${SOCK:-/var/run/docker.sock}",
+        ":",
+        "/s",
+    )
+    assert _split_short_volume("/etc:/host:ro") == ("/etc", ":", "/host:ro")
+    assert _split_short_volume("plainvol") == ("plainvol", "", "")
+
+
+def test_an_escaped_dollar_is_not_a_substitution(base_dir: Path) -> None:
+    # Compose writes a literal dollar as "$$" (issue #502), so this is a named
+    # volume called pa$w0rd_vol, not a reference.
+    path = _write(
+        base_dir,
+        'services:\n  svc:\n    image: nginx\n    volumes: ["pa$$w0rd_vol:/d"]\n',
+    )
+    data, _ = load_compose(path)
+    assert data["services"]["svc"]["volumes"] == ["pa$$w0rd_vol:/d"]


### PR DESCRIPTION
`${DOCKER_SOCKET_PATH:-/var/run/docker.sock}` mounts the live control socket on any host with that variable unset — every fresh clone of the file. compose-lint matched the source as written, so it matched no entry in any path list and reported clean.

Found by a corpus differential across the 42 commits that had never had one, not by review — the region had been read four times.

## Measured

5,417-file corpus, same snapshot both legs, against the merged tip:

| | |
|---|---|
| **+14** | `CL-0001` — interpolated socket mounts (the FN class) |
| **+8** | `CL-0025` — writable `/etc` subtrees reached via a default |
| **+19** | `CL-0013` — incl. `~/.ssh` and `/var/lib/docker` paths |
| **0** | findings removed |

## Scope

- `${VAR:-X}` and `${VAR-X}` resolve to `X`; defaults resolve *before* the relative and `~` shapes, so `${DIR:-/srv}/data` → `/srv/data` and `${DATA:-./local}` resolves against the compose file's directory.
- `${VAR}`, `${VAR:?err}` and `$VAR` are left exactly as written — no default means the path is not knowable from this file, and guessing one invents a finding.
- `$$` remains a literal dollar (#502).

## One bug found in the fix itself

`partition(":")` splits *inside* the substitution — the first colon in `${VAR:-/x}` is the `:-` — so the source came out as `${VAR` and only the rarer `${VAR-/x}` form ever worked. `_split_short_volume` now respects `${...}` and is tested directly rather than only through its callers.

## Known, not addressed here

Three of the new `CL-0013` hits are `/dev/null`. That is a pre-existing false positive in the `/dev` descent match — `/dev/hugepages`, `/dev/shm` and `/dev/null` are already 55 of the 76 `/dev` findings — and it gets its own change.