### PR TITLE
Claim what sits below the runtime directories, and stop claiming a bit bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A mount below `/run` or `/var/run` is flagged again (CL-0013, HIGH).** The
+  runtime directories moved to [CL-0001](docs/rules/CL-0001.md), which owns a
+  socket directory and its *ancestors* — the paths that actually hold the
+  control socket. CL-0013 had matched the same directories by *descent*, so the
+  move left everything strictly below them owned by neither rule and 35 HIGH
+  findings disappeared silently: `/var/run/dbus` (the system bus reaches systemd
+  and PolicyKit), `/var/run/libvirt/libvirt-sock` (VM control), `/run/udev`,
+  `/var/run/utmp`, `/run/systemd/journal`. A descendant that *is* a control
+  socket stays CL-0001's at CRITICAL, so nothing double-reports.
+- **`/dev/null` and the other inert character devices are no longer flagged
+  (CL-0013).** `/dev/null`, `/dev/zero`, `/dev/full`, `/dev/random` and
+  `/dev/urandom` disclose no host state and grant no access — mounting
+  `/dev/null` over a config file the image expects is a near-universal idiom,
+  and the `/dev` descent match priced it HIGH. 17 findings removed across the
+  corpus. The rest of `/dev`, including `/dev/shm`, is unchanged.
+
 - **A bind source written as `${VAR:-/some/path}` is now matched on its
   default.** With no `.env` and no exported variable, Compose substitutes the
   default, so the default *is* the configuration the file ships — what a fresh

--- a/docs/rules/CL-0013.md
+++ b/docs/rules/CL-0013.md
@@ -21,7 +21,8 @@
 Services that bind-mount a host path whose exposure is disclosure or a weakened
 boundary rather than host root:
 - `/sys` — kernel device and driver interfaces, in either mode
-- `/dev` — the entire host device tree, in either mode. The device *nodes* become visible but stay unusable — a bind is not `devices:`, see below
+- a path strictly below `/run` or `/var/run` — host runtime state: the system bus (`/var/run/dbus`), the libvirt control socket, udev's device database, `utmp`. The directories themselves and anything above them are [CL-0001](CL-0001.md) at CRITICAL, because those hold the daemon control socket; what sits below does not
+- `/dev` — the entire host device tree, in either mode. The device *nodes* become visible but stay unusable — a bind is not `devices:`, see below. The inert character devices `/dev/null`, `/dev/zero`, `/dev/full`, `/dev/random` and `/dev/urandom` are excluded: they disclose no host state and grant no access
 - `/home` itself, or a single user's home directory (`/home/alice`) — the whole tree, with credentials, source code and shell history, in either mode
 - a credential directory inside a home directory — `.ssh`, `.docker`, `.aws`, `.kube`, `.gnupg`, and anything below them — in either mode
 - **read-only** mounts of the root-equivalent paths `/etc`, `/proc`, `/boot`, `/root`, `/var/lib/docker`, `/var/lib/containerd` and `/var/lib` — the same paths *writable* are [CL-0025](CL-0025.md) at CRITICAL

--- a/src/compose_lint/rules/CL0001_docker_socket.py
+++ b/src/compose_lint/rules/CL0001_docker_socket.py
@@ -93,6 +93,22 @@ def _matched_socket_dir(host_path: str) -> str | None:
     return None
 
 
+def claims_host_path(host_path: str) -> bool:
+    """Whether CL-0001 owns this mount — by socket directory or socket name.
+
+    Exported so CL-0013 can claim what is left under ``/run`` and ``/var/run``
+    without guessing at the boundary. CL-0001 matches a socket directory or an
+    **ancestor** of one, so a strict descendant like ``/run/dbus`` is not its:
+    that path holds no control socket. Before the runtime directories moved
+    here, CL-0013 matched them by descent and covered those descendants; the
+    move left them claimed by neither rule, which is the gap this predicate
+    closes rather than papers over.
+    """
+    if _matched_socket_dir(host_path) is not None:
+        return True
+    return any(marker in host_path for marker in _RUNTIME_SOCKETS)
+
+
 @register_rule
 class DockerSocketRule(BaseRule):
     """Detects container-runtime control-socket mounts in service volumes."""

