### PR TITLE
Refresh the examples library against 0.16.0

### DIFF
--- a/docs/examples/ci-runner-suppression/index.md
+++ b/docs/examples/ci-runner-suppression/index.md
@@ -1,6 +1,6 @@
 # Rung 4 — Suppress it, with the risk written down
 
-**Verified against:** compose-lint 0.15.1, 2026-08-08
+**Verified against:** compose-lint 0.16.0, 2026-08-11
 
 A CI runner starts a container per job. Starting containers means calling `POST /containers/create` and `POST /containers/<id>/start`. There is no filtered subset of the Docker API that permits creating containers while withholding host compromise — the two are the same capability. `POST /containers/create` with a bind mount of `/` is the whole exploit, and it is also just how the runner does its job.
 
@@ -45,17 +45,36 @@ Worth flagging as dependent rather than justifying separately. `user: "0:${DOCKE
 
 The same goes for `no-new-privileges: true` on that service: it is set, it is not useless, and it does not contain a process that can ask the daemon to start a privileged container on its behalf. Controls that do not apply to the actual threat are worth being explicit about, or someone will read the file and conclude the runner is contained.
 
-## Four findings are left open on purpose
+## Two of these waivers no longer cover anything
+
+The `.compose-lint.yml` here is reproduced as deployed, and 0.16.0 retired a third of it without saying so. The block not quoted yet:
+
+```yaml
+  CL-0013:
+    exclude_services:
+      forge-runner: >-
+        The /var/run/docker.sock mount reported by the host-path rule is the
+        same finding as CL-0001 above.
+      forge: >-
+        /etc/timezone and /etc/localtime are read-only single files, mounted so
+        that timestamps in the UI and in commit metadata match the host.
+```
+
+The first entry was an observation about double-reporting; it is now the rule. A control-socket mount is [CL-0001](../../rules/CL-0001.md)'s alone, so the entry waives a finding that no longer exists. The second is dead for a different reason: `/etc/timezone` and `/etc/localtime` are excluded from [CL-0013](../../rules/CL-0013.md) outright.
+
+Neither is an error and nothing warns about either, because the rule ids they name are still live — a waiver only warns when its rule id is gone. This is the upgrade hazard worth internalising: **a waiver can keep parsing long after it stops covering anything**, and the only way to find out is to diff your findings across the upgrade. The reason to care is not the dead entry itself; it is that the same silence hides the opposite case, where a finding moved to a rule your config does not name and came back unwaived.
+
+## Findings left open on purpose
 
 ```
-docker-compose.yml: 4 medium  ·  6 suppressed (not counted)
+docker-compose.yml: 4 medium, 2 low  ·  3 suppressed (not counted)
 ```
 
-The open ones are CL-0006 (`cap_drop`) and CL-0007 (`read_only`), on both services. They are not suppressed, and the reason is written in the config:
+The open ones are CL-0006 (`cap_drop`) and CL-0007 (`read_only`) on both services, plus [CL-0026](../../rules/CL-0026.md), which every service in this library reports. `read_only` is a LOW rather than a MEDIUM as of 0.16.0. CL-0006 and CL-0007 are not suppressed, and the reason is written in the config:
 
 > The honest reason is that neither fix has been tested against the forge's first-boot behaviour or its backup path, and a suppression saying "pending live-test" would be the same expiry-free waiver the portainer example in this ladder exists to criticise. An open finding that is visible in every CI run is a more accurate record of the state than a waiver that says the same thing while turning the output green.
 
-This is the part most easily lost: **not every finding needs a suppression.** A waiver is a claim that you have considered the finding and decided. If you have not decided yet, an open medium finding is the truthful output, and it costs nothing as long as the failure threshold is set where you want it — here the gate is `--fail-on high`, so these four are visible without blocking.
+This is the part most easily lost: **not every finding needs a suppression.** A waiver is a claim that you have considered the finding and decided. If you have not decided yet, an open medium finding is the truthful output, and it costs nothing as long as the failure threshold is set where you want it — here the gate is `--fail-on high`, so all six are visible without blocking.
 
 The failure mode a suppression file drifts into is one entry per finding, each individually defensible, collectively meaning the tool reports nothing. Leaving things open is the pressure valve against that.
 

--- a/docs/examples/clean-edge-proxy/index.md
+++ b/docs/examples/clean-edge-proxy/index.md
@@ -1,18 +1,20 @@
 # The clean one
 
-**Verified against:** compose-lint 0.15.1, 2026-08-08
+**Verified against:** compose-lint 0.16.0, 2026-08-11
 
 Every other example in this library is a story about a finding. This one is here because a library made only of those teaches the wrong lesson — that real infrastructure inevitably needs a pile of waivers, and that a suppression file with six entries is just how it goes.
 
 It isn't. This is the public entry point for every service in the deployment, and its entire suppression file covers **one rule on one service**:
 
 ```
