### PR TITLE
Make malformed input a per-file failure, not a traceback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,37 @@ If a finding is genuinely parameterized in your deployment, that is what
 default (`${PW}` rather than `${PW:-hunter2}`) also stays exempt, because
 Compose then ships nothing.
 
+### Fixed
+
+- **Malformed input is a per-file failure, never a traceback.** Four paths let
+  an exception escape the fail-loud boundary: the CLI printed a Python
+  traceback, exited **1** — which reads as "I linted it and it failed" rather
+  than "I could not lint it" — and abandoned every remaining file in the batch.
+  All four now surface as a clean error at exit 2 with the rest of the run
+  intact. Each had a correct sibling already in the repo.
+
+  - **Deep recursion in the post-parse passes.** The loader's
+    `RecursionError` guard covered the *parse* only, so a 2000-deep `extends:`
+    chain or a self-referential `${A:-${A:-…}}` in a bind source blew the stack
+    after the loader returned. The boundary now covers every pass that walks
+    the document.
+  - **`ReaderError` from the loader constructor.** `Reader.__init__` runs the
+    printable-character check, so a document carrying a C0 byte raises at
+    construction — which happened *outside* the `try`. The constructor is now
+    inside it.
+  - **`RecursionError` in the config loader.** `except yaml.YAMLError` does not
+    catch it, since it is a `RuntimeError`. The Compose loader already
+    translated this; the config loader did not.
+  - **Write failures from `fix --apply` / `init`.** An unwrapped `OSError` — a
+    read-only directory, a full disk — aborted the batch and printed the
+    absolute workspace path in a traceback. Failures are now attributed to the
+    file they belong to, and later files still lint. The message reports the
+    condition (`Permission denied`) rather than the errno decoration and the
+    internal temp filename the caller never chose.
+  - A write target that exists but is **not a regular file** is now named as
+    such. A directory has `st_nlink >= 2`, so it was previously reported as a
+    hard link, which is not what is wrong with it.
+
 ### Security
 
 - **Four places where the tool reported a state that was not true.**

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -575,8 +575,23 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
     sys.exit(1 if has_errors else 0)
 
 
+class UnwritableTargetError(OSError):
+    """Raised when a write target exists but is not a regular file."""
+
+
 class LinkedPathError(OSError):
     """Raised when a fix target is a symlink or a multiply-linked file."""
+
+
+def _write_failure(exc: OSError) -> str:
+    """Describe a write failure without echoing the internal temp path.
+
+    An unhandled ``OSError`` renders as ``[Errno 13] Permission denied:
+    '/abs/path/.compose.yml.k6ydh20a.tmp'`` — an errno decoration and a scratch
+    filename the caller never chose. The caller already names the file it was
+    asked to write, so only the condition belongs here.
+    """
+    return exc.strerror or str(exc)
 
 
 def _atomic_write(path: Path, content: str) -> None:
@@ -604,14 +619,18 @@ def _atomic_write(path: Path, content: str) -> None:
         info = None  # a new file (`init`): nothing to link past or preserve
     if info is not None and stat.S_ISLNK(info.st_mode):
         raise LinkedPathError(
-            f"{path} is a symbolic link; writing here would replace the link "
-            "and leave its target — the file that is actually deployed — "
-            "unchanged. Point the fix at the target instead."
+            "is a symbolic link; writing here would replace the link and leave "
+            "its target — the file that is actually deployed — unchanged; "
+            "point the fix at the target instead"
         )
