### PR TITLE
Sanitize output at the sink, not at each call site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,44 @@ Compose then ships nothing.
 
 ### Security
 
+- **Everything compose-lint prints about a file is now sanitized at the sink.**
+  Escaping lived in a private helper inside the text formatter, so it covered
+  that formatter's own fields and nothing else: 26 other print sites emitted
+  attacker-derived text raw — service names, file paths, and parse-error text
+  that quotes the document — and a terminal or CI log renders control sequences.
+  The full CSI repertoire reaching stderr means the file being linted can erase
+  findings already on screen.
+
+  Escaping now lives in `compose_lint._output` and **every** stderr write goes
+  through `emit()`, so it is the default rather than something each new call
+  site must remember; a test fails the build on a raw
+  `print(..., file=sys.stderr)` anywhere in `src/`.
+
+  - **A newline can no longer forge a report line.** `_sanitize` passed `\n`
+    through "so excerpt layout survives", but the sink is a newline-delimited
+    report — a service name carrying one put attacker text in the report's own
+    left margin, indistinguishable from a line compose-lint wrote. Values
+    rendered as a single record are now escaped with `sanitize_line`, and
+    multi-line diagnostics indent their continuation lines so nothing after an
+    embedded newline can occupy column zero.
+  - **The `fix` dry-run diff is sanitized.** It is the surface a human reads to
+    authorise a destructive write, and it printed file content verbatim —
+    bidi and zero-width codepoints are YAML-printable, so they survive the
+    parser's own check and could display a line in an order the file does not
+    have. Sanitizing happens in `render_file_diff`, so all three emit sites are
+    covered at once. Display only: `fix --apply` still writes the original
+    bytes.
+  - **`format_header` sanitizes the config path**, the one unsanitized *stdout*
+    site — it sat immediately beside a correctly sanitized `files` argument.
+
+  Measured over the corpus: no findings, exit codes or errors change. Text
+  output is byte-identical on 299 of 300 sampled files; the exception is
+  PyYAML's parse-error context, whose continuation lines gain two spaces of
+  indent. Of the 16 corpus files containing a sanitizable codepoint (all
+  zero-width space or BOM), the only visible change is that a leading BOM now
+  shows as `\ufeff` in a `fix` diff instead of being invisible — which is the
+  point of the fix.
+
 - **The GitHub Action no longer passes where the CLI would fail.** Six defects
   shared that shape, and `action.yml` is fixed as one block.
 

