### PR TITLE
Hold the prose rule counts to the registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,9 @@ Trusted Publishers (OIDC) only — no manual `twine upload`. Sigstore attestatio
 
 ## Docs surfaces
 
-`docs/dockerhub-overview.md` is the Docker Hub description — hard 25000-byte cap (CI-enforced by the `readme-size` job; Docker Hub 400s over it) and deliberately version-free so it never needs a per-release bump. `README.md` is GitHub/PyPI-facing, not synced anywhere, and has no byte cap — but its integration snippets carry version pins that the RELEASING.md checklist bumps each release (as does `docs/hardening.md`).
+`docs/dockerhub-overview.md` is the Docker Hub description — hard 25000-byte cap (CI-enforced by the `readme-size` job; Docker Hub 400s over it) and deliberately free of version pins so it never needs a per-release bump. `README.md` is GitHub/PyPI-facing, not synced anywhere, and has no byte cap — but its integration snippets carry version pins that the RELEASING.md checklist bumps each release (as does `docs/hardening.md`).
+
+Prose that states how many rules there are is a different kind of pin: it goes stale when a rule lands, not when a version ships, so no release checklist catches it. Four surfaces make that claim and `tests/test_rule_surfaces.py` holds all four to the registry count.
 
 ## Things to avoid
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-compose-lint today ships 25 security rules, PyPI distribution, a published GitHub Action and Docker image, SARIF/JSON/text output, pre-commit support, per-service rule overrides, and `--explain`. The foundation is solid; the next milestone is the 1.0 stability commitment. Remaining investments make the tool more useful to the users already running it, not chase speculative distribution channels.
+compose-lint today ships 27 security rules, PyPI distribution, a published GitHub Action and Docker image, SARIF/JSON/text output, pre-commit support, per-service rule overrides, and `--explain`. The foundation is solid; the next milestone is the 1.0 stability commitment. Remaining investments make the tool more useful to the users already running it, not chase speculative distribution channels.
 
 ## Strategic framing
 
@@ -68,6 +68,20 @@ Turn findings into fixes. This is where the product's differentiation grows the 
 
 ---
 
