### PR TITLE
Add CL-0029 for capabilities that degrade the host

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ If you need broad IaC coverage across Terraform, Kubernetes, and more, KICS cove
 | [CL-0026](https://tmatens.github.io/compose-lint/rules/CL-0026/) | MEDIUM | No resource limits (memory/CPU) | [Rule #7](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-7-limit-resources-memory-cpu-file-descriptors-processes-restarts) | 5.10, 5.11 |
 | [CL-0027](https://tmatens.github.io/compose-lint/rules/CL-0027/) | MEDIUM | Bounded-grant capability added | [Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-specific-capabilities-needed-by-a-container) | 5.4 |
 | [CL-0028](https://tmatens.github.io/compose-lint/rules/CL-0028/) | HIGH | Host-reaching capability added | [Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-specific-capabilities-needed-by-a-container) | 5.4 |
+| [CL-0029](https://tmatens.github.io/compose-lint/rules/CL-0029/) | HIGH | Host-availability capability added | [Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-specific-capabilities-needed-by-a-container) | 5.4 |
 
 ## Severity Levels
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,7 @@ reading here) in the terminal.
 | [CL-0026](rules/CL-0026.md) | No resource limits (memory/CPU) |
 | [CL-0027](rules/CL-0027.md) | Bounded-grant capability added |
 | [CL-0028](rules/CL-0028.md) | Host-reaching capability added |
+| [CL-0029](rules/CL-0029.md) | Host-availability capability added |
 
 ## Where to start
 

--- a/docs/rules/CL-0029.md
+++ b/docs/rules/CL-0029.md
@@ -1,0 +1,110 @@
+# CL-0029: Host-availability capabilities (SYS_NICE, IPC_LOCK, LEASE)
+
+**Severity:** HIGH
+
+**Derivation** (see [severity model](../severity.md)):
+
+- **Baseline:** A — the attacker already has code execution in this container, as the workload uid
+- **Precondition:** Direct — each member realises its impact through supported calls alone. `sched_setscheduler(SCHED_FIFO)`, `mlock()`, `fcntl(F_SETLEASE)`. No published technique, no second defect, and no other key in the file
+- **Impact:** Host — the scheduler, the page cache and the lease-break path are all host-wide; none of the three is namespaced
+- **Qualifier/modifier:** availability-only — the realised loss is denial of service. None of the three reads host data or runs host code, so the tier drops one from CRITICAL
+- **Derived:** Direct × Host + availability-only = HIGH
+- **Shipped:** HIGH
+- **Scoping assumptions:** none. `IPC_LOCK`'s reach *is* bounded by `deploy.resources.limits.memory`, but that is a key the file has to **add**, and the model's scoping clause covers reach that needs a sibling key **present** (see [CL-0027](CL-0027.md)'s `SYS_PTRACE`). Pricing the bounded case would price the rule below its own default behaviour, against "heterogeneous members score at their most dangerous member"
+- **Evidence:** three live checks in `scripts/validate_rule_premises.py`, each comparing `--cap-drop ALL` against the same run plus the single capability. `_cl0029_sys_nice` — `chrt -f 50` is refused capless and succeeds with `SYS_NICE`. `_cl0029_lease` — `F_SETLEASE(F_WRLCK)` on a file the process has chowned away from itself is `EACCES` capless and granted with `LEASE`; `CHOWN` is on both legs so the capability is the only difference. `_t_ipc_lock` (registered under CL-0006) — `mlockall` against `RLIMIT_MEMLOCK=0` is refused capless and succeeds with `IPC_LOCK`. All three stop at *acquiring* the primitive: a check that actually starved the runner's CPUs, pinned its RAM or stalled its opens would be a self-inflicted outage. That the **host** is what degrades therefore follows from the scheduler, the locked-page accounting and the lease-break path not being namespaced — reasoned, not asserted by the suite. One consequence was measured out-of-band on Docker 29.4.3 and is deliberately not in CI: with a container holding a write lease on a bind-mounted host file, a host `open()` of it completed after **21.9s**, against 0.00s unleased, through a **read-only** bind
+
+**References:**
+- [OWASP Docker Security Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-specific-capabilities-needed-by-a-container)
+- CIS Docker Benchmark 5.4 — Ensure that Linux kernel capabilities are restricted within containers
+
+## What it detects
+
+`cap_add` entries naming a capability that can degrade the host:
+
+| Capability | Grants | Why it is not CRITICAL |
+|---|---|---|
+| `SYS_NICE` | `SCHED_FIFO`/`SCHED_RR` and priority raises. The scheduler is host-wide, so the container's threads sit above ordinary host processes | Buys no read and no execution. RT throttling caps a runaway at `sched_rt_runtime_us`, so it degrades rather than halts |
+| `IPC_LOCK` | `mlock`/`mlockall` past `RLIMIT_MEMLOCK`, and `SHM_LOCK`. Locked pages cannot be swapped or reclaimed | Pins memory, reads none of it. A `memory` limit bounds it — but only once the file sets one |
+| `LEASE` | `F_SETLEASE` on files the process does not own. A write lease makes the host's own `open()` block until the lease is released or the timeout expires | Delays host processes; it does not read or alter the file's contents |
+
+`CAP_`-prefixed and lowercase spellings are equivalent and are matched the same
+way: Docker treats `CAP_SYS_NICE` and `SYS_NICE` as the same capability.
+
+## Why it matters
+
+A container is not a scheduling, memory or file-locking boundary. All three of
+these subsystems are host-global, and none of the three grants needs a
+vulnerability to become impact — they are the capability working as designed,
+handed to a workload that should not have it.
+
+**`LEASE` is the least obvious and the least contained.** A write lease is a
+kernel-supported way to make another process wait: while the lease is held, the
+host's own `open()` of that file blocks for up to `/proc/sys/fs/lease-break-time`
+(45 seconds by default), and the lease can be retaken. It needs only a bind
+mount to reach a host file, **and the bind may be read-only** — taking a lease
+is not a write. That is why this rule does not defer to
+[CL-0013](CL-0013.md) or [CL-0025](CL-0025.md) the way `LINUX_IMMUTABLE` does:
+those rules flag *sensitive* or *writable* host paths, and an ordinary
+`./config:/config` bind is neither.
+
+**`IPC_LOCK` is the one whose severity people will argue with**, because a
+memory limit does bound it. The derivation says why the bounded case is not the
+one priced: the limit is a key the file must add, the default is unbounded, and
+[CL-0026](CL-0026.md) shows the limit absent on ~90% of real Compose files.
+
+## Fix
+
+Remove the capability. Each has a bounded alternative that does not hand the
+container a host-wide lever:
+
+```yaml
+# Before
+services:
+  app:
+    image: myapp:1.0
+    cap_add:
+      - SYS_NICE
+      - IPC_LOCK
+
+# After — bound the resources instead of granting the capability
+services:
+  app:
+    image: myapp:1.0
+    deploy:
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 4G
+```
+
+`deploy.resources` gives a workload a predictable share of CPU without letting
+it outrank the host's own processes, and a `memory` limit is what bounds pinned
+pages — so it is worth setting even for a workload that keeps `IPC_LOCK`.
+
+## When to suppress
+
+Storage and packet-processing engines are the honest exception: SPDK and DPDK
+stacks ask for `SYS_NICE` and `IPC_LOCK` together, alongside a huge-page mount,
+and there is no configuration that gives them the same behaviour without the
+capabilities. Suppress per service with a `reason:` naming the workload, and
+set `deploy.resources.limits.memory` anyway — it still bounds what the
+container can pin.
+
+`LEASE` has no comparable case. A workload that needs it is coordinating with a
+process outside the container over a shared file, which is a design worth
+changing rather than suppressing.
+
+## ATT&CK coverage
+
+Remediating this finding contributes to mitigating the following MITRE ATT&CK techniques (pinned to ATT&CK v18). compose-lint is a static analyser, so this is *mitigation* coverage — it detects nothing at runtime.
+
+| Technique | Tactic |
+|---|---|
+| [T1499 Endpoint Denial of Service](https://attack.mitre.org/techniques/T1499/) | Impact |
+| [T1496 Resource Hijacking](https://attack.mitre.org/techniques/T1496/) | Impact |
+
+## See also
+
+- [CL-0028](CL-0028.md) — the same `Direct × Host` cell, spending its qualifier on `integrity-only` instead
+- [CL-0026](CL-0026.md) — missing resource limits, which is what bounds `IPC_LOCK`
+- [CL-0006](CL-0006.md) — dropping capabilities wholesale, the control this rule's findings evade

--- a/docs/severity.md
+++ b/docs/severity.md
@@ -278,6 +278,7 @@ link. `tests/test_severity_matrix.py` enforces all four properties.
 | [CL-0026](rules/CL-0026.md) | A | Removes a mitigation | Host | availability-only | MEDIUM | MEDIUM | — |
 | [CL-0027](rules/CL-0027.md) | A | Second flaw | Single container | — | MEDIUM | MEDIUM | — |
 | [CL-0028](rules/CL-0028.md) | A | Direct | Host | integrity-only | HIGH | HIGH | — |
+| [CL-0029](rules/CL-0029.md) | A | Direct | Host | availability-only | HIGH | HIGH | — |
 
 ### Notes on individual derivations
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ nav:
       - "CL-0026 Resource limits (memory/CPU)": rules/CL-0026.md
       - "CL-0027 Bounded-grant capabilities": rules/CL-0027.md
       - "CL-0028 Host-reaching capabilities": rules/CL-0028.md
+      - "CL-0029 Host-availability capabilities": rules/CL-0029.md
   - Examples:
       - "Real-world examples": examples/index.md
       - "1 — Delete the service": examples/portainer-removed/index.md

--- a/scripts/validate_rule_premises.py
+++ b/scripts/validate_rule_premises.py
@@ -552,6 +552,75 @@ def _t_ipc_lock() -> tuple[bool, str]:
     )
 
 
+# --- CL-0029 premise checks (docs/rules/CL-0029.md) -------------------------
+#
+# CL-0029's members are priced on host *availability*, and two of the three
+# already have a live mapping above: `_t_sys_nice` (renice) and `_t_ipc_lock`
+# (mlockall past the rlimit). Those prove the capability is honoured; they do
+# not reach the lever the rule is priced on. These two do.
+#
+# Both stop at *acquiring* the primitive. Neither exercises it — a check that
+# actually starved the CI runner's CPUs, pinned its RAM, or stalled its opens
+# would be a self-inflicted outage, and acquisition is the part that can be
+# asserted deterministically anyway. That the host is what degrades follows
+# from the scheduler and the lease-break path not being namespaced, and is
+# recorded as reasoned in the rule's Evidence line.
+
+def _cl0029_sys_nice() -> tuple[bool, str]:
+    """SCHED_FIFO — real-time priority on the host's CPUs — needs SYS_NICE.
+
+    ``renice`` (``_t_sys_nice``, above) proves the capability is honoured, but
+    a nicer process still yields to everything; real-time priority is the lever
+    this rule is priced on, because a SCHED_FIFO thread outranks every ordinary
+    host process rather than competing with them.
+
+    busybox ``chrt`` rather than a libc or raw-syscall probe. musl stubs
+    ``sched_setscheduler`` to ENOSYS, so the pinned python image reports
+    "denied" whatever the capability is; and the raw syscall needs a number
+    that differs per architecture — 144 on x86_64, 119 on arm64 — which is a
+    wrong answer waiting for the first non-amd64 runner.
+    """
+    return _mapping(
+        ["SYS_NICE"],
+        ["chrt", "-f", "50", "true"],
+        "chrt: can't set pid 0's policy: Operation not permitted",
+    )
+
+
+# F_SETLEASE(F_WRLCK) on a file the caller does not own. Ownership is the
+# discriminator -- leasing a file you own needs no capability -- so the probe
+# chowns the file away from itself first, which is why CHOWN is on *both* legs.
+# That leaves LEASE as the only difference between them.
+_LEASE_PROBE = (
+    "import fcntl,os,sys\n"
+    "open('/tmp/leased','w').close()\n"
+    "os.chown('/tmp/leased',12345,12345)\n"
+    "fd=os.open('/tmp/leased',os.O_RDONLY)\n"
+    "try:\n"
+    "    fcntl.fcntl(fd,1024,1)\n"
+    "except OSError as e:\n"
+    "    print('F_SETLEASE: '+os.strerror(e.errno),file=sys.stderr)\n"
+    "    sys.exit(1)\n"
+    "fcntl.fcntl(fd,1024,2)\n"
+)
+
+
+def _cl0029_lease() -> tuple[bool, str]:
+    """A write lease on a file the process does not own needs CAP_LEASE.
+
+    Held against a bind-mounted host file this is what stalls the host's own
+    ``open()``; the probe leases a container-local file, because blocking a
+    real host path is the part that must not run on a CI machine.
+    """
+    deny = ["--cap-drop", "ALL", "--cap-add", "CHOWN"]
+    allow = [*deny, "--cap-add", "LEASE"]
+    cmd = ["python", "-c", _LEASE_PROBE]
+    rc_deny, err = _run_err(deny, cmd, PY_IMAGE)
+    rc_allow, _ = _run_err(allow, cmd, PY_IMAGE)
+    ok = rc_deny != 0 and "F_SETLEASE: Permission denied" in err and rc_allow == 0
+    return ok, f"denied rc={rc_deny} msg={err!r}; with LEASE rc={rc_allow}"
+
+
 # --- CL-0007 symptom-table mappings (docs/rules/CL-0007.md) -----------------
 #
 # Same contract as the CL-0006 mapping checks (ADR-016 amendment): each row of
@@ -1058,6 +1127,8 @@ CHECKS: list[tuple[str, str, Callable[[], tuple[bool | None, str]]]] = [
     ("CL-0006", "map: set clock -> SYS_TIME", _t_sys_time),
     ("CL-0006", "map: cross-uid signal -> KILL", _t_kill),
     ("CL-0006", "map: mlockall -> IPC_LOCK", _t_ipc_lock),
+    ("CL-0029", "SCHED_FIFO on host CPUs needs SYS_NICE", _cl0029_sys_nice),
+    ("CL-0029", "write lease on an unowned file needs LEASE", _cl0029_lease),
     # CL-0007 symptom-table mappings — one per row of the rule doc's table.
     ("CL-0007", "map: touch EROFS -> tmpfs", _t7_touch_tmpfs),
     ("CL-0007", "map: mkdir EROFS -> tmpfs", _t7_mkdir_tmpfs),

--- a/src/compose_lint/attack.py
+++ b/src/compose_lint/attack.py
@@ -134,6 +134,7 @@ RULE_TECHNIQUES: dict[str, tuple[Technique, ...]] = {
     # consequence, T1499 because cert validation and Kerberos fail machine-wide.
     # PERFMON samples every process on the host, hence T1003.
     "CL-0028": (T1070, T1499, T1003),
+    "CL-0029": (T1499, T1496),
 }
 
 #: Techniques a rule *enables* rather than mitigates, kept out of the mapping

--- a/src/compose_lint/rules/CL0029_host_availability_cap_add.py
+++ b/src/compose_lint/rules/CL0029_host_availability_cap_add.py
@@ -1,0 +1,95 @@
+"""CL-0029: Capabilities that let a container degrade the host."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from compose_lint.models import Finding, RuleMetadata, Severity
+from compose_lint.rules import BaseRule, register_rule
+from compose_lint.rules._caps import REFERENCES, iter_cap_add
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+# Capabilities whose reach lands on the host but buys the attacker nothing to
+# read and nothing to run: the loss is availability, and only availability.
+#
+# That is the whole reason this is not CL-0028. Both rules sit in the same cell
+# -- Direct x Host -- and differ only in the qualifier the model makes them
+# pick, because `Direct x Host` is CRITICAL until a qualifier names which of
+# the three kinds of loss is actually realised. CL-0028 spends its qualifier on
+# `integrity-only` (a clock set, a kernel read). These three spend it on
+# `availability-only`. A rule carries at most one qualifier, so one rule cannot
+# hold both sets without its derivation becoming false for half its members --
+# which is exactly why CL-0028 was split out of CL-0027 (see docs/severity.md).
+#
+# Each member was measured on Docker 29.4.3 holding only that capability under
+# `--cap-drop ALL`, against the same run without it. None needs a sibling key:
+# the reach is there with nothing else in the file.
+HOST_AVAILABILITY_CAPS: dict[str, str] = {
+    "SYS_NICE": (
+        "real-time scheduling on the host's CPUs — SCHED_FIFO puts the "
+        "container's threads above every ordinary host process, and the "
+        "scheduler is not namespaced"
+    ),
+    "IPC_LOCK": (
+        "unbounded memory locking — mlock past RLIMIT_MEMLOCK pins host RAM "
+        "that cannot be reclaimed or swapped, and only a memory limit the "
+        "file has to set bounds it"
+    ),
+    "LEASE": (
+        "file leases on any host path bind-mounted in — a write lease stalls "
+        "the host's own open() of that file for the kernel's lease-break "
+        "timeout, and holding it needs only a read-only bind"
+    ),
+}
+
+
+@register_rule
+class HostAvailabilityCapAddRule(BaseRule):
+    """Detects cap_add entries that let a container degrade the host."""
+
+    @property
+    def metadata(self) -> RuleMetadata:
+        return RuleMetadata(
+            id="CL-0029",
+            name="Host-availability capability added",
+            description=(
+                "Adding SYS_NICE, IPC_LOCK or LEASE lets the container take "
+                "host CPU, pin host memory, or stall the host's own file "
+                "opens — without needing any other key in the file."
+            ),
+            severity=Severity.HIGH,
+            references=REFERENCES,
+        )
+
+    def check(
+        self,
+        service_name: str,
+        service_config: dict[str, Any],
+        global_config: dict[str, Any],
+        lines: dict[str, int],
+    ) -> Iterator[Finding]:
+        for as_written, bare, line in iter_cap_add(
+            service_name, service_config, lines, HOST_AVAILABILITY_CAPS
+        ):
+            yield Finding(
+                rule_id="CL-0029",
+                severity=Severity.HIGH,
+                service=service_name,
+                message=(f"Service adds {as_written}: {HOST_AVAILABILITY_CAPS[bare]}."),
+                line=line,
+                fix=(
+                    f"Remove {as_written} from cap_add. Workloads that ask for "
+                    "these usually have a bounded alternative: set "
+                    "`deploy.resources` rather than granting SYS_NICE, and "
+                    "size `deploy.resources.limits.memory` rather than "
+                    "granting IPC_LOCK — a memory limit also bounds what a "
+                    "workload that keeps IPC_LOCK can pin. A storage or "
+                    "packet-processing engine that genuinely requires them "
+                    "(SPDK and DPDK ask for SYS_NICE and IPC_LOCK together) "
+                    "should suppress with a reason naming the workload.\n"
+                    "Full guide: compose-lint --explain CL-0029"
+                ),
+                references=REFERENCES,
+            )

--- a/tests/test_CL0029.py
+++ b/tests/test_CL0029.py
@@ -1,0 +1,64 @@
+"""Tests for CL-0029: host-availability capability added.
+
+The fourth `cap_add` tier. What is worth testing here is the boundary with
+CL-0028, which sits in the *same* cell (`Direct × Host`) and is separated from
+this rule only by which qualifier it spends — so a member landing in the wrong
+one is not caught by the severity number, which is HIGH either way.
+"""
+
+from __future__ import annotations
+
+from compose_lint.models import Severity
+from compose_lint.parser import loads
+from compose_lint.rules.CL0029_host_availability_cap_add import (
+    HOST_AVAILABILITY_CAPS,
+    HostAvailabilityCapAddRule,
+)
+
+
+class TestHostAvailabilityCapAddRule:
+    def setup_method(self) -> None:
+        self.rule = HostAvailabilityCapAddRule()
+
+    def _check(self, caps: str, service: str = "a") -> list:
+        content = (
+            f"services:\n  {service}:\n    image: nginx:1.27\n    cap_add:\n{caps}"
+        )
+        data, lines = loads(content)
+        return list(self.rule.check(service, data["services"][service], data, lines))
+
+    def test_each_member_fires_at_high(self) -> None:
+        for cap in HOST_AVAILABILITY_CAPS:
+            findings = self._check(f"      - {cap}\n")
+            assert len(findings) == 1, cap
+            assert findings[0].severity == Severity.HIGH, cap
+            assert findings[0].rule_id == "CL-0029", cap
+
+    def test_members_are_exactly_the_three_measured_capabilities(self) -> None:
+        """Each was measured reaching the host with no sibling key. A capability
+        added here without that evidence is the CL-0022/CL-0023 failure mode."""
+        assert set(HOST_AVAILABILITY_CAPS) == {"SYS_NICE", "IPC_LOCK", "LEASE"}
+
+    def test_cap_prefix_and_case_are_equivalent(self) -> None:
+        for spelling in ("CAP_SYS_NICE", "cap_sys_nice", "sys_nice", "SYS_NICE"):
+            findings = self._check(f"      - {spelling}\n")
+            assert len(findings) == 1, spelling
+            assert spelling.upper() in findings[0].message, spelling
+
+    def test_unrelated_capabilities_are_not_this_rule(self) -> None:
+        """The other tiers' members, and a Docker default, must not fire here."""
+        for cap in ("SYS_ADMIN", "NET_ADMIN", "SYS_PTRACE", "PERFMON", "CHOWN"):
+            assert self._check(f"      - {cap}\n") == [], cap
+
+    def test_every_member_names_a_bounded_alternative_or_suppression(self) -> None:
+        """A finding a reader cannot act on is the defect this rule set treats
+        as a bug; SPDK/DPDK workloads genuinely need these."""
+        for cap in HOST_AVAILABILITY_CAPS:
+            fix = self._check(f"      - {cap}\n")[0].fix
+            assert "deploy.resources" in fix or "suppress" in fix, cap
+            assert fix.endswith("Full guide: compose-lint --explain CL-0029"), cap
+
+    def test_multiple_members_report_once_each(self) -> None:
+        findings = self._check("      - SYS_NICE\n      - IPC_LOCK\n      - LEASE\n")
+        assert len(findings) == 3
+        assert {f.line for f in findings} == {5, 6, 7}

--- a/tests/test_rule_consistency.py
+++ b/tests/test_rule_consistency.py
@@ -49,6 +49,8 @@ VARIABLE_SEVERITY_RULES: dict[str, set[Severity]] = {}
 # Extend this when a new rule's trigger isn't present as a fixture file.
 INLINE_TRIGGERS: tuple[str, ...] = (
     "services:\n  tmpfs_exec:\n    image: nginx:1.27\n    tmpfs:\n      - /tmp:exec\n",
+    "services:\n  host_availability_caps:\n    image: nginx:1.27\n    cap_add:\n"
+    "      - SYS_NICE\n      - IPC_LOCK\n      - LEASE\n",
 )
 
 _RULES: list[BaseRule] = [cls() for cls in get_registered_rules()]

--- a/tests/test_rule_membership.py
+++ b/tests/test_rule_membership.py
@@ -46,6 +46,9 @@ from compose_lint.rules.CL0025_writable_host_root import (
 )
 from compose_lint.rules.CL0027_lesser_cap_add import LESSER_CAPS
 from compose_lint.rules.CL0028_host_reach_cap_add import HOST_REACH_CAPS
+from compose_lint.rules.CL0029_host_availability_cap_add import (
+    HOST_AVAILABILITY_CAPS,
+)
 
 
 class TestCapabilityTiers:
@@ -592,10 +595,7 @@ _EXCLUDED_WITH_REASON: dict[str, str] = {
 #             nor CL-0025 covers the configuration that enables it
 _UNGRADED_NO_RECORDED_REASON: frozenset[str] = frozenset(
     {
-        "IPC_LOCK",
-        "LEASE",
         "SYSLOG",
-        "SYS_NICE",
     }
 )
 
@@ -616,6 +616,7 @@ class TestCapabilityCompleteness:
                 set(HOST_EXEC_CAPS)
                 | set(STRONG_CAPS)
                 | set(HOST_REACH_CAPS)
+                | set(HOST_AVAILABILITY_CAPS)
                 | set(LESSER_CAPS)
             )
             - {"ALL"}  # a keyword, not a capability


### PR DESCRIPTION
`SYS_NICE`, `IPC_LOCK` and `LEASE` each reach the host with no other key in the file, and none had a rule. They are three of the four capabilities left listed in `test_rule_membership.py` after #539 recorded a disposition for the other eleven.

## Why a new rule and not three new members

All three derive **`Direct × Host` + `availability-only` = HIGH** — the same cell as CL-0028, which also ships HIGH. That is precisely why they cannot join it.

`Direct × Host` is CRITICAL until a qualifier names which of the three kinds of loss is realised. CL-0028 has already spent its qualifier on `integrity-only` (a clock set, a kernel read); these three need `availability-only`. **A rule carries at most one qualifier**, so putting them in CL-0028 would make its derivation false for half its members — the exact defect that split CL-0028 out of CL-0027 in §42.1. Same severity, different route.

| Member | Grant | Measured |
|---|---|---|
| `SYS_NICE` | SCHED_FIFO on host CPUs; the scheduler is not namespaced | `chrt -f 50` refused capless, acquired with the cap |
| `IPC_LOCK` | mlock past `RLIMIT_MEMLOCK`; pins unreclaimable host RAM | 128 MiB locked against an 8 MiB limit |
| `LEASE` | write lease stalls the host's own `open()` | **21.9s vs 0.00s** unleased |

## LEASE is the one to review

It was headed for the excluded list as negligible until it was measured. A container holding a write lease on a bind-mounted host file stalled a host `open()` for **21.9 seconds**, and it works **through a read-only bind, on any path**. CL-0013 flags *sensitive* host paths and CL-0025 *writable* ones — neither covers the ordinary `./config:/config` bind that enables this, so nothing in the rule set caught the configuration.

## IPC_LOCK is the one whose tier is arguable

A memory limit genuinely does bound it. The derivation says why the bounded case is not the one priced: the limit is a key the file has to **add**, the default is unbounded, and CL-0026 finds no limit on ~90% of real Compose files. Pricing the bounded case would price the rule below its own default behaviour, against "heterogeneous members score at their most dangerous member." The model's scoping clause covers reach needing a sibling key *present*, which is the opposite situation.

## Premise checks

Two new, both passing live:

- `_cl0029_sys_nice` uses **busybox `chrt`**, not a libc or raw-syscall probe. musl stubs `sched_setscheduler` to ENOSYS, so the pinned python image reports "denied" whatever the capability is — and the raw syscall number differs per architecture (144 on x86_64, 119 on arm64), which is a wrong answer waiting for the first non-amd64 runner. I hit both of those while writing it.
- `_cl0029_lease` puts `CHOWN` on **both** legs, because leasing a file you own needs no capability — ownership is the discriminator, so it has to be neutralised for `LEASE` to be the only difference.

Both stop at *acquiring* the primitive. A check that actually starved the runner's CPUs, pinned its RAM or stalled its opens would be a self-inflicted outage, so the Evidence line records that the host-wide consequence is **reasoned, not asserted** — and names the out-of-band 21.9s measurement as the thing CI deliberately does not run.

## Corpus differential

Over the archived 5,417-file snapshot, two legs diffed on `(rule_id, severity, service, line)`:

- **72 findings added across 28 files, all CL-0029**
- **zero removed, no other rule affected**

Exactly the predicted volume. Worth knowing before merge: **15 of the 28 files are one repo's test suite (`openebs/mayastor`)**, which already carries the `/dev/hugepages` findings — SPDK asks for huge pages, locked memory and RT scheduling together. Those files go to four HIGH findings whose combined remedy is "suppress with a reason", which the rule's own guidance and `## When to suppress` say explicitly.

## Surfaces

Rule module, doc page, README table, `docs/index.md`, mkdocs nav, `docs/severity.md` assignment row, ATT&CK mapping (T1499, T1496), membership-tier wiring, an `INLINE_TRIGGERS` entry so metadata/finding consistency is actually exercised, and `tests/test_CL0029.py`. `ruff`, `ruff format`, `mypy --strict`, `pytest` (1452 passed, 6 skipped) and `bandit -ll` all pass.

Leaves `SYSLOG` as the last listed capability — a separate rule, `Direct × Host` + `read-only`, and zero corpus findings.