### PR TITLE
Stop reporting states that are not true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,41 @@ Compose then ships nothing.
 
 ### Security
 
+- **Four places where the tool reported a state that was not true.**
+
+  - **`fix --apply` no longer claims to have fixed a file it did not touch.**
+    `os.replace` swaps the directory entry, not the inode behind it, so on a
+    **symlink** it dropped a regular file over the link and left the file the
+    stack actually deploys unchanged — while the run reported the fix applied.
+    On a **hard link** it broke the link and let the two names diverge in
+    silence. Both are now refused with an error naming the reason; the rest of
+    the batch continues. `setuid`/`setgid`/sticky bits are no longer carried
+    onto the replacement inode.
+  - **A `severity:` override leaves an audit record.** It was the one
+    suppression channel with none: `enabled: false` and `exclude_services` both
+    mark findings SUPPRESSED with a reason, but a re-graded finding was
+    indistinguishable from one the rule declared at that level — so three lines
+    in a policy file could take a CRITICAL below the default gate invisibly.
+    Now reported as `(severity overridden from critical)` in text,
+    `severity_overridden_from` in JSON, and `properties.severityOverriddenFrom`
+    in SARIF. Re-stating a rule's own severity records nothing, because nothing
+    changed.
+  - **Duplicate keys in `.compose-lint.yml` are a config error.** YAML resolves
+    them last-wins in silence, so a policy that disables a rule with a reason
+    and re-enables it further down read, to a human, as the first entry and
+    behaved as the second. The Compose parser already refuses duplicates for
+    this reason; the config loader was the door left open.
+  - **A line lookup never returns a line belonging to a different node.**
+    Joining path segments with `.` is lossy when a segment contains one: a
+    service named `web.logging` and service `web`'s `logging:` child both spell
+    `services.web.logging`, and last-write-wins handed one of them the other's
+    line — so a fixer evaluated its anchor/merge-key refusal against a
+    different service and applied an edit every fixer is required to refuse.
+    Colliding paths are now dropped from the map, so the lookup returns `None`
+    and the fixer fails closed. 17 corpus files use dotted service names
+    (`llama.cpp`, `smartwardrobe.api`); none of them collides, so nothing real
+    loses its line numbers.
+
 - **Everything compose-lint prints about a file is now sanitized at the sink.**
   Escaping lived in a private helper inside the text formatter, so it covered
   that formatter's own fields and nothing else: 26 other print sites emitted

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ rules:
     severity: medium
 ```
 
-Disabled and excluded findings still appear marked **SUPPRESSED** with the `reason` flowing to JSON's `suppression_reason` and SARIF's `justification` (recognized by GitHub Code Scanning) — they do not affect exit code. Pass `--skip-suppressed` to hide them.
+Disabled and excluded findings still appear marked **SUPPRESSED** with the `reason` flowing to JSON's `suppression_reason` and SARIF's `justification` (recognized by GitHub Code Scanning) — they do not affect exit code. Pass `--skip-suppressed` to hide them. A `severity:` override is reported too, as `(severity overridden from …)` in text and `severity_overridden_from` / `properties.severityOverriddenFrom` in JSON and SARIF, so a re-graded finding is distinguishable from one the rule declared at that level.
 
 See [docs/configuration.md](https://github.com/tmatens/compose-lint/blob/main/docs/configuration.md) for per-service exclusion semantics, precedence rules, and the full output-format mapping.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,6 +52,22 @@ rules:
 - **JSON**: `suppression_reason` field on each finding.
 - **SARIF**: `suppressions[].justification` (recognized by GitHub Code Scanning).
 
+`severity:` re-grades a rule's findings rather than suppressing them, and it
+leaves its own record so a reader can tell a re-graded finding from one the rule
+declared that way. Re-grading is the quietest way to neutralise a rule — three
+lines can take a CRITICAL below the default gate — so it is reported:
+
+- **Text**: `(severity overridden from critical)` after the finding.
+- **JSON**: `severity_overridden_from` on the finding (absent when not overridden).
+- **SARIF**: `properties.severityOverriddenFrom` on the result.
+
+Re-stating a rule's own severity records nothing, because nothing changed.
+
+**Duplicate keys are rejected.** Listing the same rule twice is a config error
+rather than a last-wins merge: a policy file that disables a rule "with a
+reason" and then re-enables it further down reads, to a human, as the first
+entry — and used to behave as the second.
+
 To hide suppressed findings entirely:
 
 ```bash

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -575,6 +575,10 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
     sys.exit(1 if has_errors else 0)
 
 
