### PR TITLE
Grade interpolated values as the config Compose ships

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Security-focused linter for Docker Compose files. Python >=3.10, PyYAML only run
 
 ## Architecture
 
-- **Parser**: `LineLoader(yaml.SafeLoader)` captures line numbers. `load_compose(path) -> (data, lines)`. Handles v2/v3, anchors, merge keys (`<<:`), extension fields (`x-`). Leaves `${VAR}` unresolved. Validates `services:` exists and is a mapping. Does NOT do full Compose schema validation.
+- **Parser**: `LineLoader(yaml.SafeLoader)` captures line numbers. `load_compose(path) -> (data, lines)`. Handles v2/v3, anchors, merge keys (`<<:`), extension fields (`x-`). Normalizes `${VAR:-default}` document-wide to the value Compose ships with no `.env`, so rules classify what is deployed; a reference with no default (`${VAR}`) is left as written. Validates `services:` exists and is a mapping. Does NOT do full Compose schema validation.
 - **Rules**: Classes inheriting `BaseRule`, registered via `@register_rule`. IDs are `CL-XXXX`, zero-padded. From 1.0 they are permanent and never reused; pre-1.0 a rule that should not have shipped may be removed and its id reclaimed. Rules receive plain Python types (`dict`, `list`, `str`, `int`, `bool`), never parser-specific types.
 - **Findings**: Dataclasses in `models.py`, not dicts.
 - **Formatters**: Modules in `formatters/` exposing `format(findings) -> str`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,76 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Upgrading
+
+**Rules now grade `${VAR:-default}` as the value it deploys, so files that
+passed may now fail.** With no `.env` and the variable unset, Compose ships the
+default — `privileged: ${P:-true}` deploys `privileged: true` — but only bind
+sources were being resolved, so every other rule compared its dangerous-value
+set against the literal text `"${P:-true}"` and found no match. Writing a
+dangerous value in interpolated form was a general-purpose bypass of twelve
+rules.
+
+Measured over the 5,417-file corpus: **286 files (5.3%) change findings, and
+100 (1.8%) go from pass to fail at the default `--fail-on high`.** One file
+goes the other way.
+
+| Trigger | before | after |
+|---|---|---|
+| `POSTGRES_PASSWORD: ${PW:-hunter2}` | *none* | **CL-0020** high |
+| `DATABASE_URL: postgres://${U:-u}:${P:-p}@db` | *none* | **CL-0021** high |
+| `image: nginx:${TAG:-latest}` | CL-0019 medium | **CL-0004** medium |
+| `ports: ["${BIND:-0.0.0.0}:80:80"]` | *none* | **CL-0005** medium |
+| `user: "${UID:-0}:${GID:-0}"` | *none* | **CL-0018** medium |
+| `mem_limit: "${MEM:-0}m"` | *none* | **CL-0026** medium |
+| `privileged: ${P:-true}` | *none* | **CL-0002** critical |
+
+The `image:` row is a reclassification, not a new failure: CL-0004 replaces
+CL-0019 at the same location and severity, because the tag resolves to the
+mutable `latest` rather than to an opaque `${TAG}`.
+
+Two changes go the other way and **remove** findings, both fixing false
+positives: a port whose default binds loopback (`"${PORT:-127.0.0.1:80}:80"`)
+no longer trips CL-0005, and an empty placeholder in a list-form entry
+(`- API_KEY=""`) no longer trips CL-0020 — the mapping form `API_KEY: ""` was
+already exempt.
+
+If a finding is genuinely parameterized in your deployment, that is what
+`.compose-lint.yml` suppressions are for. Writing the reference without a
+default (`${PW}` rather than `${PW:-hunter2}`) also stays exempt, because
+Compose then ships nothing.
+
 ### Changed
 