-docker-compose.yml: 0 issues  ·  2 suppressed (not counted)
+docker-compose.yml: 2 medium  ·  2 suppressed (not counted)
 ```
 
-The two suppressed findings are ports 80 and 443 on the proxy. The forward-auth service alongside it produces **no findings at all** and appears nowhere in the config.
+The two suppressed findings are ports 80 and 443 on the proxy. The two mediums are [CL-0026](../../rules/CL-0026.md) — neither service sets a memory or CPU limit — and they are the one honest gap on this page: the rule landed in 0.16.0, this stack predates it, and nobody has sized the limits yet. Left open rather than waived, for the reason [rung 4](../ci-runner-suppression/index.md) gives: an undecided finding is more truthful open than behind a waiver that says "pending".
 
-## What a zero-finding service looks like
+Apart from that, the forward-auth service alongside the proxy appears nowhere in the config and needs nothing waived.
+
+## What a service with nothing to waive looks like
 
 ```yaml
   auth:

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -21,7 +21,7 @@ Three more stacks, each carrying a lesson the ladder doesn't.
 
 | Example | The lesson |
 |---|---|
-| [Two rules in tension](read-only-in-tension/index.md) | Satisfying one rule means violating another. Buying a read-only root by accepting a CL-0022 — a medium traded for a low. |
+| [Two rules in tension](read-only-in-tension/index.md) | Satisfying one rule means violating another. Buying a read-only root by accepting a CL-0022 — one low traded for another, so the output says nothing about which posture is better. |
 | [A true premise and a false conclusion](read-only-multi-service/index.md) | A four-service stack whose waiver said read-only was impossible because the services write to volumes. True, and it doesn't follow: volumes stay writable. |
 | [The clean one](clean-edge-proxy/index.md) | The public entry point, with one waiver for the whole stack and a forward-auth service that holds *no capabilities at all*. |
 
@@ -30,20 +30,23 @@ Three more stacks, each carrying a lesson the ladder doesn't.
 Every example ships the Compose file and the `.compose-lint.yml` that goes with it, so you can reproduce these numbers:
 
 ```
-portainer-removed            exit=1   2 high            1 suppressed
-logging-without-the-socket   exit=0   0 issues          1 suppressed
-netdata-socket-proxy         exit=0   0 issues         14 suppressed
-ci-runner-suppression        exit=0   4 medium          6 suppressed
-read-only-in-tension         exit=0   0 issues          2 suppressed
-read-only-multi-service      exit=0   0 issues          3 suppressed
-clean-edge-proxy             exit=0   0 issues          2 suppressed
+portainer-removed                                   exit=0   1 medium                1 suppressed
+logging-without-the-socket                          exit=0   3 medium                1 suppressed
+netdata-socket-proxy  docker-compose.yml            exit=1   1 critical, 2 medium   10 suppressed
+netdata-socket-proxy  docker-compose.hardened.yml   exit=0   3 medium               11 suppressed
+ci-runner-suppression                               exit=0   4 medium, 2 low         3 suppressed
+read-only-in-tension                                exit=0   0 issues                1 suppressed
+read-only-multi-service                             exit=0   3 medium                2 suppressed
+clean-edge-proxy                                    exit=0   2 medium                2 suppressed
 ```
 