--- a/src/compose_lint/rules/CL0013_sensitive_mount.py
+++ b/src/compose_lint/rules/CL0013_sensitive_mount.py
@@ -12,6 +12,7 @@ from compose_lint.rules._mounts import (
     match_prefix,
     normalize_host_path,
 )
+from compose_lint.rules.CL0001_docker_socket import claims_host_path
 from compose_lint.rules.CL0025_writable_host_root import match_root_equivalent
 
 if TYPE_CHECKING:
@@ -44,6 +45,39 @@ _EXPOSED_PATHS: tuple[str, ...] = (
     # --device, which is why CL-0016 owns raw device access, not this rule.
     "/dev",
 )
+
+# Character devices that convey nothing. Mounting /dev/null into a container
+# discloses no host state and grants no access -- it is a bit bucket, and a
+# near-universal way to blank out a config file the image expects. They are
+# excluded rather than left to the /dev descent match, which priced them as
+# "exposes host kernel interfaces, devices or user data".
+_INERT_DEVICES: frozenset[str] = frozenset(
+    {"/dev/null", "/dev/zero", "/dev/full", "/dev/random", "/dev/urandom"}
+)
+
+# The runtime directories. CL-0001 owns these and their ancestors, because they
+# hold the control sockets; it does not own what sits *below* them, which holds
+# host service state instead -- the system D-Bus, the libvirt control socket,
+# udev's device database, utmp. CL-0013 matched all of it by descent until the
+# directories moved to CL-0001, and the move left the descendants claimed by
+# neither rule: measured over the corpus, 35 HIGH findings disappeared,
+# /var/run/dbus and /var/run/libvirt/libvirt-sock among them.
+_RUNTIME_DIRS: tuple[str, ...] = ("/run", "/var/run")
+
+
+def _match_runtime_descendant(normalized: str) -> str | None:
+    """The runtime directory this mount sits strictly below, or ``None``.
+
+    Callers must first confirm CL-0001 does not claim the path
+    (:func:`claims_host_path`) — a descendant that *is* a control socket, or a
+    socket directory in its own right like ``/run/containerd``, is CL-0001's at
+    CRITICAL and must not be double-reported here at HIGH.
+    """
+    for directory in _RUNTIME_DIRS:
+        if normalized.startswith(directory + "/"):
+            return directory
+    return None
+
 
 _HOME_ROOT = "/home"
 
@@ -114,10 +148,20 @@ class SensitiveMountRule(BaseRule):
         ):
             normalized = normalize_host_path(mount.host_path)
 
+            if normalized in _INERT_DEVICES:
+                continue  # a bit bucket discloses nothing
+
             matched = match_prefix(mount.host_path, _EXPOSED_PATHS) or _match_home_tree(
                 normalized
             )
             reason = "exposes host kernel interfaces, devices or user data"
+            if matched is None and not claims_host_path(mount.host_path):
+                matched = _match_runtime_descendant(normalized)
+                if matched is not None:
+                    reason = (
+                        "exposes host runtime state — service sockets, the "
+                        "system bus and device state live here"
+                    )
             if matched is None:
                 matched = match_root_equivalent(mount.host_path)
                 if matched is None:

--- a/tests/test_rule_membership.py
+++ b/tests/test_rule_membership.py
@@ -26,6 +26,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from compose_lint.engine import run_rules
+from compose_lint.parser import loads
 from compose_lint.rules._mounts import TIMEZONE_FILES, match_prefix
 from compose_lint.rules.CL0001_docker_socket import _RUNTIME_SOCKETS, _SOCKET_DIRS
 from compose_lint.rules.CL0011_dangerous_cap_add import STRONG_CAPS