+- **`${VAR:-default}` is resolved document-wide before rules run.** The parser
+  normalizes every string leaf to the value Compose ships when the variable is
+  unset, so a rule classifies the deployed configuration instead of the source
+  text. Substitution had been wired into one call site (bind sources), leaving
+  CL-0002, CL-0004, CL-0005, CL-0008, CL-0009, CL-0010, CL-0011, CL-0014,
+  CL-0016, CL-0018, CL-0020, CL-0021, CL-0022, CL-0024, CL-0026 and the
+  capability rules grading a string that is never deployed. Doing it once in the
+  parser is what keeps it from being re-litigated per rule: a rule that adds a
+  dangerous literal to its set gets the interpolated spellings for free. See
+  **Upgrading** above for the measured impact. A reference with no default is
+  still left as written — Compose ships nothing for it, so there is nothing to
+  grade.
+- **The credential rules' interpolation exemption is stated as what Compose
+  does.** CL-0020 and CL-0021 previously skipped any value *containing* a
+  reference, so appending one character to a literal (`hunter2$X`) silenced
+  them, while Compose ships `hunter2`. The exemption is now "Compose resolves
+  this value to nothing", which also correctly exempts a quoted reference in a
+  list-form entry (`- SECRET_KEY="${KEY}"`, where the quotes are literal
+  characters) that a stricter shape test would have flagged.
+- **CL-0021's rule description** now says the password half is skipped when
+  Compose resolves it to nothing, and that a defaulted password still fires.
+  Visible in `--explain CL-0021`, the docs site and SARIF rule metadata.
+- **CL-0026 no longer treats an unparseable dollar-bearing value as a limit.**
+  `mem_limit: "${MEM:-0}m"` resolves to `0m`, which Docker reads as unlimited,
+  and now fires; a bare `${MEM_LIMIT}` stays exempt as genuinely unknowable.
+- Scalars longer than 8 KB are no longer scanned for interpolation. The two
+  substitution regexes are quadratic (measured 80 KB → 0.49 s, 160 KB →
+  1.94 s), and the pass above runs them over every string rather than bind
+  sources alone; past the cap the conservative answer is returned unscanned.
 - **A Compose file containing an ambiguous line break is now refused** (exit 2,
   reported per file, with a SARIF `toolExecutionNotifications` entry) instead of
   being linted with line numbers nothing else agrees with. A lone `\r`, U+0085,

--- a/docs/rules/CL-0020.md
+++ b/docs/rules/CL-0020.md
@@ -21,7 +21,7 @@
 Environment variable entries (both list form `KEY=value` and map form `KEY: value`) where:
 
 1. The **key name** matches a credential convention (case-insensitive substring or suffix match), AND
-2. The **value** is a non-empty literal string (not a `${VAR}` substitution, not a boolean/numeric flag).
+2. The **value** ships a non-empty literal string — not a `${VAR}` reference Compose resolves to nothing, and not a boolean/numeric flag.
 
 Matched key patterns:
 
@@ -36,7 +36,9 @@ Exemptions (key matches a credential pattern but the rule does **not** fire):
 - Keys containing `ALLOW_EMPTY_` or `RANDOM_` — image-startup boolean toggles (`MYSQL_ALLOW_EMPTY_PASSWORD: "yes"`, `MYSQL_RANDOM_ROOT_PASSWORD: "yes"`).
 - Values that are exactly `yes`, `no`, `true`, `false`, `on`, `off`, `0`, or `1` (case-insensitive) — boolean flags.
 - Empty values (`PASSWORD: ""` — env unset, not a credential).
-- Pure or partial `${VAR}` substitutions — the credential is parameterized and sourced from process env, which is the documented secure-ish pattern. Compose's escaped literal dollar (`$$`) does not count: `DB_PASSWORD: "pa$$w0rd"` is a literal credential containing `$`, so it fires.
+- Values Compose ships as empty — made only of references with no default (`${DB_PASSWORD}`, or `"${DB_PASSWORD}"` in a list-form entry, where the quotes are literal characters). The credential is parameterized and sourced from process env, the documented secure-ish pattern.
+
+    Two shapes that look similar but are **not** skipped, because the file ships a literal either way: a value that merely *contains* a reference (`hunter2$X` ships `hunter2` — one appended character used to silence this rule), and a *defaulted* reference (`${DB_PASSWORD:-hunter2}` ships `hunter2`, which is a hardcoded credential in every fresh clone). Compose's escaped literal dollar (`$$`) does not count as a reference either: `DB_PASSWORD: "pa$$w0rd"` is a literal credential containing `$`, so it fires.
 
 This rule is a **naming-convention check, not a content scanner**. It does not inspect the value for entropy, length, or provider-specific formats. A value of `changeme` fires, a 40-character production credential under `BILLING_ENDPOINT` does not. For value-side detection of credentials in URL-shaped env vars, see [CL-0021](CL-0021.md).
 

