### PR TITLE
Add CL-0030 for SYSLOG, and close the ungraded set

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ If you need broad IaC coverage across Terraform, Kubernetes, and more, KICS cove
 | [CL-0026](https://tmatens.github.io/compose-lint/rules/CL-0026/) | MEDIUM | No resource limits (memory/CPU) | [Rule #7](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-7-limit-resources-memory-cpu-file-descriptors-processes-restarts) | 5.10, 5.11 |
 | [CL-0027](https://tmatens.github.io/compose-lint/rules/CL-0027/) | MEDIUM | Bounded-grant capability added | [Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-specific-capabilities-needed-by-a-container) | 5.4 |
 | [CL-0028](https://tmatens.github.io/compose-lint/rules/CL-0028/) | HIGH | Host-reaching capability added | [Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-specific-capabilities-needed-by-a-container) | 5.4 |
+| [CL-0030](https://tmatens.github.io/compose-lint/rules/CL-0030/) | HIGH | Host-disclosure capability added | [Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-specific-capabilities-needed-by-a-container) | 5.4 |
 | [CL-0029](https://tmatens.github.io/compose-lint/rules/CL-0029/) | HIGH | Host-availability capability added | [Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-specific-capabilities-needed-by-a-container) | 5.4 |
 
 ## Severity Levels

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,7 @@ reading here) in the terminal.
 | [CL-0027](rules/CL-0027.md) | Bounded-grant capability added |
 | [CL-0028](rules/CL-0028.md) | Host-reaching capability added |
 | [CL-0029](rules/CL-0029.md) | Host-availability capability added |
+| [CL-0030](rules/CL-0030.md) | Host-disclosure capability added |
 
 ## Where to start
 

--- a/docs/rules/CL-0030.md
+++ b/docs/rules/CL-0030.md
@@ -1,0 +1,96 @@
+# CL-0030: Host-disclosure capability (SYSLOG)
+
+**Severity:** HIGH
+
+**Derivation** (see [severity model](../severity.md)):
+
+- **Baseline:** A — the attacker already has code execution in this container, as the workload uid
+- **Precondition:** Direct — `syslog(2)` alone returns the buffer. No published technique, no second defect, and no other key in the file
+- **Impact:** Host — the kernel ring buffer is a single host-wide log; it is not namespaced, so what the container reads is the host's
+- **Qualifier/modifier:** read-only — the realised loss is disclosure. The capability grants no write to the buffer and no execution anywhere, so the tier drops one from CRITICAL
+- **Derived:** Direct × Host + read-only = HIGH
+- **Shipped:** HIGH
+- **Scoping assumptions:** none. The reach needs nothing else in the file, and — measured — does not depend on the host's `kernel.dmesg_restrict` either (see Evidence)
+- **Evidence:** `_cl0030_syslog` in `scripts/validate_rule_premises.py` asserts the grant against a live daemon: `dmesg` returns no lines at `--cap-drop ALL` and returns the host's buffer with `--cap-add SYSLOG`. The check compares **line counts, never content** — the host's kernel log is not something a CI log should carry. Measured on Docker 29.4.3: 0 lines capless against 1,967 with the capability, on a host where `kernel.dmesg_restrict=1` blocks an unprivileged *host* user from reading the same buffer. The independence from that sysctl was measured rather than assumed: with `kernel.dmesg_restrict=0` a capless container still read **0** lines, because Docker's own default seccomp profile admits the `syslog(2)` syscall only for `CAP_SYSLOG`. The reach is therefore gated by the capability on any host, hardened or not
+
+**References:**
+- [OWASP Docker Security Rule #3](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-specific-capabilities-needed-by-a-container)
+- CIS Docker Benchmark 5.4 — Ensure that Linux kernel capabilities are restricted within containers
+
+## What it detects
+
+`cap_add` entries naming a capability that reads host state:
+
+| Capability | Grants | Why it is not CRITICAL |
+|---|---|---|
+| `SYSLOG` | `syslog(2)` against the kernel ring buffer, and the ability to read it regardless of `kernel.dmesg_restrict` | Pure observation. It writes nothing, runs nothing, and breaks nothing — the loss is confidentiality alone |
+
+`CAP_`-prefixed and lowercase spellings are equivalent and are matched the same
+way: Docker treats `CAP_SYSLOG` and `SYSLOG` as the same capability.
+
+## Why it matters
+
+The kernel ring buffer is one log for the whole machine. A container holding
+`SYSLOG` reads the host's boot messages, its hardware and driver state, its
+filesystem and network events — and on a host that leaves `kernel.kptr_restrict`
+at `0`, kernel pointers along with them, which is the address-layout
+information a local exploit wants.
+
+**It reads what the host itself hides.** On a host with
+`kernel.dmesg_restrict=1` — the hardened default on most distributions — an
+unprivileged user *on the host* cannot read that buffer. A container granted
+this one capability can. The container is not a smaller trust domain than the
+host user in that comparison; it is a larger one.
+
+**The grant does not depend on the host being hardened.** Docker's default
+seccomp profile admits `syslog(2)` only when `CAP_SYSLOG` is held, so a capless
+container reads nothing even where `kernel.dmesg_restrict=0` would let any host
+user read everything. That was measured, not assumed, and it is why this rule
+does not carry a "depends on host configuration" caveat.
+
+## Fix
+
+Remove the capability. The kernel log belongs to the host, and so does reading
+it:
+
+```yaml
+# Before
+services:
+  monitor:
+    image: myapp:1.0
+    cap_add:
+      - SYSLOG
+
+# After — collect kernel messages on the host, not from inside a container
+services:
+  monitor:
+    image: myapp:1.0
+```
+
+Read the buffer on the host with `journalctl -k`, or run the log shipper there.
+A workload that needs kernel messages about *its own* device should be given
+that device explicitly — see [CL-0016](CL-0016.md) — rather than the whole
+machine's log.
+
+## When to suppress
+
+A host-level monitoring agent deliberately deployed as a container is the real
+case: it is doing the host's job, and reading the kernel log is the job. Such
+an agent usually announces itself with `pid: host` or a host bind mount as
+well. Suppress per service with a `reason:` naming the agent, rather than
+disabling the rule globally — the next service to ask for `SYSLOG` is unlikely
+to be a monitoring agent.
+
+## ATT&CK coverage
+
+Remediating this finding contributes to mitigating the following MITRE ATT&CK techniques (pinned to ATT&CK v18). compose-lint is a static analyser, so this is *mitigation* coverage — it detects nothing at runtime.
+
+| Technique | Tactic |
+|---|---|
+| [T1613 Container and Resource Discovery](https://attack.mitre.org/techniques/T1613/) | Discovery |
+
+## See also
+
+- [CL-0028](CL-0028.md) — the same `Direct × Host` cell, spending its qualifier on `integrity-only`
+- [CL-0029](CL-0029.md) — the same cell again, spending it on `availability-only`
+- [CL-0006](CL-0006.md) — dropping capabilities wholesale, the control this rule's findings evade

--- a/docs/severity.md
+++ b/docs/severity.md
@@ -279,6 +279,7 @@ link. `tests/test_severity_matrix.py` enforces all four properties.
 | [CL-0027](rules/CL-0027.md) | A | Second flaw | Single container | — | MEDIUM | MEDIUM | — |
 | [CL-0028](rules/CL-0028.md) | A | Direct | Host | integrity-only | HIGH | HIGH | — |
 | [CL-0029](rules/CL-0029.md) | A | Direct | Host | availability-only | HIGH | HIGH | — |
+| [CL-0030](rules/CL-0030.md) | A | Direct | Host | read-only | HIGH | HIGH | — |
 
 ### Notes on individual derivations
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ nav:
       - "CL-0027 Bounded-grant capabilities": rules/CL-0027.md
       - "CL-0028 Host-reaching capabilities": rules/CL-0028.md
       - "CL-0029 Host-availability capabilities": rules/CL-0029.md
+      - "CL-0030 Host-disclosure capability": rules/CL-0030.md
   - Examples:
       - "Real-world examples": examples/index.md
       - "1 — Delete the service": examples/portainer-removed/index.md

--- a/scripts/validate_rule_premises.py
+++ b/scripts/validate_rule_premises.py
@@ -621,6 +621,35 @@ def _cl0029_lease() -> tuple[bool, str]:
     return ok, f"denied rc={rc_deny} msg={err!r}; with LEASE rc={rc_allow}"
 
 
+# --- CL-0030 premise check (docs/rules/CL-0030.md) --------------------------
+
+
+def _cl0030_syslog() -> tuple[bool, str]:
+    """SYSLOG reads the host kernel ring buffer, which is not namespaced.
+
+    Compares **line counts, never content**: the host's kernel log is not
+    something a CI log should carry, and the claim under test is reachability,
+    not what happens to be in the buffer.
+
+    Deliberately not conditioned on the host's ``kernel.dmesg_restrict``.
+    Docker's default seccomp profile admits ``syslog(2)`` only for
+    ``CAP_SYSLOG``, so the capless leg reads nothing even where that sysctl is
+    0 and any *host* user could read everything -- measured, not assumed.
+    """
+    _, capless = _run(["--cap-drop", "ALL"], ["sh", "-c", "dmesg 2>/dev/null | wc -l"])
+    _, granted = _run(
+        ["--cap-drop", "ALL", "--cap-add", "SYSLOG"],
+        ["sh", "-c", "dmesg 2>/dev/null | wc -l"],
+    )
+    try:
+        none_capless, some_granted = int(capless) == 0, int(granted) > 0
+    except ValueError:
+        return False, f"unparsable line counts: capless={capless!r} SYSLOG={granted!r}"
+    return (
+        none_capless and some_granted
+    ), f"host kernel log lines: capless={capless}, with SYSLOG={granted}"
+
+
 # --- CL-0007 symptom-table mappings (docs/rules/CL-0007.md) -----------------
 #
 # Same contract as the CL-0006 mapping checks (ADR-016 amendment): each row of
@@ -1129,6 +1158,7 @@ CHECKS: list[tuple[str, str, Callable[[], tuple[bool | None, str]]]] = [
     ("CL-0006", "map: mlockall -> IPC_LOCK", _t_ipc_lock),
     ("CL-0029", "SCHED_FIFO on host CPUs needs SYS_NICE", _cl0029_sys_nice),
     ("CL-0029", "write lease on an unowned file needs LEASE", _cl0029_lease),
+    ("CL-0030", "host kernel ring buffer needs SYSLOG", _cl0030_syslog),
     # CL-0007 symptom-table mappings — one per row of the rule doc's table.
     ("CL-0007", "map: touch EROFS -> tmpfs", _t7_touch_tmpfs),
     ("CL-0007", "map: mkdir EROFS -> tmpfs", _t7_mkdir_tmpfs),

--- a/src/compose_lint/attack.py
+++ b/src/compose_lint/attack.py
@@ -135,6 +135,7 @@ RULE_TECHNIQUES: dict[str, tuple[Technique, ...]] = {
     # PERFMON samples every process on the host, hence T1003.
     "CL-0028": (T1070, T1499, T1003),
     "CL-0029": (T1499, T1496),
+    "CL-0030": (T1613,),
 }
 
 #: Techniques a rule *enables* rather than mitigates, kept out of the mapping

--- a/src/compose_lint/rules/CL0030_host_disclosure_cap_add.py
+++ b/src/compose_lint/rules/CL0030_host_disclosure_cap_add.py
@@ -1,0 +1,79 @@
+"""CL-0030: Capabilities that read host state the container cannot otherwise see."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from compose_lint.models import Finding, RuleMetadata, Severity
+from compose_lint.rules import BaseRule, register_rule
+from compose_lint.rules._caps import REFERENCES, iter_cap_add
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+# Capabilities whose reach is a read of host state: no write, no execution, and
+# nothing the container can break.
+#
+# The third rule in the `Direct x Host` cell, and the reason there are three is
+# that the cell is CRITICAL until a qualifier names which kind of loss lands.
+# CL-0028 takes `integrity-only`, CL-0029 `availability-only`, and this one
+# `read-only` -- the model's three kinds of loss, one rule each, because a rule
+# carries at most one qualifier. All three ship HIGH, so the split is invisible
+# in the severity and visible only in the derivation, which is exactly why the
+# member has to be placed by its route rather than by its number.
+HOST_DISCLOSURE_CAPS: dict[str, str] = {
+    "SYSLOG": (
+        "read of the host kernel ring buffer — dmesg is not namespaced, so "
+        "the container sees the host's boot and driver log, including kernel "
+        "pointers where kptr_restrict allows them"
+    ),
+}
+
+
+@register_rule
+class HostDisclosureCapAddRule(BaseRule):
+    """Detects cap_add entries that read host state from inside a container."""
+
+    @property
+    def metadata(self) -> RuleMetadata:
+        return RuleMetadata(
+            id="CL-0030",
+            name="Host-disclosure capability added",
+            description=(
+                "Adding SYSLOG lets the container read the host's kernel ring "
+                "buffer — host boot, hardware and driver state, and kernel "
+                "addresses — without needing any other key in the file."
+            ),
+            severity=Severity.HIGH,
+            references=REFERENCES,
+        )
+
+    def check(
+        self,
+        service_name: str,
+        service_config: dict[str, Any],
+        global_config: dict[str, Any],
+        lines: dict[str, int],
+    ) -> Iterator[Finding]:
+        for as_written, bare, line in iter_cap_add(
+            service_name, service_config, lines, HOST_DISCLOSURE_CAPS
+        ):
+            yield Finding(
+                rule_id="CL-0030",
+                severity=Severity.HIGH,
+                service=service_name,
+                message=(f"Service adds {as_written}: {HOST_DISCLOSURE_CAPS[bare]}."),
+                line=line,
+                fix=(
+                    f"Remove {as_written} from cap_add. A container almost "
+                    "never needs the host's kernel log: read it on the host "
+                    "with journalctl, or ship it with a log collector that "
+                    "runs there. A workload that must see kernel messages "
+                    "about its own devices should be given those devices "
+                    "explicitly rather than the whole ring buffer, and where "
+                    "it is genuinely required, suppress with a reason naming "
+                    "the workload.\n"
+                    "Full guide: compose-lint --explain CL-0030"
+                ),
+                references=REFERENCES,
+            )

--- a/tests/test_CL0030.py
+++ b/tests/test_CL0030.py
@@ -1,0 +1,60 @@
+"""Tests for CL-0030: host-disclosure capability added.
+
+The third rule in the `Direct × Host` cell. CL-0028, CL-0029 and this one all
+ship HIGH and are separated only by which qualifier they spend, so a member
+placed in the wrong one produces no visible symptom — the severity is right and
+the derivation is quietly false. These tests pin the membership boundary.
+"""
+
+from __future__ import annotations
+
+from compose_lint.models import Severity
+from compose_lint.parser import loads
+from compose_lint.rules.CL0028_host_reach_cap_add import HOST_REACH_CAPS
+from compose_lint.rules.CL0029_host_availability_cap_add import HOST_AVAILABILITY_CAPS
+from compose_lint.rules.CL0030_host_disclosure_cap_add import (
+    HOST_DISCLOSURE_CAPS,
+    HostDisclosureCapAddRule,
+)
+
+
+class TestHostDisclosureCapAddRule:
+    def setup_method(self) -> None:
+        self.rule = HostDisclosureCapAddRule()
+
+    def _check(self, caps: str, service: str = "a") -> list:
+        content = (
+            f"services:\n  {service}:\n    image: nginx:1.27\n    cap_add:\n{caps}"
+        )
+        data, lines = loads(content)
+        return list(self.rule.check(service, data["services"][service], data, lines))
+
+    def test_syslog_fires_at_high(self) -> None:
+        findings = self._check("      - SYSLOG\n")
+        assert len(findings) == 1
+        assert findings[0].severity == Severity.HIGH
+        assert findings[0].rule_id == "CL-0030"
+
+    def test_membership_is_exactly_syslog(self) -> None:
+        assert set(HOST_DISCLOSURE_CAPS) == {"SYSLOG"}
+
+    def test_the_three_host_cell_rules_stay_disjoint(self) -> None:
+        """CL-0028/0029/0030 share a cell and a severity; only the qualifier
+        separates them, so an overlap would be invisible in the output."""
+        assert not set(HOST_DISCLOSURE_CAPS) & set(HOST_AVAILABILITY_CAPS)
+        assert not set(HOST_DISCLOSURE_CAPS) & set(HOST_REACH_CAPS)
+
+    def test_cap_prefix_and_case_are_equivalent(self) -> None:
+        for spelling in ("CAP_SYSLOG", "cap_syslog", "syslog", "SYSLOG"):
+            findings = self._check(f"      - {spelling}\n")
+            assert len(findings) == 1, spelling
+            assert spelling.upper() in findings[0].message, spelling
+
+    def test_neighbouring_tiers_are_not_this_rule(self) -> None:
+        for cap in ("SYS_TIME", "PERFMON", "SYS_NICE", "IPC_LOCK", "LEASE", "CHOWN"):
+            assert self._check(f"      - {cap}\n") == [], cap
+
+    def test_fix_points_at_reading_the_log_on_the_host(self) -> None:
+        fix = self._check("      - SYSLOG\n")[0].fix
+        assert "journalctl" in fix
+        assert fix.endswith("Full guide: compose-lint --explain CL-0030")

--- a/tests/test_rule_consistency.py
+++ b/tests/test_rule_consistency.py
@@ -50,7 +50,7 @@ VARIABLE_SEVERITY_RULES: dict[str, set[Severity]] = {}
 INLINE_TRIGGERS: tuple[str, ...] = (
     "services:\n  tmpfs_exec:\n    image: nginx:1.27\n    tmpfs:\n      - /tmp:exec\n",
     "services:\n  host_availability_caps:\n    image: nginx:1.27\n    cap_add:\n"
-    "      - SYS_NICE\n      - IPC_LOCK\n      - LEASE\n",
+    "      - SYS_NICE\n      - IPC_LOCK\n      - LEASE\n      - SYSLOG\n",
 )
 
 _RULES: list[BaseRule] = [cls() for cls in get_registered_rules()]

--- a/tests/test_rule_membership.py
+++ b/tests/test_rule_membership.py
@@ -49,6 +49,9 @@ from compose_lint.rules.CL0028_host_reach_cap_add import HOST_REACH_CAPS
 from compose_lint.rules.CL0029_host_availability_cap_add import (
     HOST_AVAILABILITY_CAPS,
 )
+from compose_lint.rules.CL0030_host_disclosure_cap_add import (
+    HOST_DISCLOSURE_CAPS,
+)
 
 
 class TestCapabilityTiers:
@@ -573,31 +576,20 @@ _EXCLUDED_WITH_REASON: dict[str, str] = {
     ),
 }
 
-# Not granted by default, not graded, and no reason recorded anywhere. This is
-# a hole, and it is enumerated rather than described so that it shrinks
-# visibly: moving one of these into a tier, or into the excluded list with a
-# reason, is a one-line edit here. It is NOT an assertion that these are safe.
+# Not granted by default, not graded, and no reason recorded anywhere.
 #
-# These four are the opposite of safe: each was measured reaching the host with
-# no other key in the file, so each is owed a rule rather than an exclusion.
-# They are held here, visible, until those rules land.
+# **It is empty, and that is the point.** This set was the hole §47.4 of the
+# severity review named: fifteen capabilities that passed every disjointness
+# test by being in none of the tiers. Eleven now carry a measured reason in
+# _EXCLUDED_WITH_REASON; the other four were measured reaching the host with no
+# other key in the file and were owed rules rather than exclusions, which is
+# what CL-0029 (SYS_NICE, IPC_LOCK, LEASE) and CL-0030 (SYSLOG) are.
 #
-#   SYSLOG    read 1,967 lines of the host kernel ring buffer; Docker's own
-#             seccomp profile admits syslog(2) only for CAP_SYSLOG, so the
-#             reach does not depend on the host's kernel.dmesg_restrict
-#   SYS_NICE  took SCHED_FIFO priority 50 on host CPUs; EPERM without it
-#   IPC_LOCK  locked 128 MiB past an 8 MiB RLIMIT_MEMLOCK. A cgroup memory
-#             limit bounds it, but that is a key the file has to *add* -- the
-#             default is unbounded, so the rule prices the default
-#   LEASE     took a write lease on a host file through a bind mount and
-#             stalled a host open() for 21.9s against 0.00s unleased. Works
-#             through a *read-only* bind, and on any path, so neither CL-0013
-#             nor CL-0025 covers the configuration that enables it
-_UNGRADED_NO_RECORDED_REASON: frozenset[str] = frozenset(
-    {
-        "SYSLOG",
-    }
-)
+# Keep it empty. A capability landing here is not a neutral "to be decided" --
+# it is a capability the tool has no opinion about, which is the state this set
+# exists to make visible. Grading it, or excluding it with a reason someone can
+# check, is a one-line edit either way.
+_UNGRADED_NO_RECORDED_REASON: frozenset[str] = frozenset()
 
 
 class TestCapabilityCompleteness:
@@ -617,6 +609,7 @@ class TestCapabilityCompleteness:
                 | set(STRONG_CAPS)
                 | set(HOST_REACH_CAPS)
                 | set(HOST_AVAILABILITY_CAPS)
+                | set(HOST_DISCLOSURE_CAPS)
                 | set(LESSER_CAPS)
             )
             - {"ALL"}  # a keyword, not a capability


### PR DESCRIPTION
`SYSLOG` was the last capability in `test_rule_membership.py`'s ungraded set. It reads the host kernel ring buffer — `dmesg` is not namespaced — with nothing else in the file, so it was owed a rule rather than an exclusion.

**`_UNGRADED_NO_RECORDED_REASON` is now empty.** That closes the hole §47.4 named: all 41 kernel capabilities have a disposition, and 13 of the 15 it enumerated carry a *measured* reason rather than an argument.

## Three rules, one cell

`Direct × Host` + `read-only` = HIGH. That makes three rules sharing the cell:

| Rule | Qualifier | Kind of loss |
|---|---|---|
| CL-0028 | `integrity-only` | corruption (clock set) |
| CL-0029 | `availability-only` | denial of service |
| **CL-0030** | **`read-only`** | **disclosure** |

The model defines exactly three kinds of loss and a rule carries at most one qualifier, so the cell holds three rules — and **all three ship HIGH**, which means a member placed in the wrong one produces no visible symptom. The severity is right and the derivation is quietly false. `tests/test_CL0030.py` pins the boundary and asserts the three membership sets stay disjoint.

## The measurement that avoided a caveat

The obvious objection to this rule is that it depends on host hardening: if `kernel.dmesg_restrict=0`, any unprivileged *host* user can read the buffer, so what does the capability add? I tested it rather than reasoning about it.

**With `kernel.dmesg_restrict=0`, a capless container still read 0 lines.** Docker's own default seccomp profile admits `syslog(2)` only for `CAP_SYSLOG`. The gate is the capability on **any** host, hardened or not — so the rule carries no "depends on host configuration" caveat, because it doesn't.

On the measuring host (`dmesg_restrict=1`), the comparison is starker: a container with this one capability reads a buffer that an unprivileged user *on the host* cannot. 0 lines capless against 2,028 with it.

## Premise check

`_cl0030_syslog` compares **line counts, never content** — the host's kernel log is not something a CI log should carry, and the claim under test is reachability, not what happens to be in the buffer.

## Corpus differential

Over the archived 5,417-file snapshot: **zero delta**. No file in the corpus grants `SYSLOG`. That was the prediction and it was still run rather than assumed. The rule is grounded on the measurement, not on prevalence — a rule at zero prevalence is specific, not dead, and the corpus is large enough that "nobody does this" is itself worth knowing.

## Surfaces

Rule module, doc page, README table, `docs/index.md`, mkdocs nav, `docs/severity.md` assignment row, ATT&CK mapping (T1613, reusing an existing constant so the pinned taxonomy is untouched), membership-tier wiring, the `INLINE_TRIGGERS` entry, and `tests/test_CL0030.py`. `ruff`, `ruff format`, `mypy --strict`, `pytest` (1466 passed, 6 skipped) and `bandit -ll` all pass.