### PR TITLE
Regenerate State of Compose as a 0.16.0 baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@
 
 Static-analysis checks for `docker-compose.yml` and `compose.yaml`, covering privileged containers, unpinned images, host-network sharing, sensitive bind mounts, hard-coded credentials, and more. Full rule documentation lives at **[tmatens.github.io/compose-lint](https://tmatens.github.io/compose-lint/)** (the same pages `--explain` prints offline).
 
-In a scan of 6,444 public Docker Compose files on GitHub, **91% of those that parse had at least one security finding.** Nearly all skip basic capability restrictions, 52% run images without a pinned digest, and 58% bind ports to all interfaces. compose-lint catches these in CI before they ship. **[Read the full *State of Docker Compose Security* report →](https://tmatens.github.io/compose-lint/state-of-compose/)**
-
-*(The report is pinned to compose-lint 0.7.0. Its severity-tier percentages predate the severity-model rework and are being regenerated; the prevalence figures above are unaffected, since they count findings rather than tiers.)*
+In a scan of 5,417 public Docker Compose files on GitHub, **91% of those that parse had at least one security finding.** Nearly all skip basic capability restrictions, 49% run images without a pinned digest, and 64% bind ports to all interfaces. compose-lint catches these in CI before they ship. **[Read the full *State of Docker Compose Security* report →](https://tmatens.github.io/compose-lint/state-of-compose/)**
 
 <!-- Demo GIF. Regenerate with scripts/demo/ — see scripts/demo/README.md. -->
 ![compose-lint scanning a docker-compose.yml with two services: under `service: watchtower`, a CRITICAL mounted Docker socket (CL-0001) with a box-drawing underline, fix block and reference URL, above a MEDIUM image pinned to a tag but not a digest (CL-0019); then under `service: db`, a HIGH plaintext credential (CL-0020) with `POSTGRES_PASSWORD: hunter2` underlined — then the FAIL verdict, and `compose-lint --explain CL-0001` printing the offline rule docs.](https://raw.githubusercontent.com/tmatens/compose-lint/main/docs/assets/demo.gif)

--- a/docs/assets/findings-by-tier.svg
+++ b/docs/assets/findings-by-tier.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-22T15:09:56.082007</dc:date>
+    <dc:date>2026-08-10T23:51:24.097973</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.10.9, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -30,10 +30,10 @@ z
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 42.142428 299.653822 
-L 536.99976 299.653822 
+    <path d="M 42.497349 299.298901 
+L 536.99976 299.298901 
 L 536.99976 47.054209 
-L 42.142428 47.054209 
+L 42.497349 47.054209 
 z
 " style="fill: #ffffff"/>
    </g>
@@ -41,164 +41,164 @@ z
     <g id="xtick_1">
      <g id="line2d_1"/>
      <g id="text_1">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="103.160748" y="311.512104" transform="rotate(-0 103.160748 311.512104)">canonical</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="103.471906" y="311.157182" transform="rotate(-0 103.471906 311.157182)">canonical</text>
      </g>
     </g>
     <g id="xtick_2">
      <g id="line2d_2"/>
      <g id="text_2">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="227.434312" y="311.512104" transform="rotate(-0 227.434312 311.512104)">popular</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="227.656338" y="311.157182" transform="rotate(-0 227.656338 311.157182)">popular</text>
      </g>
     </g>
     <g id="xtick_3">
      <g id="line2d_3"/>
      <g id="text_3">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="351.707876" y="311.512104" transform="rotate(-0 351.707876 311.512104)">selfhosted</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="351.840771" y="311.157182" transform="rotate(-0 351.840771 311.157182)">selfhosted</text>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_4"/>
      <g id="text_4">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="475.98144" y="311.512104" transform="rotate(-0 475.98144 311.512104)">longtail</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="476.025204" y="311.157182" transform="rotate(-0 476.025204 311.157182)">longtail</text>
      </g>
     </g>
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_5">
-      <path d="M 42.142428 299.653822 
-L 536.99976 299.653822 
-" clip-path="url(#p08c880e1d4)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 42.497349 299.298901 
+L 536.99976 299.298901 
+" clip-path="url(#p1abb377194)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_6"/>
      <g id="text_5">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.642428" y="303.832963" transform="rotate(-0 38.642428 303.832963)">0</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.997349" y="303.477612" transform="rotate(-0 38.997349 303.477612)">0</text>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_7">
-      <path d="M 42.142428 252.876116 
-L 536.99976 252.876116 
-" clip-path="url(#p08c880e1d4)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 42.497349 252.586921 
+L 536.99976 252.586921 
+" clip-path="url(#p1abb377194)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8"/>
      <g id="text_6">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.642428" y="257.055257" transform="rotate(-0 38.642428 257.055257)">20</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.997349" y="256.765632" transform="rotate(-0 38.997349 256.765632)">20</text>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_9">
-      <path d="M 42.142428 206.09841 
-L 536.99976 206.09841 
-" clip-path="url(#p08c880e1d4)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 42.497349 205.874941 
+L 536.99976 205.874941 
+" clip-path="url(#p1abb377194)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10"/>
      <g id="text_7">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.642428" y="210.277551" transform="rotate(-0 38.642428 210.277551)">40</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.997349" y="210.053652" transform="rotate(-0 38.997349 210.053652)">40</text>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_11">
-      <path d="M 42.142428 159.320704 
-L 536.99976 159.320704 
-" clip-path="url(#p08c880e1d4)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 42.497349 159.162961 
+L 536.99976 159.162961 
+" clip-path="url(#p1abb377194)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12"/>
      <g id="text_8">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.642428" y="163.499844" transform="rotate(-0 38.642428 163.499844)">60</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.997349" y="163.341672" transform="rotate(-0 38.997349 163.341672)">60</text>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_13">
-      <path d="M 42.142428 112.542997 
-L 536.99976 112.542997 
-" clip-path="url(#p08c880e1d4)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 42.497349 112.450981 
+L 536.99976 112.450981 
+" clip-path="url(#p1abb377194)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14"/>
      <g id="text_9">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.642428" y="116.722138" transform="rotate(-0 38.642428 116.722138)">80</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.997349" y="116.629692" transform="rotate(-0 38.997349 116.629692)">80</text>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_15">
-      <path d="M 42.142428 65.765291 
-L 536.99976 65.765291 
-" clip-path="url(#p08c880e1d4)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 42.497349 65.739001 
+L 536.99976 65.739001 
+" clip-path="url(#p1abb377194)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16"/>
      <g id="text_10">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.642428" y="69.944432" transform="rotate(-0 38.642428 69.944432)">100</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.997349" y="69.917712" transform="rotate(-0 38.997349 69.917712)">100</text>
      </g>
     </g>
     <g id="text_11">
-     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="11.358521" y="173.354016" transform="rotate(-90 11.358521 173.354016)">Files with ≥1 finding (% of parsed)</text>
+     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="11.358521" y="173.176555" transform="rotate(-90 11.358521 173.176555)">Files with ≥1 finding (% of parsed)</text>
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 64.635943 299.653822 
-L 141.685552 299.653822 
-L 141.685552 106.066084 
-L 64.635943 106.066084 
+    <path d="M 64.974732 299.298901 
+L 141.96908 299.298901 
+L 141.96908 103.871229 
+L 64.974732 103.871229 
 z
-" clip-path="url(#p08c880e1d4)" style="fill: #2563eb"/>
+" clip-path="url(#p1abb377194)" style="fill: #2563eb"/>
    </g>
    <g id="patch_4">
-    <path d="M 188.909507 299.653822 
-L 265.959117 299.653822 
-L 265.959117 77.015626 
-L 188.909507 77.015626 
+    <path d="M 189.159164 299.298901 
+L 266.153512 299.298901 
+L 266.153512 77.497971 
+L 189.159164 77.497971 
 z
-" clip-path="url(#p08c880e1d4)" style="fill: #2563eb"/>
+" clip-path="url(#p1abb377194)" style="fill: #2563eb"/>
    </g>
    <g id="patch_5">
-    <path d="M 313.183071 299.653822 
-L 390.232681 299.653822 
-L 390.232681 65.765291 
-L 313.183071 65.765291 
+    <path d="M 313.343597 299.298901 
+L 390.337945 299.298901 
+L 390.337945 65.739001 
+L 313.343597 65.739001 
 z
-" clip-path="url(#p08c880e1d4)" style="fill: #b1281f; stroke: #b1281f; stroke-linejoin: miter"/>
+" clip-path="url(#p1abb377194)" style="fill: #b1281f; stroke: #b1281f; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 437.456635 299.653822 
-L 514.506245 299.653822 
-L 514.506245 116.443918 
-L 437.456635 116.443918 
+    <path d="M 437.528029 299.298901 
+L 514.522378 299.298901 
+L 514.522378 120.533112 
+L 437.528029 120.533112 
 z
-" clip-path="url(#p08c880e1d4)" style="fill: #2563eb"/>
+" clip-path="url(#p1abb377194)" style="fill: #2563eb"/>
    </g>
    <g id="patch_7">
-    <path d="M 42.142428 299.653822 
-L 42.142428 47.054209 
+    <path d="M 42.497349 299.298901 
+L 42.497349 47.054209 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_8">
-    <path d="M 42.142428 299.653822 
-L 536.99976 299.653822 
+    <path d="M 42.497349 299.298901 
+L 536.99976 299.298901 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_12">
-    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="103.160748" y="100.971766" transform="rotate(-0 103.160748 100.971766)">82.8%</text>
+    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="103.471906" y="98.425932" transform="rotate(-0 103.471906 98.425932)">83.7%</text>
    </g>
    <g id="text_13">
-    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="227.434312" y="71.921307" transform="rotate(-0 227.434312 71.921307)">95.2%</text>
+    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="227.656338" y="72.052674" transform="rotate(-0 227.656338 72.052674)">95.0%</text>
    </g>
    <g id="text_14">
-    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="351.707876" y="60.670973" transform="rotate(-0 351.707876 60.670973)">100.0%</text>
+    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="351.840771" y="60.293704" transform="rotate(-0 351.840771 60.293704)">100.0%</text>
    </g>
    <g id="text_15">
-    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="475.98144" y="111.349599" transform="rotate(-0 475.98144 111.349599)">78.3%</text>
+    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="476.025204" y="115.087815" transform="rotate(-0 476.025204 115.087815)">76.5%</text>
    </g>
    <g id="text_16">
-    <text style="font-weight: 700; font-size: 13px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="289.571094" y="35.054209" transform="rotate(-0 289.571094 35.054209)">Every tier ships findings — even the cleanest is 83%</text>
+    <text style="font-weight: 700; font-size: 13px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="289.748555" y="35.054209" transform="rotate(-0 289.748555 35.054209)">Every tier ships findings — even the cleanest is 83%</text>
    </g>
   </g>
   <g id="text_17">
-   <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #999999" x="6.48" y="10.83075" transform="rotate(-0 6.48 10.83075)">compose-lint 0.7.0  ·  corpus 20260503T034026Z  ·  n=6,266 parsed</text>
+   <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #999999" x="6.48" y="10.83075" transform="rotate(-0 6.48 10.83075)">compose-lint 0.16.0  ·  corpus 20260811T044906Z  ·  n=5,279 parsed</text>
   </g>
  </g>
  <defs>
-  <clipPath id="p08c880e1d4">
-   <rect x="42.142428" y="47.054209" width="494.857332" height="252.599614"/>
+  <clipPath id="p1abb377194">
+   <rect x="42.497349" y="47.054209" width="494.502411" height="252.244692"/>
   </clipPath>
  </defs>
 </svg>

--- a/docs/assets/parse-error-rate.svg
+++ b/docs/assets/parse-error-rate.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-22T15:09:58.733468</dc:date>
+    <dc:date>2026-08-10T23:51:24.292774</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.10.9, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -30,10 +30,10 @@ z
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 35.143678 299.653822 
-L 536.99976 299.653822 
+    <path d="M 35.498599 299.298901 
+L 536.99976 299.298901 
 L 536.99976 47.054209 
-L 35.143678 47.054209 
+L 35.498599 47.054209 
 z
 " style="fill: #ffffff"/>
    </g>
@@ -41,175 +41,164 @@ z
     <g id="xtick_1">
      <g id="line2d_1"/>
      <g id="text_1">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="97.024977" y="311.512104" transform="rotate(-0 97.024977 311.512104)">canonical</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="97.336136" y="311.157182" transform="rotate(-0 97.336136 311.157182)">canonical</text>
      </g>
     </g>
     <g id="xtick_2">
      <g id="line2d_2"/>
      <g id="text_2">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="223.056138" y="311.512104" transform="rotate(-0 223.056138 311.512104)">popular</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="223.278165" y="311.157182" transform="rotate(-0 223.278165 311.157182)">popular</text>
      </g>
     </g>
     <g id="xtick_3">
      <g id="line2d_3"/>
      <g id="text_3">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="349.087299" y="311.512104" transform="rotate(-0 349.087299 311.512104)">selfhosted</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="349.220194" y="311.157182" transform="rotate(-0 349.220194 311.157182)">selfhosted</text>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_4"/>
      <g id="text_4">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="475.11846" y="311.512104" transform="rotate(-0 475.11846 311.512104)">longtail</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="475.162224" y="311.157182" transform="rotate(-0 475.162224 311.157182)">longtail</text>
      </g>
     </g>
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_5">
-      <path d="M 35.143678 299.653822 
-L 536.99976 299.653822 
-" clip-path="url(#pa90e561641)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 35.498599 299.298901 
+L 536.99976 299.298901 
+" clip-path="url(#p1f3969c2e0)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_6"/>
      <g id="text_5">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="31.643678" y="303.832963" transform="rotate(-0 31.643678 303.832963)">0</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="31.998599" y="303.477612" transform="rotate(-0 31.998599 303.477612)">0</text>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_7">
-      <path d="M 35.143678 257.556147 
-L 536.99976 257.556147 
-" clip-path="url(#pa90e561641)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 35.498599 254.785131 
+L 536.99976 254.785131 
+" clip-path="url(#p1f3969c2e0)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8"/>
      <g id="text_6">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="31.643678" y="261.735288" transform="rotate(-0 31.643678 261.735288)">2</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="31.998599" y="258.963842" transform="rotate(-0 31.998599 258.963842)">2</text>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_9">
-      <path d="M 35.143678 215.458472 
-L 536.99976 215.458472 
-" clip-path="url(#pa90e561641)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 35.498599 210.271362 
+L 536.99976 210.271362 
+" clip-path="url(#p1f3969c2e0)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10"/>
      <g id="text_7">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="31.643678" y="219.637613" transform="rotate(-0 31.643678 219.637613)">4</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="31.998599" y="214.450073" transform="rotate(-0 31.998599 214.450073)">4</text>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_11">
-      <path d="M 35.143678 173.360797 
-L 536.99976 173.360797 
-" clip-path="url(#pa90e561641)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 35.498599 165.757593 
+L 536.99976 165.757593 
+" clip-path="url(#p1f3969c2e0)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12"/>
      <g id="text_8">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="31.643678" y="177.539937" transform="rotate(-0 31.643678 177.539937)">6</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="31.998599" y="169.936304" transform="rotate(-0 31.998599 169.936304)">6</text>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_13">
-      <path d="M 35.143678 131.263122 
-L 536.99976 131.263122 
-" clip-path="url(#pa90e561641)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 35.498599 121.243824 
+L 536.99976 121.243824 
+" clip-path="url(#p1f3969c2e0)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14"/>
      <g id="text_9">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="31.643678" y="135.442262" transform="rotate(-0 31.643678 135.442262)">8</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="31.998599" y="125.422535" transform="rotate(-0 31.998599 125.422535)">8</text>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_15">
-      <path d="M 35.143678 89.165446 
-L 536.99976 89.165446 
-" clip-path="url(#pa90e561641)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 35.498599 76.730055 
+L 536.99976 76.730055 
+" clip-path="url(#p1f3969c2e0)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16"/>
      <g id="text_10">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="31.643678" y="93.344587" transform="rotate(-0 31.643678 93.344587)">10</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="31.998599" y="80.908766" transform="rotate(-0 31.998599 80.908766)">10</text>
      </g>
     </g>
-    <g id="ytick_7">
-     <g id="line2d_17">
-      <path d="M 35.143678 47.067771 
-L 536.99976 47.067771 
-" clip-path="url(#pa90e561641)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_18"/>
-     <g id="text_11">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="31.643678" y="51.246912" transform="rotate(-0 31.643678 51.246912)">12</text>
-     </g>
-    </g>
-    <g id="text_12">
-     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="11.358521" y="173.354016" transform="rotate(-90 11.358521 173.354016)">Files failing to parse as Compose (% of tier)</text>
+    <g id="text_11">
+     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="11.358521" y="173.176555" transform="rotate(-90 11.358521 173.176555)">Files failing to parse as Compose (% of tier)</text>
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 57.955318 299.653822 
-L 136.094637 299.653822 
-L 136.094637 286.779916 
-L 57.955318 286.779916 
+    <path d="M 58.294107 299.298901 
+L 136.378165 299.298901 
+L 136.378165 286.396359 
+L 58.294107 286.396359 
 z
-" clip-path="url(#pa90e561641)" style="fill: #2563eb"/>
+" clip-path="url(#p1f3969c2e0)" style="fill: #2563eb"/>
    </g>
    <g id="patch_4">
-    <path d="M 183.986478 299.653822 
-L 262.125798 299.653822 
-L 262.125798 285.363689 
-L 183.986478 285.363689 
+    <path d="M 184.236136 299.298901 
+L 262.320194 299.298901 
+L 262.320194 276.716565 
+L 184.236136 276.716565 
 z
-" clip-path="url(#pa90e561641)" style="fill: #2563eb"/>
+" clip-path="url(#p1f3969c2e0)" style="fill: #2563eb"/>
    </g>
    <g id="patch_5">
-    <path d="M 310.017639 299.653822 
-L 388.156959 299.653822 
-L 388.156959 299.653822 
-L 310.017639 299.653822 
+    <path d="M 310.178165 299.298901 
+L 388.262223 299.298901 
+L 388.262223 299.298901 
+L 310.178165 299.298901 
 z
-" clip-path="url(#pa90e561641)" style="fill: #2563eb"/>
+" clip-path="url(#p1f3969c2e0)" style="fill: #2563eb"/>
    </g>
    <g id="patch_6">
-    <path d="M 436.0488 299.653822 
-L 514.18812 299.653822 
-L 514.18812 97.574131 
-L 436.0488 97.574131 
+    <path d="M 436.120195 299.298901 
+L 514.204253 299.298901 
+L 514.204253 97.503147 
+L 436.120195 97.503147 
 z
-" clip-path="url(#pa90e561641)" style="fill: #b1281f; stroke: #b1281f; stroke-linejoin: miter"/>
+" clip-path="url(#p1f3969c2e0)" style="fill: #b1281f; stroke: #b1281f; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 35.143678 299.653822 
-L 35.143678 47.054209 
+    <path d="M 35.498599 299.298901 
+L 35.498599 47.054209 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_8">
-    <path d="M 35.143678 299.653822 
-L 536.99976 299.653822 
+    <path d="M 35.498599 299.298901 
+L 536.99976 299.298901 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
+   <g id="text_12">
+    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="97.336136" y="280.415248" transform="rotate(-0 97.336136 280.415248)">0.6%</text>
+   </g>
    <g id="text_13">
-    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="97.024977" y="281.334934" transform="rotate(-0 97.024977 281.334934)">0.6%</text>
+    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="223.278165" y="270.735454" transform="rotate(-0 223.278165 270.735454)">1.0%</text>
    </g>
    <g id="text_14">
-    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="223.056138" y="279.918707" transform="rotate(-0 223.056138 279.918707)">0.7%</text>
+    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="349.220194" y="293.31779" transform="rotate(-0 349.220194 293.31779)">0.0%</text>
    </g>
    <g id="text_15">
-    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="349.087299" y="294.208841" transform="rotate(-0 349.087299 294.208841)">0.0%</text>
+    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="475.162224" y="91.522036" transform="rotate(-0 475.162224 91.522036)">9.1%</text>
    </g>
    <g id="text_16">
-    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="475.11846" y="92.12915" transform="rotate(-0 475.11846 92.12915)">9.6%</text>
-   </g>
-   <g id="text_17">
-    <text style="font-weight: 700; font-size: 13px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="286.071719" y="35.054209" transform="rotate(-0 286.071719 35.054209)">Parse failures are a longtail phenomenon</text>
+    <text style="font-weight: 700; font-size: 13px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="286.24918" y="35.054209" transform="rotate(-0 286.24918 35.054209)">Parse failures are a longtail phenomenon</text>
    </g>
   </g>
-  <g id="text_18">
-   <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #999999" x="6.48" y="10.83075" transform="rotate(-0 6.48 10.83075)">compose-lint 0.7.0  ·  corpus 20260503T034026Z  ·  n=6,266 parsed</text>
+  <g id="text_17">
+   <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #999999" x="6.48" y="10.83075" transform="rotate(-0 6.48 10.83075)">compose-lint 0.16.0  ·  corpus 20260811T044906Z  ·  n=5,279 parsed</text>
   </g>
  </g>
  <defs>
-  <clipPath id="pa90e561641">
-   <rect x="35.143678" y="47.054209" width="501.856082" height="252.599614"/>
+  <clipPath id="p1f3969c2e0">
+   <rect x="35.498599" y="47.054209" width="501.501161" height="252.244692"/>
   </clipPath>
  </defs>
 </svg>

--- a/docs/assets/severity-distribution.svg
+++ b/docs/assets/severity-distribution.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-22T15:09:58.056380</dc:date>
+    <dc:date>2026-08-10T23:51:24.253255</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.10.9, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -30,162 +30,166 @@ z
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 20.646574 148.485634 
-L 612.953426 148.485634 
-L 612.953426 38.990209 
-L 20.646574 38.990209 
+    <path d="M 34.965011 148.29688 
+L 598.634989 148.29688 
+L 598.634989 38.990209 
+L 34.965011 38.990209 
 z
 " style="fill: #ffffff"/>
    </g>
    <g id="patch_3">
-    <path d="M 20.646574 126.586549 
-L 27.322566 126.586549 
-L 27.322566 60.889294 
-L 20.646574 60.889294 
+    <path d="M 34.965011 126.435546 
+L 42.086783 126.435546 
+L 42.086783 60.851543 
+L 34.965011 60.851543 
 z
-" clip-path="url(#p69b55e65bf)" style="fill: #b1281f"/>
+" clip-path="url(#pcc52f10a7e)" style="fill: #b1281f"/>
    </g>
    <g id="patch_4">
-    <path d="M 27.322566 126.586549 
-L 147.554446 126.586549 
-L 147.554446 60.889294 
-L 27.322566 60.889294 
+    <path d="M 42.086783 126.435546 
+L 73.723885 126.435546 
+L 73.723885 60.851543 
+L 42.086783 60.851543 
 z
-" clip-path="url(#p69b55e65bf)" style="fill: #e06c00"/>
+" clip-path="url(#pcc52f10a7e)" style="fill: #e06c00"/>
    </g>
    <g id="patch_5">
-    <path d="M 147.554446 126.586549 
-L 612.743087 126.586549 
-L 612.743087 60.889294 
-L 147.554446 60.889294 
+    <path d="M 73.723885 126.435546 
+L 503.422378 126.435546 
+L 503.422378 60.851543 
+L 73.723885 60.851543 
 z
-" clip-path="url(#p69b55e65bf)" style="fill: #e0a800"/>
+" clip-path="url(#pcc52f10a7e)" style="fill: #e0a800"/>
    </g>
    <g id="patch_6">
-    <path d="M 612.743087 126.586549 
-L 612.953426 126.586549 
-L 612.953426 60.889294 
-L 612.743087 60.889294 
+    <path d="M 503.422378 126.435546 
+L 598.634989 126.435546 
+L 598.634989 60.851543 
+L 503.422378 60.851543 
 z
-" clip-path="url(#p69b55e65bf)" style="fill: #8a8a8a"/>
+" clip-path="url(#pcc52f10a7e)" style="fill: #8a8a8a"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1"/>
      <g id="text_1">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="20.646574" y="160.343915" transform="rotate(-0 20.646574 160.343915)">0</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="34.965011" y="160.154302" transform="rotate(-0 34.965011 160.154302)">0</text>
      </g>
     </g>
     <g id="xtick_2">
      <g id="line2d_2"/>
      <g id="text_2">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="139.107944" y="160.343915" transform="rotate(-0 139.107944 160.343915)">20</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="147.699007" y="160.154302" transform="rotate(-0 147.699007 160.154302)">20</text>
      </g>
     </g>
     <g id="xtick_3">
      <g id="line2d_3"/>
      <g id="text_3">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="257.569315" y="160.343915" transform="rotate(-0 257.569315 160.343915)">40</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="260.433002" y="160.154302" transform="rotate(-0 260.433002 160.154302)">40</text>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_4"/>
      <g id="text_4">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="376.030685" y="160.343915" transform="rotate(-0 376.030685 160.343915)">60</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="373.166998" y="160.154302" transform="rotate(-0 373.166998 160.154302)">60</text>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_5"/>
      <g id="text_5">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="494.492056" y="160.343915" transform="rotate(-0 494.492056 160.343915)">80</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="485.900993" y="160.154302" transform="rotate(-0 485.900993 160.154302)">80</text>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_6"/>
      <g id="text_6">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="612.953426" y="160.343915" transform="rotate(-0 612.953426 160.343915)">100</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="598.634989" y="160.154302" transform="rotate(-0 598.634989 160.154302)">100</text>
      </g>
     </g>
     <g id="text_7">
-     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="316.8" y="174.989853" transform="rotate(-0 316.8 174.989853)">Share of all findings (%)</text>
+     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="316.8" y="175.155161" transform="rotate(-0 316.8 175.155161)">Share of all findings (%)</text>
     </g>
    </g>
    <g id="matplotlib.axis_2"/>
    <g id="patch_7">
-    <path d="M 20.646574 148.485634 
-L 20.646574 38.990209 
+    <path d="M 34.965011 148.29688 
+L 34.965011 38.990209 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_8">
-    <path d="M 20.646574 148.485634 
-L 612.953426 148.485634 
+    <path d="M 34.965011 148.29688 
+L 598.634989 148.29688 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_8">
-    <text style="font-weight: 700; font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #ffffff" transform="translate(73.105694 90.89839)">HIGH</text>
-    <text style="font-weight: 700; font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #ffffff" transform="translate(70.092413 102.096203)">20.3%</text>
+    <text style="font-weight: 700; font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #ffffff" transform="translate(43.572521 90.240224)">HIGH</text>
+    <text style="font-weight: 700; font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #ffffff" transform="translate(44.038146 102.242177)">5.6%</text>
    </g>
    <g id="text_9">
-    <text style="font-weight: 700; font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #ffffff" transform="translate(356.710485 90.89839)">MEDIUM</text>
-    <text style="font-weight: 700; font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #ffffff" transform="translate(362.802673 102.096203)">78.5%</text>
+    <text style="font-weight: 700; font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #ffffff" transform="translate(265.13485 90.240224)">MEDIUM</text>
+    <text style="font-weight: 700; font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #ffffff" transform="translate(271.227038 102.242177)">76.2%</text>
    </g>
    <g id="text_10">
+    <text style="font-weight: 700; font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #ffffff" transform="translate(538.255246 90.240224)">LOW</text>
+    <text style="font-weight: 700; font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #ffffff" transform="translate(533.68259 102.242177)">16.9%</text>
+   </g>
+   <g id="text_11">
     <text style="font-weight: 700; font-size: 13px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="316.8" y="26.990209" transform="rotate(-0 316.8 26.990209)">Findings by severity — MEDIUM hardening misses dominate</text>
    </g>
    <g id="legend_1">
     <g id="patch_9">
-     <path d="M 31.916953 201.747627 
-L 49.916953 201.747627 
-L 49.916953 195.447627 
-L 31.916953 195.447627 
+     <path d="M 24.757734 201.492809 
+L 42.757734 201.492809 
+L 42.757734 195.192809 
+L 24.757734 195.192809 
 z
 " style="fill: #b1281f; stroke: #b1281f; stroke-linejoin: miter"/>
     </g>
-    <g id="text_11">
-     <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="57.116953" y="201.747627" transform="rotate(-0 57.116953 201.747627)">CRITICAL — 730 (1.1%)</text>
+    <g id="text_12">
+     <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="49.957734" y="201.492809" transform="rotate(-0 49.957734 201.492809)">CRITICAL — 780 (1.3%)</text>
     </g>
     <g id="patch_10">
-     <path d="M 180.564609 201.747627 
-L 198.564609 201.747627 
-L 198.564609 195.447627 
-L 180.564609 195.447627 
+     <path d="M 173.405391 201.492809 
+L 191.405391 201.492809 
+L 191.405391 195.192809 
+L 173.405391 195.192809 
 z
 " style="fill: #e06c00; stroke: #e06c00; stroke-linejoin: miter"/>
     </g>
-    <g id="text_12">
-     <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="205.764609" y="201.747627" transform="rotate(-0 205.764609 201.747627)">HIGH — 13,147 (20.3%)</text>
+    <g id="text_13">
+     <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="198.605391" y="201.492809" transform="rotate(-0 198.605391 201.492809)">HIGH — 3,465 (5.6%)</text>
     </g>
     <g id="patch_11">
-     <path d="M 331.615547 201.747627 
-L 349.615547 201.747627 
-L 349.615547 195.447627 
-L 331.615547 195.447627 
+     <path d="M 313.003828 201.492809 
+L 331.003828 201.492809 
+L 331.003828 195.192809 
+L 313.003828 195.192809 
 z
 " style="fill: #e0a800; stroke: #e0a800; stroke-linejoin: miter"/>
     </g>
-    <g id="text_13">
-     <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="356.815547" y="201.747627" transform="rotate(-0 356.815547 201.747627)">MEDIUM — 50,867 (78.5%)</text>
+    <g id="text_14">
+     <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="338.203828" y="201.492809" transform="rotate(-0 338.203828 201.492809)">MEDIUM — 47,062 (76.2%)</text>
     </g>
     <g id="patch_12">
-     <path d="M 496.890703 201.747627 
-L 514.890703 201.747627 
-L 514.890703 195.447627 
-L 496.890703 195.447627 
+     <path d="M 478.278984 201.492809 
+L 496.278984 201.492809 
+L 496.278984 195.192809 
+L 478.278984 195.192809 
 z
 " style="fill: #8a8a8a; stroke: #8a8a8a; stroke-linejoin: miter"/>
     </g>
-    <g id="text_14">
-     <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="522.090703" y="201.747627" transform="rotate(-0 522.090703 201.747627)">LOW — 23 (0.0%)</text>
+    <g id="text_15">
+     <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="503.478984" y="201.492809" transform="rotate(-0 503.478984 201.492809)">LOW — 10,428 (16.9%)</text>
     </g>
    </g>
   </g>
-  <g id="text_15">
-   <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #999999" x="7.6032" y="9.10275" transform="rotate(-0 7.6032 9.10275)">compose-lint 0.7.0  ·  corpus 20260503T034026Z  ·  n=6,266 parsed</text>
+  <g id="text_16">
+   <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #999999" x="7.6032" y="9.10275" transform="rotate(-0 7.6032 9.10275)">compose-lint 0.16.0  ·  corpus 20260811T044906Z  ·  n=5,279 parsed</text>
   </g>
  </g>
  <defs>
-  <clipPath id="p69b55e65bf">
-   <rect x="20.646574" y="38.990209" width="592.306853" height="109.495425"/>
+  <clipPath id="pcc52f10a7e">
+   <rect x="34.965011" y="38.990209" width="563.669977" height="109.306671"/>
   </clipPath>
  </defs>
 </svg>

--- a/docs/assets/top-findings.svg
+++ b/docs/assets/top-findings.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-05-22T15:09:57.102734</dc:date>
+    <dc:date>2026-08-10T23:51:24.174777</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.10.9, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -30,315 +30,326 @@ z
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 319.18899 357.007885 
-L 620.101635 357.007885 
+    <path d="M 438.561334 356.298901 
+L 620.101635 356.298901 
 L 620.101635 52.094209 
-L 319.18899 52.094209 
+L 438.561334 52.094209 
 z
 " style="fill: #ffffff"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
-      <path d="M 319.18899 357.007885 
-L 319.18899 52.094209 
-" clip-path="url(#p4b810f53c8)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 438.561334 356.298901 
+L 438.561334 52.094209 
+" clip-path="url(#p715f299a09)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_2"/>
      <g id="text_1">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="319.18899" y="368.866166" transform="rotate(-0 319.18899 368.866166)">0</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="438.561334" y="368.156322" transform="rotate(-0 438.561334 368.156322)">0</text>
      </g>
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
-      <path d="M 379.371519 357.007885 
-L 379.371519 52.094209 
-" clip-path="url(#p4b810f53c8)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 474.869394 356.298901 
+L 474.869394 52.094209 
+" clip-path="url(#p715f299a09)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_4"/>
      <g id="text_2">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="379.371519" y="368.866166" transform="rotate(-0 379.371519 368.866166)">20</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="474.869394" y="368.156322" transform="rotate(-0 474.869394 368.156322)">20</text>
      </g>
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
-      <path d="M 439.554048 357.007885 
-L 439.554048 52.094209 
-" clip-path="url(#p4b810f53c8)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 511.177454 356.298901 
+L 511.177454 52.094209 
+" clip-path="url(#p715f299a09)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_6"/>
      <g id="text_3">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="439.554048" y="368.866166" transform="rotate(-0 439.554048 368.866166)">40</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="511.177454" y="368.156322" transform="rotate(-0 511.177454 368.156322)">40</text>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_7">
-      <path d="M 499.736577 357.007885 
-L 499.736577 52.094209 
-" clip-path="url(#p4b810f53c8)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 547.485515 356.298901 
+L 547.485515 52.094209 
+" clip-path="url(#p715f299a09)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8"/>
      <g id="text_4">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="499.736577" y="368.866166" transform="rotate(-0 499.736577 368.866166)">60</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="547.485515" y="368.156322" transform="rotate(-0 547.485515 368.156322)">60</text>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_9">
-      <path d="M 559.919106 357.007885 
-L 559.919106 52.094209 
-" clip-path="url(#p4b810f53c8)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 583.793575 356.298901 
+L 583.793575 52.094209 
+" clip-path="url(#p715f299a09)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10"/>
      <g id="text_5">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="559.919106" y="368.866166" transform="rotate(-0 559.919106 368.866166)">80</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="583.793575" y="368.156322" transform="rotate(-0 583.793575 368.156322)">80</text>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_11">
-      <path d="M 620.101635 357.007885 
+      <path d="M 620.101635 356.298901 
 L 620.101635 52.094209 
-" clip-path="url(#p4b810f53c8)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p715f299a09)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12"/>
      <g id="text_6">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="620.101635" y="368.866166" transform="rotate(-0 620.101635 368.866166)">100</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="620.101635" y="368.156322" transform="rotate(-0 620.101635 368.156322)">100</text>
      </g>
     </g>
     <g id="text_7">
-     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="469.645313" y="383.512104" transform="rotate(-0 469.645313 383.512104)">Files affected (% of parsed)</text>
+     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="529.331484" y="383.157182" transform="rotate(-0 529.331484 383.157182)">Files affected (% of parsed)</text>
     </g>
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_13"/>
      <g id="text_8">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="315.68899" y="336.013262" transform="rotate(-0 315.68899 336.013262)">CL-0011  ·  Dangerous Capabilities Added</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="435.061334" y="335.362812" transform="rotate(-0 435.061334 335.362812)">CL-0011  ·  Strong host-adjacent capabilities (NET_ADMIN, BPF, SYS_BOOT)</text>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_14"/>
      <g id="text_9">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="315.68899" y="307.728134" transform="rotate(-0 315.68899 307.728134)">CL-0001  ·  Docker Socket Mounted</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="435.061334" y="307.143452" transform="rotate(-0 435.061334 307.143452)">CL-0001  ·  Host control socket exposed — root-equivalent access</text>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_15"/>
      <g id="text_10">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="315.68899" y="279.443007" transform="rotate(-0 315.68899 279.443007)">CL-0013  ·  Sensitive Host Path Mounted</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="435.061334" y="278.924093" transform="rotate(-0 435.061334 278.924093)">CL-0020  ·  Credential-shaped environment keys with literal values</text>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_16"/>
      <g id="text_11">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="315.68899" y="251.157879" transform="rotate(-0 315.68899 251.157879)">CL-0020  ·  Credential-Shaped Env Key With Literal Value</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="435.061334" y="250.704734" transform="rotate(-0 435.061334 250.704734)">CL-0004  ·  Unpinned image tags (implicit :latest)</text>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_17"/>
      <g id="text_12">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="315.68899" y="222.872751" transform="rotate(-0 315.68899 222.872751)">CL-0004  ·  Image Not Pinned to Version</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="435.061334" y="222.485375" transform="rotate(-0 435.061334 222.485375)">CL-0019  ·  Image tags without digest pins (@sha256)</text>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_18"/>
      <g id="text_13">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="315.68899" y="194.587624" transform="rotate(-0 315.68899 194.587624)">CL-0019  ·  Image Tag Without Digest</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="435.061334" y="194.266016" transform="rotate(-0 435.061334 194.266016)">CL-0005  ·  Ports published on 0.0.0.0 (all interfaces)</text>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_19"/>
      <g id="text_14">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="315.68899" y="166.302496" transform="rotate(-0 315.68899 166.302496)">CL-0005  ·  Ports Bound to All Interfaces</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="435.061334" y="166.046657" transform="rotate(-0 435.061334 166.046657)">CL-0003  ·  no-new-privileges — blocking setuid/sudo privilege escalation</text>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_20"/>
      <g id="text_15">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="315.68899" y="138.017368" transform="rotate(-0 315.68899 138.017368)">CL-0003  ·  Privilege Escalation Not Blocked</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="435.061334" y="137.827297" transform="rotate(-0 435.061334 137.827297)">CL-0026  ·  No resource limits — memory and CPU exhaustion</text>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_21"/>
      <g id="text_16">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="315.68899" y="109.732241" transform="rotate(-0 315.68899 109.732241)">CL-0007  ·  Filesystem Not Read-Only</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="435.061334" y="109.607938" transform="rotate(-0 435.061334 109.607938)">CL-0006  ·  cap_drop ALL — mapping “Operation not permitted” to capabilities</text>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_22"/>
      <g id="text_17">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="315.68899" y="81.447113" transform="rotate(-0 315.68899 81.447113)">CL-0006  ·  No Capability Restrictions</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="435.061334" y="81.388579" transform="rotate(-0 435.061334 81.388579)">CL-0007  ·  read_only — fixing “Read-only file system” errors</text>
      </g>
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 319.18899 343.148172 
-L 331.578946 343.148172 
-L 331.578946 320.52007 
-L 319.18899 320.52007 
+    <path d="M 438.561334 342.471415 
+L 445.232828 342.471415 
+L 445.232828 319.895927 
+L 438.561334 319.895927 
 z
-" clip-path="url(#p4b810f53c8)" style="fill: #e06c00"/>
+" clip-path="url(#p715f299a09)" style="fill: #e06c00"/>
    </g>
    <g id="patch_4">
-    <path d="M 319.18899 314.863045 
-L 338.350201 314.863045 
-L 338.350201 292.234943 
-L 319.18899 292.234943 
+    <path d="M 438.561334 314.252055 
+L 452.282603 314.252055 
+L 452.282603 291.676568 
+L 438.561334 291.676568 
 z
-" clip-path="url(#p4b810f53c8)" style="fill: #b1281f"/>
+" clip-path="url(#p715f299a09)" style="fill: #b1281f"/>
    </g>
    <g id="patch_5">
-    <path d="M 319.18899 286.577917 
-L 350.355972 286.577917 
-L 350.355972 263.949815 
-L 319.18899 263.949815 
+    <path d="M 438.561334 286.032696 
+L 474.394824 286.032696 
+L 474.394824 263.457209 
+L 438.561334 263.457209 
 z
-" clip-path="url(#p4b810f53c8)" style="fill: #e06c00"/>
+" clip-path="url(#p715f299a09)" style="fill: #e06c00"/>
    </g>
    <g id="patch_6">
-    <path d="M 319.18899 258.292789 
-L 378.257383 258.292789 
-L 378.257383 235.664687 
-L 319.18899 235.664687 
+    <path d="M 438.561334 257.813337 
+L 521.817456 257.813337 
+L 521.817456 235.23785 
+L 438.561334 235.23785 
 z
-" clip-path="url(#p4b810f53c8)" style="fill: #e06c00"/>
+" clip-path="url(#p715f299a09)" style="fill: #e0a800"/>
    </g>
    <g id="patch_7">
-    <path d="M 319.18899 230.007662 
-L 456.438964 230.007662 
-L 456.438964 207.37956 
-L 319.18899 207.37956 
+    <path d="M 438.561334 229.593978 
+L 527.801167 229.593978 
+L 527.801167 207.018491 
+L 438.561334 207.018491 
 z
-" clip-path="url(#p4b810f53c8)" style="fill: #e0a800"/>
+" clip-path="url(#p715f299a09)" style="fill: #e0a800"/>
    </g>
    <g id="patch_8">
-    <path d="M 319.18899 201.722534 
-L 474.975875 201.722534 
-L 474.975875 179.094432 
-L 319.18899 179.094432 
+    <path d="M 438.561334 201.374619 
+L 555.346873 201.374619 
+L 555.346873 178.799131 
+L 438.561334 178.799131 
 z
-" clip-path="url(#p4b810f53c8)" style="fill: #e0a800"/>
+" clip-path="url(#p715f299a09)" style="fill: #e0a800"/>
    </g>
    <g id="patch_9">
-    <path d="M 319.18899 173.437406 
-L 492.984531 173.437406 
-L 492.984531 150.809304 
-L 319.18899 150.809304 
+    <path d="M 438.561334 173.15526 
+L 600.946881 173.15526 
+L 600.946881 150.579772 
+L 438.561334 150.579772 
 z
-" clip-path="url(#p4b810f53c8)" style="fill: #e06c00"/>
+" clip-path="url(#p715f299a09)" style="fill: #e0a800"/>
    </g>
    <g id="patch_10">
-    <path d="M 319.18899 145.152279 
-L 589.703023 145.152279 
-L 589.703023 122.524177 
-L 319.18899 122.524177 
+    <path d="M 438.561334 144.9359 
+L 601.153216 144.9359 
+L 601.153216 122.360413 
+L 438.561334 122.360413 
 z
-" clip-path="url(#p4b810f53c8)" style="fill: #e0a800"/>
+" clip-path="url(#p715f299a09)" style="fill: #e0a800"/>
    </g>
    <g id="patch_11">
-    <path d="M 319.18899 116.867151 
-L 592.440339 116.867151 
-L 592.440339 94.239049 
-L 319.18899 94.239049 
+    <path d="M 438.561334 116.716541 
+L 603.216564 116.716541 
+L 603.216564 94.141054 
+L 438.561334 94.141054 
 z
-" clip-path="url(#p4b810f53c8)" style="fill: #e0a800"/>
+" clip-path="url(#p715f299a09)" style="fill: #e0a800"/>
    </g>
    <g id="patch_12">
-    <path d="M 319.18899 88.582023 
-L 592.488362 88.582023 
-L 592.488362 65.953921 
-L 319.18899 65.953921 
+    <path d="M 438.561334 88.497182 
+L 603.319732 88.497182 
+L 603.319732 65.921695 
+L 438.561334 65.921695 
 z
-" clip-path="url(#p4b810f53c8)" style="fill: #e0a800"/>
+" clip-path="url(#p715f299a09)" style="fill: #8a8a8a"/>
    </g>
    <g id="patch_13">
-    <path d="M 319.18899 357.007885 
-L 319.18899 52.094209 
+    <path d="M 438.561334 356.298901 
+L 438.561334 52.094209 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_14">
-    <path d="M 319.18899 357.007885 
-L 620.101635 357.007885 
+    <path d="M 438.561334 356.298901 
+L 620.101635 356.298901 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_18">
-    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="333.986247" y="334.593496" transform="rotate(-0 333.986247 334.593496)">4%</text>
+    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="446.68515" y="333.781327" transform="rotate(-0 446.68515 333.781327)">4%</text>
    </g>
    <g id="text_19">
-    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="340.757502" y="306.308369" transform="rotate(-0 340.757502 306.308369)">6%</text>
+    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="453.734925" y="305.561968" transform="rotate(-0 453.734925 305.561968)">8%</text>
    </g>
    <g id="text_20">
-    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="352.763273" y="278.023241" transform="rotate(-0 352.763273 278.023241)">10%</text>
+    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="475.847146" y="277.342609" transform="rotate(-0 475.847146 277.342609)">20%</text>
    </g>
    <g id="text_21">
-    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="380.664685" y="249.738113" transform="rotate(-0 380.664685 249.738113)">20%</text>
+    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="523.269778" y="249.12325" transform="rotate(-0 523.269778 249.12325)">46%</text>
    </g>
    <g id="text_22">
-    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="458.846266" y="221.452986" transform="rotate(-0 458.846266 221.452986)">46%</text>
+    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="529.25349" y="220.903891" transform="rotate(-0 529.25349 220.903891)">49%</text>
    </g>
    <g id="text_23">
-    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="477.383176" y="193.167858" transform="rotate(-0 477.383176 193.167858)">52%</text>
+    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="556.799196" y="192.684531" transform="rotate(-0 556.799196 192.684531)">64%</text>
    </g>
    <g id="text_24">
-    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="495.391833" y="164.88273" transform="rotate(-0 495.391833 164.88273)">58%</text>
+    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="602.399203" y="164.465172" transform="rotate(-0 602.399203 164.465172)">89%</text>
    </g>
    <g id="text_25">
-    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="592.110324" y="136.597603" transform="rotate(-0 592.110324 136.597603)">90%</text>
+    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="602.605538" y="136.245813" transform="rotate(-0 602.605538 136.245813)">90%</text>
    </g>
    <g id="text_26">
-    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="594.84764" y="108.312475" transform="rotate(-0 594.84764 108.312475)">91%</text>
+    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="604.668887" y="108.026454" transform="rotate(-0 604.668887 108.026454)">91%</text>
    </g>
    <g id="text_27">
-    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="594.895663" y="80.027347" transform="rotate(-0 594.895663 80.027347)">91%</text>
+    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="604.772054" y="79.807095" transform="rotate(-0 604.772054 79.807095)">91%</text>
    </g>
    <g id="text_28">
-    <text style="font-weight: 700; font-size: 13px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="469.645313" y="40.094209" transform="rotate(-0 469.645313 40.094209)">Most common findings across the corpus</text>
+    <text style="font-weight: 700; font-size: 13px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="529.331484" y="40.094209" transform="rotate(-0 529.331484 40.094209)">Most common findings across the corpus</text>
    </g>
    <g id="legend_1">
     <g id="text_29">
-     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="547.151869" y="296.382416" transform="rotate(-0 547.151869 296.382416)">Severity</text>
+     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="547.151869" y="277.752885" transform="rotate(-0 547.151869 277.752885)">Severity</text>
     </g>
     <g id="patch_15">
-     <path d="M 529.533823 312.528354 
-L 551.533823 312.528354 
-L 551.533823 304.828354 
-L 529.533823 304.828354 
+     <path d="M 529.533823 294.253744 
+L 551.533823 294.253744 
+L 551.533823 286.553744 
+L 529.533823 286.553744 
 z
 " style="fill: #b1281f; stroke: #b1281f; stroke-linejoin: miter"/>
     </g>
     <g id="text_30">
-     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="560.333822" y="312.528354" transform="rotate(-0 560.333822 312.528354)">CRITICAL</text>
+     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="560.333822" y="294.253744" transform="rotate(-0 560.333822 294.253744)">CRITICAL</text>
     </g>
     <g id="patch_16">
-     <path d="M 529.533823 328.674291 
-L 551.533823 328.674291 
-L 551.533823 320.974291 
-L 529.533823 320.974291 
+     <path d="M 529.533823 310.754604 
+L 551.533823 310.754604 
+L 551.533823 303.054604 
+L 529.533823 303.054604 
 z
 " style="fill: #e06c00; stroke: #e06c00; stroke-linejoin: miter"/>
     </g>
     <g id="text_31">
-     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="560.333822" y="328.674291" transform="rotate(-0 560.333822 328.674291)">HIGH</text>
+     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="560.333822" y="310.754604" transform="rotate(-0 560.333822 310.754604)">HIGH</text>
     </g>
     <g id="patch_17">
-     <path d="M 529.533823 344.820229 
-L 551.533823 344.820229 
-L 551.533823 337.120229 
-L 529.533823 337.120229 
+     <path d="M 529.533823 327.255463 
+L 551.533823 327.255463 
+L 551.533823 319.555463 
+L 529.533823 319.555463 
 z
 " style="fill: #e0a800; stroke: #e0a800; stroke-linejoin: miter"/>
     </g>
     <g id="text_32">
-     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="560.333822" y="344.820229" transform="rotate(-0 560.333822 344.820229)">MEDIUM</text>
+     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="560.333822" y="327.255463" transform="rotate(-0 560.333822 327.255463)">MEDIUM</text>
+    </g>
+    <g id="patch_18">
+     <path d="M 529.533823 343.756323 
+L 551.533823 343.756323 
+L 551.533823 336.056323 
+L 529.533823 336.056323 
+z
+" style="fill: #8a8a8a; stroke: #8a8a8a; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_33">
+     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="560.333822" y="343.756323" transform="rotate(-0 560.333822 343.756323)">LOW</text>
     </g>
    </g>
   </g>
-  <g id="text_33">
-   <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #999999" x="7.6032" y="11.91075" transform="rotate(-0 7.6032 11.91075)">compose-lint 0.7.0  ·  corpus 20260503T034026Z  ·  n=6,266 parsed</text>
+  <g id="text_34">
+   <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #999999" x="7.6032" y="11.91075" transform="rotate(-0 7.6032 11.91075)">compose-lint 0.16.0  ·  corpus 20260811T044906Z  ·  n=5,279 parsed</text>
   </g>
  </g>
  <defs>
-  <clipPath id="p4b810f53c8">
-   <rect x="319.18899" y="52.094209" width="300.912645" height="304.913676"/>
+  <clipPath id="p715f299a09">
+   <rect x="438.561334" y="52.094209" width="181.540301" height="304.204692"/>
   </clipPath>
  </defs>
 </svg>

--- a/docs/dockerhub-overview.md
+++ b/docs/dockerhub-overview.md
@@ -2,7 +2,7 @@
 
 **Security-focused linter for Docker Compose files.** Catches dangerous misconfigurations before they reach production — and auto-fixes the unambiguous ones, dry-run first. Grounded in the [OWASP Docker Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html) and [CIS Docker Benchmark](https://www.cisecurity.org/benchmark/docker).
 
-In a scan of 6,444 public Docker Compose files on GitHub, **91% of those that parse had at least one security finding** — 68% had a finding rated HIGH or CRITICAL. [Read the full *State of Docker Compose Security* report →](https://github.com/tmatens/compose-lint/blob/main/docs/state-of-compose.md)
+In a scan of 5,417 public Docker Compose files on GitHub, **91% of those that parse had at least one security finding** — 32% had a finding rated HIGH or CRITICAL, and 10% had a CRITICAL. [Read the full *State of Docker Compose Security* report →](https://github.com/tmatens/compose-lint/blob/main/docs/state-of-compose.md)
 
 ![compose-lint scanning a docker-compose.yml: severity-sorted findings with fix guidance and reference URLs, then the FAIL verdict.](https://raw.githubusercontent.com/tmatens/compose-lint/main/docs/assets/demo.gif)
 

--- a/docs/state-of-compose.md
+++ b/docs/state-of-compose.md
@@ -2,16 +2,19 @@
 
 > This is the canonical, citable version of the State of Docker Compose Security report. Tracking issue: [#186](https://github.com/tmatens/compose-lint/issues/186).
 >
-> Pinned to **compose-lint 0.7.0** and corpus run **`20260503T034026Z`** (6,444 files, 2026-05-03). Quarterly refreshes bump both with a one-line delta callout.
+> Pinned to **compose-lint 0.16.0** and corpus run **`20260811T044906Z`** (5,417 files, 2026-08-11).
+>
+> **This edition is a new baseline, not a refresh of the previous one.** The 6,444-file corpus the 0.7.0 edition was pinned to no longer exists, and it cannot be rebuilt: its `longtail` tier was a stratified GitHub code-search sweep, and GitHub does not reproduce that sweep. The rule set changed underneath it as well. Two variables moved at once, so **no delta across the two editions is measurable, and none is presented here** — figures from the 0.7.0 edition are not repeated as like-for-like comparisons, because they were not measured the same way. The snapshot behind this edition is archived rather than left in a cache directory, so the discontinuity does not happen twice, and refreshes measured against it can carry a delta callout.
 
 The first published empirical study of security misconfigurations in real-world Docker Compose files at corpus scale.
 
 ## TL;DR
 
-- **91% of public Docker Compose files** that successfully parse ship with at least one security finding (5,716 of 6,266 files in a 6,444-file corpus).
-- **Even canonical vendor examples are not clean.** The canonical tier — the awesome-compose / bitnami / grafana / vaultwarden examples people copy-paste — averages 8.0 findings per file.
-- **The top three findings are the same across every tier:** filesystem not read-only, no capability restrictions, privilege escalation not blocked. They fire on roughly 90% of every parsed file.
-- **9.6% of longtail files fail to parse as a v2/v3 Compose file at all** — almost entirely shape errors (someone wrote `services` as a string-valued mapping instead of a service-mapping), not malformed YAML. We treat the parse-error population as a finding, not a discard.
+- **91% of public Docker Compose files** that successfully parse ship with at least one security finding (4,816 of 5,279 parsed files, from a 5,417-file corpus).
+- **Even canonical vendor examples are not clean.** The canonical tier — the awesome-compose / bitnami / grafana / vaultwarden examples people copy-paste — averages 9.95 findings per file, and 83.7% of those files carry at least one.
+- **The same four rules lead every tier:** filesystem not read-only, no capability restrictions, no resource limits, privilege escalation not blocked. Each fires on 89–91% of parsed files, and their order barely changes between vendor examples and the longtail.
+- **9.1% of longtail files fail to parse as a v2/v3 Compose file at all** — almost entirely shape errors (someone wrote `services` as a string-valued mapping instead of a service-mapping), not malformed YAML. We treat the parse-error population as a finding, not a discard.
+- **Every one of the 25 rules fires on real files.** None is dead, and there were zero crashes and zero timeouts across 5,279 linted files.
 
 The framing is descriptive, not inferential. Read [§ What this study does NOT claim](#what-this-study-does-not-claim) before citing any number from this report.
 
@@ -19,22 +22,26 @@ The framing is descriptive, not inferential. Read [§ What this study does NOT c
 
 ### Corpus
 
-The corpus lives outside the repo at `~/.cache/compose-lint-corpus/`. Each unique compose file is stored by content hash; an index file maps content hash → source repo, path, blob SHA, and tier. The fetch + lint pipeline is in [`scripts/corpus/`](https://github.com/tmatens/compose-lint/tree/main/scripts/corpus). All numbers in this report come from corpus run `20260503T034026Z` (2026-05-03).
+The corpus lives outside the repo at `~/.cache/compose-lint-corpus/`. Each unique compose file is stored by content hash; an index file maps content hash → source repo, path, blob SHA, and tier. The fetch + lint pipeline is in [`scripts/corpus/`](https://github.com/tmatens/compose-lint/tree/main/scripts/corpus). All numbers in this report come from corpus run `20260811T044906Z` (2026-08-11).
 
 The corpus is divided into four tiers, each with a distinct threat-model framing:
 
 | Tier | Files | What it represents |
 | --- | ---: | --- |
-| `canonical` | 327 | Official upstream examples (awesome-compose, bitnami, docker/compose, grafana, vaultwarden, …). *Do the examples people copy-paste ship insecure defaults?* |
-| `popular` | 3,977 | High-star (≥50) GitHub repos with a Compose file pushed in the last two years. *What does production-adjacent code look like?* |
-| `selfhosted` | 588 | Curated app-store / template-registry repos (CasaOS-AppStore, runtipi-appstore, Compose-Examples, dockge, …). Distinct threat model from `popular`: home-LAN deployments, not cloud. |
-| `longtail` | 1,552 | Stratified GitHub-code-search sweep across anchor terms × filenames × size buckets — the low-visibility mass of ordinary repos (a homelab, a tutorial follow-along, a half-finished side project), as opposed to the curated, high-attention head the other three tiers represent. The name is the "long tail" of GitHub *by repo attention*, not a distribution tail in the statistical sense. *What does the median compose file in the wild look like?* |
+| `canonical` | 345 | Official upstream examples (awesome-compose, bitnami, docker/compose, grafana, vaultwarden, …). *Do the examples people copy-paste ship insecure defaults?* |
+| `popular` | 3,351 | High-star (≥50) GitHub repos with a Compose file pushed in the last two years. *What does production-adjacent code look like?* |
+| `selfhosted` | 596 | Curated app-store / template-registry repos (CasaOS-AppStore, runtipi-appstore, Compose-Examples, dockge, …). Distinct threat model from `popular`: home-LAN deployments, not cloud. |
+| `longtail` | 1,125 | Stratified GitHub-code-search sweep across anchor terms × filenames × size buckets — the low-visibility mass of ordinary repos (a homelab, a tutorial follow-along, a half-finished side project), as opposed to the curated, high-attention head the other three tiers represent. The name is the "long tail" of GitHub *by repo attention*, not a distribution tail in the statistical sense. *What does the median compose file in the wild look like?* |
+
+Tier sizes are a property of the sweep that built this snapshot, not a designed allocation, and they differ from the previous edition's. The `longtail` tier in particular is whatever the code-search sweep returned on the day it ran — which is exactly why it does not reproduce.
 
 The longtail sweep is **not random sampling.** GitHub's code-search API has no random-document primitive, so `fetch.py` runs 6 anchors × 4 filenames × 5 size buckets = 120 stratified queries × up to 200 hits each, deduped on `(repo, path, sha)` then on content hash. The exact query design and inherited biases are documented in [`scripts/corpus/README.md`](https://github.com/tmatens/compose-lint/blob/main/scripts/corpus/README.md#longtail-sampling-methodology).
 
 ### Tool
 
-All findings come from [compose-lint 0.7.0](https://github.com/tmatens/compose-lint/releases/tag/v0.7.0) running with `--fail-on low` (so every severity is reported, not gated). Each rule cites OWASP, CIS, or Docker docs; rule definitions are in [`docs/rules/`](rules/). The version pin matters: when a new rule lands or an existing rule's severity changes, the headline percentages move. Quarterly refreshes will explicitly call out compose-lint version deltas.
+All findings come from [compose-lint 0.16.0](https://github.com/tmatens/compose-lint/releases/tag/v0.16.0) — **25 rules** — running with `--fail-on low` (so every severity is reported, not gated). Each rule cites OWASP, CIS, or Docker docs; rule definitions are in [`docs/rules/`](rules/). The version pin matters: when a new rule lands or an existing rule's severity changes, the headline percentages move.
+
+Severities in this edition come from the derived two-axis model in [`docs/severity.md`](severity.md): a rule's tier is what the matrix produces for its cell under a stated attacker baseline and the grounded Docker posture, not a number chosen per rule. Any severity read off this page describes that model. It is the reason the tier shares here cannot be compared against an edition built on an earlier model, even setting the corpus change aside.
 
 ### Severity weights
 
@@ -42,74 +49,35 @@ For ranking rules by overall impact within a tier we use a doubled weighting: **
 
 ## Findings overview
 
-Across the 6,266 successfully-parsed files:
+Across the 5,279 successfully-parsed files:
 
 | Metric | Value |
 | --- | ---: |
-| Files with ≥1 finding | 5,716 (91.2%) |
-| Files clean | 550 (8.8%) |
-| Total findings | 64,767 |
-| Findings per file (mean) | 10.3 |
-| Findings per file (median) | 6 |
-| Findings per file (max) | 627 |
+| Files with ≥1 finding | 4,816 (91.2%) |
+| Files clean | 463 (8.8%) |
+| Total findings | 61,735 |
+| Findings per file (mean) | 11.7 |
+| Findings per file (median) | 7 |
+| Findings per file (max) | 323 |
 
-Severity distribution across the 64,767 findings:
+Severity distribution across the 61,735 findings:
 
 | Severity | Count | Share |
 | --- | ---: | ---: |
-| CRITICAL | 730 | 1.1% |
-| HIGH | 13,147 | 20.3% |
-| MEDIUM | 50,867 | 78.5% |
-| LOW | 23 | 0.0% |
+| CRITICAL | 780 | 1.3% |
+| HIGH | 3,465 | 5.6% |
+| MEDIUM | 47,062 | 76.2% |
+| LOW | 10,428 | 16.9% |
 
-![Stacked bar of findings by severity across all 64,767 findings: MEDIUM 78.5% (50,867), HIGH 20.3% (13,147), CRITICAL 1.1% (730), LOW 0.0% (23).](assets/severity-distribution.svg)
+![Stacked bar of findings by severity across all 61,735 findings: MEDIUM 76.2% (47,062), LOW 16.9% (10,428), HIGH 5.6% (3,465), CRITICAL 1.3% (780).](assets/severity-distribution.svg)
 
-The MEDIUM-heavy distribution is a property of compose-lint's rule design: the three most common hardening misses (read-only root FS, capability restrictions, no-new-privileges) are MEDIUM and they fire on nearly every file in the corpus. CRITICAL findings are rarer — they require something acutely dangerous like a Docker socket mount — but they appear on 6.4% of parsed files (399 of 6,266). Broadening the threshold from CRITICAL to HIGH-or-above, **68% of parsed files carry at least one finding rated HIGH or CRITICAL.** That is a majority even before the acute rules are counted: CL-0005 alone (ports bound to `0.0.0.0`, a HIGH) fires on 57.8% of files, and the leaked-credential, sensitive-host-path, socket-mount, and dangerous-capability rules lift the union the rest of the way.
+The MEDIUM-heavy distribution is a property of compose-lint's rule design, not of the corpus: the hardening misses that fire on nearly every file — capability restrictions, no-new-privileges, resource limits — sit at MEDIUM, so a near-universal rule contributes tens of thousands of findings to one tier. CRITICAL findings are rarer, because they require something acutely dangerous like a mounted control socket, but they are not marginal: **10.5% of parsed files (554 of 5,279) carry at least one CRITICAL finding**, and 7.6% carry a mounted host control socket specifically.
 
-**Why LOW is almost empty.** The 23 LOW findings (0.0%) are not a sign that compose files get the small things right — they are an artifact of the rule set. Of the 22 rules shipping at the time of this run, two are LOW — [CL-0015](rules/CL-0015.md) (healthcheck disabled) and [CL-0022](rules/CL-0022.md) (tmpfs re-enables exec/suid/dev) — and both fire only when a file *explicitly* opts out of a default, a deliberate and uncommon act rather than an omission. The severity floor is otherwise MEDIUM by design, because the tool's scope is security misconfiguration rather than style or hygiene nits. Read "0.0% LOW" as a statement about what compose-lint chooses to flag, not as a clean bill of health.
+Broadening to HIGH-or-above, **32.4% of parsed files (1,710) carry at least one finding rated HIGH or CRITICAL.** Roughly a third of public Compose files contain something the model rates as an active dangerous grant rather than a missing flag.
 
-> **The severity tiers on this page are superseded.** The severity-model rework
-> has landed, and it moves the tier of rules that fire on most files: CL-0007
-> (`read_only` absent, 90.8% of files) and CL-0017 went to LOW, CL-0005 (57.8%)
-> went to MEDIUM, CL-0016 went to CRITICAL, and CL-0026 — a new near-universal
-> MEDIUM — did not exist when this run was taken. Two rules counted here
-> (CL-0012, CL-0015) have since been removed, and CL-0011 and CL-0013 have each
-> been split.
->
-> **MEDIUM stays the largest tier, contrary to what the rework was expected to
-> do.** A full re-lint with the new rule set — 5,417 files fetched 2026-08-10,
-> 5,279 linted — gives **MEDIUM 76.3%, LOW 16.9%, HIGH 5.6%, CRITICAL 1.2%**.
-> CL-0007 vacating MEDIUM was expected to make LOW dominant, but CL-0026 was
-> added afterwards and fires on almost exactly the same population (4,727 files
-> against CL-0007's 4,791), so it backfills the tier CL-0007 left. Two rules
-> swapped places and the shape barely moved.
->
-> **This is not the refreshed report, and the numbers above should not be cited
-> as one.** That re-lint ran against a *re-fetched* corpus, not the pinned one:
-> 5,417 files against 6,444, with the longtail tier at 1,125 against 1,552,
-> because the longtail sweep is a stratified code search that GitHub does not
-> reproduce. Publishing its headline figures here would conflate corpus drift
-> with the rule changes.
->
-> **The pinned 6,444-file corpus no longer exists**, and because the longtail
-> tier does not reproduce it cannot be rebuilt. The next refresh is therefore a
-> new baseline rather than a comparison, and the delta across it is not
-> measurable — a discontinuity worth stating plainly rather than papering over
-> with a like-for-like claim the data cannot support. The 5,417-file snapshot
-> that replaces it is archived rather than left in a cache directory, so the
-> same break does not happen twice. What it is good for is direction and sanity: every one
-> of the 24 rules fires on real files, none is dead, there were zero crashes and
-> zero timeouts across 5,279 files, and the share of files carrying at least one
-> finding came out at **91.2%** — the same figure this report already cites.
->
-> **What survives unchanged:** the prevalence figures — how many files carry a
-> given finding — because they count rule hits rather than tiers. The 91%
-> headline, the per-rule hit rates and the per-tier breakdowns are all still
-> accurate for the rules that still exist.
->
-> Regenerating this report needs a fresh corpus run; until then, read every
-> *severity* on this page as describing compose-lint 0.7.0's model, not the
-> current one.
+If you remember a much larger HIGH-or-above share from the previous edition, that is a rule-model difference, not a change in what people write — the derived model moved several near-universal rules off HIGH, most consequentially the published-port rule. It cannot be quantified as a delta, because the corpus changed at the same time.
+
+**LOW is one rule.** The 10,428 LOW findings (16.9%) look like a substantial tier and are almost entirely a single rule: [CL-0007](rules/CL-0007.md) (filesystem not read-only) accounts for 10,405 of them, or 99.8%. The remaining 23 come from [CL-0014](rules/CL-0014.md) (logging driver disabled, 15), [CL-0022](rules/CL-0022.md) (tmpfs re-enables exec/suid/dev, 5), and [CL-0017](rules/CL-0017.md) (shared mount propagation, 3) — rules that fire only when a file *explicitly* opts out of a default, a deliberate and uncommon act rather than an omission. Read the LOW tier as "almost every file omits `read_only: true`", not as a broad population of small problems.
 
 ## Per-tier breakdown
 
@@ -119,92 +87,108 @@ Tier-level rates differ enough that aggregate "X% of compose files have finding 
 
 | Tier | Total | Parsed | With findings | Clean | Rate (of parsed) | Findings per parsed file |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| `canonical` | 327 | 325 | 269 | 56 | 82.8% | 8.05 |
-| `popular` | 3,977 | 3,950 | 3,760 | 190 | 95.2% | 11.33 |
-| `selfhosted` | 588 | 588 | 588 | 0 | **100.0%** | 7.53 |
-| `longtail` | 1,552 | 1,403 | 1,099 | 304 | 78.3% | 9.25 |
+| `canonical` | 345 | 343 | 287 | 56 | 83.7% | 9.95 |
+| `popular` | 3,351 | 3,317 | 3,150 | 167 | 95.0% | 13.29 |
+| `selfhosted` | 596 | 596 | 596 | 0 | **100.0%** | 9.32 |
+| `longtail` | 1,125 | 1,023 | 783 | 240 | 76.5% | 8.50 |
 
-![Bar chart of the share of parsed files with at least one finding, by tier: canonical 82.8%, popular 95.2%, selfhosted 100.0%, longtail 78.3%.](assets/findings-by-tier.svg)
+![Bar chart of the share of parsed files with at least one finding, by tier: canonical 83.7%, popular 95.0%, selfhosted 100.0%, longtail 76.5%.](assets/findings-by-tier.svg)
 
 Notable observations:
 
 - **Every `selfhosted` file has at least one finding.** The app-store templates ship with optimistic defaults — they target a home-LAN audience and frequently expose ports on `0.0.0.0`, run as root, mount large host paths, and skip the hardening flags. The fact that 100% of these files trigger compose-lint is the central finding of this tier.
-- **Popular repos are not noticeably better than the longtail.** With ≥50 stars and recent activity as the inclusion criteria, the `popular` tier averages *more* findings per file than the longtail. Higher visibility doesn't translate to hardening discipline.
-- **Canonical is the cleanest tier and still 83% with findings.** The vendor examples that READMEs tell users to copy-paste are not hardening exemplars — they're configuration demos. That's the gap this report is documenting.
+- **Popular repos are not noticeably better than the longtail.** With ≥50 stars and recent activity as the inclusion criteria, the `popular` tier averages *more* findings per file than the longtail — 13.29 against 8.50. Higher visibility doesn't translate to hardening discipline.
+- **Canonical is the cleanest tier and still 84% with findings.** The vendor examples that READMEs tell users to copy-paste are not hardening exemplars — they're configuration demos. That's the gap this report is documenting.
 
 ### Severity distribution per tier
 
 | Tier | CRITICAL | HIGH | MEDIUM | LOW |
 | --- | ---: | ---: | ---: | ---: |
-| `canonical` | 19 | 470 | 2,128 | 0 |
-| `popular` | 586 | 9,163 | 34,971 | 22 |
-| `selfhosted` | 49 | 870 | 3,506 | 0 |
-| `longtail` | 76 | 2,644 | 10,262 | 1 |
+| `canonical` | 23 | 212 | 2,591 | 587 |
+| `popular` | 624 | 2,499 | 33,550 | 7,396 |
+| `selfhosted` | 67 | 318 | 4,287 | 885 |
+| `longtail` | 66 | 436 | 6,634 | 1,560 |
 
-CRITICAL findings are concentrated in `popular` (586 of 730, 80% of all CRITICAL findings in the corpus). The dominant CRITICAL rule is **CL-0001 (Docker socket mounted)** — see § Top findings.
+CRITICAL findings are concentrated in `popular` (624 of 780, 80% of all CRITICAL findings in the corpus) — though `popular` is also the largest tier, so the concentration partly tracks tier size. Normalising to the share of each tier's parsed files carrying a mounted host control socket ([CL-0001](rules/CL-0001.md), the dominant CRITICAL rule) separates the two: `popular` 9.9%, `selfhosted` 5.2%, `canonical` 4.4%, `longtail` 2.3%. The production-adjacent tier really does mount the control socket most often, roughly four times as often as the longtail.
 
 ## Top findings
 
-Ten rules account for >95% of all findings. They cluster into three groups: hardening defaults that nobody flips, supply-chain shortcuts, and acute privilege grants.
+Ten rules account for 98% of all findings. They cluster into three groups: hardening defaults that nobody flips, supply-chain shortcuts, and acute privilege grants.
 
-![Horizontal bar chart of the ten most common rules by share of parsed files affected, coloured by severity: CL-0006 No capability restrictions 91%, CL-0007 Filesystem not read-only 91%, CL-0003 Privilege escalation not blocked 90%, CL-0005 Ports bound to all interfaces 58%, CL-0019 Image tag without digest 52%, CL-0004 Image not pinned to version 46%, CL-0020 Credential-shaped env key 20%, CL-0013 Sensitive host path mounted 10%, CL-0001 Docker socket mounted 6%, CL-0011 Dangerous capabilities added 4%.](assets/top-findings.svg)
+![Horizontal bar chart of the ten most common rules by share of parsed files affected, coloured by severity: CL-0007 read_only 91% (LOW), CL-0006 cap_drop ALL 91% (MEDIUM), CL-0026 No resource limits 90% (MEDIUM), CL-0003 no-new-privileges 89% (MEDIUM), CL-0005 Ports published on 0.0.0.0 64% (MEDIUM), CL-0019 Image tags without digest pins 49% (MEDIUM), CL-0004 Unpinned image tags 46% (MEDIUM), CL-0020 Credential-shaped environment keys 20% (HIGH), CL-0001 Host control socket exposed 8% (CRITICAL), CL-0011 Strong host-adjacent capabilities 4% (HIGH).](assets/top-findings.svg)
 
-### Hardening defaults (the bulk of MEDIUM findings)
+### Hardening defaults (the bulk of the findings)
 
-These three rules fire on roughly 90% of every parsed file in the corpus:
+These four rules fire on roughly 90% of every parsed file in the corpus:
 
 | Rule | Severity | Files affected | Share of parsed |
 | --- | --- | ---: | ---: |
-| [CL-0007](rules/CL-0007.md) Filesystem not read-only | MEDIUM | 5,690 | 90.8% |
-| [CL-0006](rules/CL-0006.md) No capability restrictions | MEDIUM | 5,691 | 90.8% |
-| [CL-0003](rules/CL-0003.md) Privilege escalation not blocked | MEDIUM | 5,633 | 89.9% |
+| [CL-0007](rules/CL-0007.md) Filesystem not read-only | LOW | 4,791 | 90.8% |
+| [CL-0006](rules/CL-0006.md) No capability restrictions | MEDIUM | 4,788 | 90.7% |
+| [CL-0026](rules/CL-0026.md) No resource limits | MEDIUM | 4,728 | 89.6% |
+| [CL-0003](rules/CL-0003.md) Privilege escalation not blocked | MEDIUM | 4,722 | 89.4% |
 
-These are MEDIUMs because each one is a *missing hardening flag* rather than an active misuse — the file isn't doing something dangerous, it's failing to opt into a defense-in-depth control. The fact that each one fires on ~90% of files is the central observation of the report: the Compose hardening triple (`read_only: true`, `cap_drop: [ALL]`, `security_opt: [no-new-privileges:true]`) is essentially never set.
+Each is a *missing hardening flag* rather than an active misuse — the file isn't doing something dangerous, it's failing to opt into a defense-in-depth control, which is why the derived model rates them MEDIUM or LOW rather than HIGH. The fact that each fires on ~90% of files is the central observation of the report: the Compose hardening set (`read_only: true`, `cap_drop: [ALL]`, `security_opt: [no-new-privileges:true]`, and a `deploy.resources.limits` block) is essentially never set.
+
+The four move together. They are not four independent habits but one: a service definition written without a hardening pass at all.
 
 ### Network and supply-chain shortcuts
 
 | Rule | Severity | Files affected | Share of parsed |
 | --- | --- | ---: | ---: |
-| [CL-0005](rules/CL-0005.md) Ports bound to all interfaces | HIGH | 3,619 | 57.8% |
-| [CL-0019](rules/CL-0019.md) Image tag without digest | MEDIUM | 3,244 | 51.8% |
-| [CL-0004](rules/CL-0004.md) Image not pinned to version | MEDIUM | 2,858 | 45.6% |
+| [CL-0005](rules/CL-0005.md) Ports bound to all interfaces | MEDIUM | 3,396 | 64.3% |
+| [CL-0019](rules/CL-0019.md) Image tag without digest | MEDIUM | 2,595 | 49.2% |
+| [CL-0004](rules/CL-0004.md) Image not pinned to version | MEDIUM | 2,421 | 45.9% |
 
-Over half of all parsed files publish at least one port to `0.0.0.0`. The image-pinning pair (CL-0019 + CL-0004) shows that ~50% of files don't pin a digest and ~46% don't even pin a tag — `latest` is still the de facto default in published examples.
+Nearly two thirds of all parsed files publish at least one port to `0.0.0.0`. The image-pinning pair (CL-0019 + CL-0004) shows that ~49% of files don't pin a digest and ~46% don't even pin a tag — `latest` is still the de facto default in published examples.
 
 ### Acute privilege grants
 
 | Rule | Severity | Files affected | Share of parsed |
 | --- | --- | ---: | ---: |
-| [CL-0020](rules/CL-0020.md) Credential-shaped env key with literal value | HIGH | 1,230 | 19.6% |
-| [CL-0013](rules/CL-0013.md) Sensitive host path mounted | HIGH (CRITICAL when `/`) | 649 | 10.4% |
-| [CL-0001](rules/CL-0001.md) Docker socket mounted | CRITICAL | 399 | 6.4% |
-| [CL-0011](rules/CL-0011.md) Dangerous capabilities added | HIGH (CRITICAL when `cap_add: ALL`) — since split into CL-0011/CL-0024/CL-0027 | 258 | 4.1% |
+| [CL-0020](rules/CL-0020.md) Credential-shaped env key with literal value | HIGH | 1,042 | 19.7% |
+| [CL-0001](rules/CL-0001.md) Host control socket exposed | CRITICAL | 399 | 7.6% |
+| [CL-0011](rules/CL-0011.md) Strong host-adjacent capability added | HIGH | 194 | 3.7% |
+| [CL-0021](rules/CL-0021.md) Credential embedded in connection-string env value | HIGH | 152 | 2.9% |
+| [CL-0008](rules/CL-0008.md) Host network mode | HIGH | 137 | 2.6% |
+| [CL-0013](rules/CL-0013.md) Sensitive host path exposed | HIGH | 126 | 2.4% |
+| [CL-0002](rules/CL-0002.md) Privileged mode enabled | CRITICAL | 121 | 2.3% |
+| [CL-0024](rules/CL-0024.md) Host-code-execution capability added | CRITICAL | 66 | 1.3% |
+| [CL-0025](rules/CL-0025.md) Root-equivalent host path mounted writable | CRITICAL | 30 | 0.6% |
 
-These are the rules where a finding indicates an *active* dangerous configuration, not a missing flag. CL-0020 is by far the most common: ~20% of files commit a literal value to an environment variable that looks like a credential (e.g., `DB_PASSWORD: hunter2`). CL-0001 (Docker socket mounted) is the canonical container-escape vector and appears on 6.4% of parsed files; in the `popular` tier specifically it appears on 8.1%.
+These are the rules where a finding indicates an *active* dangerous configuration, not a missing flag. Two observations:
+
+- **Plaintext credentials are the most common acute finding by a wide margin.** CL-0020 fires on 19.7% of parsed files — roughly one in five commits a literal value to an environment variable that looks like a credential (e.g. `DB_PASSWORD: hunter2`). Adding CL-0021's connection-string variant, better than one in five public Compose files carries a credential in cleartext.
+- **The container-escape rules are rare but not negligible.** A mounted host control socket (CL-0001, 7.6%) and `privileged: true` (CL-0002, 2.3%) each grant root-equivalent host access. Together with the capability and host-path rules, they are what lifts the CRITICAL-carrying share to 10.5% of parsed files.
+
+The remaining rules each fire on under 1.5% of files: [CL-0018](rules/CL-0018.md) explicit root user (1.3%), [CL-0009](rules/CL-0009.md) security profile disabled (1.1%), [CL-0010](rules/CL-0010.md) host namespace sharing (0.5%), [CL-0027](rules/CL-0027.md) bounded-grant capability (0.2%), [CL-0014](rules/CL-0014.md) logging driver disabled (0.2%), [CL-0016](rules/CL-0016.md) dangerous host device (0.1%), [CL-0022](rules/CL-0022.md) tmpfs re-enables exec/suid/dev (0.1%), [CL-0017](rules/CL-0017.md) shared mount propagation (0.1%), and [CL-0028](rules/CL-0028.md) host-reaching capability (one file). A rule at this rate is not dead — it is specific, and the corpus is large enough to find its handful of real instances.
 
 ## Parse errors as a finding
 
-178 of 6,444 files (2.8%) failed to parse as a v2 or v3 Compose file at all. The dominant class is shape errors — files that don't match the Compose schema's expected structure — not malformed YAML.
+138 of 5,417 files (2.5%) did not lint as a v2 or v3 Compose file. The dominant class is shape errors — files that don't match the Compose schema's expected structure — not malformed YAML.
 
 | Class | Count | Description |
 | --- | ---: | --- |
-| `services-not-mapping` | 74 | The top-level `services` key is something other than a mapping (commonly a list or a scalar) |
-| `service-not-mapping` | 49 | A specific service is a scalar instead of a mapping (e.g., `db: "postgres:14"`) |
-| `invalid-yaml` | 28 | YAML scanner / parser error |
-| `empty-file` | 13 | File parsed to nothing |
-| `top-level-not-mapping` | 8 | Root document is a list or scalar |
-| `missing-services-key` | 6 | No `services:` at the top level (likely an `extends:`-only fragment or an old v1 file) |
+| `services-not-mapping` | 55 | The top-level `services` key is something other than a mapping (commonly a list or a scalar) |
+| `service-not-mapping` | 32 | A specific service is a scalar instead of a mapping (e.g., `db: "postgres:14"`) |
+| `invalid-yaml` | 24 | YAML scanner / parser error |
+| `empty-file` | 8 | File parsed to nothing |
+| `top-level-not-mapping` | 7 | Root document is a list or scalar |
+| `other` | 7 | Not a parse failure — all seven are files using `include:`, which compose-lint declines to lint because it does not resolve included files (see below) |
+| `missing-services-key` | 5 | No `services:` at the top level (likely an `extends:`-only fragment or an old v1 file) |
+
+**Seven of the 138 are not errors.** They are `include:` files, which compose-lint deliberately refuses rather than lints: the services live in other files it does not resolve, so linting what is written would report a misleading clean result. They land in the same exit-2 population as genuine parse failures and are counted here for completeness; the real parse-failure count is 131 (2.4%).
 
 The per-tier rate is the load-bearing number:
 
 | Tier | Parse-error rate | Dominant class |
 | --- | ---: | --- |
 | `canonical` | 0.6% | invalid-yaml |
-| `popular` | 0.7% | top-level-not-mapping |
+| `popular` | 1.0% | invalid-yaml |
 | `selfhosted` | 0.0% | — |
-| `longtail` | **9.6%** | shape errors (49% + 32%) |
+| `longtail` | **9.1%** | shape errors (53% + 30%) |
 
-![Bar chart of parse-error rate by tier: canonical 0.6%, popular 0.7%, selfhosted 0.0%, longtail 9.6%.](assets/parse-error-rate.svg)
+![Bar chart of parse-error rate by tier: canonical 0.6%, popular 1.0%, selfhosted 0.0%, longtail 9.1%.](assets/parse-error-rate.svg)
 
 Longtail's parse-error tail isn't malformed YAML. It's people writing `services` as a string-valued mapping, the way a `package.json` `dependencies` block works. A reader skimming a Compose tutorial sees `nginx: image: nginx:1.25` and writes `nginx: nginx:1.25` instead. The parse error here is itself a security-relevant finding: a Compose file that doesn't parse with a real Compose engine isn't deployed by that engine, so these files are documentation, copy-paste fragments, or first-attempts — none of which are getting linted before they ship.
 
@@ -231,7 +215,8 @@ Read this section before citing any number from the report. The corpus is a desc
 - **GitHub-only.** No GitLab, Codeberg, Gitea, Bitbucket, Docker Hub README snippets, package-manager fragments, blog-post YAML blocks, or Stack Overflow answers. The longtail tier is a stratified sweep of GitHub's code search; see [`scripts/corpus/README.md`](https://github.com/tmatens/compose-lint/blob/main/scripts/corpus/README.md#longtail-sampling-methodology) for the exact query design and the four biases it inherits.
 - **Filename-pinned.** Files saved under non-standard names (`stack.yml`, `web.compose.yml`, etc.) are missed. The four canonical filenames cover the documented Compose Specification names but not every project's conventions.
 - **No statistical inference.** This is descriptive sampling for prevalence estimation. There are no hypothesis tests, no confidence intervals, no population estimates, and no claims about the "average" Compose file outside the four named tiers (`canonical`, `popular`, `selfhosted`, `longtail`). Tier counts are reported as observed; treat them as descriptive of the corpus, not extrapolated to all of GitHub.
-- **Snapshot in time.** Each report version pins to a single corpus run and a single compose-lint version. The published numbers do not move when a new rule lands; the next quarterly refresh ships a new version with a delta callout.
+- **Snapshot in time.** Each report version pins to a single corpus run and a single compose-lint version. The published numbers do not move when a new rule lands; a refresh ships a new version with its own run.
+- **Editions are not a time series.** This edition is a new baseline: the corpus behind the previous one is gone and unrebuildable, and the rule set changed at the same time, so the two cannot be differenced. Do not read successive editions of this report as a trend unless the edition explicitly states that it was measured against the same archived snapshot as its predecessor.
 
 ### Tool caveats
 
@@ -242,31 +227,33 @@ The framing is: *here is what people put in their Compose files at corpus scale,
 
 ## Reproducibility
 
-The corpus is not committed to the repo (third-party content), but the pipeline that builds it is. To reproduce these numbers from scratch:
+The corpus is not committed to the repo (third-party content), but the pipeline that builds it is. **Re-fetching does not reproduce this corpus** — see the note below — so the reproducible path is to lint the archived snapshot:
 
 ```bash
 git clone https://github.com/tmatens/compose-lint
 cd compose-lint
-git checkout v0.7.0    # the tool version this report is pinned to
+git checkout v0.16.0    # the tool version this report is pinned to
 python -m venv .venv && .venv/bin/pip install -e .
 
-# Build the corpus from public GitHub. The four fetchers + retier + enrich
-# steps are idempotent; re-running adds new files without re-downloading.
-python scripts/corpus/fetch.py
-python scripts/corpus/fetch_popular.py
-python scripts/corpus/fetch_canonical.py
-python scripts/corpus/fetch_selfhosted.py
-python scripts/corpus/retier.py
-python scripts/corpus/enrich_metadata.py
+# Restore the archived snapshot this edition is measured on.
+# sha256 d9be6bbc7a0971a37d0715b5d8ef8b9ef08b64ddd375fc6aebe4e708ffa5e0f5
+mkdir -p ~/.cache/compose-lint-corpus
+tar -xzf compose-lint-corpus-5417-20260811.tar.gz -C ~/.cache/compose-lint-corpus
 
-# Lint the corpus and write summary.md + tier_summary.md
-python scripts/corpus/run.py
+# Lint the corpus and write summary.md + tier_summary.md.
+# COMPOSE_LINT_BIN defaults to <repo>/.venv/bin/compose-lint; set it
+# explicitly if your interpreter lives anywhere else.
+COMPOSE_LINT_BIN=$PWD/.venv/bin/compose-lint python scripts/corpus/run.py
 
 # Re-render the charts in this report (matplotlib is a maintainer-only extra)
 pip install -e '.[corpus]'
 python scripts/corpus/charts.py latest
 ```
 
-The output lands in `~/.cache/compose-lint-corpus/runs/<UTC-timestamp>/`. The `summary.md` and `tier_summary.md` files there are the source artifacts every table in this report is built from; `charts.py` reads the same per-tier aggregation, so the figures in `docs/assets/` can never disagree with the tables.
+The snapshot archive is not committed to the repo — it is 5,417 third-party files, the same reason the corpus itself isn't committed. It is held by the maintainers and identified by the sha256 above; open an issue on the tracker if you want a copy to verify a number in this report against.
 
-GitHub's code-search ranking is stochastic enough that a second run will not produce a byte-identical corpus, but the headline rates (per-tier finding rate, top-rule ranking, parse-error class distribution) are stable across runs at this corpus size. Quarterly refresh PRs will land both the new run's numbers and a delta callout against the previous version.
+To build a *new* corpus from public GitHub instead — a different sample, not this one — run the four fetchers plus `retier.py` and `enrich_metadata.py` first (`fetch.py`, `fetch_popular.py`, `fetch_canonical.py`, `fetch_selfhosted.py`); they are idempotent and re-running adds new files without re-downloading.
+
+The output lands in `~/.cache/compose-lint-corpus/runs/<UTC-timestamp>/`. The `summary.md` and `tier_summary.md` files there are the source artifacts every table in this report is built from; `charts.py` reads the same per-tier aggregation, so the figures in `docs/assets/` can never disagree with the tables. A run that reports thousands of *crashes* is almost always a `COMPOSE_LINT_BIN` that does not exist — the harness buckets a missing binary as a per-file crash rather than a startup failure. Check the first few results before letting a full run proceed.
+
+**Why re-fetching does not reproduce this corpus.** Three of the four tiers are enumerable from fixed sources and re-fetch closely. The `longtail` tier is not: it is a stratified GitHub code-search sweep, and GitHub's code search neither offers a random-document primitive nor returns a stable result set for the same queries over time. A re-fetch produces *a* longtail tier, not *this* one. That is why the 6,444-file corpus behind the 0.7.0 edition could not be rebuilt once its cache was lost, and why this edition's 5,417-file snapshot is archived as a file rather than trusted to a cache directory. Refreshes measured against the archived snapshot isolate rule-set changes from corpus drift and can legitimately carry a delta; a refresh against a fresh sweep cannot.


### PR DESCRIPTION
Re-lints the archived 5,417-file snapshot with **released 0.16.0** (25 rules) and rebuilds every table, figure and alt text from run `20260811T044906Z`.

Run health: **5,279 parsed, 4,816 with findings (91.2%), 61,735 findings, 0 crashes, 0 timeouts**, and all 25 rules fire on real files — none is dead.

## Framed as a new baseline, not a refresh

The 6,444-file corpus the 0.7.0 edition was pinned to no longer exists and **cannot be rebuilt**: its `longtail` tier was a stratified GitHub code-search sweep, and GitHub does not reproduce that sweep. The severity model changed at the same time. Two variables moved at once, so no delta across the editions is measurable — and none is presented. The old headline figures are not repeated as like-for-like comparisons anywhere.

The replacement snapshot is archived and identified by sha256 in the report, and the reproducibility section now restores it rather than re-fetching, with a paragraph explaining why re-fetching gives *a* longtail tier and not *this* one. A "Editions are not a time series" caveat was added alongside it.

The superseded-severity banner is dropped — this run is what it was waiting for.

## What needed rewriting, not just renumbering

- **LOW is now 16.9% and is one rule.** CL-0007 accounts for 10,405 of 10,428 LOW findings (99.8%). The old "Why LOW is almost empty" section described a 0.0% tier and two rules that no longer apply; it is now "LOW is one rule".
- **HIGH-or-above is 32.4% of parsed files**, CRITICAL-carrying 10.5%. A note says a reader remembering a much larger share is seeing a rule-model difference, not a change in what people write — and explicitly declines to quantify it as a delta, since the corpus moved too.
- **Four rules now lead, not three** — CL-0026 (resource limits) joined the ~90% band.
- **The acute-grant table lists all nine rules in that class**, not the four that existed before, plus a tail paragraph naming every rule under 1.5% so the "no dead rules" claim is checkable.
- **The CRITICAL-by-tier claim is normalised.** `popular` holds 80% of CRITICAL findings, but it is also the largest tier; per-tier CL-0001 rates (popular 9.9%, selfhosted 5.2%, canonical 4.4%, longtail 2.3%) separate concentration from tier size.
- **7 of the 138 exit-2 files are not parse errors** — they are `include:` files compose-lint deliberately declines. Broken out rather than silently counted as failures; the real parse-failure count is 131.

## Collateral

`README.md`'s hero stat and `docs/dockerhub-overview.md` quoted figures the regenerated report now contradicts, so both are updated (Docker Hub file is 4,170 bytes, far under the 25,000 cap). The derived blog artifacts under `docs/publishing/` are records of what was published externally and are deliberately left alone — re-deriving them is an editorial decision, not a docs fix.

## Verification

- Charts re-rendered via `scripts/corpus/charts.py latest`; they read the same `run.aggregate_tiers` aggregation as the tables, so figures cannot disagree with text. Stamped `compose-lint 0.16.0 · corpus 20260811T044906Z · n=5,279 parsed`.
- Every `rules/CL-XXXX.md` and `assets/*.svg` link in the report resolves.
- `pytest` 1432 passed, 6 skipped.
- Run used `COMPOSE_LINT_BIN` pointed at a clean PyPI install of 0.16.0, sanity-checked on five files before the full sweep.

No matcher or path-list change, so no corpus differential applies.