+class LinkedPathError(OSError):
+    """Raised when a fix target is a symlink or a multiply-linked file."""
+
+
 def _atomic_write(path: Path, content: str) -> None:
     """Write ``content`` to ``path`` atomically, preserving its mode.
 
@@ -585,7 +589,31 @@ def _atomic_write(path: Path, content: str) -> None:
     the complete new one, never a truncated mix. The original file's permission
     bits carry over so the fix neither relaxes nor tightens them. ``newline=""``
     writes the computed text verbatim, with no newline translation.
+
+    Raises :class:`LinkedPathError` when the target is a symlink or has more
+    than one name. ``os.replace`` swaps the *entry*, not the inode behind it, so
+    on a symlink it drops a regular file over the link and leaves the file the
+    stack actually deploys untouched — while the run reports the fix applied.
+    On a hard link it breaks the link, so the two names silently diverge. In
+    both cases the honest answer is that this write cannot do what the caller
+    asked, which is a refusal, not a success (ADR-014: refuse, never guess).
     """
+    try:
+        info: os.stat_result | None = path.lstat()
+    except FileNotFoundError:
+        info = None  # a new file (`init`): nothing to link past or preserve
+    if info is not None and stat.S_ISLNK(info.st_mode):
+        raise LinkedPathError(
+            f"{path} is a symbolic link; writing here would replace the link "
+            "and leave its target — the file that is actually deployed — "
+            "unchanged. Point the fix at the target instead."
+        )
+    if info is not None and info.st_nlink > 1:
+        raise LinkedPathError(
+            f"{path} has {info.st_nlink} hard links; replacing it would break "
+            "the link and leave the other names on the old content."
+        )
+
     fd, tmp_name = tempfile.mkstemp(
         dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
     )
@@ -596,8 +624,12 @@ def _atomic_write(path: Path, content: str) -> None:
             tmp.flush()
             os.fsync(tmp.fileno())
         # Best-effort mode carry-over; the swap below still lands the content.
-        with contextlib.suppress(OSError):
-            os.chmod(tmp_path, stat.S_IMODE(path.stat().st_mode))
+        # setuid/setgid/sticky are deliberately dropped: a Compose file has no
+        # business carrying them, and re-applying them to a file this process
+        # just created would hand those bits to a new inode.
+        if info is not None:
+            with contextlib.suppress(OSError):
+                os.chmod(tmp_path, stat.S_IMODE(info.st_mode) & 0o777)
         os.replace(tmp_path, path)
     except BaseException:
         tmp_path.unlink(missing_ok=True)
@@ -741,7 +773,12 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
                     "(make it writable to allow `fix --apply` to modify it)"
                 )
                 continue
-            _atomic_write(Path(filepath), patched)
+            try:
+                _atomic_write(Path(filepath), patched)
+            except LinkedPathError as e:
+                emit(f"Error: {e}; no changes written")
+                had_error = True
+                continue
             # The behavior-changing caveats must surface here too, not only on
             # the dry run — nothing forces a dry run first, so a one-shot
             # `fix --apply` would otherwise mutate files silently (issue #428).
@@ -802,7 +839,11 @@ def _run_init(args: argparse.Namespace) -> NoReturn:
         sys.exit(2)
 
     existed = out_path.exists()
-    _atomic_write(out_path, render_config(findings))
+    try:
+        _atomic_write(out_path, render_config(findings))
+    except LinkedPathError as e:
+        emit(f"Error: {e}")
+        sys.exit(2)
     if not existed:
         # _atomic_write carries over an existing file's mode but a fresh file
         # inherits mkstemp's restrictive 0600. A config meant to be committed and

--- a/src/compose_lint/config.py
+++ b/src/compose_lint/config.py
@@ -65,6 +65,47 @@ def _parse_severity(value: str) -> Severity:
 ExcludedServices = dict[str, dict[str, str | None]]
 
 