+## Milestone 3.5 — Severity Grounding (v0.16) [shipped]
+
+A prerequisite for the 1.0 freeze rather than a feature: after 1.0 a severity change is a breaking change, so the numbers have to be defensible before the contract closes over them.
+
+**Severities are derived, not chosen** _(shipped in 0.16.0)_ — a two-axis matrix under a stated attacker baseline and a stated Docker posture produces each rule's value; shipping a different one requires a declared override from a closed reason list, with a link. Every rule page carries its derivation block, and a test fails if the page and the severity table disagree. See [ADR-020](adr/020-severity-scoping-and-overrides.md), [ADR-021](adr/021-critical-tier-posture.md), [ADR-022](adr/022-threat-model-grounding.md).
+
+**Grounded against a live daemon, not against reasoning** _(shipped in 0.16.0)_ — `scripts/validate_rule_premises.py` asserts the daemon under test is at Docker's defaults before measuring anything, and aborts if it is not. A premise measured on a hardened or loosened daemon returns a confidently wrong answer.
+
+**Branching rules split by what they grant** — `cap_add` became CL-0011, CL-0024, CL-0027 and CL-0028 in 0.16.0; CL-0029 (host availability) and CL-0030 (host disclosure) followed, and every remaining capability now has a recorded disposition, so the ungraded set is closed. Host paths became CL-0013 and CL-0025. A rule that branched its severity could not be represented honestly in SARIF, where `security-severity` sits on the rule descriptor (issue #503) — the split fixes that as a side effect.
+
+_Not covered by this milestone:_ the fixers, the parser, line-number accuracy and the config layer have not had an equivalent audit. None of them is a severity question, and none blocks the freeze.
+
+---
+
 ## Milestone 4 — GA / 1.0
 
 v1.0 is the **stability commitment**: the CLI surface, exit codes, configuration schema, and the JSON/SARIF output shapes come under SemVer. Breaking any of them after 1.0 requires a major version bump. The VS Code extension is explicitly *not* a 1.0 blocker — it's a reach multiplier that doesn't gate stability, and moves to Milestone 5.
@@ -75,7 +89,7 @@ v1.0 is the **stability commitment**: the CLI surface, exit codes, configuration
 **GA criteria:**
 - **Stable, documented contract** — CLI flags, exit codes ([ADR-006](adr/006-exit-codes.md)), the `.compose-lint.yml` schema, and the JSON + SARIF output shapes are frozen and documented as the 1.0 surface. The JSON output gains a versioned envelope before the freeze, so run-level metadata (tool version, parse errors) can be added later without breaking consumers.
 - **`fix` resolved** — _done._ Shipped as GA and brought under the SemVer contract in 0.11.0 ([ADR-014](adr/014-fix-remediation.md)), independently of the 1.0 cut.
-- **Grounding + severity audit complete** — every rule cites OWASP/CIS/Docker, and no severity change is pending that would alter a CI gate after the freeze.
+- **Grounding + severity audit complete** — _done for severity._ Every rule cites OWASP/CIS/Docker and derives its severity from the documented model (Milestone 3.5). What remains before the freeze is confirming no further severity change is pending that would alter a CI gate.
 - **Documented upgrade/deprecation policy** — the SemVer stability promise (rule additions, severity changes, config and output-shape changes) and the deprecation lifecycle, in [compatibility.md](compatibility.md).
 
 **At GA:** bump the PyPI classifier from `4 - Beta` to `5 - Production/Stable` in the version→1.0.0 commit, and publish a moving `v1` Action tag so users can pin `uses: tmatens/compose-lint@v1`.
@@ -130,5 +144,6 @@ Python 3.10 is scheduled to age out of the matrix when it reaches upstream EOL i
 | Per-service rule overrides | v0.4 | complete |
 | CL-0006 capability guidance + real-world examples + Homebrew tap | v0.4.x | in progress |
 | Remediation (`--explain`, `fix`, SARIF fixes, shellcheck) | v0.5–0.11 | `fix` GA in 0.11.0; shellcheck pending |
+| Severity grounding — derived severities, capability + host-path splits | v0.16 | complete |
 | GA / 1.0 — stable contract + `fix` + upgrade policy | v1.0 | next |
 | Ecosystem integrations (VS Code, custom rules) | v1.x | |

--- a/docs/SECURITY-EXPECTATIONS.md
+++ b/docs/SECURITY-EXPECTATIONS.md
@@ -82,7 +82,7 @@ pipeline, this is the page to read.
    It cannot tell you what a running container is *actually* doing —
    only what its declared configuration *would* let it do.
 
-5. **It is not exhaustive.** The 25 rules cover the misconfigurations
+5. **It is not exhaustive.** The 27 rules cover the misconfigurations
    that the OWASP Docker Security Cheat Sheet, CIS Docker Benchmark,
    and Docker official documentation ground (see
    [README.md](../README.md#rules) for the full list). Misconfigurations

--- a/docs/dockerhub-overview.md
+++ b/docs/dockerhub-overview.md
@@ -6,7 +6,7 @@ In a scan of 5,417 public Docker Compose files on GitHub, **91% of those that pa
 
 ![compose-lint scanning a docker-compose.yml: severity-sorted findings with fix guidance and reference URLs, then the FAIL verdict.](https://raw.githubusercontent.com/tmatens/compose-lint/main/docs/assets/demo.gif)
 
-**What it catches** — 25 rules, each citing its OWASP/CIS grounding ([full rules table](https://github.com/tmatens/compose-lint#rules)):
+**What it catches** — 27 rules, each citing its OWASP/CIS grounding ([full rules table](https://github.com/tmatens/compose-lint#rules)):
 
 - Privilege flaws — `privileged: true`, missing `cap_drop`, `no-new-privileges` not set, root user, host namespace sharing
 - Network exposure — wildcard port binds, `network_mode: host`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@
 # inside code fences (CL-0004, CL-0019, hardening.md docker --format examples).
 site_name: compose-lint
 site_description: >-
-  Security linter for Docker Compose files — 25 rules with actionable,
+  Security linter for Docker Compose files — 27 rules with actionable,
   runtime-proven fix guidance.
 site_url: https://tmatens.github.io/compose-lint/
 repo_url: https://github.com/tmatens/compose-lint

--- a/tests/test_rule_surfaces.py
+++ b/tests/test_rule_surfaces.py
@@ -9,6 +9,15 @@ why a rule they hit is undocumented.
 `severity.md` and the ATT&CK map already have their own coverage tests; this
 covers the remaining surfaces, and does it as one parameterised check so a
 failure names the surface rather than making someone diff six lists by hand.
+
+It also covers the *counts* stated in prose, which are a separate failure. The
+lists above are edited by whoever adds the rule, because the new page has to go
+somewhere; a sentence elsewhere saying "25 rules" is edited by nobody. CL-0029
+and CL-0030 landed and four surfaces went on claiming 25 — including the
+mkdocs `site_description`, which is the meta description search engines index,
+and the Docker Hub overview, which syncs to the Hub on every push to the
+default branch. Neither the release checklist nor the CI version-pin check
+reaches them: they go stale when a rule lands, not when a version ships.
 """
 
 from __future__ import annotations
@@ -67,3 +76,54 @@ def test_retired_ids_are_not_reused() -> None:
 def test_retired_ids_are_gone_from_every_surface(surface: str) -> None:
     lingering = sorted(FALLOW & SURFACES[surface])
     assert not lingering, f"{surface} still lists retired {lingering}"
+
+
+# Files whose counts describe a moment rather than the current tool. ADRs and
+# `docs/publishing/` are records of what was true when they were written, and
+# `state-of-compose.md` is a report pinned to the release it was generated on —
+# the CI version-pin check excludes the same three for the same reason.
+_HISTORICAL_DIRS = ("docs/adr/", "docs/publishing/")
+_HISTORICAL_FILES = ("docs/state-of-compose.md",)
+
+# Counts of something other than the current rule set. Each is a claim about a
+# past release, which stays true as the tool grows.
+HISTORICAL_COUNTS = (
+    "Added 9 rules (CL-0011 – CL-0019)",
+    "bringing the total to 19 rules",
+    "| Rule Coverage (19 rules) | v0.3 | complete |",
+)
+
+# `(?<![\d.])` keeps "post-1.0 rules" in RELEASING.md from reading as "0 rules".
+COUNT_RE = re.compile(r"(?<![\d.])(\d+) (?:security )?rules\b")
+
+
+def _live_docs() -> list[Path]:
+    candidates = [
+        REPO / "README.md",
+        REPO / "mkdocs.yml",
+        *(REPO / "docs").rglob("*.md"),
+    ]
+    return [
+        p
+        for p in candidates
+        if not p.as_posix().endswith(_HISTORICAL_FILES)
+        and not any(d in p.as_posix() for d in _HISTORICAL_DIRS)
+    ]
+
+
+def test_prose_rule_counts_match_the_registry() -> None:
+    stale: list[str] = []
+    for path in _live_docs():
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if any(known in line for known in HISTORICAL_COUNTS):
+                continue
+            for count in COUNT_RE.findall(line):
+                if int(count) != len(REGISTERED):
+                    rel = path.relative_to(REPO).as_posix()
+                    stale.append(f"{rel}: {line.strip()}")
+    assert not stale, (
+        f"{len(REGISTERED)} rules are registered, but these claim otherwise:\n"
+        + "\n".join(stale)
+        + "\n\nUpdate the count, or add the line to HISTORICAL_COUNTS if it is "
+        "describing a past release rather than the current rule set."
+    )


### PR DESCRIPTION
Four surfaces still said **25 rules** after CL-0029 and CL-0030 landed post-0.16.0. The ruleset is 27.

- `mkdocs.yml` `site_description` — the meta description search engines index
- `docs/dockerhub-overview.md` — synced to Docker Hub on every default-branch push
- `docs/SECURITY-EXPECTATIONS.md`
- `docs/ROADMAP.md` inventory line

Nothing catches this class of staleness: the RELEASING.md checklist and CI's self-referencing-version-pin check both key on *version* strings, and a rule count goes stale when a **rule** lands. `tests/test_rule_surfaces.py` now scans live docs for `N rules` and holds every match to the registry count, with the three counts that describe past releases listed as named exceptions rather than excluded by path (so a new file inventing a fifth claim is covered from its first commit).

Verified the test fails on a wrong count before trusting it.

The roadmap also carried no record of the release it just shipped — the severity work was invisible in both the milestone list and the status table. Added Milestone 3.5 (derived severity model, live-daemon premise grounding, the capability and host-path splits) and marked which half of the GA "grounding + severity audit" criterion it satisfies.

`docs/state-of-compose.md`'s "25 rules" is left alone — it is a report pinned to 0.16.0, and is excluded for the same reason CI's pin check excludes it.