-Two of these deserve comment, because they are the opposite of what a "findings went down" summary would suggest.
+Most of those mediums are the same finding. [CL-0026](../rules/CL-0026.md) — no memory or CPU limit — landed in 0.16.0 and fires on nearly every service here, because these stacks were deployed before the rule existed and nobody has sized the limits yet. They are left open rather than waived, which is the state [rung 4](ci-runner-suppression/index.md) argues for: a finding you have not decided about is more truthful open than behind a waiver that says "pending".
 
-**The socket-proxy example did not reduce its finding count.** Before hardening it reported 14 findings; after hardening it reports 14 findings. What changed is that the critical one moved from a container with host networking, the host PID namespace and an unconfined AppArmor profile, onto a scratch-image container that is read-only, capability-less and answers `403` to every API path it does not need. The number is identical and the blast radius is not. Counting findings is a bad proxy for security, and this is the clearest example of it we have.
+Two rows deserve comment, because they are the opposite of what a "findings went down" summary would suggest.
 
-**The CI-runner example still has four open medium findings.** They are not suppressed, on purpose — see [that page](ci-runner-suppression/index.md). Leaving a finding open is a valid state, and often a more honest one than a waiver that says "pending investigation" and then does not expire.
+**The socket-proxy example increased its finding count.** Before hardening it reported 13 findings; after hardening, 14. The critical one moved from a container with host networking, the host PID namespace and an unconfined AppArmor profile onto a scratch-image container that is read-only, capability-less and answers `403` to every API path it does not need — and the proxy, being a service, brought its own resource-limit finding with it. The number went the wrong way and the blast radius collapsed. Counting findings is a bad proxy for security, and this is the clearest example of it we have.
+
+**The CI-runner example has six findings open on purpose.** They are not suppressed — see [that page](ci-runner-suppression/index.md). Leaving a finding open is a valid state, and often a more honest one than a waiver that says "pending investigation" and then does not expire.
 
 ## How suppressions are written here
 

--- a/docs/examples/logging-without-the-socket/index.md
+++ b/docs/examples/logging-without-the-socket/index.md
@@ -1,6 +1,6 @@
 # Rung 2 — Re-architect so the socket isn't needed
 
-**Verified against:** compose-lint 0.15.1, 2026-08-08
+**Verified against:** compose-lint 0.16.0, 2026-08-11
 
 The management UI in [rung 1](../portainer-removed/index.md) was mounting the Docker socket, but almost all of what it was used for was reading container logs and checking whether services were up. That is a data problem, not a control problem — and the data is available without the Docker API.
 
@@ -37,11 +37,13 @@ No capability, no root, no socket — to do the job that a moment ago justified 
 ## What the linter says
 
 ```
-docker-compose.yml: 0 issues  ·  1 suppressed (not counted)
-✓ PASS  ·  threshold: high
+docker-compose.yml: 3 medium  ·  1 suppressed (not counted)
+✓ PASS  ·  threshold: high  ·  below: 3 medium
 ```
 
-One finding, on the collector, for its two host mounts:
+Nothing at or above the gate. The three mediums are [CL-0026](../../rules/CL-0026.md), one per service, none of which has a memory or CPU limit — the same finding this library reports on almost every stack in it, and a fair one: an unbounded collector on a busy host is a denial of service waiting for a log storm.
+
+One suppression, on the collector, for a host mount:
 
 ```yaml
 rules:
@@ -53,6 +55,8 @@ rules:
         and /etc/machine-id is the single file journal entries need in order to
         resolve which host they came from. No writable host path is exposed.
 ```
