### PR TITLE
Stop the Action from passing where the CLI would fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -741,16 +741,18 @@ jobs:
       # testpypi-smoke, publish.yml docker-smoke, marketplace-smoke.yml).
       # One source of truth prevents per-workflow drift.
 
-      # No `version:` pin — the action defaults to installing the latest
-      # release from PyPI. What this job tests is the action.yml contract
-      # (inputs, file discovery, SARIF wiring) against whatever compose-lint
-      # is currently published. Pinning to a stale version hid breakages
-      # between the source action and the published package through 0.3.x.
+      # `version: latest` is deliberate. The action now *pins* by default so a
+      # consumer's SHA-pinned `uses:` gets a reproducible check, but what this
+      # job tests is the action.yml contract (inputs, file discovery, SARIF
+      # wiring) against whatever compose-lint is currently published. Letting
+      # it install the pin would test the source action against itself and hide
+      # breakages between the two, which is what happened through 0.3.x.
       - name: Clean fixture should pass
         uses: ./
         with:
           files: tests/smoke/clean.yml
           fail-on: high
+          version: latest
 
       - name: Insecure fixture should fail
         id: insecure
@@ -759,6 +761,7 @@ jobs:
         with:
           files: tests/smoke/insecure.yml
           fail-on: high
+          version: latest
 
       - name: Assert insecure run failed
         if: steps.insecure.outcome != 'failure'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,39 @@ Compose then ships nothing.
 
 ### Security
 
+- **The GitHub Action no longer passes where the CLI would fail.** Six defects
+  shared that shape, and `action.yml` is fixed as one block.
+
+  - **"No Compose files found" is an error, not a green check.** The lint step
+    was gated on `if: steps.find-files.outputs.files != ''`, so a `pattern:`
+    that matched nothing skipped the step entirely and the job reported
+    success — while the CLI exits 2 for exactly that input. The decision now
+    lives inside the script, where it can fail. New `allow-no-files: true`
+    input for the case where an empty result is expected.
+  - **A SARIF artifact is never uploaded unless it was written.** The re-run
+    redirected straight at the target — truncating it before the command ran —
+    and `|| true` reported failure as success, so `always()` uploaded a 0-byte
+    document and Code Scanning showed no alerts. Output now goes to a
+    temporary file that is moved into place only once it holds a complete
+    document; a run that produces nothing fails the step, and the upload is
+    gated on the file having been written rather than on `always()`.
+  - **`sarif-file` is validated to stay inside the workspace.** `>` truncates
+    before the command runs, so an unvalidated path let a caller-supplied
+    value destroy a file anywhere the runner could write.
+  - **The install is pinned by default.** A consumer who SHA-pins `uses:` is
+    asking for a reproducible check, but the action installed whatever PyPI
+    served at that moment. It now installs the version it was released with;
+    `version: latest` opts back in to tracking PyPI.
+    `scripts/bump-version.sh` keeps the pin in step and
+    `tests/test_action_contract.py` fails if it drifts.
+  - **No attacker-controlled text reaches `$GITHUB_OUTPUT`.** Discovered paths
+    are written NUL-separated to a file under `RUNNER_TEMP` and only that
+    file's path crosses the step boundary, so a filename containing a newline
+    can no longer forge output records. Discovery uses `find -print0`, so
+    paths containing spaces survive too.
+  - **The documented consumer workflow ships a `permissions:` block** —
+    workflow-level deny-all plus the two scopes the job actually uses.
+
 - **Five rules now classify the normalized value instead of the spelling.**
   Each decided what a value *was* by matching the raw token, so an equivalent
   spelling walked past it. All five were verified against

--- a/README.md
+++ b/README.md
@@ -394,15 +394,30 @@ The easiest path — runs compose-lint and uploads findings to GitHub Code Scann
 name: Compose Lint
 on: [push, pull_request]
 
+permissions: {}
+
 jobs:
   compose-lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read          # checkout
