### PR TITLE
Refuse Compose files with an ambiguous line break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **A Compose file containing an ambiguous line break is now refused** (exit 2,
+  reported per file, with a SARIF `toolExecutionNotifications` entry) instead of
+  being linted with line numbers nothing else agrees with. A lone `\r`, U+0085,
+  U+2028 or U+2029 is a line break to the YAML parser but not to editors, SARIF
+  viewers or CI annotations, so on such a document *any* reported line number is
+  wrong for one side or the other — and the fix engine would splice at a line
+  the user is not looking at. There is no line numbering to fall back on, so the
+  file is refused rather than mislabeled. None of the 5,417 files in the corpus
+  contains one, and CRLF and LF are unaffected.
+- **The parser now reads files without universal-newline translation**, so
+  `check` and `fix` parse the same bytes for the same file. `fix` has always
+  read with `newline=""` to preserve line endings, while the parser rewrote a
+  lone `\r` to `\n` — a second, quieter version of the same disagreement.
+  Verified no behavior change: LF and CRLF documents produce byte-identical
+  findings and line numbers, and a full corpus run is unchanged.
+
 ### Fixed
 
 - **`fix --apply` could edit the wrong line and silently delete config.** The

--- a/src/compose_lint/_lines.py
+++ b/src/compose_lint/_lines.py
@@ -78,3 +78,42 @@ def line_starts(text: str) -> list[int]:
         offset += len(line)
         starts.append(offset)
     return starts
+
+
+# Breaks PyYAML honors that a consumer splitting on ``\n`` does not see. A
+# document containing one has no line numbering both sides agree on: the number
+# compose-lint reports (PyYAML's, the only correct one for a YAML construct)
+# names a different line in the editor, the SARIF viewer, and the CI annotation.
+AMBIGUOUS_BREAKS = {
+    "\r": "U+000D CARRIAGE RETURN outside a CRLF pair",
+    "\x85": "U+0085 NEXT LINE",
+    "\u2028": "U+2028 LINE SEPARATOR",
+    "\u2029": "U+2029 PARAGRAPH SEPARATOR",
+}
+
+
+def find_ambiguous_break(text: str) -> tuple[int, str] | None:
+    """Return ``(line, description)`` of the first ambiguous break, else ``None``.
+
+    ``line`` is 1-indexed in :func:`split_lines`' space. ``\\n`` and ``\\r\\n``
+    are unambiguous and skipped; a ``\\r`` *not* followed by ``\\n`` is not.
+    """
+    line = 1
+    index = 0
+    length = len(text)
+    while index < length:
+        char = text[index]
+        if char == "\r":
+            if index + 1 < length and text[index + 1] == "\n":
+                index += 2
+                line += 1
+                continue
+            return line, AMBIGUOUS_BREAKS["\r"]
+        if char == "\n":
+            line += 1
+            index += 1
+            continue
+        if char in AMBIGUOUS_BREAKS:
+            return line, AMBIGUOUS_BREAKS[char]
+        index += 1
+    return None

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import yaml
 
+from compose_lint._lines import find_ambiguous_break
 from compose_lint.config import KNOWN_TOP_LEVEL_KEYS
 from compose_lint.rules._interpolation import substitute_defaults
 