--- a/docs/rules/CL-0021.md
+++ b/docs/rules/CL-0021.md
@@ -30,11 +30,11 @@ services:
       AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow  # fires
 ```
 
-The value-side regex matches any URI scheme (`[a-zA-Z][a-zA-Z0-9+.\-]*`) followed by `://user:password@`, where the password half is non-empty and contains no `${VAR}`/`$VAR` variable substitution (Compose's escaped literal dollar, `$$`, is data, not a substitution — `pa$$w0rd` fires). The username half may be empty: RFC 3986 §3.2.1 permits it, and `redis://:password@host` — the standard Redis URL form — still leaks the password, so it fires.
+The value-side regex matches any URI scheme (`[a-zA-Z][a-zA-Z0-9+.\-]*`) followed by `://user:password@`, where the password half ships a non-empty literal — that is, it is not made up solely of `${VAR}`/`$VAR` references Compose resolves to nothing (Compose's escaped literal dollar, `$$`, is data, not a substitution — `pa$$w0rd` fires). The username half may be empty: RFC 3986 §3.2.1 permits it, and `redis://:password@host` — the standard Redis URL form — still leaks the password, so it fires.
 
 Skipped:
 
-- Password half contains `${VAR}` or `$VAR` — the credential is parameterized. (A `$`-valued *username* with a literal password still fires: the password leaks regardless. A password whose only dollars are `$$` escapes also fires — that is a literal `$` in the credential, not a substitution.)
+- Password half is made only of `${VAR}`/`$VAR` references with no default — Compose ships nothing there, so the credential is parameterized. (A `$`-valued *username* with a literal password still fires: the password leaks regardless. A password whose only dollars are `$$` escapes also fires — that is a literal `$` in the credential, not a substitution. A **defaulted** password such as `${DB_PASSWORD:-hunter2}` fires too: the default is what the file deploys.)
 - Userinfo password is empty (`scheme://user:@host`) — no credential to leak.
 - No userinfo at all (`scheme://host/path`) — nothing to flag.
 - Empty or non-string value.

--- a/docs/rules/CL-0026.md
+++ b/docs/rules/CL-0026.md
@@ -32,9 +32,12 @@ unbounded hard limit and is still flagged.
 **Neither does a non-positive value.** Docker reads `--memory 0` and `--cpus 0`
 as *unlimited*, so `mem_limit: 0` is an unbounded container wearing the syntax
 of a bounded one. The key being present is not enough; the value has to bound
-something. A `${VAR}` interpolation is treated as a limit — its value is
+something. A bare `${VAR}` interpolation is treated as a limit — its value is
 unknowable from the file, and assuming the worst would fire on every
-parameterised compose file.
+parameterised compose file. A **defaulted** interpolation is not unknowable:
+`mem_limit: "${MEM:-0}m"` ships `0m`, which Docker reads as unlimited, so it
+fires. Previously any dollar-bearing value that failed to parse as a quantity
+was credited as a limit, which let exactly that spelling through.
 
 ## Why it matters
 

--- a/docs/state-of-compose.md
+++ b/docs/state-of-compose.md
@@ -221,7 +221,7 @@ Read this section before citing any number from the report. The corpus is a desc
 ### Tool caveats
 
 - **Rules are based on hardening guidance, not on incident response data.** Each rule cites OWASP, CIS, or Docker docs. A rule firing means the file diverges from authoritative hardening guidance, not that an attacker would necessarily exploit the divergence on a given deployment.
-- **compose-lint does not validate the full Compose schema.** Files that fail to parse as v2/v3 Compose are bucketed by error class and reported as a separate population, not silently dropped. The parser does not resolve `${VAR}` interpolation or merge external `extends:` files; rules see what is written in the file, not the runtime resolution.
+- **compose-lint does not validate the full Compose schema.** Files that fail to parse as v2/v3 Compose are bucketed by error class and reported as a separate population, not silently dropped. The parser resolves `${VAR:-default}` interpolation to the value Compose ships when the variable is unset, so rules grade the deployed configuration rather than the source text; a reference with no default is left as written, and external `extends:` files are not merged.
 
 The framing is: *here is what people put in their Compose files at corpus scale, scored against published hardening guidance, with the sampling design and tool boundaries spelled out so you can re-rank, re-bucket, or re-run against your own corpus*. It is not a runtime risk assessment, a CVE database, or a population estimate.
 

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -631,6 +631,58 @@ def _resolved_bind_source(source: str, base_dir: Path) -> str | None:
     return None
 
 
+def _substitute_interpolation_defaults(data: Any) -> None:
+    """Rewrite every string leaf to the value Compose ships with no ``.env``.
+
+    Classification has to happen *after* canonicalization, not before. With
+    substitution wired into a single call site (bind sources), every other rule
+    compared its dangerous-value set against the literal text ``"${P:-true}"``
+    and found no match, while Compose deploys exactly ``true`` — verified with
+    ``docker compose config`` for ``privileged``, ``network_mode``, ``user``,
+    ``cap_add``, ``security_opt``, ``devices`` and image tags. Normalizing once
+    here is what keeps that from being re-litigated per rule: a rule that adds a
+    dangerous literal to its set gets the interpolated spellings for free, and
+    cannot forget to.
+
+    Only *values* are rewritten. Mapping keys are left alone because the
+    ``lines`` map is keyed by the raw key path, and rewriting a key would break
+    every line lookup that indexes it.
+
+    A reference with no default (``${VAR}``) is left exactly as written:
+    :func:`substitute_defaults` returns ``None`` for it, and inventing a value
+    would invent a finding. Walks are memoized by ``id`` so a document built
+    from YAML aliases is visited once per distinct object rather than once per
+    path through the alias graph.
+    """
+    seen: set[int] = set()
+
+    def resolve(value: str) -> str:
+        substituted = substitute_defaults(value)
+        return value if substituted is None else substituted
+
+    def walk(node: Any) -> None:
+        if isinstance(node, dict):
+            if id(node) in seen:
+                return
+            seen.add(id(node))
+            for key, value in node.items():
+                if isinstance(value, str):
+                    node[key] = resolve(value)
+                else:
+                    walk(value)
+        elif isinstance(node, list):
+            if id(node) in seen:
+                return
+            seen.add(id(node))
+            for index, value in enumerate(node):
+                if isinstance(value, str):
+                    node[index] = resolve(value)
+                else:
+                    walk(value)
+
+    walk(data)
+
+
 def _split_short_volume(volume: str) -> tuple[str, str, str]:
     """Split ``source:target[:mode]`` at the separator, ignoring ``${...}``.
 
@@ -808,6 +860,10 @@ def loads(
 
     lines = _collect_lines(raw, seq_lines)
     data = _strip_lines(raw)
+    # Canonicalize before anything classifies: rules and the extends/bind-source
+    # passes below all see the value the file actually ships (see the function's
+    # docstring for why this is document-wide rather than per rule).
+    _substitute_interpolation_defaults(data)
     _resolve_in_file_extends(data)
     if base_dir is not None:
         _resolve_bind_sources(data, base_dir)

--- a/src/compose_lint/rules/CL0020_credential_env_keys.py
+++ b/src/compose_lint/rules/CL0020_credential_env_keys.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from compose_lint.models import Finding, RuleMetadata, Severity
 from compose_lint.rules import BaseRule, register_rule
-from compose_lint.rules._interpolation import contains_var_ref
+from compose_lint.rules._interpolation import ships_no_literal
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -85,10 +85,14 @@ def _is_literal_credential_value(raw: Any) -> bool:
     - Booleans (a YAML `yes`/`no`/`true`/`false` toggle, not a credential)
     - Non-string, non-numeric, and empty-string values (env unset)
     - Boolean / numeric toggles like "yes", "true", "1"
-    - Any value containing a ${VAR} substitution (parameterized); the
-      credential is sourced from process env, which is the documented
-      secure-ish pattern. Compose's escaped literal dollar (`$$`) is not
-      a substitution, so `pa$$w0rd` still counts as literal (issue #502).
+    - Any value Compose ships as empty — one made only of references with
+      no default (`${PW}`, `"${PW}"`). The credential is sourced from process
+      env, the documented secure-ish pattern. A value that merely *contains* a
+      reference is not skipped: `hunter2$X` ships the literal `hunter2`, and a
+      *defaulted* reference ships its default, so `${PW:-hunter2}` is a
+      hardcoded credential (the parser resolves it before this rule runs).
+      Compose's escaped literal dollar (`$$`) is not a substitution, so
+      `pa$$w0rd` still counts as literal (issue #502).
 
     An unquoted numeric value (`DB_PASSWORD: 12345678`) decodes to a Python
     int/float; it is coerced to its string form so a numeric literal secret is
@@ -105,7 +109,7 @@ def _is_literal_credential_value(raw: Any) -> bool:
         return False
     if raw.strip().lower() in _FLAG_VALUES:
         return False
-    return not contains_var_ref(raw)
+    return not ships_no_literal(raw)
 
 
 def _iter_env(env_block: Any) -> Iterator[tuple[str, Any, int | None]]:

--- a/src/compose_lint/rules/CL0021_connection_string_credentials.py
+++ b/src/compose_lint/rules/CL0021_connection_string_credentials.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from compose_lint.models import Finding, RuleMetadata, Severity
 from compose_lint.rules import BaseRule, register_rule
-from compose_lint.rules._interpolation import contains_var_ref
+from compose_lint.rules._interpolation import ships_no_literal
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -57,8 +57,8 @@ def _iter_env(env_block: Any) -> Iterator[tuple[str, Any, int | None]]:
 def _find_inline_credential(value: str) -> tuple[str, str, str] | None:
     """Return (scheme, user, password) for an inline credential, else None.
 
-    Returns the first match whose *password* half is a literal. Only the
-    password being a `${VAR}` substitution means the secret is parameterized;
+    Returns the first match whose *password* half is a literal. Only a
+    password Compose ships as empty means the secret is parameterized;
     a substituted username with a literal password (e.g.
     `postgres://${DB_USER}:secret@db`) still leaks the credential, so it must
     not suppress the finding (issue #277 F6). The var-ref test is shared with
@@ -76,7 +76,7 @@ def _find_inline_credential(value: str) -> tuple[str, str, str] | None:
     for m in _URI_USERINFO_RE.finditer(value):
         user = m.group("user")
         password = m.group("password")
-        if contains_var_ref(password):
+        if ships_no_literal(password):
             continue
         return m.group("scheme"), user, password
     return None
@@ -102,8 +102,10 @@ class ConnectionStringCredentialsRule(BaseRule):
                 "config`, process listings, and CI logs. Where CL-0020 "
                 "matches credential-shaped *keys*, this rule matches "
                 "credential-shaped *values* regardless of the key name. "
-                "Skipped when either userinfo half is a `${VAR}` "
-                "substitution (the credential is parameterized)."
+                "Skipped when the password half is a `${VAR}` "
+                "substitution Compose resolves to nothing (the credential is "
+                "parameterized); a default such as `${PW:-hunter2}` is the "
+                "literal the file ships and still fires."
             ),
             severity=Severity.HIGH,
             references=[OWASP_REF, COMPOSE_SECRETS_REF, RFC3986_REF],

--- a/src/compose_lint/rules/CL0026_resource_limits.py
+++ b/src/compose_lint/rules/CL0026_resource_limits.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from compose_lint.models import Finding, RuleMetadata, Severity
 from compose_lint.rules import BaseRule, register_rule
+from compose_lint.rules._interpolation import ships_no_literal
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -85,11 +86,16 @@ def _is_set(value: Any) -> bool:
         try:
             return float(number) > 0
         except ValueError:
-            # A bare interpolation such as "${MEM_LIMIT}". Treat it as a limit:
-            # the value is unknowable from the file, and assuming the worst
-            # would fire on every parameterised compose file. Anything else is
-            # not a quantity Docker accepts, so it bounds nothing.
-            return "$" in text
+            # A *defaulted* interpolation never reaches here: the parser
+            # resolved it to the value the file ships, so "${MEM:-0}m" arrives
+            # as "0m" and parses as unbounded. A bare "${MEM_LIMIT}" is
+            # genuinely unknowable from this file and keeps its exemption —
+            # assuming the worst would fire on every parameterised stack.
+            # Anything else is not a quantity Docker accepts and so bounds
+            # nothing; the old "$" in text answer credited any unparseable
+            # dollar-bearing string as a limit, which is what let "${MEM:-0}m"
+            # through.
+            return ships_no_literal(text)
     return True
 
 

--- a/src/compose_lint/rules/_interpolation.py
+++ b/src/compose_lint/rules/_interpolation.py
@@ -1,25 +1,27 @@
-"""Shared classification of Compose variable substitution in env values."""
+"""Shared classification of Compose variable substitution.
+
+:func:`substitute_defaults` is applied by the parser to every string leaf in the
+document (``parser._substitute_interpolation_defaults``), so a rule compares
+against the value Compose actually ships rather than the ``${VAR:-...}`` source
+text. Rules therefore do **not** re-implement interpolation handling; the one
+question left for them is whether a value that *survived* normalization ships
+anything literal at all, which :func:`ships_no_literal` answers.
+"""
 
 from __future__ import annotations
 
 import re
 
+# Upper bound on a scalar these regexes will scan. Both the pattern below and
+# the two in `substitute_defaults` are quadratic on pathological input (measured
+# 4x per doubling: 80 KB -> 0.49 s, 160 KB -> 1.94 s), and the parser now runs
+# substitution over *every* string in the document rather than bind sources
+# alone. A Compose scalar this long carries no classification signal worth that
+# cost, so beyond the cap the conservative answer is returned without scanning.
+_MAX_SCAN_LEN = 8192
+
 # An active variable substitution ("${VAR}", "${VAR:-default}", "$VAR").
 _VAR_REF_RE = re.compile(r"\$\{[^}]+\}|\$[A-Za-z_][A-Za-z0-9_]*")
-
-
-def contains_var_ref(value: str) -> bool:
-    """Return True if ``value`` contains a ``$VAR``/``${VAR}`` substitution.
-
-    Compose writes a literal dollar as ``$$`` and consumes those escapes
-    left-to-right before interpolation, so ``pa$$w0rd`` is a literal
-    credential, not a reference to ``$w0rd`` (issue #502). ``str.replace``
-    removes non-overlapping ``$$`` pairs in the same left-to-right order,
-    so exactly the dollars Compose would treat as syntax remain to be
-    tested against the reference pattern.
-    """
-    return _VAR_REF_RE.search(value.replace("$$", "")) is not None
-
 
 # "${VAR:-default}" and "${VAR-default}". Compose distinguishes them -- ":-"
 # substitutes when unset *or empty*, "-" only when unset -- but both yield the
@@ -33,6 +35,39 @@ _VAR_DEFAULT_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*):?-([^}]*)\}")
 _VAR_NO_DEFAULT_RE = re.compile(
     r"\$\{[A-Za-z_][A-Za-z0-9_]*(:?[?+][^}]*)?\}|\$[A-Za-z_][A-Za-z0-9_]*"
 )