--- a/src/compose_lint/_output.py
+++ b/src/compose_lint/_output.py
@@ -1,0 +1,121 @@
+"""The one place externally-derived text is prepared for a terminal.
+
+Everything compose-lint prints about a Compose file is attacker-authored to
+some degree: service names, image references, env keys, parse-error text that
+quotes the document, and source excerpts read straight off disk. A terminal or
+CI log renders control sequences, so printing any of it verbatim lets the file
+being linted write the report about itself — erase findings already on screen,
+forge a verdict line, or reorder text with a bidi override so the diff a human
+approves is not the diff that will be applied.
+
+Sanitizing was previously a private helper inside the text formatter, so it
+protected the formatter's own fields and nothing else: 26 other print sites
+emitted attacker-derived text raw. Keeping the escaping here, and routing every
+stderr write through :func:`emit`, makes it the default rather than something
+each new call site has to remember.
+
+Two levels, because the sinks differ:
+
+* :func:`sanitize` keeps ``\\n`` and ``\\t`` — for content that is legitimately
+  multi-line, such as a rule's fix guidance or a unified diff.
+* :func:`sanitize_line` also escapes ``\\n`` — for anything rendered as one
+  record in a newline-delimited report, where an embedded newline lets the
+  value occupy the report's own left margin and forge a line.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from typing import TextIO
+
+# Code-point ranges (inclusive) that can spoof or corrupt terminal output:
+# C0/C1 controls — ANSI/escape-sequence injection, including the ESC and CSI
+# introducers — plus DEL, and the bidirectional and zero-width formatting
+# characters that visually reorder or hide text (e.g. U+202E RIGHT-TO-LEFT
+# OVERRIDE rendering a malicious tag as a benign one). Built from hex so no
+# invisible literals live in source. Tab and newline are excluded here and
+# handled by the two functions below, which differ only in whether a newline is
+# structural at that sink.
+_UNSAFE_RANGES = (
+    (0x00, 0x08),
+    (0x0B, 0x1F),
+    (0x7F, 0x9F),
+    (0x200B, 0x200F),
+    (0x202A, 0x202E),
+    (0x2060, 0x2064),
+    (0x2066, 0x206F),
+    (0xFEFF, 0xFEFF),
+)
+
+
+def _pattern(*extra: str) -> re.Pattern[str]:
+    ranges = "".join(f"{chr(lo)}-{chr(hi)}" for lo, hi in _UNSAFE_RANGES)
+    return re.compile("[" + ranges + "".join(extra) + "]")
+
+
+_UNSAFE_OUTPUT_CHARS = _pattern()
+_UNSAFE_LINE_CHARS = _pattern("\n")
+
+
+def _escape(match: re.Match[str]) -> str:
+    return f"\\u{ord(match.group()):04x}"
+
+
+def sanitize(text: str) -> str:
+    """Render terminal-unsafe code points as visible ``\\uXXXX`` escapes.
+
+    Newlines and tabs survive, so multi-line content (fix guidance, a unified
+    diff) keeps its layout. Clean text is returned unchanged.
+    """
+    return _UNSAFE_OUTPUT_CHARS.sub(_escape, text)
+
+
+def sanitize_line(text: str) -> str:
+    """:func:`sanitize`, and escape newlines too.
+
+    For a value rendered as one record in a newline-delimited report. Passing a
+    newline through there is not a layout question: the text after it starts at
+    column zero and is indistinguishable from a line compose-lint wrote itself,
+    which is how a service name could forge a finding against another file or a
+    ``✓ PASS`` verdict.
+    """
+    return _UNSAFE_LINE_CHARS.sub(_escape, text)
+
+
+# Continuation lines are indented so nothing after an embedded newline can sit
+# in the report's own left margin.
+_CONTINUATION_INDENT = "  "
+
+
+def emit(message: str, *, stream: TextIO | None = None) -> None:
+    """Write a sanitized diagnostic to stderr, indenting any continuation.
+
+    Every human-facing status and error line goes through here. Sanitizing at
+    the call site is opt-in and was therefore skipped 26 times; sanitizing at
+    the sink is not.
+
+    Newlines are kept rather than escaped, because some diagnostics are
+    legitimately multi-line and lose their meaning without them — PyYAML's
+    parse errors carry the offending source line and a caret under the column.
+    Escaping those into ``\u000a`` produced one unreadable line and threw away
+    the most useful part of the message.
+
+    What the forgery actually needs is the report's left margin, so that is
+    what is denied: every line after the first is indented. An embedded newline
+    still shows the text that followed it, but visibly as a continuation of
+    this record rather than as a line compose-lint wrote itself.
+    """
+    body = sanitize(message)
+    first, *rest = body.split("\n")
+    lines = [first] + [_CONTINUATION_INDENT + line for line in rest]
+    print("\n".join(lines), file=stream if stream is not None else sys.stderr)
+
+
+def emit_block(text: str) -> None:
+    """Write pre-formatted multi-line text (a diff, a banner) to stderr.
+
+    Line structure is preserved because it is the message; everything that
+    could redraw the terminal is escaped.
+    """
+    print(sanitize(text), end="", file=sys.stderr)

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, NoReturn
 
 from compose_lint import __version__
+from compose_lint._output import emit, emit_block
 from compose_lint.config import ConfigError, load_config
 from compose_lint.config_emit import render_config
 from compose_lint.engine import filter_findings, run_rules
@@ -82,7 +83,7 @@ def _report_parse_error(filepath: str, exc: FileNotFoundError | ComposeError) ->
     handled separately by each caller.
     """
     reason = "file not found" if isinstance(exc, FileNotFoundError) else str(exc)
-    print(f"Error: {filepath}: {reason}", file=sys.stderr)
+    emit(f"Error: {filepath}: {reason}")
     return reason
 
 