+      security-events: write  # upload the SARIF to Code Scanning
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: tmatens/compose-lint@e1ceb3aaac0775c7ae8b8095c95a5b7a923bdb63 # v0.17.0
         with:
           sarif-file: results.sarif
 ```
+
+The `permissions:` blocks are part of the recipe, not decoration. Without them the
+job inherits the repository default, which on many repositories is still
+read-write for every scope — so a linting job that needs only `contents: read`
+and `security-events: write` runs holding a token that can push code and edit
+releases. Denying everything at the workflow level and granting the two scopes
+the job actually uses keeps a compromised dependency in this job from reaching
+anything else.
+
+Drop `security-events: write` if you are not uploading SARIF.
 
 Or install from PyPI directly:
 

--- a/action.yml
+++ b/action.yml
@@ -38,9 +38,19 @@ inputs:
     required: false
     default: ""
   version:
-    description: "compose-lint version to install (default: latest)"
+    description: >-
+      compose-lint version to install. Defaults to the version this action was
+      released with, so a SHA-pinned `uses:` gets a reproducible check. Set to
+      "latest" to track PyPI instead.
     required: false
     default: ""
+  allow-no-files:
+    description: >-
+      Succeed when no Compose files are found instead of failing. Off by
+      default: a pattern that matches nothing is a misconfiguration, and the
+      CLI itself exits 2 in that case.
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -54,10 +64,22 @@ runs:
       env:
         CL_VERSION: ${{ inputs.version }}
       run: |
-        if [ -n "$CL_VERSION" ]; then
-          pip install "compose-lint==${CL_VERSION}"
-        else
+        # Pinned by default. A consumer who SHA-pins `uses:` is asking for a
+        # reproducible check, and installing whatever PyPI serves at that
+        # moment silently defeats that: the pinned ref selects this file, not
+        # the package it installs. Release automation keeps DEFAULT_VERSION in
+        # step with the release, and CI's "Version strings in sync" job fails
+        # if it drifts.
+        DEFAULT_VERSION="0.17.0"
+        if [ -z "$CL_VERSION" ]; then
+          pip install "compose-lint==${DEFAULT_VERSION}"
+        elif [ "$CL_VERSION" = "latest" ]; then
+          # Opt-in to tracking PyPI. Used by this repo's own smoke jobs, which
+          # exist to catch drift between the source action and the published
+          # package.
           pip install compose-lint
+        else
+          pip install "compose-lint==${CL_VERSION}"
         fi
 
     - name: Find Compose files
@@ -67,26 +89,53 @@ runs:
         CL_FILES: ${{ inputs.files }}
         CL_PATTERN: ${{ inputs.pattern }}
       run: |
-        FILES="$CL_FILES"
-        if [ -z "$FILES" ] && [ -n "$CL_PATTERN" ]; then
+        # The discovered paths are written NUL-separated to a file under
+        # RUNNER_TEMP and only the *path to that file* crosses the step
+        # boundary. $GITHUB_OUTPUT is a line-oriented text file, so putting
+        # filenames in it let a path containing a newline forge output records
+        # — `files=` could be terminated early and arbitrary step outputs
+        # appended. Nothing attacker-controlled goes into $GITHUB_OUTPUT now.
+        LIST_FILE="${RUNNER_TEMP:-/tmp}/compose-lint-files"
+        : > "$LIST_FILE"
+        COUNT=0
+
+        if [ -n "$CL_FILES" ]; then
+          # The documented contract for `files:` is a space-separated list, so
+          # a newline in it is malformed rather than a filename we should try
+          # to honour. Refuse it loudly instead of splitting on it.
+          case "$CL_FILES" in
+            *$'\n'*)
+              echo "::error::files: must be a space-separated list; it contains a newline"
+              exit 2
+              ;;
+          esac
+          for f in $CL_FILES; do
+            printf '%s\0' "$f" >> "$LIST_FILE"
+            COUNT=$((COUNT + 1))
+          done
+        elif [ -n "$CL_PATTERN" ]; then
           # -name takes a literal glob; we never eval the pattern as shell.
-          FILES=$(find . -path "./.git" -prune -o -name "$CL_PATTERN" -print | tr '\n' ' ')
-        fi
-        if [ -z "$FILES" ]; then
+          # -print0 keeps paths intact through newlines and spaces, which the
+          # previous `tr '\n' ' '` join destroyed.
+          while IFS= read -r -d '' f; do
+            printf '%s\0' "$f" >> "$LIST_FILE"
+            COUNT=$((COUNT + 1))
+          done < <(find . -path "./.git" -prune -o -name "$CL_PATTERN" -print0)
+        else
           # Default: common Compose file names in repo root
           for f in docker-compose.yml docker-compose.yaml compose.yml compose.yaml; do
-            [ -f "$f" ] && FILES="$FILES $f"
+            if [ -f "$f" ]; then
+              printf '%s\0' "$f" >> "$LIST_FILE"
+              COUNT=$((COUNT + 1))
+            fi
           done
         fi
-        if [ -z "$FILES" ]; then
-          echo "::warning::No Compose files found"
-          echo "files=" >> "$GITHUB_OUTPUT"
-        else
-          echo "files=$FILES" >> "$GITHUB_OUTPUT"
-        fi
+
+        echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+        echo "list-file=$LIST_FILE" >> "$GITHUB_OUTPUT"
 
     - name: Run compose-lint
-      if: steps.find-files.outputs.files != ''
+      id: lint
       shell: bash
       env:
         CL_CONFIG: ${{ inputs.config }}
@@ -95,8 +144,27 @@ runs:
         CL_QUIET: ${{ inputs.quiet }}
         CL_VERBOSE: ${{ inputs.verbose }}
         CL_SARIF_FILE: ${{ inputs.sarif-file }}
-        CL_TARGET_FILES: ${{ steps.find-files.outputs.files }}
+        CL_ALLOW_NO_FILES: ${{ inputs.allow-no-files }}
+        CL_COUNT: ${{ steps.find-files.outputs.count }}
+        CL_LIST_FILE: ${{ steps.find-files.outputs.list-file }}
       run: |
+        # "Nothing to lint" is not a pass. The CLI exits 2 when it finds no
+        # Compose files, and this step used to be skipped entirely by an
+        # `if:` condition — turning that fail-closed answer into a green
+        # check. A pattern that matches nothing is a misconfiguration, and a
+        # gate that reports success over an unlinted repository is the one
+        # outcome this tool must never produce.
+        if [ "${CL_COUNT:-0}" -eq 0 ]; then
+          if [ "$CL_ALLOW_NO_FILES" = "true" ]; then
+            echo "::warning::No Compose files found; allow-no-files is set"
+            exit 0
+          fi
+          echo "::error::No Compose files found. Checked the 'files' and 'pattern' inputs and the repository root. Set allow-no-files: true if an empty result is expected."
+          exit 2
+        fi
+
+        mapfile -d '' -t TARGET_FILES < "$CL_LIST_FILE"
+
         ARGS=()
         if [ -n "$CL_CONFIG" ]; then
           ARGS+=(--config "$CL_CONFIG")
@@ -112,27 +180,61 @@ runs:
           ARGS+=(--verbose)
         fi
 
-        # Word-split the file list intentionally — it is space-separated
-        # by `Find Compose files` above. `--` terminates the option namespace
-        # first, so a repository file named `--config=evil/compose.yml` arrives
-        # as a path instead of installing an attacker-authored policy.
-        # shellcheck disable=SC2086
-        compose-lint "${ARGS[@]}" -- $CL_TARGET_FILES || TEXT_EXIT=$?
+        # `--` terminates the option namespace, so a repository file named
+        # `--config=evil/compose.yml` arrives as a path instead of installing
+        # an attacker-authored policy.
+        TEXT_EXIT=0
+        compose-lint "${ARGS[@]}" -- "${TARGET_FILES[@]}" || TEXT_EXIT=$?
 
         # When a SARIF artifact is requested, re-run in SARIF mode. The first
         # run prints human-readable output to the job log and sets the exit
         # code; this run only writes the file. Rules are deterministic, so the
         # two runs report the same findings.
         if [ -n "$CL_SARIF_FILE" ]; then
-          # shellcheck disable=SC2086
-          compose-lint --format sarif "${ARGS[@]}" -- $CL_TARGET_FILES \
-            > "$CL_SARIF_FILE" || true
+          # Keep the write target inside the workspace. `>` truncates before
+          # the command runs, so an unvalidated path let a caller-supplied
+          # value destroy a file anywhere the runner could write — including
+          # outside the checkout — whether or not the lint itself succeeded.
+          WORKSPACE="$(cd "${GITHUB_WORKSPACE:-$PWD}" && pwd -P)"
+          SARIF_DIR="$(cd "$(dirname "$CL_SARIF_FILE")" 2>/dev/null && pwd -P)" || {
+            echo "::error::sarif-file directory does not exist: $CL_SARIF_FILE"
+            exit 2
+          }
+          SARIF_PATH="$SARIF_DIR/$(basename "$CL_SARIF_FILE")"
+          case "$SARIF_PATH" in
+            "$WORKSPACE"/*) ;;
+            *)
+              echo "::error::sarif-file must be inside the workspace"
+              exit 2
+              ;;
+          esac
+
+          # Write to a temporary file and move it into place only once it
+          # holds a complete document. Redirecting straight at the target
+          # truncated it first, so a failed run left a 0-byte artifact — and
+          # `|| true` reported that as success, so the upload below shipped an
+          # empty result set as if the scan had been clean.
+          SARIF_TMP="$(mktemp "${RUNNER_TEMP:-/tmp}/compose-lint-sarif.XXXXXX")"
+          SARIF_EXIT=0
+          compose-lint --format sarif "${ARGS[@]}" -- "${TARGET_FILES[@]}" \
+            > "$SARIF_TMP" || SARIF_EXIT=$?
+
+          if [ ! -s "$SARIF_TMP" ]; then
+            rm -f "$SARIF_TMP"
+            echo "::error::compose-lint produced no SARIF output (exit ${SARIF_EXIT}); refusing to upload an empty artifact"
+            exit "${SARIF_EXIT:-1}"
+          fi
+          mv "$SARIF_TMP" "$SARIF_PATH"
+          echo "sarif-written=true" >> "$GITHUB_OUTPUT"
         fi
 
-        exit ${TEXT_EXIT:-0}
+        exit "$TEXT_EXIT"
 
     - name: Upload SARIF
-      if: inputs.sarif-file != '' && always() && steps.find-files.outputs.files != ''
+      # Gated on the file actually having been written, not on `always()`.
+      # `always()` uploaded whatever was at the path even when the lint step
+      # had failed before producing a document.
+      if: inputs.sarif-file != '' && !cancelled() && steps.lint.outputs.sarif-written == 'true'
       uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         sarif_file: ${{ inputs.sarif-file }}

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -243,7 +243,7 @@ Open a PR — even for the release bump. No direct pushes to `main`.
 
 ```bash
 git checkout -b release/X.Y.Z
