### PR TITLE
Fail closed when part of the stack was not linted

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ CRITICAL > HIGH > MEDIUM > LOW. A rule's severity is **derived**, not chosen: it
 
 - 0: No findings at/above threshold
 - 1: Findings at/above threshold
-- 2: Usage error (bad args, file not found, invalid Compose)
+- 2: Usage error (bad args, file not found, invalid Compose) **or a coverage gap** — unresolved `include:` / cross-file `extends:`, where part of the stack was never linted. `--allow-partial-coverage` downgrades the gap to a stderr warning. `fix` reports gaps but never fails on them; it is not the gate.
 - Default threshold: HIGH. Configurable via `--fail-on`.
 
 ## CLI output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Upgrading
 
+**A file compose-lint cannot fully see is now an error (exit 2), not a pass.**
+`include:` and cross-file `extends: {file: ...}` reference services in other
+files, and compose-lint reads single files without following them — so those
+services were never linted. The gap was reported on stderr for `include:` and
+not at all for `extends:`, while the verdict, exit code, JSON `errors` and SARIF
+`executionSuccessful` all said the run was clean. A base carrying
+`privileged: true` and `network_mode: host` could sit unlinted behind a green
+check.
+
+Measured over the 5,417-file corpus: **31 files (0.6%) change exit code — 20
+from pass to error, 11 from fail to error.** Findings for the local services are
+still reported; the file is graded on what could be seen *and* the gap is
+recorded.
+
+```bash
+# Cover everything by linting the merged output (compose-lint reads files,
+# not stdin, so write it out first):
+docker compose config > merged.yml && compose-lint merged.yml
+
+# Or accept the gap and grade only what is visible:
+compose-lint --allow-partial-coverage docker-compose.yml
+```
+
+`fix` reports gaps but never fails on them — it is not the merge gate.
+
 **Rules now grade `${VAR:-default}` as the value it deploys, so files that
 passed may now fail.** With no `.env` and the variable unset, Compose ships the
 default — `privileged: ${P:-true}` deploys `privileged: true` — but only bind
@@ -48,6 +73,17 @@ Compose then ships nothing.
 
 ### Changed
 
+- **Coverage gaps are reported on every channel a consumer reads.** An
+  unresolved `include:` or cross-file `extends: {file: ...}` now produces a JSON
+  `errors[]` entry, a SARIF `toolExecutionNotifications` record with
+  `executionSuccessful: false`, and exit 2 — previously a stderr warning for
+  `include:` and complete silence for `extends:`. `parser.coverage_gaps(data)`
+  exposes the same list to library callers. The text verdict counts them
+  separately from parse failures, because those files parsed fine and saying
+  otherwise would misdescribe the run. See **Upgrading** above.
+- **New `--allow-partial-coverage` flag on `check`** to accept a coverage gap
+  and grade what is visible. It waives the gap, not the findings: a local
+  CRITICAL still fails the gate.
 - **`${VAR:-default}` is resolved document-wide before rules run.** The parser
   normalizes every string leaf to the value Compose ships when the variable is
   unset, so a rule classifies the deployed configuration instead of the source

--- a/README.md
+++ b/README.md
@@ -258,6 +258,8 @@ check options:
   -v, --verbose                Repeat the fix block and reference on every finding (text mode)
   -q, --quiet                  One line per finding — no fix, reference, or excerpt (text mode)
   --skip-suppressed            Hide suppressed findings from output
+  --allow-partial-coverage     Grade a file whose `include:` / cross-file `extends:`
+                               could not be resolved, instead of failing (exit 2)
   --config PATH                Path to config file (default: .compose-lint.yml)
   --strict-config              Treat config diagnostics (unknown rule id or key) as errors, not warnings
   --explain CL-XXXX            Print the full documentation for a single rule
@@ -370,7 +372,9 @@ CI log that renders ANSI.
 |------|---------|
 | 0 | No findings at or above the `--fail-on` threshold |
 | 1 | One or more findings at or above the `--fail-on` threshold |