@@ -373,7 +374,7 @@ def _report_coverage_gaps(
         return []
     label = "Error" if fatal else "Warning"
     for gap in gaps:
-        print(f"{label}: {filepath}: {gap}", file=sys.stderr)
+        emit(f"{label}: {filepath}: {gap}")
     return [(filepath, gap) for gap in gaps] if fatal else []
 
 
@@ -381,28 +382,21 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
     """Run the `check` operation: lint files and exit with the verdict code."""
     if args.explain is not None:
         if args.files:
-            print(
-                "Error: --explain cannot be combined with FILE arguments",
-                file=sys.stderr,
-            )
+            emit("Error: --explain cannot be combined with FILE arguments")
             sys.exit(2)
         # --explain emits human-readable rule prose to stdout (the requested
         # artifact of this mode). There is no JSON/SARIF form, so reject those
         # rather than silently printing markdown when one is requested.
         if args.output_format != "text":
-            print(
+            emit(
                 "Error: --explain has no JSON or SARIF form; "
-                "use the default text output",
-                file=sys.stderr,
+                "use the default text output"
             )
             sys.exit(2)
         try:
             print(load_rule_doc(args.explain))
         except UnknownRuleError:
-            print(
-                f"Error: unknown rule id '{args.explain}' (expected format: CL-XXXX)",
-                file=sys.stderr,
-            )
+            emit(f"Error: unknown rule id '{args.explain}' (expected format: CL-XXXX)")
             sys.exit(2)
         sys.exit(0)
 
@@ -413,17 +407,16 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
             args.config, strict=args.strict_config
         )
     except ConfigError as e:
-        print(f"Error: {e}", file=sys.stderr)
+        emit(f"Error: {e}")
         sys.exit(2)
 
     if not args.files:
         args.files = _discover_compose_files()
         if not args.files:
-            print(
+            emit(
                 "Error: no Compose files found. Searched for: "
                 "compose.yml, compose.yaml, "
-                "docker-compose.yml, docker-compose.yaml",
-                file=sys.stderr,
+                "docker-compose.yml, docker-compose.yaml"
             )
             sys.exit(2)
 
@@ -457,7 +450,7 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
             # v1 / fragment file: not malformed, just outside what we lint.
             # Per ADR-013 this is exit 0 (skipped, not a parse error). Must
             # precede the ComposeError clause below — it is a subclass.
-            print(f"{filepath}: {e}", file=sys.stderr)
+            emit(f"{filepath}: {e}")
             continue
         except (FileNotFoundError, ComposeError) as e:
             parse_errors.append((filepath, _report_parse_error(filepath, e)))
@@ -479,7 +472,7 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
                 f"{type(exc).__name__}: {exc}"
             )
             rule_errors.append((_filepath, msg))
-            print(f"Error: {_filepath}: {msg}", file=sys.stderr)
+            emit(f"Error: {_filepath}: {msg}")
 
         findings = run_rules(
             data,
@@ -513,7 +506,7 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
                 # unmounted, permission change). Record it and move on so one bad
                 # file can't abort the rest of the batch.
                 parse_errors.append((filepath, str(e)))
-                print(f"Error: {filepath}: {e}", file=sys.stderr)
+                emit(f"Error: {filepath}: {e}")
                 continue
             try:
                 fixes = collect_edits(findings, data, lines, text).fixed_edits
@@ -524,7 +517,7 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
                 # file's findings too (VULN-017 consequence c).
                 msg = f"could not compute fixes: {e}"
                 parse_errors.append((filepath, msg))
-                print(f"Error: {filepath}: {msg}", file=sys.stderr)
+                emit(f"Error: {filepath}: {msg}")
                 continue
             all_sarif.extend(format_sarif(findings, filepath, fixes=fixes))
         else:
@@ -537,10 +530,9 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
     for rule_id, services_map in excluded_services.items():
         for service_name in services_map:
             if service_name not in seen_services:
-                print(
+                emit(
                     f"Warning: exclude_services for {rule_id} references "
-                    f"unknown service '{service_name}'",
-                    file=sys.stderr,
+                    f"unknown service '{service_name}'"
                 )
 
     # Coverage gaps ride the same structured channel as parse errors — JSON
@@ -626,17 +618,16 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
             args.config, strict=args.strict_config
         )
     except ConfigError as e:
-        print(f"Error: {e}", file=sys.stderr)
+        emit(f"Error: {e}")
         sys.exit(2)
 
     if not args.files:
         args.files = _discover_compose_files()
         if not args.files:
-            print(
+            emit(
                 "Error: no Compose files found. Searched for: "
                 "compose.yml, compose.yaml, "
-                "docker-compose.yml, docker-compose.yaml",
-                file=sys.stderr,
+                "docker-compose.yml, docker-compose.yaml"
             )
             sys.exit(2)
 
@@ -649,7 +640,7 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
         except ComposeNotApplicableError as e:
             # v1 / fragment file: skipped, not an error (ADR-013). Must precede
             # the ComposeError clause below — it is a subclass.
-            print(f"{filepath}: {e}", file=sys.stderr)
+            emit(f"{filepath}: {e}")
             continue
         except (FileNotFoundError, ComposeError) as e:
             _report_parse_error(filepath, e)
@@ -668,7 +659,7 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
         except OSError as e:
             # Parsed above, but unreadable now (deleted, unmounted, permission
             # change) — record and continue so the rest of the batch still runs.
-            print(f"Error: {filepath}: {e}", file=sys.stderr)
+            emit(f"Error: {filepath}: {e}")
             had_error = True
             continue
         findings = run_rules(
@@ -683,25 +674,24 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
         except LineOutOfRangeError as e:
             # Same fail-closed treatment as the check path: refuse this file,
             # write nothing, let the rest of the batch run (VULN-017).
-            print(f"Error: {filepath}: could not compute fixes: {e}", file=sys.stderr)
+            emit(f"Error: {filepath}: could not compute fixes: {e}")
             had_error = True
             continue
 
         if not result.edits:
             if result.manual:
-                print(
+                emit(
                     f"{filepath}: nothing to auto-fix; "
-                    f"{len(result.manual)} finding(s) need manual review",
-                    file=sys.stderr,
+                    f"{len(result.manual)} finding(s) need manual review"
                 )
             else:
-                print(f"{filepath}: nothing to fix", file=sys.stderr)
+                emit(f"{filepath}: nothing to fix")
             continue
 
         try:
             patched = apply_edits(text, result.edits)
         except LineOutOfRangeError as e:
-            print(f"Error: {filepath}: could not apply fixes: {e}", file=sys.stderr)
+            emit(f"Error: {filepath}: could not apply fixes: {e}")
             had_error = True
             continue
 
@@ -711,15 +701,10 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
         # diff plus the parse error so it is diagnosable (issue #261).
         guard_error = reparse_or_error(patched, Path(filepath).absolute().parent)
         if guard_error is not None:
-            print(
-                render_file_diff(filepath, text, patched, result.caveats),
-                end="",
-                file=sys.stderr,
-            )
-            print(
+            emit_block(render_file_diff(filepath, text, patched, result.caveats))
+            emit(
                 f"Error: {filepath}: computed fix does not parse as Compose "
-                f"({guard_error}); no changes written",
-                file=sys.stderr,
+                f"({guard_error}); no changes written"
             )
             had_error = True
             continue
@@ -740,15 +725,8 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
             excluded_services=excluded_services,
         )
         if verify_error is not None:
-            print(
-                render_file_diff(filepath, text, patched, result.caveats),
-                end="",
-                file=sys.stderr,
-            )
-            print(
-                f"Error: {filepath}: {verify_error}; no changes written",
-                file=sys.stderr,
-            )
+            emit_block(render_file_diff(filepath, text, patched, result.caveats))
+            emit(f"Error: {filepath}: {verify_error}; no changes written")
             had_error = True
             continue
 
@@ -758,25 +736,19 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
                 # modify" signal; os.replace would still swap it in via the
                 # writable parent directory. Warn and skip rather than override
                 # the user's intent silently.
-                print(
+                emit(
                     f"Warning: {filepath}: file is not writable; skipping "
-                    "(make it writable to allow `fix --apply` to modify it)",
-                    file=sys.stderr,
+                    "(make it writable to allow `fix --apply` to modify it)"
                 )
                 continue
             _atomic_write(Path(filepath), patched)
             # The behavior-changing caveats must surface here too, not only on
             # the dry run — nothing forces a dry run first, so a one-shot
             # `fix --apply` would otherwise mutate files silently (issue #428).
-            print(
-                render_caveat_banner(result.caveats),
-                end="",
-                file=sys.stderr,
-            )
-            print(
+            emit_block(render_caveat_banner(result.caveats))
+            emit(
                 f"{filepath}: applied {len(result.edits)} fix(es) across "
-                f"{len(result.fixed)} finding(s)",
-                file=sys.stderr,
+                f"{len(result.fixed)} finding(s)"
             )
         else:
             print(
@@ -784,10 +756,9 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
                 end="",
                 flush=True,
             )
-            print(
+            emit(
                 f"{filepath}: {len(result.edits)} fix(es) available; "
-                f"{len(result.manual)} finding(s) need manual review",
-                file=sys.stderr,
+                f"{len(result.manual)} finding(s) need manual review"
             )
 
     sys.exit(2 if had_error else 0)
@@ -809,7 +780,7 @@ def _run_init(args: argparse.Namespace) -> NoReturn:
         # v1 / fragment file: skipped, not an error (ADR-013). Nothing to lint,
         # so nothing to bootstrap. Must precede the ComposeError clause below —
         # it is a subclass.
-        print(f"{args.file}: {e}", file=sys.stderr)
+        emit(f"{args.file}: {e}")
         sys.exit(0)
     except (FileNotFoundError, ComposeError) as e:
         _report_parse_error(args.file, e)
@@ -817,9 +788,8 @@ def _run_init(args: argparse.Namespace) -> NoReturn:
 
     findings = run_rules(data, lines)
     if not findings:
-        print(
-            f"{args.file}: no findings; nothing to suppress, not writing {args.output}",
-            file=sys.stderr,
+        emit(
+            f"{args.file}: no findings; nothing to suppress, not writing {args.output}"
         )
         sys.exit(0)
 
@@ -828,10 +798,7 @@ def _run_init(args: argparse.Namespace) -> NoReturn:
     # above already exited, so reaching here means there is a config to land.
     # Protect deliberate human suppression decisions from a silent clobber.
     if out_path.exists() and not args.force:
-        print(
-            f"Error: {out_path} already exists; pass --force to overwrite",
-            file=sys.stderr,
-        )
+        emit(f"Error: {out_path} already exists; pass --force to overwrite")
         sys.exit(2)
 
     existed = out_path.exists()
@@ -845,9 +812,7 @@ def _run_init(args: argparse.Namespace) -> NoReturn:
 
     rule_count = len({f.rule_id for f in findings})
     pair_count = len({(f.rule_id, f.service) for f in findings})
-    print(
-        f"wrote {out_path} with {pair_count} suppression(s) across "
-        f"{rule_count} rule(s)",
-        file=sys.stderr,
+    emit(
+        f"wrote {out_path} with {pair_count} suppression(s) across {rule_count} rule(s)"
     )
     sys.exit(0)

--- a/src/compose_lint/config.py
+++ b/src/compose_lint/config.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 from typing import Any
 
 import yaml
 
+from compose_lint._output import emit
 from compose_lint.models import Severity
 
 # Top-level keys the config schema defines today (docs/configuration.md).
@@ -41,7 +41,7 @@ def _warn(message: str, strict: bool = False) -> None:
     """
     if strict:
         raise ConfigError(message)
-    print(f"Warning: {message}", file=sys.stderr)
+    emit(f"Warning: {message}")
 
 
 def _known_rule_ids() -> set[str]:

--- a/src/compose_lint/engine.py
+++ b/src/compose_lint/engine.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import sys
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
+from compose_lint._output import emit
 from compose_lint.models import Finding, Severity
 from compose_lint.rules import get_registered_rules
 
@@ -15,10 +15,9 @@ if TYPE_CHECKING:
 
 def _default_rule_error(rule_id: str, service_name: str, exc: Exception) -> None:
     """Report a crashed rule to stderr without aborting the run."""
-    print(
+    emit(
         f"Error: rule {rule_id} failed on service '{service_name}': "
-        f"{type(exc).__name__}: {exc}",
-        file=sys.stderr,
+        f"{type(exc).__name__}: {exc}"
     )
 
 

--- a/src/compose_lint/fix.py
+++ b/src/compose_lint/fix.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from compose_lint._lines import line_starts, split_lines
+from compose_lint._output import sanitize, sanitize_line
 from compose_lint._yaml_edit import (
     DISABLED_SECURITY_PROFILES,
     _is_seq_item,
@@ -433,14 +434,23 @@ def render_file_diff(
     common Compose case) is followed by git's ``\\ No newline at end of file``
     marker. ``difflib`` omits it, which would otherwise glue that line and the
     next onto one line and garble the diff (issue #261 M2).
+
+    Content is sanitized here rather than at the three call sites, because this
+    is the surface a human reads to authorise a destructive write and it must
+    show what will actually be written. Bidi and zero-width codepoints are
+    YAML-printable, so they survive the parser's own check and reach the diff
+    intact — a right-to-left override can display a line in an order the file
+    does not have. Newlines survive sanitizing, so the diff's structure is
+    untouched.
     """
     chunks: list[str] = []
-    for line in difflib.unified_diff(
+    for raw_line in difflib.unified_diff(
         split_lines(original),
         split_lines(patched),
-        fromfile=path,
-        tofile=path,
+        fromfile=sanitize_line(path),
+        tofile=sanitize_line(path),
     ):
+        line = sanitize(raw_line)
         # Header lines (`---`/`+++`/`@@`) always end in a newline; only a final
         # content line can lack one. Re-terminate it and add the git sentinel.
         if line.endswith("\n"):

--- a/src/compose_lint/formatters/text.py
+++ b/src/compose_lint/formatters/text.py
@@ -9,6 +9,8 @@ import unicodedata
 from pathlib import Path
 
 from compose_lint._lines import BREAK_CHARS, split_lines
+from compose_lint._output import sanitize as _sanitize
+from compose_lint._output import sanitize_line as _sanitize_line
 from compose_lint.models import Finding, Severity
 
 _COLORS = {
@@ -78,40 +80,6 @@ _PRESENCE_RULES = frozenset(
 )
 
 _QUOTED = re.compile(r"'([^']+)'")
-
-# Code-point ranges (inclusive) that can spoof or corrupt terminal output when
-# an untrusted string from the Compose file (image name, service name, env key,
-# or a source line read straight off disk) is printed: C0/C1 controls —
-# ANSI/escape-sequence injection, including the ESC and CSI introducers — plus
-# DEL, and the bidirectional and zero-width formatting characters that visually
-# reorder or hide text (e.g. U+202E RIGHT-TO-LEFT OVERRIDE rendering a malicious
-# tag as a benign one). Built from hex so no invisible literals live in source;
-# tab and newline are deliberately excluded so excerpt layout survives.
-_UNSAFE_RANGES = (
-    (0x00, 0x08),
-    (0x0B, 0x1F),
-    (0x7F, 0x9F),
-    (0x200B, 0x200F),
-    (0x202A, 0x202E),
-    (0x2060, 0x2064),
-    (0x2066, 0x206F),
-    (0xFEFF, 0xFEFF),
-)
-_UNSAFE_OUTPUT_CHARS = re.compile(
-    "[" + "".join(f"{chr(lo)}-{chr(hi)}" for lo, hi in _UNSAFE_RANGES) + "]"
-)
-
-
-def _sanitize(text: str) -> str:
-    """Render terminal-unsafe code points as visible ``\\uXXXX`` escapes.
-
-    Findings and source excerpts carry attacker-controlled text. The source
-    excerpt in particular is read directly off disk (``_read_source_lines``),
-    bypassing the parser's printable-character check, so a crafted Compose file
-    could otherwise inject raw ANSI escapes or bidi overrides into a terminal
-    or CI log. Clean ASCII/Unicode text is returned unchanged.
-    """
-    return _UNSAFE_OUTPUT_CHARS.sub(lambda m: f"\\u{ord(m.group()):04x}", text)
 
 
 def _color_enabled() -> bool:
@@ -191,9 +159,9 @@ def format_header(
 ) -> str:
     """Format a branded run header showing the tool version and active parameters."""
     sep = _colorize("·", _DIM)
-    config_str = config_path if config_path else "none"
+    config_str = _sanitize_line(config_path) if config_path else "none"
     params = (
-        f"files: {', '.join(_sanitize(f) for f in files)}"
+        f"files: {', '.join(_sanitize_line(f) for f in files)}"
         f"  {sep}  config: {config_str}"
         f"  {sep}  fail-on: {fail_on.value}"
     )
@@ -233,7 +201,7 @@ def _excerpt(
     """
     if line_num < 1 or line_num > len(source_lines):
         return []
-    raw = _sanitize(source_lines[line_num - 1].rstrip())
+    raw = _sanitize_line(source_lines[line_num - 1].rstrip())
     line_label = str(line_num)
     pad = " " * len(line_label)
     bar = _colorize("│", _DIM)
@@ -291,7 +259,7 @@ def format_findings(
     )
 
     out: list[str] = []
-    out.append(_colorize(_sanitize(filepath), _BOLD))
+    out.append(_colorize(_sanitize_line(filepath), _BOLD))
     out.append("")
 
     # Dedup on (rule_id, fix, references), not rule_id alone: one rule's fix can
@@ -306,7 +274,7 @@ def format_findings(
         svc_line = next((f.line for f in group if f.line is not None), None)
         header_suffix = f"  ({_colorize('line', _DIM)} {svc_line})" if svc_line else ""
         out.append(
-            f"  {_colorize('service:', _DIM)} {_sanitize(service)}{header_suffix}"
+            f"  {_colorize('service:', _DIM)} {_sanitize_line(service)}{header_suffix}"
         )
         out.append(
             _colorize(
@@ -328,18 +296,19 @@ def format_findings(
                     f"    {line_label.rjust(4)}  "
                     f"{marker}  "
                     f"{_colorize(f.rule_id, _DIM)}  "
-                    f"{_colorize(_sanitize(f.message), _SUPPRESSED_COLOR)}"
+                    f"{_colorize(_sanitize_line(f.message), _SUPPRESSED_COLOR)}"
                 )
                 if not quiet:
                     out.append(
-                        f"          {_colorize('reason:', _DIM)} {_sanitize(reason)}"
+                        f"          {_colorize('reason:', _DIM)} "
+                        f"{_sanitize_line(reason)}"
                     )
                 continue
 
             severity_label = f.severity.value.upper().ljust(_LABEL_WIDTH)
             color = _COLORS.get(f.severity, "")
             line_label = str(f.line) if f.line else "?"
-            message = _sanitize(f.message)
+            message = _sanitize_line(f.message)
 
             fix_key = (f.rule_id, f.fix or "", tuple(f.references or ()))
             already_shown = fix_key in seen_fixes
@@ -383,7 +352,7 @@ def format_summary(
     filepath: str,
 ) -> str:
     """Format a one-line summary of findings for a single file."""
-    filepath = _sanitize(filepath)
+    filepath = _sanitize_line(filepath)
     if not findings:
         return _colorize(f"{filepath}: no issues found", _GREEN)
 

--- a/tests/test_output_sanitizing.py
+++ b/tests/test_output_sanitizing.py
@@ -1,0 +1,197 @@
+"""Externally-derived text must not be able to write compose-lint's report.
+
+Everything the tool prints about a Compose file is attacker-authored to some
+degree — service names, image refs, parse-error text quoting the document,
+source excerpts read off disk. Sanitizing used to be a private helper inside
+the text formatter, so it covered the formatter's own fields and nothing else:
+26 other print sites emitted the same class of text raw, and the ``fix``
+dry-run diff — the surface a human reads before authorising a write — printed
+file content verbatim.
+
+The escaping now lives in ``compose_lint._output`` and every stderr write goes
+through :func:`~compose_lint._output.emit`, so it is the default rather than
+something each new call site must remember. ``test_no_raw_stderr_writes``
+enforces that.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from compose_lint._output import sanitize, sanitize_line
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src" / "compose_lint"
+
+ESC = "\x1b"
+RLO = "\u202e"
+ZWSP = "\u200b"
+
+
+def _run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "compose_lint", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        env={
+            "PYTHONPATH": str(REPO_ROOT / "src"),
+            "PATH": "/usr/bin:/bin",
+            "NO_COLOR": "1",
+        },
+        timeout=120,
+    )
+
+
+# --- The two escaping levels ----------------------------------------------
+
+
+def test_sanitize_escapes_controls_and_bidi_but_keeps_layout() -> None:
+    assert sanitize(f"a{ESC}b") == "a\\u001bb"
+    assert sanitize(f"alpine{RLO}3.18") == "alpine\\u202e3.18"
+    assert sanitize(f"a{ZWSP}b") == "a\\u200bb"
+    # Multi-line content (fix guidance, a diff) keeps its structure.
+    assert sanitize("one\ntwo\tthree") == "one\ntwo\tthree"
+
+
+def test_sanitize_line_also_escapes_newlines() -> None:
+    """A newline in a single report record forges a line of the report."""
+    assert sanitize_line("one\ntwo") == "one\\u000atwo"
+    assert sanitize_line(f"a{ESC}b\nc") == "a\\u001bb\\u000ac"
+
+
+def test_clean_text_is_returned_unchanged() -> None:
+    for text in ("nginx:1.27", "services.web.image", "a-b_c.d/e:f@sha256:00"):
+        assert sanitize(text) == text
+        assert sanitize_line(text) == text
+
+
+# --- VULN-027: a service name must not be able to forge a report line -----
+
+
+def test_a_newline_in_a_service_name_cannot_forge_a_report_line(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "docker-compose.yml"
+    target.write_text(
+        'services:\n  "web\\n✓ PASS  ·  threshold: high":\n'
+        "    image: nginx:latest\n    privileged: true\n",
+        encoding="utf-8",
+    )
+    proc = _run([str(target)], tmp_path)
+    # The forged verdict must not appear on a line of its own.
+    for line in proc.stdout.splitlines():
+        assert line.strip() != "✓ PASS  ·  threshold: high", proc.stdout
+    assert "\\u000a" in proc.stdout, "the newline should be visible as an escape"
+
+
+# --- VULN-028: no raw control bytes on any diagnostic path ----------------
+
+
+def test_no_raw_escape_reaches_stderr(tmp_path: Path) -> None:
+    """A double-quoted YAML `\\e` decodes *after* the parser's printable check."""
+    target = tmp_path / "docker-compose.yml"
+    target.write_text(
+        'services:\n  web:\n    image: "nginx\\e[2J:1.27"\n    ports: [x\n',
+        encoding="utf-8",
+    )
+    proc = _run([str(target)], tmp_path)
+    assert ESC not in proc.stderr, "raw ESC reached stderr"
+    assert ESC not in proc.stdout, "raw ESC reached stdout"
+
+
+def test_no_raw_stderr_writes_outside_the_output_module() -> None:
+    """Guard: sanitizing at the sink, not opt-in per call site.
+
+    A new ``print(..., file=sys.stderr)`` is exactly how the previous 26
+    unsanitized sites accumulated. Use ``compose_lint._output.emit`` (or
+    ``emit_block`` for pre-formatted multi-line text) instead.
+    """
+    offenders: list[str] = []
+    for path in sorted(SRC.rglob("*.py")):
+        if path.name == "_output.py":
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "print"
+                and any(
+                    kw.arg == "file" and ast.unparse(kw.value).endswith("stderr")
+                    for kw in node.keywords
+                )
+            ):
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{node.lineno}")
+    assert not offenders, (
+        "raw stderr writes found — route them through compose_lint._output.emit:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_the_guard_can_see_a_raw_stderr_write() -> None:
+    """Guard the guard: prove the matcher fires on a known-bad snippet."""
+    tree = ast.parse("import sys\nprint('x', file=sys.stderr)\n")
+    found = [
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Name)
+        and n.func.id == "print"
+        and any(
+            kw.arg == "file" and ast.unparse(kw.value).endswith("stderr")
+            for kw in n.keywords
+        )
+    ]
+    assert len(found) == 1
+
+
+def test_the_config_path_in_the_header_is_sanitized(tmp_path: Path) -> None:
+    """The only unsanitized *stdout* site, beside a correctly sanitized one."""
+    from compose_lint.formatters.text import format_header
+    from compose_lint.models import Severity
+
+    header = format_header(["clean.yml"], f"cfg{RLO}.yml", Severity.HIGH, "0.0.0")
+    assert RLO not in header
+    assert "\\u202e" in header
+
+
+# --- VULN-029: the diff must show what will be written --------------------
+
+
+def test_the_dry_run_diff_does_not_pass_bidi_through(tmp_path: Path) -> None:
+    target = tmp_path / "docker-compose.yml"
+    target.write_text(
+        "services:\n"
+        "  web:\n"
+        "    image: nginx:1.27\n"
+        f'    labels:\n      note: "start{RLO}end"\n'
+        "    logging:\n"
+        "      driver: none\n",
+        encoding="utf-8",
+    )
+    proc = _run(["fix", str(target)], tmp_path)
+    assert RLO not in proc.stdout, "raw bidi override reached the approval surface"
+    assert RLO not in proc.stderr
+
+
+@pytest.mark.parametrize("char,escape", [(ESC, "\\u001b"), (RLO, "\\u202e")])
+def test_diff_content_is_escaped_but_structure_survives(
+    tmp_path: Path, char: str, escape: str
+) -> None:
+    from compose_lint.fix import render_file_diff
+
+    original = f"a: 1\nb: bad{char}value\n"
+    patched = "a: 1\n"
+    diff = render_file_diff("compose.yml", original, patched, [])
+    assert char not in diff
+    assert escape in diff
+    # Diff structure is the message — it must not be escaped away.
+    assert diff.startswith("---")
+    assert "\n" in diff
+    assert "+++" in diff


### PR DESCRIPTION
Resolves three findings from a [VulnHunter](https://github.com/capitalone/vulnhunter) security audit of this repository (tracked internally as VULN-027, 028, 029 — all Medium). One root cause.

## The defect

Everything compose-lint prints about a Compose file is attacker-authored to some degree: service names, image refs, parse-error text that quotes the document, source excerpts read straight off disk. Escaping lived in a private helper inside the text formatter, so it protected that formatter's own fields and **nothing else** — an AST walk found 26 other print sites emitting the same class of text raw.

A terminal or CI log renders control sequences, so the full CSI repertoire reaching stderr lets the file being linted erase findings already on screen. PyYAML rejects a *raw* ESC byte, but a double-quoted `\e` escape is decoded **after** the printability check, so it arrives intact.

Two more shapes on top of that:

- **A newline forged report lines.** The old helper deliberately passed `\n` through "so excerpt layout survives" — but the sink is a newline-delimited report, so a service name carrying one put attacker text in the report's own left margin, indistinguishable from a line compose-lint wrote. A forged `✓ PASS` verdict, or a finding attributed to another file.
- **The `fix` dry-run diff printed file content verbatim.** That is the surface a human reads to authorise a destructive write. Bidi and zero-width codepoints are YAML-printable, so they survive the parser's own check and can display a line in an order the file does not have.

## The fix

Escaping moves to `compose_lint._output`, and **every** stderr write goes through `emit()`. Sanitizing at the call site is opt-in, which is exactly how 26 sites came to skip it; sanitizing at the sink is not. A test fails the build on a raw `print(..., file=sys.stderr)` anywhere in `src/`.

Two levels, because the sinks differ:

- `sanitize()` keeps `\n` and `\t` — for content that is legitimately multi-line (fix guidance, a diff).
- `sanitize_line()` also escapes `\n` — for a value rendered as one record in the report.

`render_file_diff` sanitizes, which covers all three of its emit sites at once. `format_header` sanitizes the config path — the one unsanitized *stdout* site, which sat immediately beside a correctly sanitized `files` argument.

**Display only.** Verified that `fix --apply` still writes the original bytes: a file with a leading BOM comes out `efbbbf…` byte-for-byte, with no `﻿` text written.

## One design correction worth reading

My first version had `emit()` escape newlines too. That was wrong, and the corpus caught it: PyYAML's parse errors carry the offending source line and a caret under the column, and collapsing that to one line of `
` throws away the most useful part of the message.

```
BEFORE (and after the correction)      MY FIRST ATTEMPT (regression)
Error: f.yml: Invalid YAML: dup key    Error: ...dup key
  in "<unicode
  in "<unicode string>", line 11:      string>", line 11:
  max-size...
        max-size: "50m"
        ^
```

What a forgery actually needs is the report's **left margin**, so that is what is denied: multi-line diagnostics keep their newlines and indent every continuation line. An embedded newline still shows the text that followed it, but visibly as a continuation of that record rather than as a line compose-lint wrote.

## Behavior change

No findings, exit codes or errors change anywhere in the 5,417-file corpus.

Text output was compared before/after on 300 corpus files: **299 byte-identical.** The one difference is PyYAML's parse-error context gaining two spaces of indent (the continuation rule above).

I also scanned the whole corpus for files containing a sanitizable codepoint — 16 of 5,417, all zero-width space or BOM — and diffed `check` *and* `fix` output on each. The only visible change: a leading BOM now shows as `﻿` in a `fix` diff instead of being invisible. That is the fix doing its job.

Output shape: JSON and SARIF are unaffected (`json.dumps` already escapes). Text-mode findings are unchanged except for the above.

Semver: **patch**.

## Tests

11 new tests in `tests/test_output_sanitizing.py`: both escaping levels, the forged-verdict scenario end-to-end, `\e`-decoded ESC on the diagnostic path, the sanitized config path, the diff (escaped content, structure intact), and the AST guard — plus a check that the guard itself fires on a known-bad snippet.

Full suite 1653 passed / 6 skipped; `ruff check`, `ruff format --check`, `mypy src/` clean.