-git add pyproject.toml src/compose_lint/__init__.py CHANGELOG.md
+git add pyproject.toml src/compose_lint/__init__.py action.yml CHANGELOG.md
 git commit -m "Prepare X.Y.Z release"
 git push -u origin release/X.Y.Z
 gh pr create --fill
@@ -376,8 +376,13 @@ After approval, `publish` and `docker-publish` run in parallel.
 
 ## Why this checklist exists
 
-- Two version strings (`pyproject.toml` and `__init__.py`) drift if you
-  only bump one. We almost shipped 0.2.0 with a mismatch.
+- Three version strings (`pyproject.toml`, `__init__.py`, and `action.yml`'s
+  `DEFAULT_VERSION`) drift if you only bump some. We almost shipped 0.2.0 with a
+  mismatch between the first two. `DEFAULT_VERSION` is the package the Action
+  installs when a consumer does not pass `version:`, so a stale one means a
+  SHA-pinned `uses:` silently gets a different linter than the action it pinned;
+  `scripts/bump-version.sh` rewrites all three and
+  `tests/test_action_contract.py` fails if they disagree.
 - PyPI version numbers are permanent; a rushed release with a broken
   wheel burns the number forever.
 - Signed, annotated tags are the root of the provenance chain that

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
-# Bump the two source-of-truth version files: pyproject.toml and
-# src/compose_lint/__init__.py. README snippets and the CHANGELOG are handled
-# by hand per the docs/RELEASING.md "Bump the version" checklist.
+# Bump the three source-of-truth version files: pyproject.toml,
+# src/compose_lint/__init__.py, and action.yml's DEFAULT_VERSION (the package
+# the Action installs when a consumer does not pass `version:`). README
+# snippets and the CHANGELOG are handled by hand per the docs/RELEASING.md
+# "Bump the version" checklist.
 # Usage: scripts/bump-version.sh X.Y.Z
 set -euo pipefail
 