+
+
+def ships_no_literal(value: str) -> bool:
+    """Whether Compose ships ``value`` as empty, leaving nothing to classify.
+
+    This is the exemption a credential rule should grant, and it is stated as
+    what Compose *does* rather than as a shape the text happens to have. An
+    unset reference with no default substitutes to nothing — ``${PW}`` ships
+    ``POSTGRES_PASSWORD: ""`` (verified with ``docker compose config``) — so a
+    value made only of such references carries no secret.
+
+    Asking instead whether a value merely *contains* a reference exempted
+    ``hunter2$X``, which ships the literal ``hunter2``: one appended character
+    silenced the rule. Asking whether it is *exactly* one reference is the
+    opposite error — it flagged ``- SECRET_KEY="${PLANKA_SECRET_KEY}"``, where
+    the quotes are literal characters of a list-form entry and the secret is
+    properly externalized (8 such values across the corpus). Resolving to empty
+    is the test that gets both right.
+
+    ``$$`` is Compose's literal-dollar escape, consumed before interpolation,
+    so stripping the escapes first leaves exactly the dollars Compose treats as
+    syntax. A *defaulted* reference is deliberately not removed: its default is
+    the literal the file ships.
+    """
+    if len(value) > _MAX_SCAN_LEN:
+        return False  # too long to classify; not exempt
+    text = value.replace("$$", "")
+    # A list-form entry ("- KEY=value") is one plain scalar, so quotes around
+    # the value are literal characters rather than YAML syntax. They carry no
+    # secret, so judge what they wrap.
+    if len(text) >= 2 and text[0] == text[-1] and text[0] in "\"'":
+        text = text[1:-1]
+    return _VAR_NO_DEFAULT_RE.sub("", text) == ""
 
 
 def substitute_defaults(value: str) -> str | None:
