### PR TITLE
Terminate the option namespace in the shipped harnesses

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,6 +2,18 @@
   name: compose-lint
   description: Security-focused linter for Docker Compose files
   entry: compose-lint
+  # pre-commit runs `entry + args + filenames`, so a trailing `--` here is
+  # what separates options from the paths it appends. Without it a
+  # repository path like `--config=cfgdir/compose.yml` (a directory named
+  # `--config=cfgdir`) is absorbed as a flag: the file leaves the lint set
+  # and an attacker-authored policy is installed for the run.
+  #
+  # It lives in `args` rather than at the end of `entry` because a user's
+  # own `args:` would land *after* an entry-level `--` and be read as
+  # paths, breaking every config that passes flags. Setting `args:`
+  # replaces this default, so a config that passes flags should end its
+  # list with `--` (see README).
+  args: [--]
   language: python
   types: [yaml]
   files: (^|/)(docker-)?compose[^/]*\.ya?ml$

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,29 @@ If a finding is genuinely parameterized in your deployment, that is what
 default (`${PW}` rather than `${PW:-hunter2}`) also stays exempt, because
 Compose then ships nothing.
 
+### Security
+
+- **The shipped harnesses now terminate the option namespace with `--`.** A
+  repository can contain a directory named `--config=cfgdir` holding a
+  `compose.yml`; the resulting path `--config=cfgdir/compose.yml` matches the
+  pre-commit hook's `files:` pattern and the Action's discovery, so a harness
+  that globbed repo paths straight into argv handed argparse something it read
+  as an option. The crafted file left the lint set *and* an attacker-authored
+  policy disabling every rule was installed for the run — the gate went green
+  over a `privileged` stack mounting `/var/run/docker.sock`. Confirmed
+  end-to-end: the pre-commit hook reported `Passed` before this change and
+  `Failed` after, on the same repository.
+
+  The pre-commit hook ships `args: [--]` and the Action passes `--` before the
+  file list in both invocations (the text run and the SARIF re-run). Setting
+  `args:` in your `.pre-commit-config.yaml` replaces the default, so keep `--`
+  last if you pass flags — see README.
+
+  The separator is deliberately **not** inserted by the CLI's argv shim: it
+  cannot tell a genuine `--config=x` from a file named that, and terminating
+  before the first positional would break the documented
+  `compose-lint init docker-compose.yml -o ci.yml` form.
+
 ### Changed
 
 - **Coverage gaps are reported on every channel a consumer reads.** An

