### PR TITLE
Correct what SYS_ADMIN's judgment call actually decides

### DIFF
--- a/docs/rules/CL-0024.md
+++ b/docs/rules/CL-0024.md
@@ -10,7 +10,7 @@
 - **Qualifier/modifier:** none
 - **Derived:** Direct × Host = CRITICAL
 - **Shipped:** CRITICAL
-- **Scoping assumptions:** `SYS_ADMIN` is placed here on consistency grounds rather than on a verified no-technique escape — see the note below. The other three are mechanical
+- **Scoping assumptions:** `SYS_ADMIN` is placed here on consistency grounds rather than on a verified no-technique escape — see the note below. That affects which rule reports it, not what it derives: `Technique × Host` is also CRITICAL. The other three are mechanical
 - **Evidence:** `_cl0011` proves only that `cap_add` deposits the capability into the effective set — not that any member reaches host code execution. Those reaches (module loading via `SYS_MODULE`, raw I/O port access via `SYS_RAWIO`, the full set via `ALL`) are kernel properties reasoned from the capability model and Docker's default seccomp profile, not exercised by a check
 
 ## What it detects
@@ -34,13 +34,21 @@ A container is not a security boundary against code running in the kernel.
 both and everything else. None of these needs a vulnerability — they are the
 capability working as designed, granted to a workload that should not have it.
 
-**`SYS_ADMIN` is a judgment call, and the rule says so rather than implying an
-observation.** Escaping with `SYS_ADMIN` does need a technique — mounting a
-cgroup hierarchy, abusing a filesystem, or similar — so on a strict reading of
-this tier's definition it belongs one tier down. It sits here because it grants
-a superset of what the other three do in practice, and because a user triaging
-findings is not served by `SYS_MODULE` and `SYS_ADMIN` landing in different
-buckets. That is a scale choice, documented as one.
+**`SYS_ADMIN` is a judgment call about membership, not about severity.**
+Escaping with `SYS_ADMIN` does need a technique — mounting a cgroup hierarchy,
+abusing a filesystem, or similar — so on a strict reading of *this rule's
+membership test* (a capability reaching host code execution with no technique)
+it does not qualify. Its severity does not turn on that question: the matrix
+gives `Technique × Host = CRITICAL` exactly as it gives `Direct × Host =
+CRITICAL`, so `SYS_ADMIN` derives CRITICAL on either reading of the
+precondition axis.
+
+It sits in this rule because it grants a superset of what the other three do in
+practice, and because a user triaging findings is not served by `SYS_MODULE`
+and `SYS_ADMIN` landing in different buckets. Grouping it here is a scale
+choice, documented as one — but it is not the reason it is CRITICAL. Relegating
+it to CL-0011 would score it HIGH only by also moving its impact axis to
+Cross-container, and a `SYS_ADMIN` escape reaches the host.
 
 ## Fix
 


### PR DESCRIPTION
Result of independently verifying CL-0024's derivation — the last of the §47.8 items that could be closed without a new decision.

## The derivation checks out

- `Direct × Host = CRITICAL` matches the matrix in `docs/severity.md`.
- The assignment-table row (`A | Direct | Host | — | CRITICAL | CRITICAL | —`) agrees with the rule doc. No override, correctly.
- Membership was blind-scored in the review's §42.1 — that part was already sound.
- The Evidence line is honest that the three mechanical reaches are reasoned from the capability model rather than exercised by a premise check, and says so explicitly.

## One thing was wrong

The derivation bullet says `SYS_ADMIN` sits in this cell as a judgment call and that "both readings land at CRITICAL, so the cell is unaffected." That claim is **correct** — the matrix gives `Technique × Host = CRITICAL` just as it gives `Direct × Host = CRITICAL`.

But the "Why it matters" prose said that on a strict reading `SYS_ADMIN` "belongs one tier down." Read as a severity statement that is false, and it contradicts the bullet directly above it. The strict reading moves only the precondition axis, and that axis does not change the result at Host impact. The only route to HIGH is to also move the impact axis to Cross-container — which would be wrong, because a `SYS_ADMIN` escape reaches the host, not merely a sibling container.

The net effect was to undersell the rule: it presented CRITICAL for `SYS_ADMIN` as a scale choice that a stricter reviewer would reverse, when the model delivers CRITICAL either way.

So the prose now says the judgment call decides **which rule reports the capability**, not what it derives, and the scoping-assumptions bullet carries the same clarification.

Documentation only — no matcher, no path list, no membership change, no shipped-severity change, so no corpus differential applies. `pytest` 1432 passed, 6 skipped; `ruff` clean.