### PR TITLE
Give compose-lint one authoritative line space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`fix --apply` could edit the wrong line and silently delete config.** The
+  fix engine's offset table counted only `\n`, while the line numbers it
+  converted come from PyYAML, which also breaks on a lone `\r`, U+0085,
+  U+2028 and U+2029. One such codepoint inside a quoted scalar shifted every
+  later splice a line, so a fix could remove a line the user never selected —
+  and because the result was still valid Compose, every safety net passed and
+  the run exited 0. `compose_lint._lines` now owns a single definition of a
+  line break, with `split_lines` and `line_starts` derived from one scan so
+  they cannot disagree; the fixers, the fix engine and the text formatter's
+  source excerpt all use it. A CI guard fails the build on a bare
+  `str.splitlines()` in `src/`. Documents free of those four codepoints —
+  effectively all real Compose files — are unaffected: a 5,417-file corpus run
+  shows zero change in findings, exit codes or errors.
+- **A file whose fixes could not be computed no longer destroys the batch.**
+  The same desync could push a line number past the offset table and raise a
+  bare `IndexError`, which aborted the whole run: `check --format sarif` then
+  emitted a 0-byte document, discarding the findings of every other file
+  scanned alongside it. Out-of-range positions now raise a
+  `LineOutOfRangeError` that the CLI reports as a per-file failure (exit 2,
+  the usage-error code) while the rest of the batch still lints and still
+  ships its findings.
+
 ## [0.17.0] - 2026-08-12
 
 ### Upgrading from 0.16.x

--- a/src/compose_lint/_lines.py
+++ b/src/compose_lint/_lines.py
@@ -1,0 +1,80 @@
+"""The single authoritative definition of "a line" for compose-lint.
+
+Every line number compose-lint handles originates with PyYAML: the parser's
+``lines`` map is built from ``start_mark.line``, fixers index ``source_lines``
+with those numbers, and the fix engine converts them to byte offsets to splice
+edits. Three different splitters used to serve those three roles, and they did
+not agree — ``fix._line_starts`` counted only ``\\n`` while PyYAML and
+``str.splitlines()`` also break on lone ``\\r``, U+0085, U+2028 and U+2029. One
+such codepoint inside a quoted scalar shifted every later splice one line, so
+``fix --apply`` deleted a line the user never selected.
+
+This module removes the possibility of disagreement rather than patching the
+one splitter that was wrong: :func:`split_lines` and :func:`line_starts` are
+derived from *the same* scan, so an offset table can never describe a different
+line space than the list of lines it indexes.
+
+The break set is **PyYAML's**, not ``str.splitlines()``'s. That is the correct
+authority because the line numbers being converted were authored by PyYAML.
+``str.splitlines()`` additionally breaks on ``\\v``, ``\\f``, ``\\x1c``,
+``\\x1d`` and ``\\x1e``; PyYAML rejects documents containing those with a
+``ReaderError``, so on any document that parses the two agree — but matching
+PyYAML keeps that agreement a property of the code rather than a coincidence of
+the reader's rejection list.
+"""
+
+from __future__ import annotations
+
+# The characters PyYAML's Reader counts as advancing a line (see its
+# ``Reader.forward`` / ``Scanner.scan_line_break``). ``\r\n`` counts once.
+BREAK_CHARS = "\n\r\x85\u2028\u2029"
+_BREAKS = frozenset(BREAK_CHARS)
+
+
+def split_lines(text: str) -> list[str]:
+    """Split ``text`` into lines, keeping each line's terminator attached.
+
+    Equivalent in shape to ``text.splitlines(keepends=True)`` but using
+    PyYAML's break set, so ``source_lines[n - 1]`` is the line PyYAML called
+    ``n``. A trailing break does not produce a final empty line.
+    """
+    lines: list[str] = []
+    start = 0
+    index = 0
+    length = len(text)
+    while index < length:
+        char = text[index]
+        if char in _BREAKS:
+            # CRLF is one break, so the LF is consumed with the CR rather than
+            # starting an empty line of its own.
+            if char == "\r" and index + 1 < length and text[index + 1] == "\n":
+                index += 2
+            else:
+                index += 1
+            lines.append(text[start:index])
+            start = index
+        else:
+            index += 1
+    if start < length:
+        lines.append(text[start:])
+    return lines
+
+
+def line_starts(text: str) -> list[int]:
+    """Return the absolute offset at which each 1-indexed line begins.
+
+    ``starts[0]`` is line 1's offset (always 0); a position on line ``n`` is
+    ``starts[n - 1] + (col - 1)``. Derived by accumulating :func:`split_lines`
+    lengths, so the two functions cannot describe different line spaces.
+
+    The list carries one entry per line plus a final sentinel at ``len(text)``.
+    The sentinel makes "the start of the line after the last one" addressable,
+    which fixers rely on when appending at the end of a file (see
+    ``CL0003._append_item``).
+    """
+    starts = [0]
+    offset = 0
+    for line in split_lines(text):
+        offset += len(line)
+        starts.append(offset)
+    return starts