-| 2 | compose-lint couldn't run (invalid args, file not found, invalid Compose file, or a rule crashed) |
+| 2 | compose-lint couldn't run, or couldn't see the whole stack (invalid args, file not found, invalid Compose file, a rule crashed, or a coverage gap — see below) |
+
+**Coverage gaps.** compose-lint reads single files and does no I/O to follow references out of them, so `include:` and cross-file `extends: {file: ...}` leave part of the stack unlinted. Reporting a pass over a partial view is the one failure mode a merge gate cannot have, so a gap is an error: exit 2, a JSON `errors[]` entry, and a SARIF `toolExecutionNotifications` record. Lint the merged output (`docker compose config`) to cover everything, or pass `--allow-partial-coverage` to accept the gap and grade what is visible.
 
 The default threshold is `high` — medium and low findings don't fail CI unless you opt in:
 

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -38,7 +38,12 @@ from compose_lint.formatters.text import (
 )
 from compose_lint.formatters.text import format_findings as format_text
 from compose_lint.models import Finding, Severity
-from compose_lint.parser import ComposeError, ComposeNotApplicableError, load_compose
+from compose_lint.parser import (
+    ComposeError,
+    ComposeNotApplicableError,
+    coverage_gaps,
+    load_compose,
+)
 
 
 def _severity_type(value: str) -> Severity:
