### PR TITLE
Give /dev/shm and /dev/hugepages a followable fix

### DIFF
--- a/docs/rules/CL-0013.md
+++ b/docs/rules/CL-0013.md
@@ -94,6 +94,80 @@ services:
       - app-config:/app/config
 ```
 
+### `/dev/shm` and `/dev/hugepages`
+
+For these two, "remove the mount" on its own is not followable — the workload
+wants the facility, not the host's copy of it. Compose can give it the facility
+without the host exposure, and the finding names the alternative directly.
+
+**`/dev/shm`.** A container already has its own `/dev/shm`, 64 MiB by default.
+If the bind exists only because that is too small — the usual reason, and why
+Chrome and Selenium images ask for it — resize it:
+
+```yaml
+# Before
+services:
+  browser:
+    image: selenium/standalone-chrome:130.0
+    volumes:
+      - /dev/shm:/dev/shm
+
+# After — a bigger private segment, host's untouched
+services:
+  browser:
+    image: selenium/standalone-chrome:130.0
+    shm_size: 2gb
+```
+
+If two services genuinely need to share one segment, scope the sharing to them
+rather than to the host:
+
+```yaml
+services:
+  owner:
+    image: myapp:1.0
+    ipc: shareable
+  worker:
+    image: myapp:1.0
+    ipc: service:owner
+```
+
+Both services then see one shared `/dev/shm`; the host and every other
+container are excluded. Sharing the *host's* namespace instead — `ipc: host` —
+is [CL-0010](CL-0010.md), and is the thing this avoids.
+
+**`/dev/hugepages`.** A local volume backed by `hugetlbfs` mounts a *fresh*
+hugetlbfs instance, so the workload keeps huge pages without seeing the host's:
+
+```yaml
+services:
+  spdk:
+    image: myapp:1.0
+    volumes:
+      - hugepages:/dev/hugepages
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+
+volumes:
+  hugepages:
+    driver: local
+    driver_opts:
+      type: hugetlbfs
+      device: hugetlbfs
+```
+
+A file created inside that volume is invisible on the host's `/dev/hugepages`
+and through a bind of it (verified on Docker 29.4.3), so the container cannot
+read or corrupt pages another workload mapped. What it does **not** change is
+the size of the pool: huge pages are a host-wide resource, so bound the service
+with `deploy.resources.limits` as well.
+
+If the workload really does need the host's own huge-page files — some DPDK and
+SPDK deployments coordinate through them — that is a case for suppressing the
+finding with a `reason:`, not for pretending the mount is safe.
+
 ## ATT&CK coverage
 
 Remediating this finding contributes to mitigating the following MITRE ATT&CK techniques (pinned to ATT&CK v18). compose-lint is a static analyser, so this is *mitigation* coverage — it detects nothing at runtime.

--- a/src/compose_lint/rules/CL0013_sensitive_mount.py
+++ b/src/compose_lint/rules/CL0013_sensitive_mount.py
@@ -72,6 +72,7 @@ _INERT_DEVICES: frozenset[str] = frozenset(
 # Neither alternative bounds the underlying host-wide resource (the huge-page
 # pool is global), which is what `deploy.resources.limits` is for.
 _SCOPED_ALTERNATIVES: dict[str, str] = {
+    # nosec B108 - naming the path is the rule's job, not a temp-file use
     "/dev/shm": (
         "Don't bind the host's /dev/shm. If the container only needs a larger "
         "shared-memory segment than the 64 MiB default, set `shm_size:` on the "

--- a/src/compose_lint/rules/CL0013_sensitive_mount.py
+++ b/src/compose_lint/rules/CL0013_sensitive_mount.py
@@ -55,6 +55,41 @@ _INERT_DEVICES: frozenset[str] = frozenset(
     {"/dev/null", "/dev/zero", "/dev/full", "/dev/random", "/dev/urandom"}
 )
 
+# Paths where "remove the bind mount" is not a followable instruction, because
+# the workload needs the facility the mount provides. Compose has a scoped
+# alternative for each that keeps the facility and drops the host exposure, so
+# the finding stays and the guidance names the alternative instead.
+#
+# Verified against Docker 29.4.3, and each is clean under this rule set:
+#   /dev/shm       `shm_size:` resizes the container's own /dev/shm (64 MiB by
+#                  default) without exposing the host's; `ipc: shareable` plus
+#                  `ipc: service:<owner>` shares one segment between named
+#                  services with the host and every other container excluded.
+#   /dev/hugepages a local volume with `type: hugetlbfs` mounts a *fresh*
+#                  hugetlbfs instance — a file created in it is invisible both
+#                  on the host's /dev/hugepages and through a bind of it.
+#
+# Neither alternative bounds the underlying host-wide resource (the huge-page
+# pool is global), which is what `deploy.resources.limits` is for.
+_SCOPED_ALTERNATIVES: dict[str, str] = {
+    "/dev/shm": (
+        "Don't bind the host's /dev/shm. If the container only needs a larger "
+        "shared-memory segment than the 64 MiB default, set `shm_size:` on the "
+        "service. If two services genuinely need to share one, set "
+        "`ipc: shareable` on the owner and `ipc: service:<owner>` on the "
+        "other — that scopes the segment to those services instead of exposing "
+        "every segment on the host."
+    ),
+    "/dev/hugepages": (
+        "Don't bind the host's /dev/hugepages. Declare a volume with "
+        "`driver_opts: {type: hugetlbfs, device: hugetlbfs}` and mount that "
+        "instead: the container gets its own hugetlbfs instance, so it can "
+        "still use huge pages but cannot read or corrupt the pages another "
+        "workload mapped. The page pool stays host-wide, so also bound the "
+        "service with `deploy.resources.limits`."
+    ),
+}
+
 # The runtime directories. CL-0001 owns these and their ancestors, because they
 # hold the control sockets; it does not own what sits *below* them, which holds
 # host service state instead -- the system D-Bus, the libvirt control socket,
@@ -187,6 +222,12 @@ class SensitiveMountRule(BaseRule):
                 else:
                     continue  # writable root-equivalent — CL-0025's
 
+            remedy = _SCOPED_ALTERNATIVES.get(normalized) or (
+                f"Remove the bind mount for {mount.host_path}. If the "
+                "container needs specific files, copy them into the image at "
+                "build time or use a named volume with only the required data."
+            )
+
             yield Finding(
                 rule_id="CL-0013",
                 severity=Severity.HIGH,
@@ -196,12 +237,6 @@ class SensitiveMountRule(BaseRule):
                     f"(under {matched}). The mount {reason}."
                 ),
                 line=mount.line,
-                fix=(
-                    f"Remove the bind mount for {mount.host_path}. If the "
-                    "container needs specific files, copy them into the image "
-                    "at build time or use a named volume with only the "
-                    "required data.\n"
-                    "Full guide: compose-lint --explain CL-0013"
-                ),
+                fix=f"{remedy}\nFull guide: compose-lint --explain CL-0013",
                 references=REFERENCES,
             )

--- a/tests/test_CL0013.py
+++ b/tests/test_CL0013.py
@@ -238,3 +238,60 @@ class TestRunMount:
             "      - /run/containerd:/x\n"
         )
         assert self._check(content) == []
+
+
+class TestScopedAlternatives:
+    """/dev/shm and /dev/hugepages get guidance a reader can act on.
+
+    Both still fire — a host bind of either exposes segments belonging to the
+    host and to every other container, which is the same reach `ipc: host`
+    carries at HIGH under CL-0010. What the generic advice got wrong is the
+    remedy: "copy them into the image at build time" is not something a
+    workload wanting a bigger /dev/shm or a huge-page pool can do. Compose has
+    a scoped alternative for each, so the finding names it.
+    """
+
+    def setup_method(self) -> None:
+        self.rule = SensitiveMountRule()
+
+    def _check(self, host_path: str, service: str = "a") -> list:
+        content = (
+            f"services:\n  {service}:\n    image: nginx\n    volumes:\n"
+            f"      - {host_path}:/x\n"
+        )
+        data, lines = loads(content)
+        return list(self.rule.check(service, data["services"][service], data, lines))
+
+    def test_dev_shm_still_fires_at_high(self) -> None:
+        findings = self._check("/dev/shm")
+        assert len(findings) == 1
+        assert findings[0].severity == Severity.HIGH
+
+    def test_dev_shm_names_shm_size_and_scoped_ipc(self) -> None:
+        fix = self._check("/dev/shm")[0].fix
+        assert "shm_size:" in fix
+        assert "ipc: shareable" in fix
+        assert "copy them into the image" not in fix
+
+    def test_dev_hugepages_names_a_hugetlbfs_volume(self) -> None:
+        fix = self._check("/dev/hugepages")[0].fix
+        assert "hugetlbfs" in fix
+        assert "copy them into the image" not in fix
+
+    def test_guidance_survives_docker_path_normalisation(self) -> None:
+        """Docker cleans a mount source before using it, so the alternatives
+        must key off the normalised path rather than the string as written."""
+        for spelling in ("/dev/shm/", "/dev/./shm", "//dev/shm", "/dev/foo/../shm"):
+            assert "shm_size:" in self._check(spelling)[0].fix, spelling
+
+    def test_other_dev_paths_keep_the_generic_remedy(self) -> None:
+        """Only the two paths with a scoped alternative are special-cased."""
+        fix = self._check("/dev/disk")[0].fix
+        assert "copy them into the image" in fix
+        assert "shm_size:" not in fix
+
+    def test_every_finding_still_points_at_the_full_guide(self) -> None:
+        for path in ("/dev/shm", "/dev/hugepages", "/dev/disk", "/sys"):
+            assert self._check(path)[0].fix.endswith(
+                "Full guide: compose-lint --explain CL-0013"
+            ), path


### PR DESCRIPTION
Closes the `/dev/shm` / `/dev/hugepages` item from the severity review's §47.8. The answer to the open question is **keep HIGH** — the defect was never the severity.

## Why HIGH is right

`ipc: host` is already **HIGH** under CL-0010, derived on precisely this reasoning:

> Precondition: Technique — ... reading and writing a shared memory segment another workload trusts
> Impact: Cross-container — every container's processes and IPC objects, plus the host's

A host `/dev/shm` bind delivers the POSIX-shm half of that same reach through the same technique. Pricing the narrower path below the broader one, on an identical derivation, would be incoherent. The only route to MEDIUM is the `Removes a mitigation` precondition, and the model's own **named-primitive test** rules it out: the mount leaves a concrete nameable primitive — the host's shm segments. Every other reading (`Direct × Cross-container`, `Second flaw × Host`, `Technique × Cross-container`, `Direct × Host` + `read-only`) also lands on HIGH.

## What was actually broken

Both findings told the reader to *"remove the bind mount ... copy them into the image at build time or use a named volume with only the required data."* Neither is possible for a workload that wants a bigger shared-memory segment or a huge-page pool. `CLAUDE.md` requires every finding be actionable with specific fix guidance; these two failed that bar.

## Alternatives — verified, not assumed

Each was measured against Docker 29.4.3, and each is clean under this rule set:

| Alternative | Verified behaviour |
|---|---|
| `shm_size: 2gb` | `/dev/shm` grew 64 MiB → 2 GiB; a canary written in the container did **not** appear on the host |
| `ipc: shareable` + `ipc: service:<owner>` | joiner saw the owner's segment; an unrelated container and the host did **not** |
| volume with `type: hugetlbfs` | mounts a **fresh** hugetlbfs instance — a file created in it is invisible on the host's `/dev/hugepages` *and* through a bind of it |

I had assumed no substitute existed for `/dev/hugepages`. That was wrong, and checking is what caught it.

Both limits are stated rather than glossed: the huge-page pool stays host-wide (so the guidance also points at `deploy.resources.limits`), and a workload that genuinely needs the host's own huge-page files — some DPDK/SPDK deployments coordinate through them — is told to suppress with a `reason:` rather than pretend the mount is safe.

## Verification

**Corpus differential** over the archived 5,417-file snapshot, two legs, findings diffed on `(rule_id, severity, service, line)`:

- **0 files with a finding-set delta**
- exactly **39 fix texts changed — 9 `shm_size`, 30 `hugetlbfs`** — matching the 9 `/dev/shm` and 30 `/dev/hugepages` findings exactly, and nothing else

Six new tests pin the guidance, including that it survives Docker's path normalisation (`/dev/shm/`, `/dev/./shm`, `//dev/shm`, `/dev/foo/../shm`) and that other `/dev` paths keep the generic remedy. `ruff`, `ruff format`, `mypy --strict`, `pytest` — all pass (1438 passed, 6 skipped).

The remedy is built before the `Finding` rather than inline, because a nested f-string would have been PEP 701 syntax and this project's matrix starts at Python 3.10.