+class _StrictLoader(yaml.SafeLoader):
+    """A SafeLoader that refuses duplicate mapping keys.
+
+    Plain YAML resolves a duplicate key last-wins and says nothing, so a policy
+    file listing a rule twice silently kept only the second entry. That is the
+    worst failure mode a policy file has: the reviewer reads a config that
+    disables a rule "with a reason", ships it, and the rule is on — or off —
+    depending on which duplicate happened to be last. The parser already
+    refuses duplicates in Compose documents for the same reason; the config
+    loader was the one door left open.
+    """
+
+
+def _reject_duplicate_config_keys(
+    loader: _StrictLoader, node: yaml.MappingNode
+) -> dict[Any, Any]:
+    seen: set[Any] = set()
+    for key_node, _value_node in node.value:
+        key = loader.construct_object(key_node, deep=True)
+        try:
+            duplicate = key in seen
+        except TypeError:
+            continue  # unhashable key — the construction below reports it
+        if duplicate:
+            raise yaml.constructor.ConstructorError(
+                None,
+                None,
+                f"found duplicate key {key!r}; the later entry would silently "
+                "replace the earlier one",
+                key_node.start_mark,
+            )
+        seen.add(key)
+    return loader.construct_mapping(node, deep=True)
+
+
+_StrictLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _reject_duplicate_config_keys,
+)
+
+
 def load_config(
     path: str | Path | None = None,
     strict: bool = False,
@@ -118,7 +159,7 @@ def _read_raw_config(path: str | Path | None) -> dict[str, Any] | None:
         raise ConfigError(f"Cannot read config file: {e}") from e
 
     try:
-        data = yaml.safe_load(content)
+        data = yaml.load(content, Loader=_StrictLoader)  # noqa: S506  # nosec B506
     except yaml.YAMLError as e:
         raise ConfigError(f"Invalid YAML in config file: {e}") from e
 

--- a/src/compose_lint/engine.py
+++ b/src/compose_lint/engine.py
@@ -72,7 +72,14 @@ def run_rules(
                 # reported: if the rule is globally suppressed the finding is
                 # already suppressed below, so re-grading its severity is moot.
                 if rule_id in overrides and not is_suppressed:
-                    finding = replace(finding, severity=overrides[rule_id])
+                    if overrides[rule_id] != finding.severity:
+                        finding = replace(
+                            finding,
+                            severity=overrides[rule_id],
+                            severity_overridden_from=finding.severity,
+                        )
+                    else:
+                        finding = replace(finding, severity=overrides[rule_id])
                 # Suppression precedence: a global disable (whole rule off) wins
                 # over a per-service exclusion. Both set suppressed=True, but the
                 # reason differs, so this must be if/elif, not two independent

--- a/src/compose_lint/formatters/json.py
+++ b/src/compose_lint/formatters/json.py
@@ -36,6 +36,8 @@ def format_findings(findings: list[Finding], filepath: str) -> list[dict[str, ob
         }
         if f.suppressed:
             entry["suppression_reason"] = f.suppression_reason
+        if f.severity_overridden_from is not None:
+            entry["severity_overridden_from"] = f.severity_overridden_from.value
         results.append(entry)
     return results
 

--- a/src/compose_lint/formatters/sarif.py
+++ b/src/compose_lint/formatters/sarif.py
@@ -358,6 +358,10 @@ def format_findings(
         if edits:
             result["fixes"] = [_build_fix(edits, filepath)]
 
+        if f.severity_overridden_from is not None:
+            props = result.setdefault("properties", {})
+            props["severityOverriddenFrom"] = f.severity_overridden_from.value
+
         if f.suppressed:
             result["suppressions"] = [
                 {

--- a/src/compose_lint/formatters/text.py
+++ b/src/compose_lint/formatters/text.py
@@ -314,8 +314,14 @@ def format_findings(
             already_shown = fix_key in seen_fixes
             show_fix = not quiet and (verbose or not already_shown)
             suffix = ""
+            if f.severity_overridden_from is not None:
+                # The one suppression channel that used to leave no trace. A
+                # reader must be able to tell a re-graded finding from one the
+                # rule declared at this severity.
+                was = f.severity_overridden_from.value
+                suffix += f"   {_colorize(f'(severity overridden from {was})', _DIM)}"
             if not quiet and already_shown and not verbose and (f.fix or f.references):
-                suffix = f"   {_colorize('(see fix above)', _DIM)}"
+                suffix += f"   {_colorize('(see fix above)', _DIM)}"
 
             out.append(
                 f"    {line_label.rjust(4)}  "

--- a/src/compose_lint/models.py
+++ b/src/compose_lint/models.py
@@ -68,6 +68,13 @@ class Finding:
     references: list[str] = field(default_factory=list)
     suppressed: bool = False
     suppression_reason: str | None = None
+    # The rule's own severity, recorded when `.compose-lint.yml` re-graded this
+    # finding. `enabled: false` and `exclude_services` both leave a visible
+    # record (a SUPPRESSED marker and a reason); `severity:` left none, so a
+    # config could quietly downgrade a CRITICAL below the gate and the output
+    # gave a reader no way to tell it apart from a rule that never fired that
+    # hard. None means the rule's declared severity is what is shown.
+    severity_overridden_from: Severity | None = None
 
 
 @dataclass(frozen=True)

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -489,6 +489,25 @@ def _collect_lines(
     seq_lines = seq_lines or {}
     lines: dict[str, int] = {}
     expanded: set[int] = set()
+    # Paths that two different nodes both claim. Joining path segments with "."
+    # is lossy when a segment contains one: a service named `web.logging` and
+    # service `web`'s `logging:` child both spell `services.web.logging`, and
+    # last-write-wins handed one of them the other's line. A fixer then checked
+    # its anchor/merge-key refusal against a different service's line, and an
+    # edit every fixer is required to refuse was applied. Rather than return a
+    # line belonging to somewhere else, drop the key: `lines.get` yields None,
+    # which every consumer already treats as "cannot locate this — refuse".
+    ambiguous: set[str] = set()
+
+    def record(full_key: str, line: int) -> None:
+        previous = lines.get(full_key)
+        # The same node reached by two paths yields two different keys, so a
+        # repeat with a *different* line is always a genuine collision.
+        if previous is not None and previous != line:
+            ambiguous.add(full_key)
+        else:
+            lines[full_key] = line
+
     stack: list[tuple[Any, str]] = [(data, prefix)]
     while stack:
         current, current_prefix = stack.pop()
@@ -502,7 +521,7 @@ def _collect_lines(
                     continue
                 full_key = f"{current_prefix}.{key}" if current_prefix else key
                 if key in line_map:
-                    lines[full_key] = line_map[key]
+                    record(full_key, line_map[key])
                 if first:
                     stack.append((value, full_key))
         elif isinstance(current, list):
@@ -513,9 +532,11 @@ def _collect_lines(
             for i, item in enumerate(current):
                 full_key = f"{current_prefix}[{i}]"
                 if i in item_lines:
-                    lines[full_key] = item_lines[i]
+                    record(full_key, item_lines[i])
                 if first:
                     stack.append((item, full_key))
+    for key in ambiguous:
+        lines.pop(key, None)
     return lines
 
 

--- a/tests/test_assurance.py
+++ b/tests/test_assurance.py
@@ -1,0 +1,236 @@
+"""The tool must not report a state that is not true.
+
+Four defects of that shape: a fix reported as applied to a file it never
+touched, a policy file whose second entry silently replaced the first, a
+re-graded finding that looked exactly like one the rule declared that way, and
+a line lookup that returned a line belonging to a different service — which let
+an edit land that every fixer is required to refuse.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from compose_lint import cli
+from compose_lint.config import ConfigError, load_config
+from compose_lint.engine import run_rules
+from compose_lint.parser import loads
+
+_PRIVILEGED = "services:\n  web:\n    image: nginx:1.27\n    privileged: true\n"
+_FIXABLE = (
+    "services:\n  web:\n    image: nginx:1.27\n    logging:\n      driver: none\n"
+)
+
+
+# --- VULN-018: a line lookup must never return another node's line --------
+
+
+def test_a_dotted_service_name_does_not_steal_another_services_line() -> None:
+    """`services.web.logging` is spelled by two different nodes."""
+    _data, lines = loads(
+        "services:\n"
+        "  web:\n"
+        "    image: nginx:1.27\n"
+        "    logging:\n"
+        "      driver: none\n"
+        "  web.logging:\n"
+        "    image: nginx:1.27\n"
+    )
+    # Ambiguous: dropped rather than resolved to whichever was written last.
+    assert "services.web.logging" not in lines
+    # Everything unambiguous is unaffected.
+    assert lines["services.web"] == 2
+    assert lines["services.web.image"] == 3
+    assert lines["services.web.logging.driver"] == 5
+
+
+def test_an_ordinary_dotted_service_name_still_gets_its_lines() -> None:
+    """17 corpus files use names like `llama.cpp`; only collisions are dropped."""
+    _data, lines = loads(
+        "services:\n  llama.cpp:\n    image: nginx:1.27\n    privileged: true\n"
+    )
+    assert lines["services.llama.cpp"] == 2
+    assert lines["services.llama.cpp.privileged"] == 4
+
+
+def test_the_collision_makes_the_fixer_refuse(tmp_path: Path) -> None:
+    """Failing closed is the point: no line means no edit."""
+    target = tmp_path / "compose.yml"
+    target.write_text(
+        "services:\n"
+        "  web: &base\n"
+        "    image: nginx:1.27\n"
+        "    logging:\n"
+        "      driver: none\n"
+        "  web.logging:\n"
+        "    <<: *base\n",
+        encoding="utf-8",
+    )
+    before = target.read_bytes()
+    with pytest.raises(SystemExit):
+        cli.main(["fix", "--only", "CL-0014", "--apply", str(target)])
+    assert target.read_bytes() == before
+
+
+# --- VULN-019: never report a fix applied to a file it did not touch ------
+
+
+def test_fix_refuses_a_symlink_instead_of_replacing_it(tmp_path: Path) -> None:
+    real = tmp_path / "real-compose.yml"
+    real.write_text(_FIXABLE, encoding="utf-8")
+    link = tmp_path / "docker-compose.yml"
+    link.symlink_to(real)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["fix", "--apply", str(link)])
+
+    assert exc.value.code != 0
+    # The link is still a link, and the deployed file is untouched.
+    assert link.is_symlink()
+    assert real.read_text(encoding="utf-8") == _FIXABLE
+
+
+def test_fix_refuses_a_hard_linked_file(tmp_path: Path) -> None:
+    original = tmp_path / "docker-compose.yml"
+    original.write_text(_FIXABLE, encoding="utf-8")
+    second = tmp_path / "also-compose.yml"
+    os.link(original, second)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["fix", "--apply", str(original)])
+
+    assert exc.value.code != 0
+    # Both names still share one inode holding the original content.
+    assert original.stat().st_ino == second.stat().st_ino
+    assert original.read_text(encoding="utf-8") == _FIXABLE
+
+
+def test_a_plain_file_is_still_fixed(tmp_path: Path) -> None:
+    target = tmp_path / "docker-compose.yml"
+    target.write_text(_FIXABLE, encoding="utf-8")
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["fix", "--only", "CL-0014", "--apply", str(target)])
+    assert exc.value.code == 0
+    assert "driver: none" not in target.read_text(encoding="utf-8")
+
+
+def test_setuid_is_not_carried_onto_the_replacement(tmp_path: Path) -> None:
+    """A newly created inode must not inherit setuid from what it replaces."""
+    target = tmp_path / "docker-compose.yml"
+    target.write_text(_FIXABLE, encoding="utf-8")
+    target.chmod(0o4755)
+
+    with pytest.raises(SystemExit):
+        cli.main(["fix", "--only", "CL-0014", "--apply", str(target)])
+
+    mode = target.stat().st_mode
+    assert not mode & stat.S_ISUID, oct(mode)
+    assert stat.S_IMODE(mode) == 0o755, oct(mode)
+
+
+# --- VULN-024: a re-graded finding says so --------------------------------
+
+
+def _finding(source: str, config: dict[str, object] | None = None):
+    data, lines = loads(source)
+    from compose_lint.models import Severity
+
+    overrides = {"CL-0002": Severity.LOW} if config else None
+    findings = run_rules(data, lines, severity_overrides=overrides)
+    return next(f for f in findings if f.rule_id == "CL-0002")
+
+
+def test_an_overridden_severity_records_what_it_was() -> None:
+    from compose_lint.models import Severity
+
+    plain = _finding(_PRIVILEGED)
+    assert plain.severity is Severity.CRITICAL
+    assert plain.severity_overridden_from is None
+
+    graded = _finding(_PRIVILEGED, config={"severity": "low"})
+    assert graded.severity is Severity.LOW
+    assert graded.severity_overridden_from is Severity.CRITICAL
+
+
+def test_the_override_is_visible_in_every_output_format(tmp_path: Path) -> None:
+    target = tmp_path / "compose.yml"
+    target.write_text(_PRIVILEGED, encoding="utf-8")
+    config = tmp_path / "downgrade.yml"
+    config.write_text("rules:\n  CL-0002:\n    severity: low\n", encoding="utf-8")
+
+    import subprocess
+    import sys
+
+    def run(*args: str) -> str:
+        return subprocess.run(
+            [sys.executable, "-m", "compose_lint", "check", *args, str(target)],
+            capture_output=True,
+            text=True,
+            cwd=tmp_path,
+            env={
+                "PYTHONPATH": str(Path(__file__).resolve().parent.parent / "src"),
+                "PATH": "/usr/bin:/bin",
+                "NO_COLOR": "1",
+            },
+            timeout=120,
+        ).stdout
+
+    js = json.loads(run("--format", "json", "--config", str(config)))
+    entry = next(f for f in js["findings"] if f["rule_id"] == "CL-0002")
+    assert entry["severity"] == "low"
+    assert entry["severity_overridden_from"] == "critical"
+
+    sarif = json.loads(run("--format", "sarif", "--config", str(config)))
+    result = next(r for r in sarif["runs"][0]["results"] if r["ruleId"] == "CL-0002")
+    assert result["properties"]["severityOverriddenFrom"] == "critical"
+
+    assert "severity overridden from critical" in run("--config", str(config))
+
+
+def test_a_no_op_override_is_not_recorded() -> None:
+    """Re-stating a rule's own severity changes nothing, so it claims nothing."""
+    from compose_lint.models import Severity
+
+    data, lines = loads(_PRIVILEGED)
+    findings = run_rules(data, lines, severity_overrides={"CL-0002": Severity.CRITICAL})
+    finding = next(f for f in findings if f.rule_id == "CL-0002")
+    assert finding.severity_overridden_from is None
+
+
+# --- VULN-025: a policy file's second entry must not win in silence -------
+
+
+def test_duplicate_rule_keys_are_refused(tmp_path: Path) -> None:
+    config = tmp_path / ".compose-lint.yml"
+    config.write_text(
+        "rules:\n"
+        "  CL-0002:\n"
+        "    enabled: false\n"
+        '    reason: "reviewed"\n'
+        "  CL-0002:\n"
+        "    enabled: true\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigError, match="duplicate key"):
+        load_config(config)
+
+
+def test_a_config_without_duplicates_still_loads(tmp_path: Path) -> None:
+    config = tmp_path / ".compose-lint.yml"
+    config.write_text(
+        "rules:\n"
+        "  CL-0002:\n"
+        "    enabled: false\n"
+        '    reason: "reviewed"\n'
+        "  CL-0004:\n"
+        "    severity: low\n",
+        encoding="utf-8",
+    )
+    disabled, overrides, _excluded = load_config(config)
+    assert disabled == {"CL-0002": "reviewed"}
+    assert [r.value for r in overrides.values()] == ["low"]


### PR DESCRIPTION
Resolves four findings from a [VulnHunter](https://github.com/capitalone/vulnhunter) security audit of this repository (tracked internally as VULN-018, 019, 024, 025 — all Medium). One shape: compose-lint told the operator something that was not the case, on the surfaces used to decide whether a stack is safe.

## What was untrue

**`fix --apply` reported success on files it never touched.** `os.replace` swaps the directory entry, not the inode behind it:

- on a **symlink**, it dropped a regular file over the link and left the file the stack actually deploys unchanged — while reporting the fix applied
- on a **hard link**, it broke the link and let the two names diverge in silence
- `path.stat()` follows symlinks, so the *target's* mode — `setuid` included — was copied onto the replacement

Both link cases are now refused with an error naming the reason, and the rest of the batch continues. `setuid`/`setgid`/sticky are no longer carried onto an inode this process just created.

**A `severity:` override left no audit record** — the one suppression channel with none. `enabled: false` and `exclude_services` both mark findings SUPPRESSED with a reason; a re-graded finding was indistinguishable from one the rule declared at that level. Three lines in a committed policy file could take a CRITICAL below the default gate with nothing to show for it:

```
   4  LOW  CL-0002  Service runs in privileged mode. …   (severity overridden from critical)
```
```json
{"rule_id": "CL-0002", "severity": "low", "suppressed": false,
 "severity_overridden_from": "critical"}
```
SARIF gets `properties.severityOverriddenFrom`. Re-stating a rule's own severity records nothing, because nothing changed.

**Duplicate keys in `.compose-lint.yml` resolved last-wins in silence.** A policy that disables a rule with a reason and re-enables it further down reads, to a human, as the first entry and behaved as the second. Now a config error — the Compose parser already refuses duplicates for exactly this reason; the config loader was the door left open.

**A line lookup could return a line belonging to a different node.** Joining path segments with `.` is lossy when a segment contains one: a service named `web.logging` and service `web`'s `logging:` child both spell `services.web.logging`. A fixer then evaluated its anchor/merge-key refusal against a different service's line and applied an edit every fixer is required to refuse.

## One deliberate narrowing, with the measurement behind it

The audit asked for tuple path keys, which cannot collide by construction. That is **77 lookup sites** across every rule, and it changes the shape of `lines`, which is part of the library API.

The property actually needed is *never return the wrong line*. Dropping the ambiguous key gives exactly that: the lookup returns `None`, and every consumer already treats `None` as "cannot locate this — refuse". Fail-closed rather than resolved-correctly.

I measured the cost before choosing rather than after: **17 corpus files use dotted service names** (`llama.cpp`, `smartwardrobe.api`, `fabric-peer0.org1.…`) and **none of them collides**, so nothing real loses its line numbers. Tests cover both sides — the collision is dropped, an ordinary dotted name keeps all its lines.

## Behavior change

**No findings, exit codes or errors change across the 5,417-file corpus.**

Output shape (all additive):

| surface | change |
|---|---|
| JSON | new `severity_overridden_from` key, present only when overridden |
| SARIF | new `properties.severityOverriddenFrom`, same condition |
| text | `(severity overridden from …)` suffix on a re-graded finding |

Newly failing input:

- `fix --apply` on a symlink or hard-linked file now errors instead of silently doing the wrong thing
- a `.compose-lint.yml` with a duplicated key is now a config error

Verified that `init`-generated configs and non-duplicate configs still load, and that a plain file is still fixed normally.

Semver: **minor** — additive output keys, and two inputs that previously "worked" now fail.

## Note on the VULN-024 exploit test

`test_vuln_024_severity_override_leaves_no_audit_record` **still passes** after this change, and that is correct rather than a gap. Its assertions are specifically about *suppression* markers — `suppressed is False`, `suppressions[]` absent, `"suppress"` not in text — and all three remain true, because an override is not a suppression: the finding still reports, at a different level. The audit record it asked for is the new `severity_overridden_from` field, which the test does not look for. `tests/test_assurance.py` covers it on all three surfaces.

## Tests

12 new tests in `tests/test_assurance.py`: the line-map collision and its fail-closed consequence plus an ordinary dotted name, symlink and hard-link refusal with the target verified untouched, setuid not carried over, a plain file still fixed, the override record on all three output surfaces, the no-op override recording nothing, and duplicate-key rejection with a non-duplicate control.

Full suite 1665 passed / 6 skipped; `ruff check`, `ruff format --check`, `mypy src/` clean.
