### PR TITLE
Say why last-writer-wins is safe in config_emit severity

### DIFF
--- a/src/compose_lint/config_emit.py
+++ b/src/compose_lint/config_emit.py
@@ -62,8 +62,18 @@ def render_config(findings: list[Finding]) -> str:
     severities: dict[str, Severity] = {}
     for f in findings:
         by_rule.setdefault(f.rule_id, set()).add(f.service)
-        # Severity is rule-stable under the empty config init runs with, so the
-        # last writer per rule is as good as any.
+        # Last writer per rule wins, which is only sound because severity is
+        # rule-stable here: init runs with an empty config, so no per-rule
+        # override applies, and every rule emits exactly one severity — an
+        # invariant tests/test_rule_consistency.py enforces through its
+        # deliberately empty VARIABLE_SEVERITY_RULES allow-list.
+        #
+        # This was false when #503 was filed: CL-0011 and CL-0013 branched, and
+        # this line labelled them by whichever finding the rule emitted last.
+        # Both stopped branching when the capability and host-path splits gave
+        # each tier its own id. Putting an entry back on that allow-list
+        # silently reinstates the mislabelling here, so a branching rule needs
+        # this to take the highest severity per rule rather than the last.
         severities[f.rule_id] = f.severity
 
     names = _rule_names()


### PR DESCRIPTION
`config_emit.py` keeps one severity per rule by letting the last finding win. The comment justifying that asserted severity is "rule-stable under the empty config init runs with" without saying what makes it so — and the assertion was **false when #503 was filed**. CL-0011 and CL-0013 branched their severity, so `init` labelled them by whichever finding the rule happened to emit last.

It is true now: the capability and host-path splits gave each tier its own rule id, and no rule branches any more.

Verified rather than assumed — no rule file contains more than one `severity=Severity.*` literal, and none computes severity dynamically. The invariant's real enforcement is the deliberately empty `VARIABLE_SEVERITY_RULES` allow-list in `tests/test_rule_consistency.py`; `test_findings_agree_with_metadata` pins emitted severity to the metadata baseline for every rule not listed there.

So the comment now names that allow-list and says what breaks here if an entry goes back on it: this line silently returns to labelling by emission order, and a branching rule would need it to take the highest severity per rule instead. Comment-only change.

Closes the correctness note left over from the severity review.