--- a/README.md
+++ b/README.md
@@ -459,6 +459,13 @@ repos:
       - id: compose-lint
 ```
 
+The hook ships `args: [--]`. pre-commit builds the command as `entry + args + filenames`, so that trailing `--` is what stops a repository path from being read as an option — a directory named `--config=cfgdir` holding a `compose.yml` otherwise arrives as `--config=cfgdir/compose.yml` and installs an attacker-authored policy for the run. Setting `args:` **replaces** that default, so keep `--` last if you pass flags:
+
+```yaml
+      - id: compose-lint
+        args: [--fail-on, low, --]
+```
+
 ## Security posture
 
 compose-lint is built to be safe to depend on:

--- a/action.yml
+++ b/action.yml
@@ -113,9 +113,11 @@ runs:
         fi
 
         # Word-split the file list intentionally — it is space-separated
-        # by `Find Compose files` above.
+        # by `Find Compose files` above. `--` terminates the option namespace
+        # first, so a repository file named `--config=evil/compose.yml` arrives
+        # as a path instead of installing an attacker-authored policy.
         # shellcheck disable=SC2086
-        compose-lint "${ARGS[@]}" $CL_TARGET_FILES || TEXT_EXIT=$?
+        compose-lint "${ARGS[@]}" -- $CL_TARGET_FILES || TEXT_EXIT=$?
 
         # When a SARIF artifact is requested, re-run in SARIF mode. The first
         # run prints human-readable output to the job log and sets the exit
@@ -123,7 +125,7 @@ runs:
         # two runs report the same findings.
         if [ -n "$CL_SARIF_FILE" ]; then
           # shellcheck disable=SC2086
-          compose-lint --format sarif "${ARGS[@]}" $CL_TARGET_FILES \
+          compose-lint --format sarif "${ARGS[@]}" -- $CL_TARGET_FILES \
             > "$CL_SARIF_FILE" || true
         fi
 

--- a/tests/test_harness_end_of_options.py
+++ b/tests/test_harness_end_of_options.py
@@ -1,0 +1,145 @@
+"""Every shipped harness must terminate the option namespace with ``--``.
+
+A repository can contain a *directory* named ``--config=cfgdir`` holding a
+``compose.yml``. The resulting path ``--config=cfgdir/compose.yml`` matches the
+pre-commit hook's ``files:`` regex and the Action's discovery, so a harness that
+globs repo paths straight into argv hands argparse something it reads as an
+option: the crafted file leaves the lint set *and* an attacker-authored policy
+disabling every rule is installed for the run. The gate goes green over a
+privileged, ``docker.sock``-mounting stack.
+
+The defense has to live in the callers. The CLI cannot distinguish a genuine
+``--config=x`` from a file that happens to be named that, and inserting ``--``
+inside the argv shim would break the documented
+``compose-lint init docker-compose.yml -o ci.yml`` form, where flags follow a
+positional. These tests therefore pin the harnesses, and one end-to-end case
+proves the separator is what changes the verdict.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_COMPOSE = (
+    "services:\n"
+    "  web:\n"
+    "    image: nginx:latest\n"
+    "    privileged: true\n"
+    "    volumes:\n"
+    "      - /var/run/docker.sock:/var/run/docker.sock\n"
+    "    cap_add:\n"
+    "      - SYS_ADMIN\n"
+)
+_ATTACKER_POLICY = (
+    'rules:\n  CL-0001: {enabled: false, reason: "x"}\n'
+    '  CL-0002: {enabled: false, reason: "x"}\n'
+    '  CL-0024: {enabled: false, reason: "x"}\n'
+)
+
+
+def _hook() -> dict[str, Any]:
+    hooks = yaml.safe_load((REPO_ROOT / ".pre-commit-hooks.yaml").read_text())
+    return next(h for h in hooks if h["id"] == "compose-lint")
+
+
+def test_precommit_default_args_terminate_options() -> None:
+    """pre-commit runs ``entry + args + filenames``, so ``--`` must end ``args``.
+
+    Not the end of ``entry``: a user's own ``args:`` would then land *after* the
+    separator and be read as paths. Verified against pre-commit 4.x —
+    ``compose-lint -- --fail-on low docker-compose.yml`` reports two files that
+    could not be parsed and exits 2.
+    """
+    hook = _hook()
+    assert hook["entry"].split() == ["compose-lint"], hook["entry"]
+    assert hook.get("args", [])[-1:] == ["--"], (
+        f"default args must end with `--`, got {hook.get('args')!r}"
+    )
+
+
+def test_precommit_entry_does_not_carry_the_separator() -> None:
+    """Pins the reason for the placement, so it is not 'tidied' back later."""
+    assert "--" not in _hook()["entry"].split()
+
+
+def test_action_passes_double_dash_before_the_file_list() -> None:
+    """Both invocations — the text run and the SARIF re-run — need it."""
+    action = (REPO_ROOT / "action.yml").read_text(encoding="utf-8")
+    invocations = [
+        line.strip()
+        for line in action.splitlines()
+        if "compose-lint" in line and "$CL_TARGET_FILES" in line
+    ]
+    assert len(invocations) == 2, f"expected 2 invocations, found {invocations!r}"
+    for line in invocations:
+        assert "-- $CL_TARGET_FILES" in line, f"missing `--` separator: {line!r}"
+
+
+def test_double_dash_is_what_changes_the_verdict(tmp_path: Path) -> None:
+    """End-to-end: same argv, separator alone flips the false pass to a fail."""
+    (tmp_path / "compose.yml").write_text(_COMPOSE, encoding="utf-8")
+    (tmp_path / "cfgdir").mkdir()
+    (tmp_path / "cfgdir" / "compose.yml").write_text(_ATTACKER_POLICY, encoding="utf-8")
+    # To git this is a directory named `--config=cfgdir` holding a compose file.
+    (tmp_path / "--config=cfgdir").mkdir()
+    (tmp_path / "--config=cfgdir" / "compose.yml").write_text(
+        _ATTACKER_POLICY, encoding="utf-8"
+    )
+
+    argv = ["--config=cfgdir/compose.yml", "cfgdir/compose.yml", "compose.yml"]
+
+    def run(args: list[str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, "-m", "compose_lint", *args],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            env={"PYTHONPATH": str(REPO_ROOT / "src"), "PATH": "/usr/bin:/bin"},
+            timeout=120,
+        )
+
+    without = run(argv)
+    with_separator = run(["--", *argv])
+
+    assert without.returncode == 0, "precondition: the unseparated form passes"
+    assert with_separator.returncode == 1, (
+        "with `--` the crafted path must be linted as a file, not read as a "
+        f"config flag; got exit {with_separator.returncode}"
+    )
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["init", "docker-compose.yml", "-o", "out.yml"],
+        ["init", "docker-compose.yml", "--force"],
+    ],
+)
+def test_flags_after_a_positional_still_work(tmp_path: Path, argv: list[str]) -> None:
+    """Why the shim cannot insert ``--`` itself: this form is documented.
+
+    ``compose-lint init docker-compose.yml -o ci.yml`` appears in README.md and
+    docs/configuration.md. An end-of-options marker before the first positional
+    would turn ``-o`` into a path and break it, which is why the separator is
+    the caller's job.
+    """
+    (tmp_path / "docker-compose.yml").write_text(
+        "services:\n  web:\n    image: nginx:1.27\n", encoding="utf-8"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-m", "compose_lint", *argv],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        env={"PYTHONPATH": str(REPO_ROOT / "src"), "PATH": "/usr/bin:/bin"},
+        timeout=120,
+    )
+    assert proc.returncode == 0, proc.stderr


### PR DESCRIPTION
Resolves a finding from a [VulnHunter](https://github.com/capitalone/vulnhunter) security audit of this repository (tracked internally as VULN-034, High).

## The defect

A repository can contain a **directory** named `--config=cfgdir` holding a `compose.yml`. The resulting path `--config=cfgdir/compose.yml` matches the pre-commit hook's `files:` pattern and the Action's discovery, so a harness that globs repo paths straight into argv hands argparse something it reads as an option.

Two things happen at once: the crafted file leaves the lint set, **and** an attacker-authored policy disabling every rule is installed for the run.

Confirmed end-to-end against pre-commit 4.x, on a repository holding a `privileged` service that mounts `/var/run/docker.sock`:

```
BEFORE:  compose-lint.......................................Passed
AFTER:   compose-lint.......................................Failed
         ✗ FAIL  ·  1 finding at or above high