+
+The reason names both host mounts, and as of 0.16.0 only one of them still reports: `/etc/machine-id` is under `/etc`, and a read-only mount of a CL-0025 path is [CL-0013](../../rules/CL-0013.md) at HIGH. `/var/log/journal` is not on the sensitive-path list at all. The waiver is left as written rather than narrowed to the one path, because it documents a decision about the collector's whole mount set, and a reason that only survives as long as the rule's path list does is a worse artifact than one that says what was actually decided.
 
 Note what this suppression does *not* have to say. There is no residual risk paragraph, because there is no residual risk to state: the mount is read-only, it contains log data, and a compromise of this container yields the logs it was already reading. Compare that with the suppression in [rung 4](../ci-runner-suppression/index.md), which has to be explicit that the risk is accepted rather than mitigated. The difference in how those two reasons read is a decent smell test for which rung you are actually on.
 

--- a/docs/examples/netdata-socket-proxy/index.md
+++ b/docs/examples/netdata-socket-proxy/index.md
@@ -1,6 +1,6 @@
 # Rung 3 — Constrain it when the need is real
 
-**Verified against:** compose-lint 0.15.1, 2026-08-08
+**Verified against:** compose-lint 0.16.0, 2026-08-11
 
 A host-metrics agent needs the Docker API. Not log data, not "container state" in the abstract — it calls `/containers/json` to enumerate containers and `/containers/<id>/json` to map a cgroup back to a container name. There is no journal file that answers those, so [rung 2](../logging-without-the-socket/index.md) does not apply.
 
@@ -70,13 +70,13 @@ BLOCKED methods:
 
 The proxy logs each rejection, so attempts show up in the same log pipeline as everything else rather than failing silently.
 
-## The finding count did not go down
+## The finding count went up
 
-Before: 14 findings. After: 14 findings.
+Before: 13 findings. After: 14.
 
-The critical one moved from the metrics agent — host network, host PID namespace, unconfined AppArmor, several sensitive host mounts — to a scratch-image container that is read-only, has no capabilities, runs as `nobody` and answers `403` to everything it does not need. Same number, different blast radius.
+The critical one moved from the metrics agent — host network, host PID namespace, unconfined AppArmor, several sensitive host mounts — to a scratch-image container that is read-only, has no capabilities, runs as `nobody` and answers `403` to everything it does not need. Nothing else about the agent changed, so its twelve other findings are still there, and the fourteenth is new: the proxy is a service, and a service with no memory or CPU limit reports [CL-0026](../../rules/CL-0026.md) like any other.
 
-If you are tracking a finding count as a security metric, this refactor is invisible to you. That is a problem with the metric.
+So the refactor that collapsed the blast radius made the number worse. If you are tracking a finding count as a security metric, this looks like a regression. That is a problem with the metric, and it is worth seeing in the direction that stings — an architecture that introduces a container to *contain* something will usually cost you findings on that container.
 
 ## Capabilities, and a failure the healthcheck did not catch
 
@@ -243,6 +243,12 @@ A global `enabled: false` would have been shorter and would have quietly re-perm
 
 The remaining suppressions cover what a host-metrics agent inherently needs — host networking for interface metrics, host PID for process attribution, read-only `/proc`, `/sys`, `/etc/passwd` and `/etc/group` to attribute metrics to real users, and an unconfined AppArmor profile for that access. Each is scoped to the agent, so the proxy is still held to the default standard, which it meets.
 