@@ -20,14 +22,19 @@ root="$(git rev-parse --show-toplevel)"
 
 sed -i "s/^version = \".*\"/version = \"${version}\"/" "${root}/pyproject.toml"
 sed -i "s/^__version__ = \".*\"/__version__ = \"${version}\"/" "${root}/src/compose_lint/__init__.py"
+# tests/test_action_contract.py fails if this drifts from __version__, so a
+# missed bump here is caught before release rather than shipping an Action that
+# installs a different linter than it claims.
+sed -i "s/^\( *\)DEFAULT_VERSION=\".*\"/\1DEFAULT_VERSION=\"${version}\"/" "${root}/action.yml"
 
 echo "Bumped to ${version}:"
 grep '^version' "${root}/pyproject.toml"
 grep '__version__' "${root}/src/compose_lint/__init__.py"
+grep 'DEFAULT_VERSION=' "${root}/action.yml"
 echo ""
 echo "Still to do by hand (see docs/RELEASING.md 'Bump the version'):"
 echo "  - README.md snippets: pre-commit rev:, pip ==, docker tag, Action # vX.Y.Z"
 echo "  - CHANGELOG.md: author the ${version} entry"
 echo "Then:"
-echo "  git add pyproject.toml src/compose_lint/__init__.py README.md CHANGELOG.md"
+echo "  git add pyproject.toml src/compose_lint/__init__.py action.yml README.md CHANGELOG.md"
 echo "  git commit -S -m 'Prepare ${version} release'"