```

## The fix

`--` before the file list in both shipped harnesses:

- **Action** — both invocations, the text run and the SARIF re-run.
- **pre-commit** — as the hook's default `args`, *not* at the end of `entry`.

That placement is the part worth reviewing. pre-commit builds its command as `entry + args + filenames`, so an entry-level `--` puts a user's own `args:` *after* the separator, where they are read as paths:

```console
$ compose-lint -- --fail-on low docker-compose.yml
⚠ ERROR  ·  2 files could not be parsed
exit=2
```

That would break every config that passes flags. As the hook's default `args`, the separator protects the default case and degrades to today's behavior when a user sets `args:` — which the README now documents, telling them to keep `--` last.

Verified all three forms:

| pre-commit config | argv | result |
|---|---|---|
| default | `compose-lint -- <files>` | exit 1 — attack neutralized |
| `args: [--fail-on, low, --]` | `compose-lint --fail-on low -- <files>` | exit 1 — works and protected |
| `args: [--fail-on, low]` | `compose-lint --fail-on low <files>` | works, unprotected — unchanged from today |

## Why not in the CLI, as the audit proposed

The report's fix (2) was to insert `--` before the first positional in `_normalize_argv`. I implemented it, and it is wrong on two counts:

1. **It breaks documented usage.** `compose-lint init docker-compose.yml -o ci.yml` appears in README.md and docs/configuration.md, and puts flags *after* a positional. Terminating before the first positional turns `-o` into a path — 8 tests fail.
2. **It does not stop the attack.** The crafted path is a single token starting with a dash. The CLI cannot distinguish it from a genuine `--config=x`, so in the single-argument case there is nothing to anchor on. Reordering options ahead of positionals does not help either — the crafted path sorts with the options, because it looks like one.

The caller is the only layer that knows which tokens are paths. There is a test pinning the `init ... -o ...` form with that reasoning, so the shim change is not reintroduced later.

## Behavior change

None for ordinary repositories. A repository containing a flag-named path gets that path **linted as a file** instead of absorbed as an option — which is the fix. No rule, severity, message, exit code, or output-shape change.

Semver: **patch**. The one thing a user could notice is a pre-commit config that sets `args:` — it behaves exactly as before, but is not covered by the new default, hence the README note.

## Note on the exploit test

`test_vuln_034_arg_injection.py` **still passes** after this change. That is expected and not a gap: it drives the CLI directly with no separator, which is precisely the case the CLI cannot fix. Its own final assertion — that adding `--` restores exit 1 — is what this PR makes the harnesses do. The new `tests/test_harness_end_of_options.py` covers what actually shipped.

## Deferred

The audit also lists `find -print0` + `mapfile -d ''` for the Action's file discovery under this item. That is entangled with how the file list crosses the step boundary through `$GITHUB_OUTPUT` (a text file, which cannot carry NUL) and with VULN-040's newline injection into the same variable. Both belong to the `action.yml:69-136` block handled as one unit in the Action group, so it is deferred there rather than half-done here.

## Tests

5 new tests: the pre-commit default `args`, that `entry` does *not* carry the separator (pinning the reason so it is not "tidied" back), both Action invocations, an end-to-end case proving the separator alone flips the verdict, and the `init ... -o ...` form that rules out the shim-side fix.

Full suite 1573 passed / 6 skipped; `ruff check`, `ruff format --check`, `mypy src/` clean.