--- a/src/compose_lint/_yaml_edit.py
+++ b/src/compose_lint/_yaml_edit.py
@@ -3,7 +3,9 @@
 Extracted from ``fix.py`` so the rule modules can import them as an explicit
 shared-primitive layer rather than reaching into the fix engine's internals;
 ``fix.py`` consumes them from here too. They operate on
-``source_lines = text.splitlines(keepends=True)`` where a 1-indexed line ``n`` is
+``source_lines = split_lines(text)`` (:mod:`compose_lint._lines`, the one
+definition of a line break — never ``str.splitlines()``, see VULN-017) where a
+1-indexed line ``n`` is
 ``source_lines[n - 1]``, so individual fixers infer indentation, block extent,
 and refusal conditions the same way (ADR-014, Part 1: "a shared helper layer so
 individual rules stay small") instead of each re-deriving them.

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -18,6 +18,7 @@ from compose_lint.config_emit import render_config
 from compose_lint.engine import filter_findings, run_rules
 from compose_lint.explain import UnknownRuleError, load_rule_doc
 from compose_lint.fix import (
+    LineOutOfRangeError,
     apply_edits,
     collect_edits,
     render_caveat_banner,
@@ -486,7 +487,17 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
                 parse_errors.append((filepath, str(e)))
                 print(f"Error: {filepath}: {e}", file=sys.stderr)
                 continue
-            fixes = collect_edits(findings, data, lines, text).fixed_edits
+            try:
+                fixes = collect_edits(findings, data, lines, text).fixed_edits
+            except LineOutOfRangeError as e:
+                # A fixer addressed a line this file does not have. Report the
+                # file and keep going: SARIF is serialized once for the whole
+                # batch, so letting this escape would destroy every *other*
+                # file's findings too (VULN-017 consequence c).
+                msg = f"could not compute fixes: {e}"
+                parse_errors.append((filepath, msg))
+                print(f"Error: {filepath}: {msg}", file=sys.stderr)
+                continue
             all_sarif.extend(format_sarif(findings, filepath, fixes=fixes))
         else:
             all_json.extend(format_json(findings, filepath))
@@ -622,7 +633,14 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
             severity_overrides=severity_overrides,
             excluded_services=excluded_services,
         )
-        result = collect_edits(findings, data, lines, text, only=only)
+        try:
+            result = collect_edits(findings, data, lines, text, only=only)
+        except LineOutOfRangeError as e:
+            # Same fail-closed treatment as the check path: refuse this file,
+            # write nothing, let the rest of the batch run (VULN-017).
+            print(f"Error: {filepath}: could not compute fixes: {e}", file=sys.stderr)
+            had_error = True
+            continue
 
         if not result.edits:
             if result.manual:
@@ -635,7 +653,12 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
                 print(f"{filepath}: nothing to fix", file=sys.stderr)
             continue
 
-        patched = apply_edits(text, result.edits)
+        try:
+            patched = apply_edits(text, result.edits)
+        except LineOutOfRangeError as e:
+            print(f"Error: {filepath}: could not apply fixes: {e}", file=sys.stderr)
+            had_error = True
+            continue
 
         # Safety net (ADR-014): re-parse the candidate before persisting it. If
         # the combined edits do not produce valid Compose, that is a fixer bug,

--- a/src/compose_lint/fix.py
+++ b/src/compose_lint/fix.py
@@ -17,6 +17,7 @@ import difflib
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from compose_lint._lines import line_starts, split_lines
 from compose_lint._yaml_edit import (
     DISABLED_SECURITY_PROFILES,
     _is_seq_item,
@@ -40,21 +41,30 @@ class OverlappingEditError(ValueError):
     """Raised when two edits target overlapping regions of the same file."""
 
 
-def _line_starts(text: str) -> list[int]:
-    """Return the absolute offset at which each 1-indexed line begins.
+class LineOutOfRangeError(ValueError):
+    """Raised when an edit names a line outside the file's line space.
 
-    ``starts[0]`` is line 1's offset (always 0). A position on line ``n`` is
-    ``starts[n - 1] + (col - 1)``.
+    The offset table and the ``source_lines`` fixers index are now derived from
+    one scan (:mod:`compose_lint._lines`), so a fixer can only land here through
+    a bug of its own. Failing with a named domain error keeps that diagnosable
+    and lets the CLI report a per-file failure instead of letting a bare
+    ``IndexError`` abort the whole batch (issue: VULN-017 consequence b/c).
     """
-    starts = [0]
-    for index, char in enumerate(text):
-        if char == "\n":
-            starts.append(index + 1)
-    return starts
 
 
 def _offset(starts: list[int], line: int, col: int) -> int:
-    """Convert a 1-indexed ``(line, col)`` position to an absolute offset."""
+    """Convert a 1-indexed ``(line, col)`` position to an absolute offset.
+
+    ``starts`` comes from :func:`compose_lint._lines.line_starts`, whose final
+    sentinel entry makes end-of-file addressable as the start of the line after
+    the last one.
+    """
+    if line < 1 or line > len(starts):
+        raise LineOutOfRangeError(
+            f"edit names line {line}, outside the file's {len(starts) - 1} line(s)"
+        )
+    if col < 1:
+        raise LineOutOfRangeError(f"edit names column {col}, which is below 1")
     return starts[line - 1] + (col - 1)
 
 
@@ -72,7 +82,7 @@ def apply_edits(text: str, edits: list[TextEdit]) -> str:
     if not edits:
         return text
 
-    starts = _line_starts(text)
+    starts = line_starts(text)
     spans = [
         (
             _offset(starts, edit.start_line, edit.start_col),
@@ -339,7 +349,7 @@ def collect_edits(
         and finding.rule_id in rules_by_id
     ]
 
-    source_lines = text.splitlines(keepends=True)
+    source_lines = split_lines(text)
 
     # Coordination pass first, per service, so consumed findings skip their own
     # (refusing) fixers below.
@@ -366,7 +376,7 @@ def collect_edits(
         else:
             manual.append(finding)
 
-    starts = _line_starts(text)
+    starts = line_starts(text)
 
     def spans_of(edits: list[TextEdit]) -> list[tuple[int, int]]:
         return [
@@ -426,8 +436,8 @@ def render_file_diff(
     """
     chunks: list[str] = []
     for line in difflib.unified_diff(
-        original.splitlines(keepends=True),
-        patched.splitlines(keepends=True),
+        split_lines(original),
+        split_lines(patched),
         fromfile=path,
         tofile=path,
     ):

--- a/src/compose_lint/formatters/text.py
+++ b/src/compose_lint/formatters/text.py
@@ -8,6 +8,7 @@ import sys
 import unicodedata
 from pathlib import Path
 
+from compose_lint._lines import BREAK_CHARS, split_lines
 from compose_lint.models import Finding, Severity
 
 _COLORS = {
@@ -200,10 +201,18 @@ def format_header(
 
 
 def _read_source_lines(filepath: str) -> list[str] | None:
+    """Read ``filepath`` as the line list :func:`_excerpt` indexes by line number.
+
+    Split with the parser's own line space rather than ``str.splitlines()``: the
+    ``line_num`` this list is indexed with came from PyYAML, so any disagreement
+    about what counts as a break would print a *different* line than the one the
+    finding is about (VULN-017's display-layer sibling).
+    """
     try:
-        return Path(filepath).read_text(encoding="utf-8").splitlines()
+        text = Path(filepath).read_text(encoding="utf-8")
     except OSError:
         return None
+    return [line.rstrip(BREAK_CHARS) for line in split_lines(text)]
 
 
 def _excerpt(

--- a/src/compose_lint/rules/CL0003_no_new_privileges.py
+++ b/src/compose_lint/rules/CL0003_no_new_privileges.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from compose_lint._lines import split_lines
 from compose_lint._yaml_edit import (
     DISABLED_SECURITY_PROFILES,
     block_span,
@@ -131,7 +132,7 @@ class NoNewPrivilegesRule(BaseRule):
         key_line = lines.get(f"services.{service}")
         if key_line is None:
             return None
-        source_lines = text.splitlines(keepends=True)
+        source_lines = split_lines(text)
         n = len(source_lines)
         if not 1 <= key_line <= n:
             return None

--- a/src/compose_lint/rules/CL0005_unbound_ports.py
+++ b/src/compose_lint/rules/CL0005_unbound_ports.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any
 
+from compose_lint._lines import split_lines
 from compose_lint._yaml_edit import is_anchored_or_merged, line_indent
 from compose_lint.models import Finding, RuleMetadata, Severity, TextEdit
 from compose_lint.rules import BaseRule, register_rule
@@ -235,7 +236,7 @@ class UnboundPortsRule(BaseRule):
         service_line = lines.get(f"services.{service}")
         if item_line is None or service_line is None:
             return None
-        source_lines = text.splitlines(keepends=True)
+        source_lines = split_lines(text)
         n = len(source_lines)
         if not (1 <= item_line <= n and 1 <= service_line <= n):
             return None

--- a/src/compose_lint/rules/CL0007_read_only.py
+++ b/src/compose_lint/rules/CL0007_read_only.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from compose_lint._lines import split_lines
 from compose_lint._yaml_edit import (
     first_child_indent,
     is_anchored_or_merged,
@@ -111,7 +112,7 @@ class ReadOnlyFilesystemRule(BaseRule):
         key_line = lines.get(f"services.{service}")
         if key_line is None:
             return None
-        source_lines = text.splitlines(keepends=True)
+        source_lines = split_lines(text)
         if not 1 <= key_line <= len(source_lines):
             return None
 

--- a/src/compose_lint/rules/CL0009_security_profile.py
+++ b/src/compose_lint/rules/CL0009_security_profile.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from compose_lint._lines import split_lines
 from compose_lint._yaml_edit import (
     DISABLED_SECURITY_PROFILES,
     delete_lines,
@@ -176,7 +177,7 @@ class SecurityProfileRule(BaseRule):
         if item_line is None or so_line is None or service_line is None:
             return None
 
-        source_lines = text.splitlines(keepends=True)
+        source_lines = split_lines(text)
         n = len(source_lines)
         if not (1 <= service_line <= n and 1 <= so_line <= n and 1 <= item_line <= n):
             return None

--- a/src/compose_lint/rules/CL0014_logging_disabled.py
+++ b/src/compose_lint/rules/CL0014_logging_disabled.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from compose_lint._lines import split_lines
 from compose_lint._yaml_edit import (
     block_span,
     delete_lines,
@@ -116,7 +117,7 @@ class LoggingDisabledRule(BaseRule):
         if logging_line is None or service_line is None:
             return None
 
-        source_lines = text.splitlines(keepends=True)
+        source_lines = split_lines(text)
         n = len(source_lines)
         if not (1 <= service_line <= n and 1 <= logging_line <= n):
             return None

--- a/tests/test_fix_line_space.py
+++ b/tests/test_fix_line_space.py
@@ -1,0 +1,163 @@
+"""End-to-end regression: `fix --apply` must not splice in a desynced line space.
+
+The unit-level invariants live in ``test_lines.py``. These drive the real CLI,
+because the defect's severity came from the *combination* — a misplaced splice
+that still produced valid Compose, so every downstream safety net (reparse,
+structural-drift, convergence, no-new-finding) passed and the run exited 0.
+
+The attack: a low-severity ``CL-0014`` fix is requested on a document carrying
+one invisible line-break codepoint, and the splice lands one line late on the
+service's network-isolation directive.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from compose_lint import cli
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# The four break codepoints PyYAML counts and a naive `\n`-only scan does not.
+DESYNC_BREAKS = {"CR": "\r", "NEL": "\x85", "LS": "\u2028", "PS": "\u2029"}
+
+_IMAGE = "nginx@sha256:" + "ab" * 32
+
+
+def _compose(sep: str) -> str:
+    """A hardened service whose `logging: driver: none` is CL-0014-fixable.
+
+    ``sep`` sits inside a *quoted scalar*, so the document is valid Compose for
+    every value of ``sep`` including the plain-space control. The line right
+    after the block CL-0014 deletes is the network-isolation directive.
+    """
+    return (
+        "services:\n"
+        "  web:\n"
+        f"    image: {_IMAGE}\n"
+        "    labels:\n"
+        f'      note: "line one{sep}line two"\n'
+        "    logging:\n"
+        "      driver: none\n"
+        "    networks: [internal]\n"
+        "    read_only: true\n"
+        '    user: "1000:1000"\n'
+        '    security_opt: ["no-new-privileges:true"]\n'
+        "    cap_drop: [ALL]\n"
+        "networks:\n"
+        "  internal:\n"
+        "    internal: true\n"
+    )
+
+
+def _write(path: Path, text: str) -> Path:
+    # newline="" so a lone CR survives to disk unmangled.
+    with open(path, "w", encoding="utf-8", newline="") as fh:
+        fh.write(text)
+    return path
+
+
+@pytest.mark.parametrize("name,sep", sorted({"control": " ", **DESYNC_BREAKS}.items()))
+def test_fix_apply_deletes_only_the_requested_block(
+    tmp_path: Path, name: str, sep: str
+) -> None:
+    """`fix --only CL-0014 --apply` removes the logging block and nothing else."""
+    target = _write(tmp_path / f"{name}.yml", _compose(sep))
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["fix", "--only", "CL-0014", "--apply", str(target)])
+    assert exc.value.code == 0, name
+
+    after = target.read_text(encoding="utf-8")
+    # The requested edit completed...
+    assert "logging:" not in after, name
+    assert "driver: none" not in after, name
+    # ...and the security config the user never selected survives.
+    assert "networks: [internal]" in after, name
+    assert "read_only: true" in after, name
+    assert "cap_drop: [ALL]" in after, name
+
+
+@pytest.mark.parametrize("name,sep", sorted(DESYNC_BREAKS.items()))
+def test_sarif_fix_region_covers_the_logging_block(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    name: str,
+    sep: str,
+) -> None:
+    """The exported fix region names the lines the fixer actually meant.
+
+    ``check --format sarif`` exports ``artifactChanges`` without going through
+    the apply-time safety nets, so the region is pinned directly.
+    """
+    from compose_lint._lines import split_lines
+
+    target = _write(tmp_path / f"sarif_{name}.yml", _compose(sep))
+
+    with pytest.raises(SystemExit):
+        cli.main(["check", "--format", "sarif", str(target)])
+    doc = json.loads(capsys.readouterr().out)
+
+    source = split_lines(target.read_text(encoding="utf-8"))
+    regions = [
+        r["fixes"][0]["artifactChanges"][0]["replacements"][0]["deletedRegion"]
+        for r in doc["runs"][0]["results"]
+        if r["ruleId"] == "CL-0014" and r.get("fixes")
+    ]
+    assert regions, f"{name}: no CL-0014 fix exported"
+    region = regions[0]
+    end = region.get("endLine", region["startLine"])
+    if region.get("endColumn", 1) == 1:
+        end -= 1
+    covered = [line.strip() for line in source[region["startLine"] - 1 : end]]
+    assert covered == ["logging:", "driver: none"], f"{name}: covered {covered}"
+
+
+def test_batch_sarif_survives_a_file_whose_fixes_cannot_be_computed(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One unfixable file must not destroy the whole batch's SARIF.
+
+    SARIF is serialized once per run, so an exception escaping the per-file fix
+    computation used to take every *other* file's findings with it. The failure
+    is injected here rather than spelled as a document, because the line space
+    is now consistent by construction — the point under test is the CLI's
+    containment of the error, not a way to still trigger it.
+    """
+    from compose_lint import cli as cli_module
+    from compose_lint.fix import LineOutOfRangeError
+
+    good = _write(
+        tmp_path / "good.yml",
+        "services:\n  api:\n    image: nginx:latest\n    privileged: true\n",
+    )
+    poisoned = _write(tmp_path / "poisoned.yml", _compose(" "))
+
+    real_collect = cli_module.collect_edits
+
+    def _explode(findings, data, lines, text, **kwargs):  # type: ignore[no-untyped-def]
+        if "line one" in text:  # the poisoned document
+            raise LineOutOfRangeError(
+                "edit names line 99, outside the file's 15 line(s)"
+            )
+        return real_collect(findings, data, lines, text, **kwargs)
+
+    monkeypatch.setattr(cli_module, "collect_edits", _explode)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["check", "--format", "sarif", str(good), str(poisoned)])
+
+    captured = capsys.readouterr()
+    doc = json.loads(captured.out)
+    rule_ids = {r["ruleId"] for r in doc["runs"][0]["results"]}
+    # The clean file's CRITICAL finding still ships.
+    assert "CL-0002" in rule_ids
+    # The failure is reported, not swallowed, and takes the usage-error exit.
+    assert "could not compute fixes" in captured.err
+    assert exc.value.code == 2

--- a/tests/test_line_space_guard.py
+++ b/tests/test_line_space_guard.py
@@ -1,0 +1,54 @@
+"""Guard: `src/` must not re-introduce a second definition of "a line".
+
+The line-space desync was not a typo — it was two modules each deciding for
+themselves what a line break is. ``compose_lint._lines`` is now the single
+authority, and this test keeps it that way: a future ``text.splitlines()`` in
+``src/`` silently reintroduces the divergence (``str.splitlines()`` breaks on
+five codepoints PyYAML does not), and nothing else in the suite would catch it
+until a fixer spliced the wrong bytes again.
+
+Fix a failure by importing ``split_lines`` from ``compose_lint._lines``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parent.parent / "src" / "compose_lint"
+
+# The module that *owns* the definition is allowed to implement it.
+_EXEMPT = {"_lines.py"}
+
+
+def _split_lines_calls(tree: ast.AST) -> list[int]:
+    """Line numbers of every ``<expr>.splitlines(...)`` call in ``tree``."""
+    return [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "splitlines"
+    ]
+
+
+def test_no_bare_splitlines_in_src() -> None:
+    offenders: list[str] = []
+    for path in sorted(SRC.rglob("*.py")):
+        if path.name in _EXEMPT:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for lineno in _split_lines_calls(tree):
+            offenders.append(f"{path.relative_to(SRC.parent.parent)}:{lineno}")
+
+    assert not offenders, (
+        "str.splitlines() found in src/ — use compose_lint._lines.split_lines() "
+        "so the fix engine, the fixers and the parser share one line space:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_the_guard_can_actually_see_a_call() -> None:
+    """Guard the guard: prove the AST matcher fires on a known-bad snippet."""
+    tree = ast.parse("def f(t):\n    return t.splitlines(keepends=True)\n")
+    assert _split_lines_calls(tree) == [2]

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -1,0 +1,183 @@
+"""Tests for the one authoritative line space (:mod:`compose_lint._lines`).
+
+Regression coverage for the line-space desync: the fix engine's offset table
+counted only ``\\n`` while the parser's line numbers came from PyYAML, which
+also breaks on lone ``\\r``, U+0085, U+2028 and U+2029. A single such codepoint
+inside a quoted scalar shifted every later splice one line, so ``fix --apply``
+deleted a line the user never selected and exited 0.
+
+The four trigger characters are covered as a table, not one representative:
+patching only the character in the original proof of concept would have left
+three live bypasses.
+"""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from compose_lint._lines import BREAK_CHARS, line_starts, split_lines
+from compose_lint.fix import LineOutOfRangeError, _offset, apply_edits
+from compose_lint.models import TextEdit
+
+# Every codepoint Python or PyYAML treats as a line break, split by whether
+# PyYAML accepts a document containing it. `str.splitlines()` breaks on all of
+# them; PyYAML rejects the second group with a ReaderError, which is why the
+# break set here must be PyYAML's and not `str.splitlines()`'s.
+PYYAML_BREAKS = {
+    "LF": "\n",
+    "CRLF": "\r\n",
+    "CR": "\r",
+    "NEL": "\x85",
+    "LS": "\u2028",
+    "PS": "\u2029",
+}
+# The four PyYAML counts that a naive `\n`-only scan does not: the desync set.
+DESYNC_BREAKS = {k: v for k, v in PYYAML_BREAKS.items() if k not in ("LF", "CRLF")}
+PYYAML_REJECTS = {
+    "VT": "\x0b",
+    "FF": "\x0c",
+    "FS": "\x1c",
+    "GS": "\x1d",
+    "RS": "\x1e",
+}
+
+
+def _doc(sep: str) -> str:
+    """A valid Compose document with ``sep`` inside a quoted scalar."""
+    return (
+        "services:\n"
+        "  web:\n"
+        "    image: nginx:1.25\n"
+        "    labels:\n"
+        f'      note: "one{sep}two"\n'
+        "    read_only: true\n"
+    )
+
+
+def _pyyaml_line(text: str, key: str) -> int:
+    """The 1-indexed line PyYAML reports for ``key`` under ``services.web``."""
+    node = yaml.compose(text)
+    for top_key, top_val in node.value:
+        if top_key.value != "services":
+            continue
+        for _svc_name, svc in top_val.value:
+            for child_key, _child_val in svc.value:
+                if child_key.value == key:
+                    return int(child_key.start_mark.line) + 1
+    raise AssertionError(f"{key} not found")
+
+
+# --- The two functions cannot describe different line spaces ---------------
+
+
+@pytest.mark.parametrize("name,sep", sorted(PYYAML_BREAKS.items()))
+def test_line_starts_agrees_with_split_lines(name: str, sep: str) -> None:
+    """``line_starts`` is derived from ``split_lines``, so offsets match lengths."""
+    text = _doc(sep)
+    lines = split_lines(text)
+    starts = line_starts(text)
+    assert len(starts) == len(lines) + 1, name
+    for index, line in enumerate(lines):
+        assert text[starts[index] : starts[index] + len(line)] == line, name
+    assert starts[-1] == len(text), name
+
+
+@pytest.mark.parametrize("name,sep", sorted(PYYAML_BREAKS.items()))
+def test_offset_lands_on_the_line_pyyaml_reported(name: str, sep: str) -> None:
+    """The core invariant: a PyYAML line number converts to that line's offset."""
+    text = _doc(sep)
+    line = _pyyaml_line(text, "read_only")
+    offset = _offset(line_starts(text), line, 1)
+    assert text[offset:].startswith("    read_only: true"), name
+
+
+@pytest.mark.parametrize("name,sep", sorted(PYYAML_BREAKS.items()))
+def test_split_lines_indexes_as_pyyaml_numbers(name: str, sep: str) -> None:
+    """``source_lines[n - 1]`` is the line PyYAML called ``n``."""
+    text = _doc(sep)
+    line = _pyyaml_line(text, "read_only")
+    assert split_lines(text)[line - 1].strip() == "read_only: true", name
+
+
+def test_crlf_is_one_break_not_two() -> None:
+    assert split_lines("a\r\nb\r\n") == ["a\r\n", "b\r\n"]
+
+
+def test_trailing_break_does_not_make_an_empty_final_line() -> None:
+    assert split_lines("a\nb\n") == ["a\n", "b\n"]
+    assert split_lines("a\nb") == ["a\n", "b"]
+
+
+def test_empty_text() -> None:
+    assert split_lines("") == []
+    assert line_starts("") == [0]
+
+
+def test_break_chars_is_exactly_pyyamls_set() -> None:
+    """Pin the break set: `str.splitlines()`'s extra characters are excluded."""
+    assert set(BREAK_CHARS) == {"\n", "\r", "\x85", "\u2028", "\u2029"}
+    for char in PYYAML_REJECTS.values():
+        assert char not in BREAK_CHARS
+
+
+@pytest.mark.parametrize("name,char", sorted(PYYAML_REJECTS.items()))
+def test_pyyaml_rejects_the_characters_we_exclude(name: str, char: str) -> None:
+    """The excluded characters are unreachable: PyYAML refuses such documents.
+
+    This is the evidence that excluding them cannot hide a real document from
+    the fixers — it is not a judgement call.
+    """
+    with pytest.raises(yaml.YAMLError):
+        yaml.compose(_doc(char))
+
+
+# --- Bounds checking replaces a bare IndexError ----------------------------
+
+
+def test_offset_rejects_a_line_past_the_end() -> None:
+    starts = line_starts("a\nb\n")
+    with pytest.raises(LineOutOfRangeError, match="outside the file"):
+        _offset(starts, 99, 1)
+
+
+def test_offset_rejects_a_nonpositive_line() -> None:
+    starts = line_starts("a\nb\n")
+    with pytest.raises(LineOutOfRangeError, match="outside the file"):
+        _offset(starts, 0, 1)
+
+
+def test_offset_rejects_a_nonpositive_column() -> None:
+    starts = line_starts("a\nb\n")
+    with pytest.raises(LineOutOfRangeError, match="below 1"):
+        _offset(starts, 1, 0)
+
+
+def test_offset_allows_the_end_of_file_sentinel() -> None:
+    """Appending at EOF addresses the line after the last one (CL-0003 relies on it)."""
+    text = "a: 1\nb: 2\n"
+    starts = line_starts(text)
+    assert _offset(starts, 3, 1) == len(text)
+    assert apply_edits(text, [TextEdit(3, 1, 3, 1, "c: 3\n")]) == "a: 1\nb: 2\nc: 3\n"
+
+
+def test_apply_edits_raises_the_domain_error_not_indexerror() -> None:
+    with pytest.raises(LineOutOfRangeError):
+        apply_edits("a: 1\n", [TextEdit(9, 1, 9, 1, "x")])
+
+
+# --- Splicing is correct in every break space ------------------------------
+
+
+@pytest.mark.parametrize("name,sep", sorted(DESYNC_BREAKS.items()))
+def test_edit_splices_at_the_pyyaml_line_for_every_break(name: str, sep: str) -> None:
+    """Deleting "the line PyYAML calls N" removes exactly that line."""
+    text = _doc(sep)
+    line = _pyyaml_line(text, "read_only")
+    lines = split_lines(text)
+    end_col = len(lines[line - 1]) + 1
+    patched = apply_edits(text, [TextEdit(line, 1, line, end_col, "")])
+    assert "read_only" not in patched, name
+    # ...and nothing else was touched.
+    assert 'note: "one' in patched, name
+    assert "image: nginx:1.25" in patched, name


### PR DESCRIPTION
Resolves a finding from a [VulnHunter](https://github.com/capitalone/vulnhunter) security audit of this repository (tracked internally as VULN-017).

## The defect

`fix.py` built its byte-offset table by counting only `\n`, but the line numbers it converts are authored by PyYAML, which also treats a lone `\r`, U+0085, U+2028 and U+2029 as line breaks. One such codepoint in a document shifted every later splice a line, so `fix --apply` could edit a line the user never selected. Because the result was still valid Compose, the reparse, structural-drift, convergence and no-new-finding nets all passed and the run exited 0.

The same skew could push a line number past the end of the table and raise a bare `IndexError`. That aborted the whole run, so `check --format sarif` emitted a 0-byte document and discarded the findings of every other file scanned alongside it.

`docker compose config` accepts all four codepoints, so the affected documents are ordinary deployable Compose files.

## The fix

A new `compose_lint._lines` owns the single definition of a line break. `split_lines` and `line_starts` are derived from *the same* scan, so an offset table can no longer describe a different line space than the list of lines it indexes.

The break set is PyYAML's rather than `str.splitlines()`'s: PyYAML is the authority for the numbers being converted, and `str.splitlines()` breaks on five more codepoints that PyYAML rejects outright with a `ReaderError`. A test pins that rejection so the exclusion rests on evidence rather than judgement.

- The fix engine, the five fixers with edit support (CL-0003/0005/0007/0009/0014) and the text formatter's source excerpt all route through it.
- `_offset` bounds-checks into a named `LineOutOfRangeError` instead of an `IndexError`; the CLI reports it as a per-file failure so one bad file no longer takes the rest of the batch's findings with it.
- A CI guard fails the build on a bare `str.splitlines()` in `src/` — the defect was two modules each deciding for themselves what a line is, so the guard targets the class rather than the instance.

## Behavior change

**Documents without those four codepoints are unaffected.** A 5,417-file corpus run against this branch versus `main` shows **zero** change in findings, exit codes or errors.

For documents that do contain them:

| | before | after |
|---|---|---|
| `fix --apply` | edits the wrong line, exit 0 | edits the requested line, exit 0 |
| 2+ codepoints | `IndexError` traceback, exit 1 | per-file failure, exit 2 |
| batch SARIF | 0 bytes, all findings lost | other files' findings ship normally |

The exit 1 → 2 move is the one contract change: exit 2 is the documented usage/invalid-file code, and exit 1 previously claimed the file had been linted when it had not. Anyone whose SARIF was silently arriving empty will now see real Code Scanning alerts, which can turn a previously-green check red.

No rule fires or stops firing on any input; no severity, message, rule ID or ATT&CK mapping changes; no config, suppression, or Action input changes; output shape is unchanged.

Patch-level — no API removals.

## Tests

48 new tests. All four trigger codepoints are covered as a table rather than the one that happened to be found first.

- `tests/test_lines.py` — line-space invariants, PyYAML agreement, bounds checking, the pinned break set
- `tests/test_fix_line_space.py` — end-to-end `fix --apply` and SARIF fix regions through the real CLI, plus batch containment
- `tests/test_line_space_guard.py` — the `str.splitlines()` ban, including a check that the guard itself can see a call

Full suite 1515 passed / 6 skipped; `ruff check`, `ruff format --check`, `mypy src/` clean.