+    if info is not None and not stat.S_ISREG(info.st_mode):
+        # A directory has st_nlink >= 2, so without this it would be reported
+        # as a hard link, which is not what is wrong with it.
+        raise UnwritableTargetError("not a regular file; refusing to write over it")
     if info is not None and info.st_nlink > 1:
         raise LinkedPathError(
-            f"{path} has {info.st_nlink} hard links; replacing it would break "
-            "the link and leave the other names on the old content."
+            f"has {info.st_nlink} hard links; replacing it would break the link "
+            "and leave the other names on the old content"
         )
 
     fd, tmp_name = tempfile.mkstemp(
@@ -775,8 +794,13 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
                 continue
             try:
                 _atomic_write(Path(filepath), patched)
-            except LinkedPathError as e:
-                emit(f"Error: {e}; no changes written")
+            except OSError as e:
+                # Any write failure — a link refusal, a full disk, a read-only
+                # mount, a directory that vanished — belongs to this file, not
+                # to the run. Unwrapped it reached the CLI as a traceback: exit
+                # 1 where the contract says 2, every later file in the batch
+                # never examined, and the absolute path printed into the log.
+                emit(f"Error: {filepath}: {_write_failure(e)}; no changes written")
                 had_error = True
                 continue
             # The behavior-changing caveats must surface here too, not only on
@@ -841,8 +865,8 @@ def _run_init(args: argparse.Namespace) -> NoReturn:
     existed = out_path.exists()
     try:
         _atomic_write(out_path, render_config(findings))
-    except LinkedPathError as e:
-        emit(f"Error: {e}")
+    except OSError as e:
+        emit(f"Error: {out_path}: {_write_failure(e)}")
         sys.exit(2)
     if not existed:
         # _atomic_write carries over an existing file's mode but a fresh file

--- a/src/compose_lint/config.py
+++ b/src/compose_lint/config.py
@@ -162,6 +162,14 @@ def _read_raw_config(path: str | Path | None) -> dict[str, Any] | None:
         data = yaml.load(content, Loader=_StrictLoader)  # noqa: S506  # nosec B506
     except yaml.YAMLError as e:
         raise ConfigError(f"Invalid YAML in config file: {e}") from e
+    except RecursionError as e:
+        # PyYAML's composer recurses with no depth limit, and RecursionError is
+        # a RuntimeError rather than a YAMLError, so it walks straight past the
+        # clause above. The Compose loader already translates this; the config
+        # loader raised a traceback and exit 1 on the same class of input.
+        raise ConfigError(
+            "Invalid YAML in config file: input is too deeply nested"
+        ) from e
 
     if data is None:
         return None

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -923,10 +923,16 @@ def loads(
     # deserialize arbitrary Python objects. The assertion makes that
     # invariant explicit so a future refactor can't silently break it.
     assert issubclass(LineLoader, yaml.SafeLoader)  # noqa: S101
-    # Instantiate explicitly (instead of yaml.load) so we can read the
-    # per-load seq_lines sidecar after parsing finishes.
-    loader = LineLoader(content)  # noqa: S506  # nosec B506 - SafeLoader subclass
+    # Constructing the loader is *inside* the try: `Reader.__init__` runs the
+    # printable-character check, so a document carrying a C0 byte raises
+    # `ReaderError` here rather than at `get_single_data()`. Built outside, that
+    # walked straight past the fail-loud boundary and reached the CLI as an
+    # unhandled traceback with exit 1.
+    loader = None
     try:
+        # Instantiate explicitly (instead of yaml.load) so we can read the
+        # per-load seq_lines sidecar after parsing finishes.
+        loader = LineLoader(content)  # noqa: S506  # nosec B506 - SafeLoader subclass
         raw = loader.get_single_data()
         seq_lines = loader._seq_lines
     except yaml.YAMLError as e:
@@ -940,21 +946,35 @@ def loads(
         # contract holds for all malformed input.
         raise ComposeError("Invalid YAML: input is too deeply nested") from e
     finally:
-        loader.dispose()  # type: ignore[no-untyped-call]
+        if loader is not None:
+            loader.dispose()  # type: ignore[no-untyped-call]
 
     if raw is None:
         raise ComposeError("Not a valid Compose file: file is empty")
 
     _validate_compose(raw)
 
-    lines = _collect_lines(raw, seq_lines)
-    data = _strip_lines(raw)
-    # Canonicalize before anything classifies: rules and the extends/bind-source
-    # passes below all see the value the file actually ships (see the function's
-    # docstring for why this is document-wide rather than per rule).
-    _substitute_interpolation_defaults(data)
-    _resolve_in_file_extends(data)
-    if base_dir is not None:
-        _resolve_bind_sources(data, base_dir)
+    # The post-parse passes recurse too, and the guard above covered only the
+    # parse. A 2000-deep `extends:` chain, or a self-referential
+    # `${A:-${A:-...}}` in a bind source, exhausted the stack *after* the loader
+    # returned: a raw traceback, exit 1 where the contract says 2, and every
+    # later file in the batch never linted. The fail-loud boundary has to cover
+    # each pass that walks the document, not only the one that builds it.
+    try:
+        lines = _collect_lines(raw, seq_lines)
+        data = _strip_lines(raw)
+        # Canonicalize before anything classifies: rules and the extends and
+        # bind-source passes below all see the value the file actually ships
+        # (see that function's docstring for why this is document-wide).
+        _substitute_interpolation_defaults(data)
+        _resolve_in_file_extends(data)
+        if base_dir is not None:
+            _resolve_bind_sources(data, base_dir)
+    except RecursionError as e:
+        raise ComposeError(
+            "Invalid Compose file: resolving the document is too deeply nested "
+            "(check for a long `extends:` chain or a self-referential "
+            "`${VAR}` default)"
+        ) from e
 
     return data, lines

--- a/tests/test_exit_code_contract.py
+++ b/tests/test_exit_code_contract.py
@@ -1,0 +1,201 @@
+"""Malformed input is a per-file failure, never a traceback.
+
+The documented contract is exit 0 (clean), 1 (findings at or above the
+threshold), 2 (compose-lint could not run). Four paths violated it by letting an
+exception escape: the CLI printed a Python traceback, exited 1 — which reads as
+"I linted it and it failed" — and abandoned every remaining file in the batch.
+
+Each had a correct sibling in the same repo. The parser already translated
+``RecursionError`` from the loader; the same hazard in the post-parse passes was
+unguarded. The Compose loader was wrapped; the config loader was not.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+from compose_lint.config import ConfigError, load_config
+from compose_lint.parser import ComposeError, loads
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_FIXABLE = (
+    "services:\n  web:\n    image: nginx:1.27\n    logging:\n      driver: none\n"
+)
+_PRIVILEGED = "services:\n  api:\n    image: nginx:latest\n    privileged: true\n"
+
+
+def _deep_extends_chain(depth: int = 2000) -> str:
+    body = ["services:"]
+    for i in range(depth):
+        body.append(f"  s{i}:")
+        body.append("    image: nginx:1.27")
+        body.append(f"    extends: {{service: s{i + 1}}}")
+    body.append(f"  s{depth}:")
+    body.append("    image: nginx:1.27")
+    return "\n".join(body) + "\n"
+
+
+def _run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "compose_lint", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        env={
+            "PYTHONPATH": str(REPO_ROOT / "src"),
+            "PATH": "/usr/bin:/bin",
+            "NO_COLOR": "1",
+        },
+        timeout=180,
+    )
+
+
+def _assert_no_traceback(proc: subprocess.CompletedProcess[str]) -> None:
+    assert "Traceback" not in proc.stderr, proc.stderr
+    assert 'File "' not in proc.stderr, proc.stderr
+
+
+@pytest.fixture
+def restore_mode() -> Iterator[list[Path]]:
+    touched: list[Path] = []
+    yield touched
+    for path in touched:
+        with contextlib.suppress(OSError):
+            path.chmod(0o755)
+
+
+# --- VULN-005: the guard must cover every pass that walks the document ----
+
+
+def test_a_deep_extends_chain_is_a_compose_error_not_a_crash() -> None:
+    """`_resolve_in_file_extends` recurses; only the *parse* was guarded."""
+    with pytest.raises(ComposeError, match="too deeply nested"):
+        loads(_deep_extends_chain())
+
+
+def test_a_deep_extends_chain_exits_two_with_no_traceback(tmp_path: Path) -> None:
+    target = tmp_path / "docker-compose.yml"
+    target.write_text(_deep_extends_chain(), encoding="utf-8")
+
+    proc = _run([str(target)], tmp_path)
+    assert proc.returncode == 2, proc.stderr
+    _assert_no_traceback(proc)
+
+
+def test_one_bad_file_does_not_abandon_the_batch(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.yml"
+    bad.write_text(_deep_extends_chain(), encoding="utf-8")
+    good = tmp_path / "good.yml"
+    good.write_text(_PRIVILEGED, encoding="utf-8")
+
+    proc = _run(["--format", "json", str(bad), str(good)], tmp_path)
+    assert proc.returncode == 2
+    _assert_no_traceback(proc)
+    # The clean file was still linted and its CRITICAL still reported.
+    assert "CL-0002" in proc.stdout
+
+
+# --- VULN-033: the loader constructor is inside the boundary --------------
+
+
+def test_a_c0_byte_is_a_compose_error_not_a_reader_error() -> None:
+    """`Reader.__init__` runs the printable check, so it raises at construction."""
+    with pytest.raises(ComposeError, match="Invalid YAML"):
+        loads("services:\n  web:\n    image: ngi\x00nx\n")
+
+
+def test_a_c0_byte_exits_two_with_no_traceback(tmp_path: Path) -> None:
+    target = tmp_path / "docker-compose.yml"
+    target.write_bytes(b"services:\n  web:\n    image: ngi\x00nx\n")
+    proc = _run([str(target)], tmp_path)
+    assert proc.returncode == 2, proc.stderr
+    _assert_no_traceback(proc)
+
+
+# --- VULN-023: the config loader has the same hazard ---------------------
+
+
+def test_a_deeply_nested_config_is_a_config_error(tmp_path: Path) -> None:
+    config = tmp_path / ".compose-lint.yml"
+    config.write_text("rules: " + "[" * 60_000 + "]" * 60_000, encoding="utf-8")
+    with pytest.raises(ConfigError, match="too deeply nested"):
+        load_config(config)
+
+
+def test_a_deeply_nested_config_exits_two_with_no_traceback(tmp_path: Path) -> None:
+    (tmp_path / "docker-compose.yml").write_text(_FIXABLE, encoding="utf-8")
+    config = tmp_path / "deep.yml"
+    config.write_text("rules: " + "[" * 60_000 + "]" * 60_000, encoding="utf-8")
+
+    proc = _run(["--config", str(config), "docker-compose.yml"], tmp_path)
+    assert proc.returncode == 2, proc.stderr
+    _assert_no_traceback(proc)
+
+
+# --- VULN-020: a write failure belongs to its file, not to the run -------
+
+
+def test_an_unwritable_directory_does_not_abort_the_batch(
+    tmp_path: Path, restore_mode: list[Path]
+) -> None:
+    locked = tmp_path / "locked"
+    locked.mkdir()
+    first = locked / "a.yml"
+    first.write_text(_FIXABLE, encoding="utf-8")
+    locked.chmod(0o555)
+    restore_mode.append(locked)
+
+    later = tmp_path / "later.yml"
+    later.write_text(_FIXABLE, encoding="utf-8")
+
+    proc = _run(
+        ["fix", "--only", "CL-0014", "--apply", str(first), str(later)], tmp_path
+    )
+
+    assert proc.returncode == 2, proc.stderr
+    _assert_no_traceback(proc)
+    # The failure is attributed to the file it belongs to...
+    assert "a.yml" in proc.stderr
+    # ...and the later file was still examined and fixed.
+    assert "driver: none" not in later.read_text(encoding="utf-8")
+
+
+def test_the_error_does_not_leak_the_internal_temp_filename(
+    tmp_path: Path, restore_mode: list[Path]
+) -> None:
+    locked = tmp_path / "locked"
+    locked.mkdir()
+    target = locked / "a.yml"
+    target.write_text(_FIXABLE, encoding="utf-8")
+    locked.chmod(0o555)
+    restore_mode.append(locked)
+
+    proc = _run(["fix", "--apply", str(target)], tmp_path)
+    assert "Permission denied" in proc.stderr
+    assert ".tmp" not in proc.stderr, proc.stderr
+    assert "Errno" not in proc.stderr, proc.stderr
+
+
+def test_init_to_a_directory_is_a_clean_error(tmp_path: Path) -> None:
+    """A directory has st_nlink >= 2, so it must not be reported as a hard link."""
+    (tmp_path / "docker-compose.yml").write_text(_PRIVILEGED, encoding="utf-8")
+    out = tmp_path / "adirectory"
+    out.mkdir()
+
+    proc = _run(["init", "docker-compose.yml", "-o", str(out), "--force"], tmp_path)
+    assert proc.returncode == 2, proc.stderr
+    _assert_no_traceback(proc)
+    assert "not a regular file" in proc.stderr
+    assert "hard link" not in proc.stderr
+    assert os.path.isdir(out)


### PR DESCRIPTION
Resolves four findings from a [VulnHunter](https://github.com/capitalone/vulnhunter) security audit of this repository (tracked internally as VULN-005, 020, 023, 033).

## The defect

The exit-code contract is 0 (clean), 1 (findings at or above the threshold), 2 (compose-lint could not run). Four paths broke it by letting an exception escape: the CLI printed a Python traceback, exited **1** — which reads as *"I linted it and it failed"* rather than *"I could not lint it"* — and abandoned every remaining file in the batch.

Each had a correct sibling already in the repo, which is what makes them oversights rather than design choices.

| | before | after |
|---|---|---|
| 2000-deep `extends:` chain | traceback, exit 1, batch aborted | clean error, **exit 2**, batch continues |
| C0 byte in the document | traceback, exit 1 | clean error, **exit 2** |
| deeply nested `.compose-lint.yml` | traceback, exit 1 | clean `ConfigError`, **exit 2** |
| unwritable dir during `fix --apply` | traceback, exit 1, batch aborted | per-file error, **exit 2**, later files still fixed |

- **Post-parse recursion.** The loader's `RecursionError` guard covered the *parse* only, so the passes that walk the same document afterwards were unprotected — a long `extends:` chain or a self-referential `${A:-${A:-…}}` in a bind source blew the stack after the loader returned. The boundary now covers every pass that walks the document, not only the one that builds it.
- **`ReaderError` from the constructor.** `Reader.__init__` runs the printable-character check, so a C0 byte raises at *construction* — which happened outside the `try`. The constructor is now inside it.
- **`RecursionError` in the config loader.** `except yaml.YAMLError` does not catch it (it is a `RuntimeError`). The Compose loader already translated this; the config loader did not.
- **Write failures.** An unwrapped `OSError` from `_atomic_write` aborted the batch and printed the absolute workspace path in a traceback. Failures are attributed to the file they belong to and the run continues:

```
Error: lock/a.yml: Permission denied; no changes written
later.yml: applied 3 fix(es) across 3 finding(s)
exit=2
```

The message reports the condition rather than `[Errno 13] Permission denied: '/abs/path/.a.yml.k6ydh20a.tmp'` — the errno decoration and an internal temp filename the caller never chose.

**Also fixed:** a write target that exists but is not a regular file is now named as such. A directory has `st_nlink >= 2`, so the hard-link check added in #556 reported a directory as a hard link — true, but not what is wrong with it.

## Behavior change

**No findings, exit codes or errors change across the 5,417-file corpus.**

What changes only affects input that previously crashed: a traceback at exit 1 becomes a clean diagnostic at exit 2, and the rest of the batch survives. Anyone whose CI distinguishes exit 2 from exit 1 will see the correct code for the first time on this input — previously it claimed the file had been linted when nothing had been.

No output-shape change (no new JSON/SARIF keys). Semver: **patch**.

## Tests

10 new tests in `tests/test_exit_code_contract.py`, each asserting both halves — the right exit code *and* no traceback — plus the batch-survival property that is the actual damage: a bad file must not take the clean files' findings with it.

Full suite 1675 passed / 6 skipped; `ruff check`, `ruff format --check`, `mypy src/` clean.