@@ -355,3 +357,61 @@ class TestDeviceMembership:
         """
         assert r"^/dev/loop" in self._patterns()
         assert r"^/dev/kmsg$" in self._patterns()
+
+
+class TestRuntimeDirectoryPartition:
+    """`/run` and `/var/run` split between CL-0001 and CL-0013 by direction.
+
+    CL-0001 owns a socket directory and its *ancestors*, because those hold the
+    control socket. What sits strictly *below* holds host service state instead
+    -- the system bus, the libvirt socket, udev's database -- and that is
+    CL-0013's. CL-0013 matched all of it by descent until the directories moved
+    to CL-0001; the move left the descendants owned by neither, and 35 HIGH
+    findings vanished from the corpus without anything recording the decision.
+    """
+
+    def _owners(self, host_path: str) -> set[str]:
+        data, lines = loads(
+            f"services:\n  a:\n    image: x\n    volumes:\n      - {host_path}:/mnt\n"
+        )
+        return {
+            f.rule_id
+            for f in run_rules(data, lines)
+            if f.rule_id in {"CL-0001", "CL-0013", "CL-0025"}
+        }
+
+    def test_socket_directories_and_ancestors_are_cl0001s(self) -> None:
+        for path in ("/", "/var", "/run", "/var/run", "/run/containerd"):
+            assert self._owners(path) == {"CL-0001"}, path
+
+    def test_strict_descendants_are_cl0013s(self) -> None:
+        # None of these holds a control socket, so CRITICAL would be false --
+        # but they are not nothing either.
+        for path in (
+            "/run/dbus",
+            "/var/run/dbus",
+            "/var/run/libvirt/libvirt-sock",
+            "/run/udev",
+            "/run/user/1000",
+            "/run/myapp",
+        ):
+            assert self._owners(path) == {"CL-0013"}, path
+
+    def test_a_descendant_that_is_a_socket_stays_cl0001s(self) -> None:
+        # The socket-name match still wins, so these must not double-report.
+        for path in (
+            "/run/docker.sock",
+            "/var/run/docker.sock",
+            "/run/systemd/private",
+        ):
+            assert self._owners(path) == {"CL-0001"}, path
+
+    def test_inert_devices_are_claimed_by_nobody(self) -> None:
+        # A bit bucket discloses nothing. /dev/null:/some/config is a common way
+        # to blank a file the image expects, and it was priced HIGH.
+        for path in ("/dev/null", "/dev/zero", "/dev/urandom", "/dev/random"):
+            assert self._owners(path) == set(), path
+
+    def test_the_rest_of_dev_is_untouched(self) -> None:
+        for path in ("/dev", "/dev/shm", "/dev/sda"):
+            assert "CL-0013" in self._owners(path), path


### PR DESCRIPTION
Two CL-0013 membership corrections, both found by a corpus differential across the 42 commits that had never had one.

## 1. A partition gap opened when `/run` moved

`/run` and `/var/run` moved to CL-0001, which owns a socket directory and its **ancestors** — the paths that actually hold the control socket. CL-0013 had matched the same directories by **descent**. So everything strictly *below* them ended up owned by neither rule, and **35 HIGH findings disappeared silently**:

| Path | What was lost |
|---|---|
| `/var/run/dbus` | the system bus — reaches systemd and PolicyKit |
| `/var/run/libvirt/libvirt-sock` | VM control |
| `/run/udev`, `/var/run/utmp`, `/run/systemd/journal` | host runtime state |

None holds a control socket, so CRITICAL would be false — but they aren't nothing, and HIGH is where they sat before the move.

The boundary is now **stated rather than inferred**: CL-0001 exposes `claims_host_path`, and CL-0013 claims a runtime descendant only where CL-0001 does not. A descendant that *is* a socket (`/run/docker.sock`, `/run/systemd/private`) stays CRITICAL.

## 2. `/dev/null` is not a disclosure

`/dev/null`, `/dev/zero`, `/dev/full`, `/dev/random`, `/dev/urandom` convey no host state and grant no access. Mounting `/dev/null` over a config file the image insists on reading is a near-universal idiom, and the `/dev` descent match priced it HIGH.

The rest of `/dev` is untouched, **`/dev/shm` included** — shared memory between containers is a real if minor isolation question, and deciding it isn't this change.

## Measured

Same corpus snapshot both legs:

- **+43** CL-0013 from runtime descendants
- **−17** from inert devices — 16 `/dev/null` + 1 `/dev/urandom`, exactly the population measured beforehand
- no other rule moved
- **0 double-reports** across a 21-path partition probe covering both directions