@@ -159,6 +164,17 @@ def _add_check_subparser(
         action="store_true",
         default=False,
         help="hide suppressed findings from output",
+    )
+    check.add_argument(
+        "--allow-partial-coverage",
+        action="store_true",
+        default=False,
+        help=(
+            "grade a file even though part of its stack could not be linted "
+            "(unresolved 'include:' or cross-file 'extends:'). Without this, "
+            "such a gap is an error (exit 2) so a merge gate cannot pass on a "
+            "partial view; with it, the gap is reported on stderr only"
+        ),
     )
     verbosity = check.add_mutually_exclusive_group()
     verbosity.add_argument(
@@ -335,21 +351,30 @@ def main(argv: list[str] | None = None) -> NoReturn:
     _run_check(args)
 
 
-def _warn_unresolved_include(filepath: str, data: dict[str, Any]) -> None:
-    """Warn that `include:` brings in services compose-lint does not lint.
+def _report_coverage_gaps(
+    filepath: str, data: dict[str, Any], *, fatal: bool
+) -> list[tuple[str, str]]:
+    """Report parts of ``filepath`` that were not linted; return them if fatal.
 
-    An include-*only* file is rejected at parse (ComposeError); here `include`
-    coexists with `services`, so the local services lint normally but services
-    from the included files are invisible. Surface the coverage gap (issue
-    #516) rather than reporting a clean pass over a partial view.
+    A coverage gap used to be a stderr warning, which is the one channel no
+    machine consumer reads: the verdict, the exit code, JSON ``errors`` and
+    SARIF ``executionSuccessful`` all still said clean while a service carrying
+    ``privileged: true`` sat unparsed in an included file. For a tool whose
+    shipped deployment model is a merge gate, "I could not see all of it" has
+    to reach the same channels as "I found something".
+
+    Returned entries join the parse-error channel, so they surface as JSON
+    ``errors[]`` and SARIF ``toolExecutionNotifications`` and force exit 2.
+    With ``--allow-partial-coverage`` the gap is stated on stderr and the run
+    is graded on what could be seen.
     """
-    if "include" in data:
-        print(
-            f"Warning: {filepath}: 'include:' is not resolved; services from "
-            "included files are not linted. Lint the merged output "
-            "(docker compose config) to cover them.",
-            file=sys.stderr,
-        )
+    gaps = coverage_gaps(data)
+    if not gaps:
+        return []
+    label = "Error" if fatal else "Warning"
+    for gap in gaps:
+        print(f"{label}: {filepath}: {gap}", file=sys.stderr)
+    return [(filepath, gap) for gap in gaps] if fatal else []
 
 
 def _run_check(args: argparse.Namespace) -> NoReturn:
@@ -420,6 +445,7 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
     all_sarif: list[dict[str, object]] = []
     all_file_findings: list[tuple[list[Finding], str]] = []
     parse_errors: list[tuple[str, str]] = []
+    coverage_errors: list[tuple[str, str]] = []
     rule_errors: list[tuple[str, str]] = []
     has_errors = False
     seen_services: set[str] = set()
@@ -437,7 +463,9 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
             parse_errors.append((filepath, _report_parse_error(filepath, e)))
             continue
 
-        _warn_unresolved_include(filepath, data)
+        coverage_errors.extend(
+            _report_coverage_gaps(filepath, data, fatal=not args.allow_partial_coverage)
+        )
         seen_services.update(data.get("services", {}).keys())
 
         def _record_rule_error(
@@ -515,25 +543,42 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
                     file=sys.stderr,
                 )
 
+    # Coverage gaps ride the same structured channel as parse errors — JSON
+    # `errors[]`, SARIF `toolExecutionNotifications`, exit 2 — but are counted
+    # separately in the text verdict, because "could not be parsed" is not what
+    # happened and the tool must not report a state that is not true.
+    run_errors = parse_errors + coverage_errors
+
     if args.output_format == "text":
         if len(args.files) > 1:
             print()
-            print(format_aggregate_summary(all_file_findings, len(parse_errors)))
-        print(format_verdict(all_file_findings, args.fail_on, len(parse_errors)))
+            print(
+                format_aggregate_summary(
+                    all_file_findings, len(parse_errors), len(coverage_errors)
+                )
+            )
+        print(
+            format_verdict(
+                all_file_findings,
+                args.fail_on,
+                len(parse_errors),
+                len(coverage_errors),
+            )
+        )
     elif args.output_format == "json":
         # allow_nan=False makes a stray float NaN/Infinity raise rather than emit
         # bare `NaN`/`Infinity` tokens, which RFC 8259 forbids and strict parsers
         # reject. The formatter already coerces `service` to str, so this guards
         # any future numeric field; the same applies to the SARIF dump below.
-        json_log = build_json_log(all_json, parse_errors)
+        json_log = build_json_log(all_json, run_errors)
         print(json.dumps(json_log, indent=2, allow_nan=False))
     elif args.output_format == "sarif":
         sarif_log = build_sarif_log(
-            all_sarif, parse_errors, severity_overrides=severity_overrides
+            all_sarif, run_errors, severity_overrides=severity_overrides
         )
         print(json.dumps(sarif_log, indent=2, allow_nan=False))
 
-    if parse_errors or rule_errors:
+    if run_errors or rule_errors:
         sys.exit(2)
     sys.exit(1 if has_errors else 0)
 
@@ -611,7 +656,7 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
             had_error = True
             continue
 
-        _warn_unresolved_include(filepath, data)
+        _report_coverage_gaps(filepath, data, fatal=False)
 
         try:
             # newline="" preserves the file's original line endings: read_text's

--- a/src/compose_lint/formatters/text.py
+++ b/src/compose_lint/formatters/text.py
@@ -417,12 +417,15 @@ def format_summary(
 def format_aggregate_summary(
     file_findings: list[tuple[list[Finding], str]],
     parse_error_count: int = 0,
+    coverage_gap_count: int = 0,
 ) -> str:
     """Format a combined summary line across all scanned files (multi-file runs).
 
     ``parse_error_count`` is the number of input files that could not be
     parsed; surfaced inline as ``N skipped (failed to parse)`` so multi-file
     runs make skipped files visible in the same place as the totals.
+    ``coverage_gap_count`` counts files that parsed but were only partly
+    linted, which is a different failure and is labelled as one.
     """
     total_files = len(file_findings)
     by_severity: dict[str, int] = {}
@@ -441,9 +444,15 @@ def format_aggregate_summary(
     sep = _colorize("·", _DIM)
 
     skipped_suffix = ""
+    notes = []
     if parse_error_count:
-        skipped_text = f"{parse_error_count} skipped (failed to parse)"
-        skipped_suffix = f"  {sep}  {_colorize(skipped_text, _COLORS[Severity.HIGH])}"
+        notes.append(f"{parse_error_count} skipped (failed to parse)")
+    if coverage_gap_count:
+        notes.append(f"{coverage_gap_count} partly unlinted (coverage gap)")
+    if notes:
+        skipped_suffix = (
+            f"  {sep}  {_colorize(', '.join(notes), _COLORS[Severity.HIGH])}"
+        )
 
     if total_issues == 0 and suppressed_total == 0:
         body = _colorize("no issues found", _GREEN)
@@ -491,6 +500,7 @@ def format_verdict(
     file_findings: list[tuple[list[Finding], str]],
     fail_on: Severity,
     parse_error_count: int = 0,
+    coverage_gap_count: int = 0,
 ) -> str:
     """Return the verdict line, matching the CLI's three exit-code outcomes.
 
@@ -499,6 +509,11 @@ def format_verdict(
     reader can tell a broken-input problem from an insecure-config one. A
     passing run that still has sub-threshold findings names them, so the
     ``✓ PASS`` line does not read as "nothing found".
+
+    ``coverage_gap_count`` shares the ``⚠ ERROR`` verdict and exit 2 but is
+    worded separately: those files parsed fine, and saying they "could not be
+    parsed" would misdescribe what happened. What went wrong is that part of
+    the stack was never linted.
     """
     failing = sum(
         1
@@ -509,11 +524,19 @@ def format_verdict(
 
     sep = _colorize("·", _DIM)
 
-    if parse_error_count:
-        file_word = "file" if parse_error_count == 1 else "files"
-        parsed_text = f"{parse_error_count} {file_word} could not be parsed"
+    if parse_error_count or coverage_gap_count:
+        parts = []
+        if parse_error_count:
+            file_word = "file" if parse_error_count == 1 else "files"
+            parts.append(f"{parse_error_count} {file_word} could not be parsed")
+        if coverage_gap_count:
+            gap_word = "gap" if coverage_gap_count == 1 else "gaps"
+            parts.append(
+                f"{coverage_gap_count} coverage {gap_word}: "
+                "part of the stack was not linted"
+            )
         error_label = _colorize("⚠ ERROR", _ERROR_COLOR)
-        result = f"{error_label}  {sep}  {_colorize(parsed_text, _ERROR_COLOR)}"
+        result = f"{error_label}  {sep}  {_colorize(', '.join(parts), _ERROR_COLOR)}"
         if failing:
             word = "finding" if failing == 1 else "findings"
             result += f"  {sep}  {failing} {word} at or above {fail_on.value}"

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -631,6 +631,50 @@ def _resolved_bind_source(source: str, base_dir: Path) -> str | None:
     return None
 
 
+def coverage_gaps(data: dict[str, Any]) -> list[str]:
+    """Describe every part of ``data`` compose-lint could not actually lint.
+
+    compose-lint reads single files and does no I/O to follow references out of
+    them, so two spellings leave services ungraded: ``include:`` alongside
+    ``services:`` (the included files' services are never seen) and
+    ``extends: {file: ...}`` (the base is never merged, so the child is graded
+    on its own keys only). Both are invisible in the result — the run reports a
+    clean pass over a partial view, which for a merge gate is the one failure
+    mode that matters.
+
+    Returned as messages rather than raised, because the local services *can*
+    still be linted usefully; the caller decides whether the gap is fatal. An
+    ``include``-only file has no local services at all and is already rejected
+    at parse time, which is the precedent this generalizes.
+    """
+    gaps: list[str] = []
+    services = data.get("services")
+    if "include" in data and isinstance(services, dict):
+        gaps.append(
+            "'include:' is not resolved, so services from the included files "
+            "were not linted. Lint the merged output (docker compose config) "
+            "to cover them, or pass --allow-partial-coverage to accept the gap."
+        )
+    if isinstance(services, dict):
+        unmerged = sorted(
+            name
+            for name, config in services.items()
+            if isinstance(config, dict)
+            and isinstance(config.get("extends"), dict)
+            and config["extends"].get("file")
+        )
+        if unmerged:
+            listed = ", ".join(repr(name) for name in unmerged)
+            gaps.append(
+                f"cross-file 'extends: {{file: ...}}' is not resolved, so "
+                f"{listed} {'was' if len(unmerged) == 1 else 'were'} graded "
+                "without the inherited base. Lint the merged output "
+                "(docker compose config) to cover it, or pass "
+                "--allow-partial-coverage to accept the gap."
+            )
+    return gaps
+
+
 def _substitute_interpolation_defaults(data: Any) -> None:
     """Rewrite every string leaf to the value Compose ships with no ``.env``.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -139,15 +139,29 @@ class TestCLI:
         assert result.returncode == 2
         assert "include" in result.stderr.lower()
 
-    def test_include_with_services_warns_and_still_lints(self, tmp_path: Path) -> None:
-        # When include coexists with services, the local services lint normally
-        # but a warning flags that the included files are not covered.
+    def test_include_with_services_is_a_coverage_error(self, tmp_path: Path) -> None:
+        # The local services still lint, but the included files were never seen,
+        # so the run cannot claim a verdict over the whole stack: exit 2, not the
+        # exit 1 that says "I checked this and it failed" (nor the exit 0 it used
+        # to give when nothing local was wrong).
         f = tmp_path / "docker-compose.yml"
         f.write_text(
             "include:\n  - base.yml\n"
             "services:\n  web:\n    image: nginx:1.27\n    privileged: true\n"
         )
         result = run_cli(str(f))
+        assert result.returncode == 2
+        assert "CL-0002" in result.stdout
+        assert "include" in result.stderr.lower()
+
+    def test_include_gap_can_be_accepted_explicitly(self, tmp_path: Path) -> None:
+        # Opting in grades what could be seen and returns the normal verdict.
+        f = tmp_path / "docker-compose.yml"
+        f.write_text(
+            "include:\n  - base.yml\n"
+            "services:\n  web:\n    image: nginx:1.27\n    privileged: true\n"
+        )
+        result = run_cli("--allow-partial-coverage", str(f))
         assert result.returncode == 1
         assert "CL-0002" in result.stdout
         assert "include" in result.stderr.lower()

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -1,0 +1,227 @@
+"""A coverage gap must reach every channel a consumer reads.
+
+compose-lint's shipped deployment model is a merge gate, so "part of this stack
+was never linted" has to be as visible as "I found something". Both gaps used to
+be invisible to machines: ``include:`` warned on stderr only, and cross-file
+``extends: {file: ...}`` said nothing at all. In both cases the verdict, the exit
+code, JSON ``errors`` and SARIF ``executionSuccessful`` reported a clean run over
+a partial view.
+
+The asymmetry that proved it was a bug: an ``include``-*only* file (no local
+services) has always been rejected at parse time with exit 2.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from compose_lint import cli
+from compose_lint.parser import coverage_gaps, loads
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# A base carrying full host control, so a run that misses it is unambiguously
+# reporting on something other than what would be deployed.
+DANGEROUS_BASE = (
+    "services:\n"
+    "  app:\n"
+    "    image: nginx:1.27\n"
+    "    privileged: true\n"
+    "    network_mode: host\n"
+)
+
+
+def _write(path: Path, text: str) -> Path:
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+# --- Detection -------------------------------------------------------------
+
+
+def test_include_alongside_services_is_a_gap() -> None:
+    data, _lines = loads(
+        "include:\n  - base.yml\nservices:\n  web:\n    image: nginx:1.27\n"
+    )
+    assert any("include" in gap for gap in coverage_gaps(data))
+
+
+def test_cross_file_extends_is_a_gap_and_names_the_service() -> None:
+    data, _lines = loads(
+        "services:\n"
+        "  web:\n"
+        "    image: nginx:1.27\n"
+        "    extends:\n"
+        "      file: base.yml\n"
+        "      service: app\n"
+    )
+    gaps = coverage_gaps(data)
+    assert len(gaps) == 1
+    assert "extends" in gaps[0]
+    assert "'web'" in gaps[0]
+
+
+def test_in_file_extends_is_not_a_gap() -> None:
+    """It is resolved, so nothing is unlinted — the distinction that matters."""
+    data, _lines = loads(
+        "services:\n"
+        "  base:\n"
+        "    image: nginx:1.27\n"
+        "  web:\n"
+        "    extends:\n"
+        "      service: base\n"
+    )
+    assert coverage_gaps(data) == []
+
+
+def test_an_ordinary_file_has_no_gaps() -> None:
+    data, _lines = loads("services:\n  web:\n    image: nginx:1.27\n")
+    assert coverage_gaps(data) == []
+
+
+# --- The gate: exit code, not just stderr ---------------------------------
+
+
+@pytest.mark.parametrize("kind", ["include", "extends"])
+def test_a_gap_fails_the_gate_even_when_local_services_are_clean(
+    tmp_path: Path, kind: str
+) -> None:
+    """The false-clean case: nothing locally wrong, everything dangerous hidden."""
+    _write(tmp_path / "base.yml", DANGEROUS_BASE)
+    if kind == "include":
+        body = (
+            "include:\n  - base.yml\n"
+            "services:\n"
+            "  web:\n"
+            "    image: nginx@sha256:" + "ab" * 32 + "\n"
+            "    read_only: true\n"
+            "    cap_drop: [ALL]\n"
+            '    security_opt: ["no-new-privileges:true"]\n'
+            '    user: "1000:1000"\n'
+        )
+    else:
+        body = (
+            "services:\n"
+            "  web:\n"
+            "    image: nginx@sha256:" + "ab" * 32 + "\n"
+            "    extends:\n"
+            "      file: base.yml\n"
+            "      service: app\n"
+            "    read_only: true\n"
+            "    cap_drop: [ALL]\n"
+            '    security_opt: ["no-new-privileges:true"]\n'
+            '    user: "1000:1000"\n'
+        )
+    target = _write(tmp_path / "compose.yml", body)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["check", str(target)])
+    assert exc.value.code == 2, kind
+
+
+@pytest.mark.parametrize("kind", ["include", "extends"])
+def test_the_gap_is_machine_readable_in_json(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], kind: str
+) -> None:
+    _write(tmp_path / "base.yml", DANGEROUS_BASE)
+    body = (
+        "include:\n  - base.yml\nservices:\n  web:\n    image: nginx:1.27\n"
+        if kind == "include"
+        else (
+            "services:\n  web:\n    image: nginx:1.27\n"
+            "    extends:\n      file: base.yml\n      service: app\n"
+        )
+    )
+    target = _write(tmp_path / "compose.yml", body)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["check", "--format", "json", str(target)])
+    assert exc.value.code == 2, kind
+
+    doc = json.loads(capsys.readouterr().out)
+    assert doc["errors"], f"{kind}: JSON errors[] is empty"
+    assert any("not resolved" in e["message"] for e in doc["errors"]), kind
+
+
+@pytest.mark.parametrize("kind", ["include", "extends"])
+def test_the_gap_is_machine_readable_in_sarif(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], kind: str
+) -> None:
+    _write(tmp_path / "base.yml", DANGEROUS_BASE)
+    body = (
+        "include:\n  - base.yml\nservices:\n  web:\n    image: nginx:1.27\n"
+        if kind == "include"
+        else (
+            "services:\n  web:\n    image: nginx:1.27\n"
+            "    extends:\n      file: base.yml\n      service: app\n"
+        )
+    )
+    target = _write(tmp_path / "compose.yml", body)
+
+    with pytest.raises(SystemExit):
+        cli.main(["check", "--format", "sarif", str(target)])
+
+    invocation = json.loads(capsys.readouterr().out)["runs"][0]["invocations"][0]
+    assert invocation["executionSuccessful"] is False, kind
+    assert any(
+        "not resolved" in n["message"]["text"]
+        for n in invocation["toolExecutionNotifications"]
+    ), kind
+
+
+# --- The opt-out -----------------------------------------------------------
+
+
+def test_allow_partial_coverage_grades_what_it_can_see(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write(tmp_path / "base.yml", DANGEROUS_BASE)
+    target = _write(
+        tmp_path / "compose.yml",
+        "include:\n  - base.yml\n"
+        "services:\n  web:\n    image: nginx:1.27\n    privileged: true\n",
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["check", "--allow-partial-coverage", str(target)])
+    # The local CRITICAL still fails the gate — the opt-out waives the *gap*,
+    # not the findings.
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert "CL-0002" in captured.out
+    assert "include" in captured.err.lower()
+
+
+def test_opting_out_keeps_the_gap_out_of_the_structured_errors(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write(tmp_path / "base.yml", DANGEROUS_BASE)
+    target = _write(
+        tmp_path / "compose.yml",
+        "include:\n  - base.yml\nservices:\n  web:\n    image: nginx:1.27\n",
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["check", "--allow-partial-coverage", "--format", "json", str(target)])
+    assert exc.value.code == 0
+    assert json.loads(capsys.readouterr().out)["errors"] == []
+
+
+def test_fix_reports_the_gap_without_failing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``fix`` is not the merge gate, so a gap is advisory there."""
+    _write(tmp_path / "base.yml", DANGEROUS_BASE)
+    target = _write(
+        tmp_path / "compose.yml",
+        "include:\n  - base.yml\nservices:\n  web:\n    image: nginx:1.27\n",
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["fix", str(target)])
+    assert exc.value.code == 0
+    assert "include" in capsys.readouterr().err.lower()


### PR DESCRIPTION
Resolves two findings from a [VulnHunter](https://github.com/capitalone/vulnhunter) security audit of this repository (tracked internally as VULN-002 and VULN-003). Both are High, and both are the same defect on two keys.

## The defect

compose-lint reads single files and does no I/O to follow references out of them, so two spellings leave services ungraded:

- `include:` alongside `services:` — the included files' services are never seen
- `extends: {file: ...}` — the base is never merged, so the child is graded on its own keys only

The gap reached **stderr for `include:`, and nothing at all for `extends:`**. The verdict, the exit code, JSON `errors` and SARIF `executionSuccessful` all reported a clean run. A base carrying `privileged: true` and `network_mode: host` could sit unlinted behind a green check.

The asymmetry that proves it was a bug rather than a decision: an `include`-**only** file (no local services) has always been rejected at parse time with exit 2.

## The fix

Detect both in one place — `parser.coverage_gaps(data)`, public so library callers get it too — and route them through the channel parse errors already use: JSON `errors[]`, SARIF `toolExecutionNotifications` with `executionSuccessful: false`, and exit 2.

- **Local services are still linted and their findings still reported.** The file is graded on what could be seen *and* the gap is recorded. Verified on a real corpus file: exit 2, 8 findings emitted, plus the gap in `errors[]`.
- **Counted separately from parse failures in the text verdict.** Those files parsed fine; `"N files could not be parsed"` would misdescribe the run — which is the exact failure class this change exists to remove.
- **New `--allow-partial-coverage` on `check`** accepts the gap and grades what is visible. It waives the *gap*, not the findings: a local CRITICAL still fails the gate.
- **`fix` reports gaps without failing** — it is not the merge gate.

## Behavior change

Measured over the 5,417-file corpus, patched vs `main`:

```
31 files (0.6%) change exit code at the default gate
  20  pass  -> error   (CI newly red)
  11  fail  -> error   (already red, different code)
```

No findings change. (The raw `snapshot.py`-style diff appears to show findings vanishing — that is an artifact of `scripts/corpus/run.py`, which discards the JSON body when the exit code is 2. Confirmed by hand that findings are still emitted.)

| Trigger | before | after |
|---|---|---|
| `include:` + `services:` | stderr warning, exit 0/1 | **exit 2**, JSON `errors[]`, SARIF notification |
| `extends: {file: ...}` | *silent*, exit 0/1 | **exit 2**, JSON `errors[]`, SARIF notification |
| either, with `--allow-partial-coverage` | — | stderr note, normal verdict |

Output shape: JSON `errors[]` and SARIF `toolExecutionNotifications` gain entries in cases where they were previously empty; the text verdict and aggregate summary gain a distinct coverage-gap wording. `format_verdict` and `format_aggregate_summary` take a new optional `coverage_gap_count` parameter (defaulted, so existing callers are unaffected).

Semver: **minor** — new flag, and a case that previously exited 0/1 now exits 2.

**Known interaction, not fixed here:** the composite Action currently turns a CLI exit 2 into a green pass (VULN-037, group 6), so until that lands an Action user will not see these gaps fail. Flagging it so the sequencing is deliberate rather than an oversight.

## Surfaces updated

`README.md` (flag list, exit-code table, and a new paragraph explaining coverage gaps) and `AGENTS.md` (exit-code contract). While writing the remediation advice I checked whether `docker compose config | compose-lint -` works — it does not, compose-lint reads files and not stdin — so the documented workaround writes the merged output to a file first.

## Tests

13 new tests in `tests/test_coverage_gaps.py`: detection for both keys (including that in-file `extends:` is *not* a gap, since it is resolved), the false-clean case where local services are hardened and everything dangerous is hidden, JSON and SARIF structure for both, and the opt-out in both directions. One existing test encoded the old behavior and was updated with the reason.

Full suite 1567 passed / 6 skipped; `ruff check`, `ruff format --check`, `mypy src/` clean.