--- a/tests/test_action_contract.py
+++ b/tests/test_action_contract.py
@@ -1,0 +1,391 @@
+"""The Action must never be more permissive than the CLI it wraps.
+
+Six defects shared that shape: a skipped step turned the CLI's fail-closed
+"no Compose files" (exit 2) into a green check; `|| true` on the SARIF re-run
+reported a destroyed artifact as success; the install ignored the pin a
+SHA-pinned `uses:` implies; discovered paths crossed the step boundary through
+a line-oriented file; and `sarif-file` was an unvalidated write target.
+
+Every step's ``run:`` body is **extracted from action.yml here**, not copied,
+so these tests cannot drift from the file they are asserting about. The runner
+is emulated only where it has to be: ``env:`` blocks become real environment
+variables under the same names, ``$GITHUB_OUTPUT`` becomes a real file parsed
+the way the runner parses it, and ``pip``/``compose-lint`` are shimmed onto
+PATH where the point is *what was invoked* rather than what it did.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+VENV_BIN = REPO_ROOT / ".venv" / "bin"
+
+_INSECURE = (
+    "services:\n"
+    "  web:\n"
+    "    image: nginx:latest\n"
+    "    privileged: true\n"
+    "    volumes:\n"
+    "      - /var/run/docker.sock:/var/run/docker.sock\n"
+)
+
+
+def _action() -> dict[str, Any]:
+    return yaml.safe_load((REPO_ROOT / "action.yml").read_text(encoding="utf-8"))
+
+
+def _step(name: str) -> dict[str, Any]:
+    for step in _action()["runs"]["steps"]:
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"no step named {name!r}")
+
+
+def _run_step(
+    name: str,
+    env: dict[str, str],
+    workspace: Path,
+    outputs: Path,
+    extra_path: Path | None = None,
+) -> tuple[int, str, str]:
+    """Execute a step's `run:` body the way the runner would."""
+    script = _step(name)["run"]
+    path = f"{VENV_BIN}:{os.environ.get('PATH', '')}"
+    if extra_path is not None:
+        path = f"{extra_path}:{path}"
+    full_env = {
+        "PATH": path,
+        "HOME": str(workspace),
+        "GITHUB_OUTPUT": str(outputs),
+        "GITHUB_WORKSPACE": str(workspace),
+        "RUNNER_TEMP": str(workspace / "_temp"),
+        **env,
+    }
+    (workspace / "_temp").mkdir(exist_ok=True)
+    proc = subprocess.run(
+        ["bash", "--noprofile", "--norc", "-eo", "pipefail", "-c", script],
+        cwd=workspace,
+        env=full_env,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def _outputs(path: Path) -> dict[str, str]:
+    """Fold `key=value` records the way the runner does (last record wins)."""
+    result: dict[str, str] = {}
+    if not path.exists():
+        return result
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if "=" in line:
+            key, _, value = line.partition("=")
+            result[key] = value
+    return result
+
+
+@pytest.fixture
+def ws(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+@pytest.fixture
+def outputs(tmp_path: Path) -> Path:
+    p = tmp_path / "gh_output"
+    p.write_text("", encoding="utf-8")
+    return p
+
+
+def _discover(ws: Path, outputs: Path, **env: str) -> tuple[int, str, str]:
+    base = {"CL_FILES": "", "CL_PATTERN": ""}
+    base.update(env)
+    return _run_step("Find Compose files", base, ws, outputs)
+
+
+def _lint(ws: Path, outputs: Path, **env: str) -> tuple[int, str, str]:
+    base = {
+        "CL_CONFIG": "",
+        "CL_FAIL_ON": "high",
+        "CL_SKIP_SUPPRESSED": "false",
+        "CL_QUIET": "false",
+        "CL_VERBOSE": "false",
+        "CL_SARIF_FILE": "",
+        "CL_ALLOW_NO_FILES": "false",
+        "CL_COUNT": "0",
+        "CL_LIST_FILE": "",
+    }
+    base.update(env)
+    return _run_step("Run compose-lint", base, ws, outputs)
+
+
+# --- VULN-037: "nothing to lint" is not a pass ----------------------------
+
+
+def test_no_compose_files_fails_like_the_cli(ws: Path, outputs: Path) -> None:
+    rc, _out, err = _lint(ws, outputs, CL_COUNT="0")
+    assert rc == 2, "the CLI exits 2 with no Compose files; the Action must too"
+    assert "No Compose files found" in err or "No Compose files found" in _out
+
+
+def test_allow_no_files_opts_out(ws: Path, outputs: Path) -> None:
+    rc, out, err = _lint(ws, outputs, CL_COUNT="0", CL_ALLOW_NO_FILES="true")
+    assert rc == 0
+    assert "::warning::" in (out + err)
+
+
+def test_the_lint_step_is_not_gated_on_a_file_count(ws: Path, outputs: Path) -> None:
+    """The skip is what turned exit 2 into a green check — it must not return.
+
+    An `if:` on this step means the runner reports success without running
+    anything, so the decision has to live inside the script where it can fail.
+    """
+    assert "if" not in _step("Run compose-lint"), (
+        "the lint step must run unconditionally; a skipped step reports "
+        "success without linting anything"
+    )
+
+
+# --- VULN-040: nothing attacker-controlled in $GITHUB_OUTPUT --------------
+
+
+def test_a_newline_in_files_is_refused(ws: Path, outputs: Path) -> None:
+    rc, out, err = _discover(ws, outputs, CL_FILES="a.yml\nfiles=evil")
+    assert rc == 2, "a newline in a space-separated list is malformed"
+    assert "newline" in (out + err)
+
+
+def test_an_ordinary_files_input_is_accepted(ws: Path, outputs: Path) -> None:
+    """The guard must reject only a newline, not every input.
+
+    A pattern built with `$(printf '\\n')` collapses to the empty string and
+    matches everything, which would refuse every `files:` value there is.
+    """
+    (ws / "a.yml").write_text(_INSECURE, encoding="utf-8")
+    (ws / "b.yml").write_text(_INSECURE, encoding="utf-8")
+    rc, out, err = _discover(ws, outputs, CL_FILES="a.yml b.yml")
+    assert rc == 0, out + err
+    recorded = _outputs(outputs)
+    assert recorded["count"] == "2"
+    entries = Path(recorded["list-file"]).read_bytes().split(b"\0")[:-1]
+    assert entries == [b"a.yml", b"b.yml"], entries
+
+
+def test_a_single_file_input_is_accepted(ws: Path, outputs: Path) -> None:
+    (ws / "only.yml").write_text(_INSECURE, encoding="utf-8")
+    rc, out, err = _discover(ws, outputs, CL_FILES="only.yml")
+    assert rc == 0, out + err
+    assert _outputs(outputs)["count"] == "1"
+
+
+def test_discovery_puts_no_filename_into_github_output(ws: Path, outputs: Path) -> None:
+    (ws / "docker-compose.yml").write_text(_INSECURE, encoding="utf-8")
+    rc, _out, _err = _discover(ws, outputs)
+    assert rc == 0
+    recorded = _outputs(outputs)
+    assert set(recorded) == {"count", "list-file"}, recorded
+    assert recorded["count"] == "1"
+    # The path travels in a file, not in the line-oriented output stream.
+    assert "docker-compose.yml" not in outputs.read_text(encoding="utf-8")
+
+
+def test_discovery_preserves_a_path_containing_spaces(ws: Path, outputs: Path) -> None:
+    nested = ws / "my stack"
+    nested.mkdir()
+    (nested / "docker-compose.yml").write_text(_INSECURE, encoding="utf-8")
+    rc, _out, _err = _discover(ws, outputs, CL_PATTERN="docker-compose.yml")
+    assert rc == 0
+    recorded = _outputs(outputs)
+    assert recorded["count"] == "1"
+    entries = Path(recorded["list-file"]).read_bytes().split(b"\0")[:-1]
+    assert entries == [b"./my stack/docker-compose.yml"], entries
+
+
+# --- VULN-038: never ship an artifact that was not written ----------------
+
+
+def test_sarif_is_written_and_flagged_on_a_normal_run(ws: Path, outputs: Path) -> None:
+    (ws / "docker-compose.yml").write_text(_INSECURE, encoding="utf-8")
+    _discover(ws, outputs)
+    listed = _outputs(outputs)["list-file"]
+    sarif = ws / "results.sarif"
+
+    rc, _out, _err = _lint(
+        ws, outputs, CL_COUNT="1", CL_LIST_FILE=listed, CL_SARIF_FILE=str(sarif)
+    )
+    assert rc == 1, "findings present, so the gate fails"
+    assert sarif.exists() and sarif.stat().st_size > 0
+    json.loads(sarif.read_text(encoding="utf-8"))  # a complete document
+    assert _outputs(outputs).get("sarif-written") == "true"
+
+
+def test_a_failed_sarif_run_leaves_no_truncated_artifact(
+    ws: Path, outputs: Path
+) -> None:
+    """The redirect used to truncate the target before the command ran.
+
+    Combined with `|| true`, a failed run left a 0-byte file and reported
+    success, and the upload shipped an empty result set as a clean scan.
+    """
+    (ws / "docker-compose.yml").write_text(_INSECURE, encoding="utf-8")
+    _discover(ws, outputs)
+    listed = _outputs(outputs)["list-file"]
+
+    sarif = ws / "results.sarif"
+    sarif.write_text("PREVIOUS CONTENT", encoding="utf-8")
+
+    # A shim that fails the way a crashing linter would: no stdout, non-zero.
+    shim_dir = ws / "shim"
+    shim_dir.mkdir()
+    shim = shim_dir / "compose-lint"
+    shim.write_text(
+        "#!/usr/bin/env bash\n"
+        'for a in "$@"; do\n'
+        '  if [ "$a" = "sarif" ]; then echo boom >&2; exit 2; fi\n'
+        "done\n"
+        f'exec {VENV_BIN / "compose-lint"} "$@"\n',
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+
+    script_env = {
+        "CL_CONFIG": "",
+        "CL_FAIL_ON": "high",
+        "CL_SKIP_SUPPRESSED": "false",
+        "CL_QUIET": "false",
+        "CL_VERBOSE": "false",
+        "CL_SARIF_FILE": str(sarif),
+        "CL_ALLOW_NO_FILES": "false",
+        "CL_COUNT": "1",
+        "CL_LIST_FILE": listed,
+    }
+    rc, out, err = _run_step(
+        "Run compose-lint", script_env, ws, outputs, extra_path=shim_dir
+    )
+
+    assert rc != 0, "a SARIF run that produced nothing must not report success"
+    assert "refusing to upload an empty artifact" in (out + err)
+    # The previously valid artifact was not truncated by the redirect.
+    assert sarif.read_text(encoding="utf-8") == "PREVIOUS CONTENT"
+    assert _outputs(outputs).get("sarif-written") != "true"
+
+
+def test_upload_is_gated_on_the_file_being_written(ws: Path) -> None:
+    condition = str(_step("Upload SARIF")["if"])
+    assert "sarif-written" in condition, condition
+    assert "always()" not in condition, condition
+
+
+# --- VULN-041: the SARIF path is a write target ---------------------------
+
+
+def test_sarif_file_outside_the_workspace_is_refused(
+    ws: Path, outputs: Path, tmp_path_factory: pytest.TempPathFactory
+) -> None:
+    (ws / "docker-compose.yml").write_text(_INSECURE, encoding="utf-8")
+    _discover(ws, outputs)
+    listed = _outputs(outputs)["list-file"]
+
+    outside_dir = tmp_path_factory.mktemp("outside")
+    victim = outside_dir / "important.txt"
+    victim.write_text("do not truncate me", encoding="utf-8")
+
+    rc, out, err = _lint(
+        ws,
+        outputs,
+        CL_COUNT="1",
+        CL_LIST_FILE=listed,
+        CL_SARIF_FILE=str(victim),
+    )
+    assert rc == 2
+    assert "inside the workspace" in (out + err)
+    assert victim.read_text(encoding="utf-8") == "do not truncate me"
+
+
+def test_sarif_traversal_out_of_the_workspace_is_refused(
+    ws: Path, outputs: Path
+) -> None:
+    (ws / "docker-compose.yml").write_text(_INSECURE, encoding="utf-8")
+    _discover(ws, outputs)
+    listed = _outputs(outputs)["list-file"]
+    rc, out, err = _lint(
+        ws,
+        outputs,
+        CL_COUNT="1",
+        CL_LIST_FILE=listed,
+        CL_SARIF_FILE=str(ws / ".." / "escaped.sarif"),
+    )
+    assert rc == 2
+    assert "inside the workspace" in (out + err)
+
+
+# --- VULN-039: a SHA-pinned `uses:` should pin the package too ------------
+
+
+def _pip_shim(ws: Path) -> tuple[Path, Path]:
+    shim_dir = ws / "pipshim"
+    shim_dir.mkdir()
+    log = ws / "pip.log"
+    shim = shim_dir / "pip"
+    shim.write_text(
+        f'#!/usr/bin/env bash\nprintf "%s\\n" "$*" >> {log}\n', encoding="utf-8"
+    )
+    shim.chmod(0o755)
+    return shim_dir, log
+
+
+def test_install_pins_by_default(ws: Path, outputs: Path) -> None:
+    shim_dir, log = _pip_shim(ws)
+    rc, _out, _err = _run_step(
+        "Install compose-lint", {"CL_VERSION": ""}, ws, outputs, extra_path=shim_dir
+    )
+    assert rc == 0
+    assert "compose-lint==" in log.read_text(encoding="utf-8")
+
+
+def test_install_tracks_pypi_only_when_asked(ws: Path, outputs: Path) -> None:
+    shim_dir, log = _pip_shim(ws)
+    rc, _out, _err = _run_step(
+        "Install compose-lint",
+        {"CL_VERSION": "latest"},
+        ws,
+        outputs,
+        extra_path=shim_dir,
+    )
+    assert rc == 0
+    assert log.read_text(encoding="utf-8").strip() == "install compose-lint"
+
+
+def test_install_honours_an_explicit_version(ws: Path, outputs: Path) -> None:
+    shim_dir, log = _pip_shim(ws)
+    rc, _out, _err = _run_step(
+        "Install compose-lint",
+        {"CL_VERSION": "0.16.0"},
+        ws,
+        outputs,
+        extra_path=shim_dir,
+    )
+    assert rc == 0
+    assert "compose-lint==0.16.0" in log.read_text(encoding="utf-8")
+
+
+def test_the_default_pin_matches_the_package_version() -> None:
+    """Drift here would ship an action that installs a different linter."""
+    import re
+
+    from compose_lint import __version__
+
+    script = _step("Install compose-lint")["run"]
+    match = re.search(r'DEFAULT_VERSION="([^"]+)"', script)
+    assert match, "no DEFAULT_VERSION in the install step"
+    assert match.group(1) == __version__, (
+        f"action.yml pins {match.group(1)}, package is {__version__}"
+    )

--- a/tests/test_harness_end_of_options.py
+++ b/tests/test_harness_end_of_options.py
@@ -76,11 +76,11 @@ def test_action_passes_double_dash_before_the_file_list() -> None:
     invocations = [
         line.strip()
         for line in action.splitlines()
-        if "compose-lint" in line and "$CL_TARGET_FILES" in line
+        if "compose-lint" in line and "TARGET_FILES" in line
     ]
     assert len(invocations) == 2, f"expected 2 invocations, found {invocations!r}"
     for line in invocations:
-        assert "-- $CL_TARGET_FILES" in line, f"missing `--` separator: {line!r}"
+        assert '-- "${TARGET_FILES[@]}"' in line, f"missing `--` separator: {line!r}"
 
 
 def test_double_dash_is_what_changes_the_verdict(tmp_path: Path) -> None:


### PR DESCRIPTION
Resolves six findings from a [VulnHunter](https://github.com/capitalone/vulnhunter) security audit of this repository (tracked internally as VULN-037 through VULN-042). They are fixed as one block because they compose: file discovery feeds the skip that feeds the upload.

**The design rule: the Action must never be more permissive than the CLI it wraps.** It was, in six ways.

## What changed

| | before | after |
|---|---|---|
| no Compose files found | step skipped → **green check** | exit 2, like the CLI (`allow-no-files:` to opt out) |
| SARIF re-run fails | `\|\| true` → success, 0-byte artifact uploaded | step fails, previous artifact intact, no upload |
| `sarif-file` path | unvalidated write target, truncated by `>` | must resolve inside the workspace |
| install | `pip install compose-lint` (whatever PyPI serves) | pinned to the released version; `version: latest` opts out |
| discovered paths | joined with spaces into `$GITHUB_OUTPUT` | NUL-separated file under `RUNNER_TEMP`; only its path crosses |
| consumer workflow docs | no `permissions:` | deny-all + the two scopes the job uses |

Details worth reading:

- **"Nothing to lint" was a pass.** The step was gated on `if: steps.find-files.outputs.files != ''`, so a `pattern:` matching nothing skipped it and the job reported success — while the CLI exits 2 for the same input. A skipped step cannot fail, so the decision moved inside the script.

- **The SARIF redirect truncated before the command ran.** Combined with `|| true`, a failed run left a 0-byte file *and* reported success, and `always()` uploaded it — Code Scanning then showed no alerts over a scan that never completed. Output now goes to a temp file and is moved into place only once it holds a complete document.

- **The pin didn't pin.** A SHA-pinned `uses:` selects this file, not the package it installs. The default is now the released version. This repo's own smoke jobs pass `version: latest` explicitly, which preserves the drift detection the old comment was protecting.

- **`find -print0`** also lands here, deferred from #552 — it was entangled with the `$GITHUB_OUTPUT` transport, which is the VULN-040 fix. Paths containing spaces now survive; the old `tr '\n' ' '` join destroyed them.

## Two things I want to flag

**1. I nearly shipped a total breakage of the `files:` input.** My first newline guard was:

```bash
case "$CL_FILES" in *"$(printf '\n')"*)
```

Command substitution strips trailing newlines, so that collapses to the empty string and the pattern matches **everything** — every `files:` value would have been rejected as "contains a newline". My own tests missed it because none of them passed a *valid* `CL_FILES`. Caught it by hand, fixed to `*$'\n'*`, and added the two tests that were missing (`test_an_ordinary_files_input_is_accepted`, `test_a_single_file_input_is_accepted`).

**2. The audit's exploit tests can no longer validate this area.** `action_harness.sh` embeds the `run:` bodies as *verbatim copies by line number* (`action.yml` lines 56-61, 69-86, 99-130), so it is stale the moment the script moves — it now tests code that no longer exists. VULN-038's test additionally stopped reproducing for an unrelated reason: #549 made compose-lint refuse the poisoned file cleanly, so the crash the chain depended on is gone (SARIF is 65,610 bytes instead of 0). The `|| true` defect it pointed at was still real and is fixed here.

The replacement evidence is `tests/test_action_contract.py`, which **extracts** each step's `run:` body from `action.yml` instead of copying it, so it cannot drift. **14 of its 17 tests fail against the previous `action.yml`** — that is the check that the tests catch the defects rather than merely describing the fix.

## Behavior change

No linting behavior changes — `src/` is untouched, so no corpus impact.

For Action users:

- A workflow whose `pattern:` matches nothing **starts failing** (exit 2). That is the point; set `allow-no-files: true` if an empty result is expected.
- The installed compose-lint version becomes deterministic. A workflow relying on the Action to auto-upgrade must now pass `version: latest`.
- A `files:` value containing a newline is rejected.
- SARIF uploads stop happening when the document was not produced — previously they happened and were empty.

Semver: **minor** — new inputs, and cases that previously passed now fail.

## Also updated

`scripts/bump-version.sh` rewrites `DEFAULT_VERSION` alongside the other two version strings, `docs/RELEASING.md` records why, and `tests/test_action_contract.py` fails if they disagree — so a missed bump is caught before release rather than shipping an Action that installs a different linter than it claims.

Full suite 1642 passed / 6 skipped; `ruff check`, `ruff format --check`, `mypy src/` clean.