@@ -50,6 +85,11 @@ def substitute_defaults(value: str) -> str | None:
     file do on its own", not "what will it do in your deployment", and a
     deployment that sets the variable is the case suppressions exist for.
     """
+    if len(value) > _MAX_SCAN_LEN:
+        # Conservative: report the value as unknowable rather than spend
+        # quadratic time proving it. Callers leave such a scalar as written,
+        # which is exactly the behavior before substitution was document-wide.
+        return None
     escaped = value.replace("$$", "")
     if not _VAR_REF_RE.search(escaped):
         return value  # nothing to substitute

--- a/tests/test_CL0020.py
+++ b/tests/test_CL0020.py
@@ -195,19 +195,26 @@ class TestCredentialEnvKeysRule:
         findings = self._check("skip_pure_var_ref")
         assert findings == []
 
-    def test_skip_pure_var_with_default(self) -> None:
+    def test_defaulted_var_is_graded_on_the_value_it_ships(self) -> None:
+        # "${POSTGRES_PASSWORD:-fallback}" ships the literal "fallback" with no
+        # .env set (verified with `docker compose config`), so the credential is
+        # in the file and the rule must say so. Previously exempted for carrying
+        # a reference at all, which made the default a free bypass.
         findings = self._check("skip_pure_var_default")
-        assert findings == []
+        assert len(findings) == 1
+        assert findings[0].rule_id == "CL-0020"
 
     def test_skip_short_var(self) -> None:
         findings = self._check("skip_short_var")
         assert findings == []
 
-    def test_skip_mixed_var_reference(self) -> None:
-        # Per design: any ${VAR} present → skip. Corpus shows 1 case in
-        # 1554 files; not worth bespoke handling.
+    def test_mixed_var_reference_is_not_exempt(self) -> None:
+        # Only a value that is *wholly* a reference is unknowable. A value that
+        # merely contains one still ships its literal part: "hunter2$X" ships
+        # "hunter2". The old "any reference → skip" rule made appending one
+        # character enough to silence the rule on a hardcoded credential.
         findings = self._check("skip_mixed_var_reference")
-        assert findings == []
+        assert len(findings) == 1
 
     # ---- $$ escape: a literal dollar is not a substitution (issue #502) ----
 

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -1,0 +1,157 @@
+"""Tests for interpolation normalization (``rules/_interpolation`` + the parser pass).
+
+Classification has to happen after canonicalization. With substitution wired
+into a single call site, every rule but one compared its dangerous-value set
+against the literal text ``"${P:-true}"`` while Compose deploys ``true``, so
+``${VAR:-danger}`` was a general-purpose bypass.
+
+Every expectation about what Compose ships was captured with
+``docker compose config`` on Docker Compose 29.7.2 and is named in the test that
+relies on it, rather than reasoned from the substitution syntax.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from compose_lint.parser import loads
+from compose_lint.rules._interpolation import (
+    _MAX_SCAN_LEN,
+    ships_no_literal,
+    substitute_defaults,
+)
+
+# --- The parser normalizes the whole document ------------------------------
+
+
+@pytest.mark.parametrize(
+    "field,written,shipped",
+    [
+        # Each row was confirmed with `docker compose config`: an unset variable
+        # makes Compose deploy the default verbatim. Substitution yields a
+        # *string* — YAML already typed the scalar as one — so a rule reads it
+        # through `as_bool`/the normalizers rather than as a native bool.
+        ("privileged", "${P:-true}", "true"),
+        ("network_mode", "${NM:-host}", "host"),
+        ("user", "${U:-root}", "root"),
+        ("pid", "${PID:-host}", "host"),
+        ("image", "nginx:${T:-latest}", "nginx:latest"),
+        # A default containing a literal tail keeps it.
+        ("working_dir", "${D:-/srv}/data", "/srv/data"),
+        # Partial interpolation: `pre${U:-root}post` ships `prerootpost`.
+        ("user", "pre${U2:-root}post", "prerootpost"),
+    ],
+)
+def test_defaulted_values_are_normalized(
+    field: str, written: str, shipped: object
+) -> None:
+    data, _lines = loads(f"services:\n  web:\n    {field}: {written}\n")
+    assert data["services"]["web"][field] == shipped
+
+
+def test_reference_without_a_default_is_left_as_written() -> None:
+    """Nothing to resolve to, and inventing a value would invent a finding."""
+    data, _lines = loads("services:\n  web:\n    image: nginx:${TAG}\n")
+    assert data["services"]["web"]["image"] == "nginx:${TAG}"
+
+
+def test_normalization_reaches_nested_lists_and_maps() -> None:
+    data, _lines = loads(
+        "services:\n"
+        "  web:\n"
+        "    image: nginx:1.25\n"
+        "    cap_add:\n"
+        "      - ${C:-SYS_ADMIN}\n"
+        "    volumes:\n"
+        "      - type: ${VT:-bind}\n"
+        "        source: /srv\n"
+        "        target: /out\n"
+    )
+    web = data["services"]["web"]
+    assert web["cap_add"] == ["SYS_ADMIN"]
+    assert web["volumes"][0]["type"] == "bind"
+
+
+def test_mapping_keys_are_not_rewritten() -> None:
+    """Keys index the ``lines`` map; rewriting one would break every lookup."""
+    source = (
+        "services:\n  web:\n    image: nginx:1.25\n    environment:\n      ${K:-A}: v\n"
+    )
+    data, lines = loads(source)
+    assert "${K:-A}" in data["services"]["web"]["environment"]
+    assert any(path.endswith("${K:-A}") for path in lines)
+
+
+def test_alias_shared_nodes_are_visited_once() -> None:
+    """The walk is id-memoized, so an alias DAG cannot blow up or double-apply."""
+    data, _lines = loads(
+        "x-common: &common\n"
+        "  user: ${U:-root}\n"
+        "services:\n"
+        "  a:\n"
+        "    image: nginx:1.25\n"
+        "    <<: *common\n"
+        "  b:\n"
+        "    image: nginx:1.25\n"
+        "    <<: *common\n"
+    )
+    assert data["services"]["a"]["user"] == "root"
+    assert data["services"]["b"]["user"] == "root"
+
+
+# --- ships_no_literal: the exemption, stated as what Compose does ----------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "${PW}",  # ships ""
+        "$PW",
+        "${PW:?err}",
+        "${A}${B}",
+        '"${PW}"',  # list-form entry: the quotes are literal characters
+        "'${PW}'",
+        "",
+    ],
+)
+def test_values_that_ship_nothing_are_exempt(value: str) -> None:
+    assert ships_no_literal(value) is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "hunter2$X",  # ships "hunter2" — the VULN-006 bypass
+        "prefix-${TOKEN}",  # ships "prefix-"
+        "hunter2",
+        "${PW:-hunter2}",  # a default is a literal the file ships
+        "$${PW}",  # `$$` is an escaped dollar, not a reference
+    ],
+)
+def test_values_that_ship_a_literal_are_not_exempt(value: str) -> None:
+    assert ships_no_literal(value) is False
+
+
+# --- The length cap that keeps the document-wide pass affordable -----------
+
+
+def test_substitute_defaults_declines_an_oversized_scalar() -> None:
+    """Both regexes are quadratic; past the cap, answer without scanning.
+
+    Returning ``None`` is the conservative answer — callers leave the scalar as
+    written, which is what happened before substitution went document-wide.
+    """
+    assert substitute_defaults("${A:-b}" * 10) == "b" * 10
+    assert substitute_defaults("${a-" * (_MAX_SCAN_LEN // 2)) is None
+
+
+def test_ships_no_literal_declines_an_oversized_scalar() -> None:
+    assert ships_no_literal("${PW}" + "x" * _MAX_SCAN_LEN) is False
+
+
+def test_oversized_scalar_is_left_intact_by_the_parser() -> None:
+    big = "${A:-b}" * (_MAX_SCAN_LEN // 4)
+    data, _lines = loads(
+        f"services:\n  web:\n    image: nginx:1.25\n    command: {big}\n"
+    )
+    assert data["services"]["web"]["command"] == big

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -290,10 +290,13 @@ class TestLoadCompose:
         assert "services" in data
         assert "web" in data["services"]
 
-    def test_env_interpolation_preserved(self) -> None:
+    def test_defaulted_interpolation_is_resolved(self) -> None:
+        # The parser normalizes "${VAR:-default}" document-wide to the value
+        # Compose ships with no .env, so rules classify what is deployed rather
+        # than the source text. A reference with no default stays as written.
         data, _lines = load_compose(FIXTURES / "valid_env_interpolation.yml")
         app = data["services"]["app"]
-        assert "${APP_VERSION:-latest}" in app["image"]
+        assert app["image"] == "myapp:latest"
 
     def test_file_not_found(self) -> None:
         with pytest.raises(FileNotFoundError):


### PR DESCRIPTION
Resolves six findings from a [VulnHunter](https://github.com/capitalone/vulnhunter) security audit of this repository (tracked internally as VULN-006, 008, 011, 048, 049, 050, 051). They share one root cause and one fix.

## The defect

With no `.env` and the variable unset, Compose substitutes the default — `privileged: ${P:-true}` deploys `privileged: true`. Confirmed with `docker compose config` for `privileged`, `network_mode`, `user`, `pid`, `cap_add`, `security_opt`, `devices` and image tags.

`substitute_defaults` was wired into exactly one call site (bind sources), so every other rule compared its dangerous-value set against the literal text `"${P:-true}"` and found no match. **Writing a dangerous value in interpolated form was a general-purpose bypass of twelve rules**, including CL-0002 (critical).

## The fix

Normalize the whole document once in `parser.loads`, after the line map is built and before anything classifies. Per-rule handling would mean each rule re-deriving interpolation semantics and each new rule remembering to; doing it in the parser means a rule that adds a dangerous literal to its set gets the interpolated spellings for free.

- Only *values* are rewritten — the `lines` map is keyed by the raw key path.
- The walk is `id`-memoized, so an alias DAG is visited once per object, not once per path.
- A reference with no default is left as written: Compose ships nothing for it, so there is nothing to grade.

**The credential exemption is now stated as what Compose does, not as a shape the text has.** Skipping any value that *contained* a reference let one appended character silence CL-0020/CL-0021 on a literal secret (`hunter2$X` ships `hunter2`). Skipping only a value that is *exactly* one reference is the opposite error — it flags `- SECRET_KEY="${KEY}"`, where the quotes are literal characters of a list-form entry. The test that gets both right is whether Compose resolves the value to nothing.

**CL-0026's `"$" in text` fallback is gone.** It credited any unparseable dollar-bearing string as a limit, so `mem_limit: "${MEM:-0}m"` — an uncapped container — passed as bounded. A bare `${MEM_LIMIT}` stays exempt.

**Interpolation scanning is capped at 8 KB.** Both substitution regexes are quadratic (measured 80 KB → 0.49 s, 160 KB → 1.94 s) and this change runs them over every string rather than bind sources alone. Without the cap the fix would have made that cost materially worse.

## Behavior change — this one is large

Measured over the 5,417-file corpus, patched vs `main`:

```
286 files (5.3%) change findings
100 files (1.8%) go from pass to FAIL at the default --fail-on high
  1 file goes from FAIL to pass

ADDED    CL-0020 +494   CL-0004 +288   CL-0021 +104   CL-0005 +21   CL-0018 +6
REMOVED  CL-0019 -288   CL-0005 -12    CL-0020  -5
```

Note `scripts/corpus/run.py` records exit codes at `--fail-on low`, where any finding fails; the 100/1 figures come from re-running both versions at the real default gate.

**The CL-0004/CL-0019 swap is a reclassification, not a new failure** — verified 1:1, every one at the same `service:line`, same severity. `image: ${REPO:-stackstorm/}api:${VER:-latest}` resolves to a `latest` tag, so "mutable tag" replaces "tag without digest".

**The new credential findings are real:**
```
ADMIN_PASSWORD=${ADMIN_PASSWORD:-admin}
JWT_SECRET=${JWT_SECRET:-your-secret-key-change-in-production}
POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
```

**Both removal sets are false positives being fixed**, checked individually:
- CL-0005 −12: `"${ST2_EXPOSE_HTTP:-127.0.0.1:80}:80"` binds loopback, not all interfaces.
- CL-0020 −5: `- API_KEY=""` is an empty placeholder; the mapping form `API_KEY: ""` was already exempt.

Semver: **minor**. `CHANGELOG.md` carries an `Upgrading` section with the trigger table.

## Surfaces updated

`AGENTS.md`/`CLAUDE.md` and `docs/state-of-compose.md` both stated the parser "leaves `${VAR}` unresolved" — no longer true. `docs/rules/CL-0020.md`, `CL-0021.md` and `CL-0026.md` documented the old exemption. CL-0021's rule `description` also changed, which is user-visible in `--explain`, the docs site and SARIF rule metadata.

## Tests

26 new tests in `tests/test_interpolation.py` covering the document-wide pass (nested lists/maps, keys left alone, alias memoization), the exemption predicate in both directions, and the length cap. Three existing tests encoded the old behavior and were updated with the reason; one of them, `test_skip_mixed_var_reference`, carried the explicit note *"Per design: any ${VAR} present → skip"* — that decision is what VULN-006 overturns.

Full suite 1553 passed / 6 skipped; `ruff check`, `ruff format --check`, `mypy src/` clean.