+### What 0.16.0 did to this file
+
+The config is reproduced as deployed, and the capability split moved out from under two of its entries. The `CL-0011` waiver covered `DAC_OVERRIDE` and `SYS_PTRACE`; `DAC_OVERRIDE` is a Docker default and is no longer flagged at all, and `SYS_PTRACE` is [CL-0027](../../rules/CL-0027.md) now. So the waiver still parses, still names a live rule, and covers neither capability — while the `SYS_PTRACE` finding it was written for is back in the output as an unwaived MEDIUM. A `CL-0013` entry on the proxy is dead for the same reason as in [rung 4](../ci-runner-suppression/index.md#two-of-these-waivers-no-longer-cover-anything): the socket path belongs to CL-0001 alone.
+
+This is the more dangerous half of that hazard. A waiver that covers nothing is untidy; a finding that reappears *unwaived* is a re-opened decision nobody was told about, and it looks exactly like a new problem to whoever sees it next. The reason text here is still true — the drop-test above is what established it — so migrating it is a rename, not a re-derivation. Finding out that it needed one took diffing the findings across the upgrade.
+
 ## Scope note
 
-Files are sanitized: hostnames, paths and the docker group id are replaced. The finding set of the sanitized file was compared against the deployed original and is identical — 14 findings, same rules, same services. Capability and mount claims were verified against the running containers.
+Files are sanitized: hostnames, paths and the docker group id are replaced. The finding set of the sanitized file was compared against the deployed original when it landed and was identical — same count, same rules, same services. Capability and mount claims were verified against the running containers.

--- a/docs/examples/portainer-removed/index.md
+++ b/docs/examples/portainer-removed/index.md
@@ -1,6 +1,6 @@
 # Rung 1 — Delete the service
 
-**Verified against:** compose-lint 0.15.1, 2026-08-08
+**Verified against:** compose-lint 0.16.0, 2026-08-11
 
 The cheapest fix for a critical finding is the one nobody proposes: stop running the thing.
 
@@ -9,20 +9,20 @@ This example is a container-management UI that mounted the Docker socket. It was
 ## What the linter says
 
 ```
-  service: portainer  (line 24)
+  service: portainer  (line 11)
     line  severity    rule     message
       24  CRITICAL    CL-0001  Docker runtime socket mounted via
                                '/var/run/docker.sock:/var/run/docker.sock'. This gives the
                                container full control over the Docker runtime — equivalent
                                to root on the host.
-      24  HIGH        CL-0013  Service mounts sensitive host path '/var/run/docker.sock'
-                               (under /var/run). This exposes host system files to the
-                               container.
-      26  HIGH        CL-0013  Service mounts sensitive host path
-                               '/home/deploy/.local/bin/curl-static' (under /home).
+      11  MEDIUM      CL-0026  Service declares no memory limit and no CPU limit. Docker
+                               imposes neither by default, so the container can consume
+                               the host's memory or CPU until other workloads are starved.
 ```
 
-The third finding is worth a moment. A static `curl` binary was bind-mounted from the host purely so the healthcheck had something to run, because the image ships no shell. It is unrelated to the socket, and it is the kind of thing that accumulates around a service you are keeping alive.
+One finding, one rung. The socket line is the whole example, and CL-0026 is the ambient one every service in this library reports until someone sizes it.
+
+Two findings this file used to report are worth naming, because both left in 0.16.0 and neither left because the file changed. A second HIGH used to fire on the socket path itself, from the sensitive-host-path rule — the same mount counted twice, once as the daemon API and once as a file under `/var/run`. That path is [CL-0001](../../rules/CL-0001.md)'s alone now. And a static `curl` binary is bind-mounted at line 26 from `/home/deploy/.local/bin`, put there so the healthcheck had something to run against an image that ships no shell; that used to report as a sensitive home-directory mount. [CL-0013](../../rules/CL-0013.md) now matches the home tree by depth — `/home`, a user's home directory, and the credential directories below it — so an application's own path further down is no longer flagged. It is still the kind of thing that accumulates around a service you are keeping alive; it is no longer something the linter will point at.
 
 ## The suppression that was there
 

--- a/docs/examples/read-only-in-tension/index.md
+++ b/docs/examples/read-only-in-tension/index.md
@@ -1,6 +1,6 @@
 # Two rules in tension — buying `read_only` with a CL-0022
 
-**Verified against:** compose-lint 0.15.1, 2026-08-08
+**Verified against:** compose-lint 0.16.0, 2026-08-11
 
 Most hardening advice reads as though the rules point the same direction. Sometimes satisfying one means violating another, and the useful skill is deciding which finding you would rather have.
 
@@ -51,15 +51,15 @@ A sound observation, a correct mechanism, and a conclusion that reached one step
 `:exec` re-enables execution on a writable in-memory filesystem. That is a genuine weakening and CL-0022 exists to flag it. The finding does not go away — it is traded:
 
 ```
-before:  CL-0007  medium   writable root filesystem
+before:  CL-0007  low      writable root filesystem
 after:   CL-0022  low      /run permits execution
 ```
 
-Both files also carry an unrelated CL-0011 for the capability add-backs, unchanged by any of this.
+The trade is worth taking. Before, the *entire* root filesystem was writable, and a tmpfs at `/run` was writable and executable anyway once the container booted. After, exactly one mount is writable-and-executable and everything else is read-only. The attack surface strictly shrinks.
 
-The trade is worth taking. Before, the *entire* root filesystem was writable, and a tmpfs at `/run` was writable and executable anyway once the container booted. After, exactly one mount is writable-and-executable and everything else is read-only. The attack surface strictly shrinks, and this time the linter agrees — a medium becomes a low.
+**The output does not shrink with it.** One low leaves and one low arrives, so a reader comparing severities across the change sees no movement at all, and a reader comparing counts sees none either. That is not the linter failing to notice — it is the linter declining to price two different weaknesses against each other, which is not something a static rule can do without knowing what writes to `/run`. The decision here was made by reading the posture, and the output is the same either way. Elsewhere in this library the number moves the *wrong* way against a real improvement ([that one](../read-only-multi-service/index.md#when-the-number-and-the-posture-disagree)); this is the quieter version of the same warning.
 
-That agreement is not guaranteed. Hardening can move the output the wrong way; there is [an example of that](../read-only-multi-service/index.md#when-the-number-and-the-posture-disagree) elsewhere in this library. Here the number and the posture move together, which is the easy case.
+Neither file reports anything for the capability add-backs. `DAC_OVERRIDE` and `NET_RAW` are both in Docker's default set, so adding them back after `cap_drop: ALL` returns the container to the default posture rather than exceeding it — and a rule that flagged them would be scoring the declaration rather than the runtime state. `DAC_OVERRIDE` was flagged here until 0.16.0, which is why an earlier version of this page named a capability finding that no longer exists. The comments in the file explaining why each one is needed are still worth keeping: they are the record of a drop-test, and the next person to prune that list needs them whether or not a rule fires.
 
 ## Scoping the exception
 

--- a/docs/examples/read-only-multi-service/index.md
+++ b/docs/examples/read-only-multi-service/index.md
@@ -1,6 +1,6 @@
 # A true premise and a false conclusion
 
-**Verified against:** compose-lint 0.15.2 plus the CL-0011 fix from issue #492, 2026-08-09
+**Verified against:** compose-lint 0.16.0, 2026-08-11
 
 A four-service stack — application server, database, cache, machine-learning worker — where every service runs with a read-only root filesystem. For a long time its config said that was impossible:
 
@@ -75,15 +75,15 @@ The entrypoint starts as root, and root without `DAC_OVERRIDE` cannot traverse a
 
 The compose file records that next to the `cap_add`, so the next person to re-derive it does not repeat the shortcut.
 
-## A warning this page used to carry
+## When the number and the posture disagree
 
 Until recently this section said that dropping capabilities could make the linter's output *worse*, and it was right.
 
 A service with no `cap_drop` holds roughly fourteen default capabilities, several of them dangerous, and reports a single CL-0006 **medium**. Converting it to `cap_drop: ALL` plus explicit add-backs turned `DAC_OVERRIDE` — one of those same fourteen — into a CL-0011 **high**. A strictly smaller set of privileges, reported more severely, because the implicit ones were never visible and the explicit one was.
 
-That was a defect in the linter rather than a fact about capabilities, and it is fixed (issue #492). CL-0011 no longer flags Docker's default capabilities, on the same reasoning that already excluded `MKNOD` and `SYS_CHROOT`: the container holds them either way, so flagging them scored the declaration rather than the runtime state. The waiver this stack needed for `DAC_OVERRIDE` is gone from its config as a result — nothing about the deployment changed.
+That was a defect in the linter rather than a fact about capabilities, and it is fixed (issue #492, shipped in 0.16.0). No capability rule flags Docker's default set any more, on the same reasoning that already excluded `MKNOD` and `SYS_CHROOT`: the container holds them either way, so flagging them scored the declaration rather than the runtime state. The waiver this stack needed for `DAC_OVERRIDE` is gone from its config as a result — nothing about the deployment changed.
 
-Adding back a capability that is **not** a default — `SYS_ADMIN`, `NET_ADMIN`, `SYS_MODULE` — is a genuine escalation above Docker's baseline and still reports HIGH. That is a different situation and the severity is correct there.
+Adding back a capability that is **not** a default is a genuine escalation above Docker's baseline, and 0.16.0 stopped pricing all of those the same. `cap_add` is four rules now, split by what the capability actually grants: `SYS_ADMIN` and `SYS_MODULE` are [CL-0024](../../rules/CL-0024.md) at CRITICAL, because each is a path to the host on its own; `NET_ADMIN` stays [CL-0011](../../rules/CL-0011.md) at HIGH; `SYS_PTRACE` is [CL-0027](../../rules/CL-0027.md) at MEDIUM. The severity is a statement about the specific capability, not about the act of adding one.
 
 The habit is worth keeping even though the bug is gone: read a suppression file for what it *permits*, not for how many entries it has.
 


### PR DESCRIPTION
Every page in `docs/examples/` was stamped **0.15.1** or **0.15.2**. 0.16.0 re-derived the severities, moved findings between rules and added CL-0026, so every documented output on the live site was wrong — including two exit codes that inverted (`portainer-removed` documented `exit=1`, now passes; the unhardened netdata file documented as part of a passing example now fails).

Re-linted all eight compose files and rewrote what changed.

## What actually moved

| Example | Documented | Actual |
|---|---|---|
| portainer-removed | exit=1, 2 high, 1 suppressed | exit=0, 1 medium, 1 suppressed |
| logging-without-the-socket | 0 issues, 1 suppressed | 3 medium, 1 suppressed |
| netdata-socket-proxy (hardened) | 0 issues, 14 suppressed | 3 medium, 11 suppressed |
| ci-runner-suppression | 4 medium, 6 suppressed | 4 medium + 2 low, 3 suppressed |
| read-only-in-tension | 0 issues, 2 suppressed | 0 issues, 1 suppressed |
| read-only-multi-service | 0 issues, 3 suppressed | 3 medium, 2 suppressed |
| clean-edge-proxy | 0 issues, 2 suppressed | 2 medium, 2 suppressed |

## Two narratives needed more than a number swap

**The socket-proxy page's headline argument.** It read "before 14, after 14 — same number, different blast radius". It is now **13 before, 14 after**: the proxy is a service, so it brought its own CL-0026. The refactor that collapsed the blast radius makes the count *worse*, which is a stronger version of the same point and is written that way.

**The tension page traded a medium for a low.** CL-0007 is LOW as of 0.16.0, so it now trades a low for a low. The page said "this time the linter agrees"; it no longer does, and the rewrite says the output gives no signal either way and the decision has to come from the posture.

## Waivers the upgrade emptied out

Two pages gained a section on this, because both configs demonstrate it and they demonstrate different halves:

- **ci-runner** — its `CL-0013` entries waive findings that no longer exist (the socket path is CL-0001's alone; `/etc/timezone` and `/etc/localtime` are excluded outright). Nothing warns, because the rule id is still live.
- **netdata** — its `CL-0011` waiver lost `SYS_PTRACE` to CL-0027, so the finding is back in the output **unwaived**. That is the dangerous half: a re-opened decision that looks like a new problem.

Both `.compose-lint.yml` files are left as deployed — they are artifacts, and the pages now say what the upgrade did to them.

Also renames a heading on the multi-service page so `#when-the-number-and-the-posture-disagree`, which two other pages link to, resolves — it was broken before this PR.

## Verification

Findings are **byte-identical** between released 0.16.0 (clean venv, `pip install compose-lint==0.16.0`) and this tree on all eight files, so the pages are stamped `0.16.0` rather than an unreleased `main`. Every summary block on a page was diffed against a live run; `mkdocs build` is clean for these pages and both anchors resolve in the built HTML.