### PR TITLE
Record that the pinned corpus is gone, and why that is not recoverable

### DIFF
--- a/docs/state-of-compose.md
+++ b/docs/state-of-compose.md
@@ -89,7 +89,15 @@ The MEDIUM-heavy distribution is a property of compose-lint's rule design: the t
 > 5,417 files against 6,444, with the longtail tier at 1,125 against 1,552,
 > because the longtail sweep is a stratified code search that GitHub does not
 > reproduce. Publishing its headline figures here would conflate corpus drift
-> with the rule changes. What it is good for is direction and sanity: every one
+> with the rule changes.
+>
+> **The pinned 6,444-file corpus no longer exists**, and because the longtail
+> tier does not reproduce it cannot be rebuilt. The next refresh is therefore a
+> new baseline rather than a comparison, and the delta across it is not
+> measurable — a discontinuity worth stating plainly rather than papering over
+> with a like-for-like claim the data cannot support. The 5,417-file snapshot
+> that replaces it is archived rather than left in a cache directory, so the
+> same break does not happen twice. What it is good for is direction and sanity: every one
 > of the 24 rules fires on real files, none is dead, there were zero crashes and
 > zero timeouts across 5,279 files, and the share of files carrying at least one
 > finding came out at **91.2%** — the same figure this report already cites.


### PR DESCRIPTION
The report is pinned to a 6,444-file corpus run from 2026-05-03. **That corpus no longer exists on disk**, and the longtail tier — 1,552 of those files — came from a stratified GitHub code search that does not reproduce. A re-fetch gets 5,417 files with 1,125 in that tier.

The banner already warned that the recent re-lint was not the refresh. It did not say that the refresh, *when it happens*, cannot be a comparison at all: there is nothing left to compare against.

Worth stating plainly, because the alternative is a future refresh quietly presenting a delta the data cannot support — the same conflation of corpus drift with rule changes the banner exists to prevent, arriving through the front door.

The 5,417-file snapshot that replaces it is now archived out of the cache directory it was living in, where a cache cleaner would have taken the only reproducible baseline in existence with it.