@@ -708,7 +709,14 @@ def load_compose(
     """
     filepath = Path(path)
     try:
-        content = filepath.read_text(encoding="utf-8")
+        # newline="" disables universal-newline translation so the parser sees
+        # the file's real bytes. read_text() would rewrite a lone \r (and CRLF)
+        # to \n, which hid a lone \r from the ambiguous-break check below and,
+        # worse, meant `check` and `fix` parsed *different* text for the same
+        # file — `fix` has always read with newline="" to preserve line endings.
+        # One read shape for both is the same principle as one line space.
+        with filepath.open(encoding="utf-8", newline="") as fh:
+            content = fh.read()
     except FileNotFoundError:
         raise
     except UnicodeDecodeError as e:
@@ -752,6 +760,24 @@ def loads(
     Raises:
         ComposeError: If the text is not valid YAML or not a valid Compose file.
     """
+    # Refuse a document whose line numbering has no answer both sides agree on.
+    # PyYAML breaks on a lone \r, U+0085, U+2028 and U+2029; editors, SARIF
+    # viewers and CI annotators split on \n. compose-lint must report one line
+    # number, and on such a document any choice is wrong for somebody — the fix
+    # engine would splice at a line the user is not looking at. Refusing is the
+    # only answer that cannot mislabel, and it costs nothing real: none of the
+    # 5,417 files in the corpus contains one.
+    ambiguous = find_ambiguous_break(content)
+    if ambiguous is not None:
+        line, description = ambiguous
+        raise ComposeError(
+            f"Ambiguous line break on line {line}: {description}. "
+            "This is a line break to the YAML parser but not to editors, SARIF "
+            "viewers or CI annotations, so no reported line number would be "
+            "correct for both. Use LF or CRLF line endings and remove the "
+            "character."
+        )
+
     # LineLoader is a yaml.SafeLoader subclass — this call cannot
     # deserialize arbitrary Python objects. The assertion makes that
     # invariant explicit so a future refactor can't silently break it.

--- a/tests/test_fix_line_space.py
+++ b/tests/test_fix_line_space.py
@@ -61,42 +61,76 @@ def _write(path: Path, text: str) -> Path:
     return path
 
 
-@pytest.mark.parametrize("name,sep", sorted({"control": " ", **DESYNC_BREAKS}.items()))
-def test_fix_apply_deletes_only_the_requested_block(
-    tmp_path: Path, name: str, sep: str
-) -> None:
+def test_fix_apply_deletes_only_the_requested_block(tmp_path: Path) -> None:
     """`fix --only CL-0014 --apply` removes the logging block and nothing else."""
-    target = _write(tmp_path / f"{name}.yml", _compose(sep))
+    target = _write(tmp_path / "control.yml", _compose(" "))
 
     with pytest.raises(SystemExit) as exc:
         cli.main(["fix", "--only", "CL-0014", "--apply", str(target)])
-    assert exc.value.code == 0, name
+    assert exc.value.code == 0
 
     after = target.read_text(encoding="utf-8")
     # The requested edit completed...
-    assert "logging:" not in after, name
-    assert "driver: none" not in after, name
+    assert "logging:" not in after
+    assert "driver: none" not in after
     # ...and the security config the user never selected survives.
-    assert "networks: [internal]" in after, name
-    assert "read_only: true" in after, name
-    assert "cap_drop: [ALL]" in after, name
+    assert "networks: [internal]" in after
+    assert "read_only: true" in after
+    assert "cap_drop: [ALL]" in after
 
 
 @pytest.mark.parametrize("name,sep", sorted(DESYNC_BREAKS.items()))
-def test_sarif_fix_region_covers_the_logging_block(
+def test_fix_refuses_a_document_with_an_ambiguous_break(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
     name: str,
     sep: str,
 ) -> None:
-    """The exported fix region names the lines the fixer actually meant.
+    """`fix` writes nothing when no line number could be reported correctly."""
+    target = _write(tmp_path / f"{name}.yml", _compose(sep))
+    before = target.read_bytes()
 
-    ``check --format sarif`` exports ``artifactChanges`` without going through
-    the apply-time safety nets, so the region is pinned directly.
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["fix", "--only", "CL-0014", "--apply", str(target)])
+
+    assert exc.value.code == 2, name
+    assert "Ambiguous line break on line 5" in capsys.readouterr().err, name
+    assert target.read_bytes() == before, f"{name}: the file was modified"
+
+
+@pytest.mark.parametrize("name,sep", sorted(DESYNC_BREAKS.items()))
+def test_sarif_reports_an_ambiguous_break_as_a_file_error(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    name: str,
+    sep: str,
+) -> None:
+    """The refusal is machine-readable, not stderr-only.
+
+    A coverage gap that only exists on stderr is invisible to the CI consumer
+    that decides whether the gate passes, so the SARIF document has to carry it.
     """
+    target = _write(tmp_path / f"sarif_{name}.yml", _compose(sep))
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["check", "--format", "sarif", str(target)])
+    assert exc.value.code == 2, name
+
+    doc = json.loads(capsys.readouterr().out)
+    assert doc["runs"][0]["results"] == [], name
+    notifications = doc["runs"][0]["invocations"][0]["toolExecutionNotifications"]
+    assert any("Ambiguous line break" in n["message"]["text"] for n in notifications), (
+        name
+    )
+
+
+def test_sarif_fix_region_covers_the_logging_block(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The exported fix region names the lines the fixer actually meant."""
     from compose_lint._lines import split_lines
 
-    target = _write(tmp_path / f"sarif_{name}.yml", _compose(sep))
+    target = _write(tmp_path / "sarif_control.yml", _compose(" "))
 
     with pytest.raises(SystemExit):
         cli.main(["check", "--format", "sarif", str(target)])
@@ -108,13 +142,13 @@ def test_sarif_fix_region_covers_the_logging_block(
         for r in doc["runs"][0]["results"]
         if r["ruleId"] == "CL-0014" and r.get("fixes")
     ]
-    assert regions, f"{name}: no CL-0014 fix exported"
+    assert regions, "no CL-0014 fix exported"
     region = regions[0]
     end = region.get("endLine", region["startLine"])
     if region.get("endColumn", 1) == 1:
         end -= 1
     covered = [line.strip() for line in source[region["startLine"] - 1 : end]]
-    assert covered == ["logging:", "driver: none"], f"{name}: covered {covered}"
+    assert covered == ["logging:", "driver: none"], f"covered {covered}"
 
 
 def test_batch_sarif_survives_a_file_whose_fixes_cannot_be_computed(

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -16,9 +16,16 @@ from __future__ import annotations
 import pytest
 import yaml
 
-from compose_lint._lines import BREAK_CHARS, line_starts, split_lines
+from compose_lint._lines import (
+    AMBIGUOUS_BREAKS,
+    BREAK_CHARS,
+    find_ambiguous_break,
+    line_starts,
+    split_lines,
+)
 from compose_lint.fix import LineOutOfRangeError, _offset, apply_edits
 from compose_lint.models import TextEdit
+from compose_lint.parser import ComposeError, loads
 
 # Every codepoint Python or PyYAML treats as a line break, split by whether
 # PyYAML accepts a document containing it. `str.splitlines()` breaks on all of
@@ -181,3 +188,43 @@ def test_edit_splices_at_the_pyyaml_line_for_every_break(name: str, sep: str) ->
     # ...and nothing else was touched.
     assert 'note: "one' in patched, name
     assert "image: nginx:1.25" in patched, name
+
+
+# --- Ambiguous breaks are refused at the parser boundary -------------------
+
+
+def test_find_ambiguous_break_ignores_lf_and_crlf() -> None:
+    assert find_ambiguous_break("a\nb\n") is None
+    assert find_ambiguous_break("a\r\nb\r\n") is None
+    assert find_ambiguous_break("") is None
+
+
+@pytest.mark.parametrize("name,sep", sorted(DESYNC_BREAKS.items()))
+def test_find_ambiguous_break_reports_line_and_character(name: str, sep: str) -> None:
+    found = find_ambiguous_break(f"a\nb\nc{sep}d")
+    assert found is not None, name
+    line, description = found
+    assert line == 3, name
+    assert description in AMBIGUOUS_BREAKS.values(), name
+
+
+def test_find_ambiguous_break_counts_preceding_crlf_lines() -> None:
+    """The reported line number is in the same space as everything else."""
+    found = find_ambiguous_break("a\r\nb\r\nc\x85d")
+    assert found == (3, AMBIGUOUS_BREAKS["\x85"])
+
+
+@pytest.mark.parametrize("name,sep", sorted(DESYNC_BREAKS.items()))
+def test_loads_refuses_a_document_with_an_ambiguous_break(name: str, sep: str) -> None:
+    source = f'services:\n  web:\n    image: nginx\n    labels:\n      n: "a{sep}b"\n'
+    with pytest.raises(ComposeError, match="Ambiguous line break"):
+        loads(source)
+
+
+def test_loads_accepts_lf_and_crlf_identically() -> None:
+    """The read-shape change must not move a single line number."""
+    source = "services:\n  web:\n    image: nginx\n    privileged: true\n"
+    lf_data, lf_lines = loads(source)
+    crlf_data, crlf_lines = loads(source.replace("\n", "\r\n"))
+    assert lf_data == crlf_data
+    assert lf_lines == crlf_lines


### PR DESCRIPTION
Resolves the remaining consequence of a finding from a [VulnHunter](https://github.com/capitalone/vulnhunter) security audit of this repository (tracked internally as VULN-017).

> Follow-up to #547, now merged. Supersedes #548, which GitHub auto-closed when that PR's branch was deleted.

## Why #547 wasn't the whole fix

#547 made compose-lint's line space internally consistent, which closed the silent-deletion, crash and batch-wipe consequences. It did not close the last one, and the reason is that it isn't an *internal* disagreement:

```
document containing U+2028, SARIF deletedRegion: lines 7..8
  compose-lint line space -> ['    logging:', '      driver: none']   ← correct
  LF-only  line space     -> ['      driver: none', '    networks: [internal]']
```

The exported region is right in the parser's line space and still names different lines in a consumer's. PyYAML breaks on a lone `\r`, U+0085, U+2028 and U+2029; editors, SARIF viewers and CI annotations split on `\n`. compose-lint reports **one** line number per finding, so on such a document any choice is wrong for somebody — and the fix engine would splice at a line the user is not looking at. No break set satisfies both sides.

This affects every finding's line number, not only fixes.

## What this does

Refuse the document. A lone `\r`, U+0085, U+2028 or U+2029 is now a parse error: exit 2, reported per file, carried in SARIF `toolExecutionNotifications`, with the rest of the batch still linted and still shipping its findings.

Refusing is the only answer that cannot mislabel, and it matches how the parser already treats input it cannot represent faithfully.

It also **reads files without universal-newline translation**. `read_text()` rewrote a lone `\r` to `\n`, which hid it from the check — and meant `check` and `fix` parsed *different bytes for the same file*, since `fix` has always read with `newline=""` to preserve line endings. That is a second, quieter version of the same defect; one read shape for both is the same principle as one line space.

## Behavior change

**This one can reject files that previously linted** — that is the point, and it is the reason for the evidence below.

| | before | after |
|---|---|---|
| lone `\r`, U+0085, U+2028, U+2029 | linted, line numbers nothing agrees with | exit 2, refused, reported |
| LF | unchanged | unchanged |
| CRLF | unchanged | unchanged |

Measured rather than asserted:

- **0 of 5,417** corpus files contain any of the four characters.
- A full corpus run against `main` shows **zero** change in findings, exit codes or errors.
- **39** corpus files use CRLF, so the read-shape change is genuinely exercised. LF and CRLF documents produce byte-identical findings and line numbers, and `fix` still preserves CRLF endings.

No rule fires or stops firing; no severity, message, rule ID or ATT&CK mapping changes; no config or Action input changes.

Semver: refusing input that previously produced output is a behavior change, but it only affects documents whose reported line numbers were already wrong. Reasonable to ship as a patch alongside #547; call it minor if you'd rather be conservative.

## Tests

11 new tests on top of #547's: `find_ambiguous_break` unit coverage including the CRLF-counting case, parser-level refusal for all four characters, `fix` writing nothing and leaving the file byte-identical, the SARIF notification, and an LF/CRLF parity test pinning that the read-shape change moved no line number.

Full suite 1527 passed / 6 skipped; `ruff check`, `ruff format --check`, `mypy src/` clean.
