### PR TITLE
Bound the work one small file can buy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,48 @@ Compose then ships nothing.
 
 ### Fixed
 
+- **A small file can no longer buy a large amount of work.** Nine defects
+  shared that shape: input that parses in milliseconds and then costs seconds
+  or gigabytes downstream, while producing no finding and exiting 0 — so
+  nothing in the output signalled it. Measured at 800 services, `fix` went from
+  2.67 s to 0.65 s and SARIF from 2.37 s to 0.36 s, and both are now linear in
+  service count rather than approaching quadratic.
+
+  - **Reading a path that is not a bounded regular file.** `.exists()` is true
+    of a FIFO and of `/dev/zero`, and a repository can commit a *symlink* to
+    either — it survives clone and checkout, and the runner resolves it.
+    Reading one hung the job forever; the other allocated until the runner
+    died. Both the Compose loader and the config loader now check the resolved
+    file's shape before reading a byte, with the descriptor opened
+    `O_NONBLOCK` — a plain `open()` on a FIFO blocks *before* any check can
+    run — and the read bounded at 8 MB.
+  - **`str()` on a YAML container.** Aliases share nodes by reference, so a
+    22-level doubling chain is under 1 KB on disk and 22 nodes in memory, but
+    `str()` serializes it as a *tree*: 4M elements from one call. Eleven rule
+    sinks and three config fields did that to whatever the document handed
+    them. They now refuse a container rather than render it — a list is not a
+    capability, a port, a mount spec, or a suppression reason.
+  - **Repeated work over one document.** `split_lines` was called once per
+    fixer and re-split the whole file each time (2.24 s of a 2.58 s run at 800
+    services); `extends_targets` walked every service once per *finding*; and
+    `_merge_extends` re-walked a shared alias subtree once per path through the
+    DAG (805 B → 5.4 s). All three are now memoized per document, and
+    `split_lines` takes a C-speed path when the text contains none of the five
+    characters `str.splitlines()` breaks on and PyYAML does not.
+  - **Quadratic scanning of a long scalar.** CL-0021's userinfo pattern
+    retried from every offset (20 KB → 1.1 s, 40 KB → 4.1 s). Its quantifiers
+    are now bounded and the scalar is capped before scanning.
+  - **The edit-conflict check** compared every pair of fix units. It now sweeps
+    spans sorted by offset and stops as soon as a later span begins past the
+    current one's end.
+  - **SARIF output that a consumer would reject.** 1,500 aliased services in
+    29 KB produced a document over GitHub Code Scanning's 10 MB ceiling — and
+    an artifact that large is *rejected*, so the run showed no alerts at all.
+    Output is capped at 5,000 results, the omission is stated in
+    `toolExecutionNotifications`, `executionSuccessful` is false, and the run
+    exits 2 so a gate cannot read success from a knowingly incomplete artifact.
+    Use `--format json` for the complete set.
+
 - **Malformed input is a per-file failure, never a traceback.** Four paths let
   an exception escape the fail-loud boundary: the CLI printed a Python
   traceback, exited **1** — which reads as "I linted it and it failed" rather

--- a/src/compose_lint/_limits.py
+++ b/src/compose_lint/_limits.py
@@ -1,0 +1,21 @@
+"""Bounds on the work one untrusted scalar can cause.
+
+A Compose file is a human-authored document, but nothing stops one from
+carrying a 200 KB environment value. Several rules scan such values with
+regexes whose worst case is quadratic, so the size of a value decides how long
+the run takes — which makes a cheap denial of service out of a file that
+produces no findings at all and exits 0, so nothing in the output signals it.
+
+Capping the input is the layer that closes the whole class: a pattern can be
+rewritten to remove one backtracking path, but the next pattern added to a rule
+brings its own. Above the cap the caller returns its conservative answer without
+scanning.
+"""
+
+from __future__ import annotations
+
+# Chosen far above anything a real Compose scalar reaches — the largest value
+# in a 5,417-file corpus is a fraction of this — so the cap only ever fires on
+# input written to be pathological. Below it, even a quadratic pattern is
+# bounded at a few milliseconds.
+MAX_SCAN_LEN = 8192

--- a/src/compose_lint/_lines.py
+++ b/src/compose_lint/_lines.py
@@ -31,13 +31,44 @@ BREAK_CHARS = "\n\r\x85\u2028\u2029"
 _BREAKS = frozenset(BREAK_CHARS)
 
 
+# The characters `str.splitlines()` breaks on and PyYAML does not. When a
+# document contains none of them — which is every document PyYAML accepts, since
+# it rejects all five with a ReaderError — the two agree exactly and the C
+# implementation can be used.
+_SPLITLINES_ONLY = ("\v", "\f", "\x1c", "\x1d", "\x1e")
+
+# One entry, keyed by id and holding the text so the id cannot be recycled.
+# Every fixer asks for the same document's lines, so without this a file with
+# n fixable findings re-split the whole text n times — O(n^2), and the profile
+# showed it at 2.24 s of a 2.58 s run on 800 services.
+_SPLIT_CACHE: dict[int, tuple[str, list[str]]] = {}
+
+
 def split_lines(text: str) -> list[str]:
     """Split ``text`` into lines, keeping each line's terminator attached.
 
     Equivalent in shape to ``text.splitlines(keepends=True)`` but using
     PyYAML's break set, so ``source_lines[n - 1]`` is the line PyYAML called
     ``n``. A trailing break does not produce a final empty line.
+
+    The returned list is cached and shared between callers, so it must be
+    treated as read-only. Every consumer indexes it to read a line; none
+    mutates it.
     """
+    cached = _SPLIT_CACHE.get(id(text))
+    if cached is not None and cached[0] is text:
+        return cached[1]
+    result = _split_lines_uncached(text)
+    _SPLIT_CACHE.clear()
+    _SPLIT_CACHE[id(text)] = (text, result)
+    return result
+
+
+def _split_lines_uncached(text: str) -> list[str]:
+    if not any(char in text for char in _SPLITLINES_ONLY):
+        # Same answer, at C speed: the two break sets differ only by the
+        # characters just ruled out.
+        return text.splitlines(keepends=True)
     lines: list[str] = []
     start = 0
     index = 0

--- a/src/compose_lint/_safe_read.py
+++ b/src/compose_lint/_safe_read.py
@@ -1,0 +1,86 @@
+"""Bounded reads of files compose-lint was pointed at.
+
+``Path.exists()`` and ``open()`` answer "is there something here", not "is this
+a file I can safely read to the end". Both are true of a FIFO and of
+``/dev/zero``, and a repository can commit a *symlink* to either — the link is
+an ordinary tracked object, so it survives clone and checkout and the runner
+resolves it. Reading one hangs the job forever; reading the other allocates
+until the runner is killed. Neither produces a finding, an error, or a verdict.
+
+So the shape of the target is checked before any bytes are read (``S_ISREG``,
+on the resolved file, not the link), and the read is bounded rather than
+unbounded. A Compose file or a policy file is a human-authored document of a
+few kilobytes; the caps here are far above anything real and exist only to make
+the failure a message instead of an outage.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# Generous by design. The largest file in a 5,417-file corpus of real-world
+# Compose documents is well under 200 KB, so this bounds the pathological case
+# without being a limit anyone writing a Compose file can reach.
+MAX_FILE_BYTES = 8 * 1024 * 1024
+
+
+class UnsafeFileError(OSError):
+    """Raised when a path is not a regular file, or is larger than the cap."""
+
+
+def read_text_bounded(
+    path: Path,
+    *,
+    max_bytes: int = MAX_FILE_BYTES,
+    newline: str | None = None,
+) -> str:
+    """Read ``path`` as UTF-8, refusing anything that is not a bounded regular file.
+
+    ``newline=""`` disables universal-newline translation for callers that need
+    the file's real bytes.
+
+    Raises :class:`UnsafeFileError` for a FIFO, device, socket or directory, and
+    for a regular file over ``max_bytes``. ``FileNotFoundError`` still surfaces
+    for a missing path, because "not there" and "not readable safely" are
+    different answers and callers already distinguish them.
+
+    The descriptor is opened first and inspected with ``fstat``, so the check
+    and the read see the same object — a path re-pointed between the two cannot
+    slip a FIFO past a ``stat`` that saw a regular file.
+
+    ``O_NONBLOCK`` is what makes that ordering possible: opening a FIFO for
+    reading blocks until a writer appears, so a plain ``open()`` hangs *before*
+    any check can run. It has no effect on a regular file. Symlinks are
+    deliberately followed — a symlink to a real Compose file is ordinary, and
+    it is the resolved target's shape that matters.
+    """
+    fd = os.open(path, os.O_RDONLY | os.O_NONBLOCK)
+    try:
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode):
+            raise UnsafeFileError(
+                f"{path} is not a regular file (reading it could block "
+                "forever or never end)"
+            )
+        if info.st_size > max_bytes:
+            raise UnsafeFileError(
+                f"{path} is {info.st_size} bytes, over the {max_bytes}-byte limit"
+            )
+        with os.fdopen(fd, "r", encoding="utf-8", newline=newline) as handle:
+            fd = -1  # ownership passed to the context manager
+            # Bounded even though the size was checked: a regular file can grow
+            # between fstat and read, and the point of this module is that no
+            # read here is unbounded.
+            content = handle.read(max_bytes + 1)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+
+    if len(content) > max_bytes:
+        raise UnsafeFileError(f"{path} exceeds the {max_bytes}-byte limit")
+    return content

--- a/src/compose_lint/_scalar.py
+++ b/src/compose_lint/_scalar.py
@@ -1,0 +1,41 @@
+"""Read a YAML *scalar* leaf as text, refusing containers.
+
+``str(value)`` on a leaf looks harmless until the leaf is a list. YAML aliases
+let a document reference the same node many times, so ``l1: [*l0, *l0]``
+repeated 22 times is a few hundred bytes on disk and a DAG of 22 nodes in
+memory — but ``str()`` serializes it as a *tree*, materializing 2^22 elements
+in one call. The file parses in milliseconds; the rule layer then burns CPU and
+memory on a document that produces no findings and exits 0, so nothing in the
+output signals what happened.
+
+The fix is not a size cap on the result — by the time there is a result the
+allocation has already happened. It is to notice that a list is not a value any
+of these fields can hold. ``cap_add: [[a, b]]``, ``user: {a: b}`` and
+``network_mode: [x]`` are not configurations Docker accepts; a rule comparing
+them against a set of dangerous strings has nothing to compare. Returning
+``None`` lets each caller skip the entry, which is what it would have done with
+the giant string anyway.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# The YAML scalar types PyYAML's SafeLoader produces. `datetime` and `date` are
+# included because a bare `2024-01-01` resolves to one, and a rule reading it as
+# text is well-defined; a list or dict is not.
+_SCALAR_TYPES = (str, int, float, bool, bytes)
+
+
+def as_scalar_text(value: Any) -> str | None:
+    """Return ``value`` as text if it is a scalar, else ``None``.
+
+    ``None`` (a bare YAML ``null``) is itself a scalar and renders as ``"None"``,
+    preserving what ``str()`` did for the fields that check for it.
+    """
+    if value is None or isinstance(value, _SCALAR_TYPES):
+        return str(value)
+    if isinstance(value, (list, dict, set, tuple)):
+        return None
+    # An unexpected type (a date, say) is still a leaf, not a container.
+    return str(value)

--- a/src/compose_lint/_yaml_edit.py
+++ b/src/compose_lint/_yaml_edit.py
@@ -42,6 +42,13 @@ def normalize_security_opt(opt: Any) -> str:
     return str(opt).strip().lower().replace("=", ":", 1)
 
 
+# One entry is enough: a run processes one document at a time, and the fix
+# engine's verification re-parse produces a new dict (a new id) rather than
+# mutating this one. The document is kept alive by the cache, so the id cannot
+# be recycled underneath the entry while it is live.
+_EXTENDS_TARGETS_CACHE: dict[int, tuple[dict[str, Any], set[str]]] = {}
+
+
 def extends_targets(data: dict[str, Any]) -> set[str]:
     """Return the names of services another in-file service ``extends``.
 
@@ -59,21 +66,33 @@ def extends_targets(data: dict[str, Any]) -> set[str]:
     at a base in another file, so a like-named local service is not its target.
     Both the mapping form (``extends: {service: base}``) and the string short
     form (``extends: base``) are recognised.
+
+    Memoized per document. Every caller asks the same question of the same
+    ``data`` once per *finding*, and answering it walks every service — so a
+    file with n services and a finding per service did O(n^2) work building the
+    same set n times. That is what made SARIF output superlinear against a
+    JSON run of the identical findings.
     """
+    cached = _EXTENDS_TARGETS_CACHE.get(id(data))
+    if cached is not None and cached[0] is data:
+        return cached[1]
+
     services = data.get("services")
-    if not isinstance(services, dict):
-        return set()
     targets: set[str] = set()
-    for _name, config in services.items():
-        if not isinstance(config, dict):
-            continue
-        ext = config.get("extends")
-        if isinstance(ext, str):
-            targets.add(ext)
-        elif isinstance(ext, dict) and not ext.get("file"):
-            service = ext.get("service")
-            if isinstance(service, str):
-                targets.add(service)
+    if isinstance(services, dict):
+        for _name, config in services.items():
+            if not isinstance(config, dict):
+                continue
+            ext = config.get("extends")
+            if isinstance(ext, str):
+                targets.add(ext)
+            elif isinstance(ext, dict) and not ext.get("file"):
+                service = ext.get("service")
+                if isinstance(service, str):
+                    targets.add(service)
+
+    _EXTENDS_TARGETS_CACHE.clear()
+    _EXTENDS_TARGETS_CACHE[id(data)] = (data, targets)
     return targets
 
 

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -29,7 +29,7 @@ from compose_lint.fix import (
 )
 from compose_lint.formatters.json import build_json_log
 from compose_lint.formatters.json import format_findings as format_json
-from compose_lint.formatters.sarif import build_sarif_log
+from compose_lint.formatters.sarif import MAX_SARIF_RESULTS, build_sarif_log
 from compose_lint.formatters.sarif import format_findings as format_sarif
 from compose_lint.formatters.text import (
     format_aggregate_summary,
@@ -565,6 +565,18 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
         json_log = build_json_log(all_json, run_errors)
         print(json.dumps(json_log, indent=2, allow_nan=False))
     elif args.output_format == "sarif":
+        if len(all_sarif) > MAX_SARIF_RESULTS:
+            # The document below reports the truncation itself; record it here
+            # too so the run exits 2. A gate must not read "success" from an
+            # artifact that is knowingly incomplete.
+            omitted = len(all_sarif) - MAX_SARIF_RESULTS
+            message = (
+                f"SARIF output truncated to {MAX_SARIF_RESULTS} findings "
+                f"({omitted} omitted) to stay within the size a consumer will "
+                "accept; use --format json for the complete set"
+            )
+            run_errors = [*run_errors, ("", message)]
+            emit(f"Error: {message}")
         sarif_log = build_sarif_log(
             all_sarif, run_errors, severity_overrides=severity_overrides
         )

--- a/src/compose_lint/config.py
+++ b/src/compose_lint/config.py
@@ -8,6 +8,8 @@ from typing import Any
 import yaml
 
 from compose_lint._output import emit
+from compose_lint._safe_read import read_text_bounded
+from compose_lint._scalar import as_scalar_text
 from compose_lint.models import Severity
 
 # Top-level keys the config schema defines today (docs/configuration.md).
@@ -154,8 +156,13 @@ def _read_raw_config(path: str | Path | None) -> dict[str, Any] | None:
             return None
 
     try:
-        content = config_path.read_text(encoding="utf-8")
+        # A committed symlink to a FIFO or /dev/zero passes `.exists()` and
+        # every permission check; reading one hangs the job or allocates until
+        # the runner dies. Same bounded read the Compose loader uses.
+        content = read_text_bounded(config_path)
     except OSError as e:
+        # UnsafeFileError is an OSError, so one clause covers both the refusal
+        # and an ordinary read failure.
         raise ConfigError(f"Cannot read config file: {e}") from e
 
     try:
@@ -178,6 +185,31 @@ def _read_raw_config(path: str | Path | None) -> dict[str, Any] | None:
         raise ConfigError("Config file must be a YAML mapping")
 
     return data
+
+
+def _scalar_field(value: Any, rule_id: str, field: str) -> str | None:
+    """Coerce a config value to text, refusing a container.
+
+    ``str()`` on a YAML node is only safe if the node is a scalar. PyYAML shares
+    aliased nodes by reference, so `reason: *l22` loads in about a millisecond
+    and serializes as a *tree* — a 579-byte config produced 151 MB. The sibling
+    ``enabled`` field already type-checks strictly for a related reason (a
+    quoted ``'false'`` would silently leave the rule on); ``reason``,
+    ``severity`` and the exclusion reasons simply missed that treatment.
+
+    Refusing is right rather than merely safe: a list is not a reason, and a
+    policy file that contains one is malformed in a way the author wants to know
+    about.
+    """
+    if value is None:
+        return None
+    text = as_scalar_text(value)
+    if text is None:
+        raise ConfigError(
+            f"Config for rule '{rule_id}': '{field}' must be a scalar, "
+            f"not a {type(value).__name__}"
+        )
+    return text
 
 
 def _parse_rules(
@@ -223,11 +255,15 @@ def _parse_rules(
                     "silently leave the rule on"
                 )
             if enabled is False:
-                reason = rule_config.get("reason")
-                disabled[rule_id] = str(reason) if reason is not None else None
+                disabled[rule_id] = _scalar_field(
+                    rule_config.get("reason"), rule_id, "reason"
+                )
 
         if "severity" in rule_config:
-            overrides[rule_id] = _parse_severity(str(rule_config["severity"]))
+            severity_text = _scalar_field(rule_config["severity"], rule_id, "severity")
+            if severity_text is None:
+                raise ConfigError(f"Config for rule '{rule_id}': 'severity' is empty")
+            overrides[rule_id] = _parse_severity(severity_text)
 
         if "exclude_services" in rule_config:
             excluded[rule_id] = _parse_exclude_services(
@@ -262,10 +298,9 @@ def _parse_exclude_services(rule_id: str, value: Any) -> dict[str, str | None]:
                     f"exclude_services for '{rule_id}' keys must be "
                     "service name strings"
                 )
-            if reason is None:
-                result[service_name] = None
-            else:
-                result[service_name] = str(reason)
+            result[service_name] = _scalar_field(
+                reason, rule_id, f"exclude_services[{service_name}]"
+            )
         return result
 
     raise ConfigError(f"exclude_services for '{rule_id}' must be a list or mapping")

--- a/src/compose_lint/fix.py
+++ b/src/compose_lint/fix.py
@@ -390,11 +390,29 @@ def collect_edits(
 
     spanned = [(unit, spans_of(unit.edits)) for unit in units]
     refused: set[int] = set()
-    for i in range(len(spanned)):
-        for j in range(i + 1, len(spanned)):
-            if any(_spans_conflict(x, y) for x in spanned[i][1] for y in spanned[j][1]):
-                refused.add(i)
-                refused.add(j)
+
+    # Sweep sorted spans instead of comparing every pair of units. The pairwise
+    # loop did O(units^2) work on a file whose edits mostly cannot touch each
+    # other — a service count in the hundreds is ordinary, and each one can
+    # contribute a unit. Sorting by start offset makes the scan stop as soon as
+    # a later span begins past the current one's end, which is sound because
+    # every conflict shape needs the later span to begin at or before that end:
+    # two regions overlap only while `b.start < a.end`, and an insertion
+    # conflicts with a region only at `a.start < point <= a.end`.
+    flat = sorted(
+        (start, end, index)
+        for index, (_unit, spans) in enumerate(spanned)
+        for start, end in spans
+    )
+    for position, (a_start, a_end, a_unit) in enumerate(flat):
+        for b_start, b_end, b_unit in flat[position + 1 :]:
+            if b_start > a_end:
+                break  # sorted by start, so nothing later can reach back
+            if a_unit == b_unit:
+                continue  # a unit's own edits are applied together
+            if _spans_conflict((a_start, a_end), (b_start, b_end)):
+                refused.add(a_unit)
+                refused.add(b_unit)
 
     result = FixResult()
     seen_caveats: set[tuple[str, str]] = set()

--- a/src/compose_lint/formatters/sarif.py
+++ b/src/compose_lint/formatters/sarif.py
@@ -33,6 +33,12 @@ SARIF_SCHEMA = (
     "sarif-schema-2.1.0.json"
 )
 
+# Chosen from measurement: results serialize at roughly 1.2 KB each, and GitHub
+# Code Scanning rejects a SARIF document over 10 MB outright — so what an
+# uncapped document buys is a run with no artifact at all. 5,000 leaves
+# comfortable headroom under that ceiling.
+MAX_SARIF_RESULTS = 5000
+
 # Symbolic base for relativized artifact URIs. Declared once per run in
 # ``originalUriBaseIds`` (pointed at the working directory) and referenced from
 # each in-tree ``artifactLocation`` via ``uriBaseId``; GitHub Code Scanning
@@ -394,13 +400,39 @@ def build_sarif_log(
     taxonomy, taxa_index = _build_attack_taxonomy()
     rules, _ = _build_rules(severity_overrides, taxa_index)
 
+    # A file can declare many services cheaply through YAML aliases — 1,500 of
+    # them in 29 KB — and each one's findings are real. The document that
+    # results is not: at ~1.2 KB per result it passes GitHub Code Scanning's
+    # 10 MB ceiling, and an artifact that large is *rejected*, so the run shows
+    # no alerts at all. Truncating and saying so keeps the artifact usable and
+    # keeps the gate honest; silently shipping something the consumer will drop
+    # is the same false-clean as producing nothing.
+    truncated = max(0, len(all_results) - MAX_SARIF_RESULTS)
+    results = all_results[:MAX_SARIF_RESULTS] if truncated else all_results
+
     working_dir_uri = _working_dir_uri()
     invocation: dict[str, Any] = {
-        "executionSuccessful": not parse_errors,
+        "executionSuccessful": not parse_errors and not truncated,
         "workingDirectory": {"uri": working_dir_uri},
     }
+    notifications: list[dict[str, Any]] = []
+    if truncated:
+        notifications.append(
+            {
+                "level": "error",
+                "message": {
+                    "text": (
+                        f"Reported {MAX_SARIF_RESULTS} of "
+                        f"{len(all_results)} findings: the rest were omitted to "
+                        "keep this document under the size a SARIF consumer "
+                        "will accept. Re-run with --format json for the "
+                        "complete set."
+                    )
+                },
+            }
+        )
     if parse_errors:
-        invocation["toolExecutionNotifications"] = [
+        notifications.extend(
             {
                 "level": "error",
                 "message": {"text": message},
@@ -413,7 +445,9 @@ def build_sarif_log(
                 ],
             }
             for filepath, message in parse_errors
-        ]
+        )
+    if notifications:
+        invocation["toolExecutionNotifications"] = notifications
 
     return {
         "$schema": SARIF_SCHEMA,
@@ -431,7 +465,7 @@ def build_sarif_log(
                 "taxonomies": [taxonomy],
                 "originalUriBaseIds": {_URI_BASE_ID: {"uri": working_dir_uri}},
                 "invocations": [invocation],
-                "results": all_results,
+                "results": results,
             },
         ],
     }

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -10,6 +10,7 @@ from typing import Any
 import yaml
 
 from compose_lint._lines import find_ambiguous_break
+from compose_lint._safe_read import UnsafeFileError, read_text_bounded
 from compose_lint.config import KNOWN_TOP_LEVEL_KEYS
 from compose_lint.rules._interpolation import substitute_defaults
 
@@ -565,20 +566,47 @@ def _validate_compose(data: Any) -> dict[str, Any]:
     return data
 
 
-def _merge_extends(base: Any, over: Any) -> Any:
+def _merge_extends(
+    base: Any, over: Any, memo: dict[tuple[int, int], Any] | None = None
+) -> Any:
     """Merge a resolved ``extends`` base under an overriding child value.
 
     Follows Compose's ``extends`` semantics: child scalars win, mappings merge
     (child wins per key), sequences concatenate with the base first (Docker
     append-merges the base's list into every service that extends it).
+
+    Memoized on the ``(id(base), id(over))`` pair, as ``_strip_lines`` and
+    ``_collect_lines`` already are. YAML aliases make the document a DAG rather
+    than a tree, so without a memo a subtree shared by *n* paths is re-merged
+    once per path: an 805-byte file took 5.4 s, and 869 bytes took 21.5 s —
+    4x per two alias levels, from a document PyYAML parses in 2 ms. The ids are
+    stable for the call because ``data`` holds every node alive throughout.
+
+    This does not subsume the recursion guard in :func:`loads`: memoizing
+    removes repeated work, not depth, so a long chain still needs the
+    ``RecursionError`` translation.
     """
+    if memo is None:
+        memo = {}
+    key = (id(base), id(over))
+    cached = memo.get(key)
+    if cached is not None:
+        return cached
+
     if isinstance(base, dict) and isinstance(over, dict):
         merged = dict(base)
-        for key, value in over.items():
-            merged[key] = _merge_extends(base[key], value) if key in base else value
+        for child_key, value in over.items():
+            merged[child_key] = (
+                _merge_extends(base[child_key], value, memo)
+                if child_key in base
+                else value
+            )
+        memo[key] = merged
         return merged
     if isinstance(base, list) and isinstance(over, list):
-        return [*base, *over]
+        joined = [*base, *over]
+        memo[key] = joined
+        return joined
     return over
 
 
@@ -856,8 +884,9 @@ def load_compose(
         # worse, meant `check` and `fix` parsed *different* text for the same
         # file — `fix` has always read with newline="" to preserve line endings.
         # One read shape for both is the same principle as one line space.
-        with filepath.open(encoding="utf-8", newline="") as fh:
-            content = fh.read()
+        content = read_text_bounded(filepath, newline="")
+    except UnsafeFileError as e:
+        raise ComposeError(str(e)) from e
     except FileNotFoundError:
         raise
     except UnicodeDecodeError as e:

--- a/src/compose_lint/rules/CL0001_docker_socket.py
+++ b/src/compose_lint/rules/CL0001_docker_socket.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from compose_lint._scalar import as_scalar_text
 from compose_lint.models import Finding, RuleMetadata, Severity
 from compose_lint.rules import BaseRule, register_rule
 from compose_lint.rules._mounts import iter_bind_mounts, normalize_host_path
@@ -152,7 +153,11 @@ class DockerSocketRule(BaseRule):
         }
 
         for i, volume in enumerate(volumes):
-            volume_str = str(volume)
+            # Only for the message; the match below uses the resolved host path.
+            # Long syntax is a mapping, and `str()` on it serialized whatever it
+            # contained — which YAML aliases make exponential. The host path is
+            # what the message is about, so it is the better fallback anyway.
+            volume_str = as_scalar_text(volume) or host_paths.get(i, "")
             # Match the *host* side only. Matching the whole entry reported
             # `- /tmp/fake:/var/run/docker.sock` as a socket mount, which is
             # false: the container path is where the socket lands, not where it

--- a/src/compose_lint/rules/CL0004_image_not_pinned.py
+++ b/src/compose_lint/rules/CL0004_image_not_pinned.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from compose_lint._scalar import as_scalar_text
 from compose_lint.models import Finding, RuleMetadata, Severity
 from compose_lint.rules import BaseRule, register_rule
 from compose_lint.rules._image import MUTABLE_TAGS, OWASP_IMAGE_REF, split_image_ref
@@ -50,7 +51,10 @@ class ImageNotPinnedRule(BaseRule):
         if image is None:
             return
 
-        image = str(image)
+        text = as_scalar_text(image)
+        if text is None:
+            return
+        image = text
 
         # Digest-pinned images are always fine
         if "@sha256:" in image:

--- a/src/compose_lint/rules/CL0005_unbound_ports.py
+++ b/src/compose_lint/rules/CL0005_unbound_ports.py
@@ -7,6 +7,7 @@ import re
 from typing import TYPE_CHECKING, Any
 
 from compose_lint._lines import split_lines
+from compose_lint._scalar import as_scalar_text
 from compose_lint._yaml_edit import is_anchored_or_merged, line_indent
 from compose_lint.models import Finding, RuleMetadata, Severity, TextEdit
 from compose_lint.rules import BaseRule, register_rule
@@ -113,7 +114,10 @@ class UnboundPortsRule(BaseRule):
             if isinstance(port, dict):
                 yield from self._check_long_syntax(port, service_name, lines, i)
             else:
-                yield from self._check_short_syntax(str(port), service_name, lines, i)
+                text = as_scalar_text(port)
+                if text is None:
+                    continue  # a container is not a port spec
+                yield from self._check_short_syntax(text, service_name, lines, i)
 
     def _check_short_syntax(
         self,

--- a/src/compose_lint/rules/CL0008_host_network.py
+++ b/src/compose_lint/rules/CL0008_host_network.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from compose_lint._scalar import as_scalar_text
 from compose_lint.models import Finding, RuleMetadata, Severity
 from compose_lint.rules import BaseRule, register_rule
 
@@ -46,7 +47,7 @@ class HostNetworkRule(BaseRule):
         lines: dict[str, int],
     ) -> Iterator[Finding]:
         network_mode = service_config.get("network_mode", "")
-        if str(network_mode) == "host":
+        if as_scalar_text(network_mode) == "host":
             yield Finding(
                 rule_id="CL-0008",
                 severity=Severity.HIGH,

--- a/src/compose_lint/rules/CL0017_shared_mount.py
+++ b/src/compose_lint/rules/CL0017_shared_mount.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from compose_lint._scalar import as_scalar_text
 from compose_lint.models import Finding, RuleMetadata, Severity
 from compose_lint.rules import BaseRule, register_rule
 
@@ -53,7 +54,15 @@ class SharedMountRule(BaseRule):
             if self._is_shared_short_syntax(volume) or self._is_shared_long_syntax(
                 volume
             ):
-                yield self._make_finding(service_name, lines, str(volume), i)
+                # Only for the message. Long syntax is a mapping, and `str()`
+                # on it serialized whatever it contained — exponential once
+                # YAML aliases share a subtree. Name the source instead, which
+                # is the part of the entry the finding is about.
+                text = as_scalar_text(volume)
+                if text is None:
+                    source = volume.get("source") if isinstance(volume, dict) else None
+                    text = as_scalar_text(source) or "<long-syntax mount>"
+                yield self._make_finding(service_name, lines, text, i)
 
     def _is_shared_short_syntax(self, volume: Any) -> bool:
         """Check for :shared suffix in short-syntax volume strings."""

--- a/src/compose_lint/rules/CL0018_explicit_root.py
+++ b/src/compose_lint/rules/CL0018_explicit_root.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from compose_lint._scalar import as_scalar_text
 from compose_lint.models import Finding, RuleMetadata, Severity
 from compose_lint.rules import BaseRule, register_rule
 
@@ -61,7 +62,10 @@ class ExplicitRootRule(BaseRule):
         if user is None:
             return
 
-        user_str = str(user).strip().lower()
+        text = as_scalar_text(user)
+        if text is None:
+            return
+        user_str = text.strip().lower()
         if _is_root_user(user_str):
             yield Finding(
                 rule_id="CL-0018",

--- a/src/compose_lint/rules/CL0019_image_no_digest.py
+++ b/src/compose_lint/rules/CL0019_image_no_digest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from compose_lint._scalar import as_scalar_text
 from compose_lint.models import Finding, RuleMetadata, Severity
 from compose_lint.rules import BaseRule, register_rule
 from compose_lint.rules._image import (
@@ -51,7 +52,10 @@ class ImageNoDigestRule(BaseRule):
         if image is None:
             return
 
-        image = str(image)
+        text = as_scalar_text(image)
+        if text is None:
+            return
+        image = text
 
         # Already digest-pinned — clean
         if "@sha256:" in image:

--- a/src/compose_lint/rules/CL0020_credential_env_keys.py
+++ b/src/compose_lint/rules/CL0020_credential_env_keys.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from compose_lint._scalar import as_scalar_text
 from compose_lint.models import Finding, RuleMetadata, Severity
 from compose_lint.rules import BaseRule, register_rule
 from compose_lint.rules._interpolation import ships_no_literal
@@ -102,7 +103,10 @@ def _is_literal_credential_value(raw: Any) -> bool:
     if isinstance(raw, bool):
         return False
     if isinstance(raw, (int, float)):
-        raw = str(raw)
+        text = as_scalar_text(raw)
+        if text is None:
+            return False
+        raw = text
     if not isinstance(raw, str):
         return False
     if raw == "":

--- a/src/compose_lint/rules/CL0021_connection_string_credentials.py
+++ b/src/compose_lint/rules/CL0021_connection_string_credentials.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any
 
+from compose_lint._limits import MAX_SCAN_LEN
 from compose_lint.models import Finding, RuleMetadata, Severity
 from compose_lint.rules import BaseRule, register_rule
 from compose_lint.rules._interpolation import ships_no_literal
@@ -28,10 +29,15 @@ RFC3986_REF = "https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.1"
 # `redis://:password@host` — the standard Redis URL form — must still fire
 # (issue #279 R2). The var-ref guard below filters out variable substitutions
 # in the password half.
+# Every quantifier is bounded. Unbounded, the engine retries the scheme from
+# each of n offsets and rescans the tail from each — O(n^2) on a value shaped
+# like `scheme://<many>:<many>` (20 KB took 1.1 s, 40 KB took 4.1 s). The
+# ceilings are far above any real URL: RFC 3986 schemes are a handful of
+# characters, and a userinfo half in the hundreds is already implausible.
 _URI_USERINFO_RE = re.compile(
-    r"(?P<scheme>[a-zA-Z][a-zA-Z0-9+.\-]*)://"
-    r"(?P<user>[^:/@\s]*):"
-    r"(?P<password>[^@/\s]+)@"
+    r"(?P<scheme>[a-zA-Z][a-zA-Z0-9+.\-]{0,63})://"
+    r"(?P<user>[^:/@\s]{0,512}):"
+    r"(?P<password>[^@/\s]{1,512})@"
 )
 
 
@@ -72,6 +78,11 @@ def _find_inline_credential(value: str) -> tuple[str, str, str] | None:
     # rescan the whole tail from every offset — O(n^2) on attacker-controlled
     # env values, a cheap DoS when sweeping untrusted compose files.
     if "@" not in value:
+        return None
+    if len(value) > MAX_SCAN_LEN:
+        # The guard above is re-armed by a single trailing '@', so it does not
+        # bound anything on its own. A scalar this long is not a connection
+        # string; scanning it is pure cost.
         return None
     for m in _URI_USERINFO_RE.finditer(value):
         user = m.group("user")

--- a/src/compose_lint/rules/_caps.py
+++ b/src/compose_lint/rules/_caps.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from compose_lint._scalar import as_scalar_text
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
@@ -45,7 +47,10 @@ def normalize_cap(cap: object) -> str:
     ``ALL`` keeps its exception (see :func:`iter_cap_add`) at the call site,
     because it is only ``cap_add`` that must reject the prefixed form.
     """
-    return str(cap).strip().upper().removeprefix("CAP_")
+    text = as_scalar_text(cap)
+    if text is None:
+        return ""  # a container is not a capability name; matches nothing
+    return text.strip().upper().removeprefix("CAP_")
 
 
 def iter_cap_add(
@@ -74,7 +79,12 @@ def iter_cap_add(
         return
 
     for i, cap in enumerate(cap_add):
-        as_written = str(cap).strip().upper()
+        raw = as_scalar_text(cap)
+        if raw is None:
+            # An alias-expanded nested list here is what made `str()` allocate
+            # 2^depth characters; it is also not a capability, so skip it.
+            continue
+        as_written = raw.strip().upper()
         bare = normalize_cap(cap)
         if bare == "ALL" and as_written != "ALL":
             continue  # CAP_ALL is not a capability Docker accepts — see above

--- a/src/compose_lint/rules/_interpolation.py
+++ b/src/compose_lint/rules/_interpolation.py
@@ -12,13 +12,15 @@ from __future__ import annotations
 
 import re
 
+from compose_lint._limits import MAX_SCAN_LEN
+
 # Upper bound on a scalar these regexes will scan. Both the pattern below and
 # the two in `substitute_defaults` are quadratic on pathological input (measured
 # 4x per doubling: 80 KB -> 0.49 s, 160 KB -> 1.94 s), and the parser now runs
 # substitution over *every* string in the document rather than bind sources
 # alone. A Compose scalar this long carries no classification signal worth that
 # cost, so beyond the cap the conservative answer is returned without scanning.
-_MAX_SCAN_LEN = 8192
+_MAX_SCAN_LEN = MAX_SCAN_LEN
 
 # An active variable substitution ("${VAR}", "${VAR:-default}", "$VAR").
 _VAR_REF_RE = re.compile(r"\$\{[^}]+\}|\$[A-Za-z_][A-Za-z0-9_]*")

--- a/src/compose_lint/rules/_mounts.py
+++ b/src/compose_lint/rules/_mounts.py
@@ -14,6 +14,7 @@ import posixpath
 import re
 from typing import TYPE_CHECKING, Any, NamedTuple
 
+from compose_lint._scalar import as_scalar_text
 from compose_lint.rules._bool import as_bool
 
 if TYPE_CHECKING:
@@ -61,7 +62,8 @@ def _extract_short(volume: str) -> tuple[str, bool] | None:
 
 def _opt_flags(driver_opts: dict[str, Any]) -> set[str]:
     """The comma-separated flags in a volume's ``o:`` driver option."""
-    return {part.strip().lower() for part in str(driver_opts.get("o", "")).split(",")}
+    text = as_scalar_text(driver_opts.get("o", "")) or ""
+    return {part.strip().lower() for part in text.split(",")}
 
 
 def _is_local_bind(driver_opts: dict[str, Any]) -> bool:

--- a/tests/test_resource_bounds.py
+++ b/tests/test_resource_bounds.py
@@ -1,0 +1,287 @@
+"""A small file must not be able to buy a large amount of work.
+
+Every finding here shares a shape: input that parses in milliseconds and then
+costs seconds or gigabytes downstream, while producing no finding and exiting 0
+— so nothing in the output signals what happened. YAML aliases make a document
+a DAG, and any pass that treats it as a tree pays 2^depth; a quadratic regex
+turns a long scalar into CPU; and `.exists()` says yes to a FIFO.
+
+Most assertions here are structural rather than timed, because a wall-clock
+threshold is the flakiest thing you can put in CI. Where timing is the only
+honest measure, the bound is generous — the defects were 4x-per-doubling, so a
+loose ceiling still separates fixed from broken by orders of magnitude.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from compose_lint._lines import split_lines
+from compose_lint._safe_read import MAX_FILE_BYTES, UnsafeFileError, read_text_bounded
+from compose_lint._scalar import as_scalar_text
+from compose_lint._yaml_edit import extends_targets
+from compose_lint.config import ConfigError, load_config
+from compose_lint.engine import run_rules
+from compose_lint.formatters.sarif import MAX_SARIF_RESULTS
+from compose_lint.parser import ComposeError, loads
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _run(args: list[str], cwd: Path, timeout: int = 120):
+    return subprocess.run(
+        [sys.executable, "-m", "compose_lint", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        env={
+            "PYTHONPATH": str(REPO_ROOT / "src"),
+            "PATH": "/usr/bin:/bin",
+            "NO_COLOR": "1",
+        },
+        timeout=timeout,
+    )
+
+
+def _alias_dag(depth: int, tail: str) -> str:
+    """A doubling-by-reference alias chain: n nodes, 2^n leaves if expanded."""
+    lines = ["x-l0: &l0 [a]"]
+    for i in range(1, depth + 1):
+        lines.append(f"x-l{i}: &l{i} [*l{i - 1}, *l{i - 1}]")
+    return "\n".join(lines) + "\n" + tail
+
+
+# --- Reading a path that is not a bounded regular file --------------------
+
+
+def test_a_fifo_is_refused_instead_of_hanging(tmp_path: Path) -> None:
+    fifo = tmp_path / "pipe"
+    os.mkfifo(fifo)
+    link = tmp_path / "docker-compose.yml"
+    link.symlink_to(fifo)
+
+    start = time.perf_counter()
+    with pytest.raises(UnsafeFileError):
+        read_text_bounded(link)
+    # The point is that it returns at all; a plain open() blocks forever.
+    assert time.perf_counter() - start < 10
+
+
+def test_a_character_device_is_refused_instead_of_allocating(tmp_path: Path) -> None:
+    link = tmp_path / "docker-compose.yml"
+    link.symlink_to(Path("/dev/zero"))
+    with pytest.raises(UnsafeFileError):
+        read_text_bounded(link)
+
+
+def test_a_directory_is_refused(tmp_path: Path) -> None:
+    with pytest.raises(UnsafeFileError):
+        read_text_bounded(tmp_path)
+
+
+def test_a_symlink_to_a_real_file_is_still_followed(tmp_path: Path) -> None:
+    """Only the resolved shape matters — a symlinked Compose file is ordinary."""
+    real = tmp_path / "real.yml"
+    real.write_text("services:\n  web:\n    image: nginx:1.27\n", encoding="utf-8")
+    link = tmp_path / "docker-compose.yml"
+    link.symlink_to(real)
+    assert "nginx" in read_text_bounded(link)
+
+
+def test_an_oversized_file_is_refused(tmp_path: Path) -> None:
+    big = tmp_path / "big.yml"
+    big.write_text("#" * (MAX_FILE_BYTES + 1), encoding="utf-8")
+    with pytest.raises(UnsafeFileError, match="limit"):
+        read_text_bounded(big)
+
+
+def test_the_cli_reports_a_fifo_and_keeps_going(tmp_path: Path) -> None:
+    fifo = tmp_path / "pipe"
+    os.mkfifo(fifo)
+    poisoned = tmp_path / "poisoned.yml"
+    poisoned.symlink_to(fifo)
+    good = tmp_path / "good.yml"
+    good.write_text(
+        "services:\n  api:\n    image: nginx:latest\n    privileged: true\n",
+        encoding="utf-8",
+    )
+
+    proc = _run(["--format", "json", str(poisoned), str(good)], tmp_path, timeout=60)
+    assert proc.returncode == 2
+    assert "Traceback" not in proc.stderr
+    # The clean file was still linted.
+    assert "CL-0002" in proc.stdout
+
+
+def test_a_config_pointing_at_a_fifo_is_refused(tmp_path: Path) -> None:
+    fifo = tmp_path / "pipe"
+    os.mkfifo(fifo)
+    cfg = tmp_path / "cfg.yml"
+    cfg.symlink_to(fifo)
+    with pytest.raises(ConfigError):
+        load_config(cfg)
+
+
+# --- `str()` on a container is an unbounded serialization ----------------
+
+
+@pytest.mark.parametrize("value", [["a"], {"a": 1}, {"a"}, ("a",)])
+def test_a_container_has_no_scalar_text(value: object) -> None:
+    assert as_scalar_text(value) is None
+
+
+@pytest.mark.parametrize(
+    "value,expected", [("a", "a"), (1, "1"), (True, "True"), (None, "None")]
+)
+def test_a_scalar_keeps_its_text(value: object, expected: str) -> None:
+    assert as_scalar_text(value) == expected
+
+
+def test_an_alias_dag_under_cap_add_does_not_expand(tmp_path: Path) -> None:
+    """22 levels is 4M leaves if serialized as a tree; the file is under 1 KB."""
+    source = _alias_dag(
+        22, "services:\n  web:\n    image: nginx:1.27\n    cap_add: *l22\n"
+    )
+    target = tmp_path / "docker-compose.yml"
+    target.write_text(source, encoding="utf-8")
+    assert len(source) < 2048
+
+    start = time.perf_counter()
+    proc = _run([str(target)], tmp_path, timeout=60)
+    elapsed = time.perf_counter() - start
+    assert proc.returncode in (0, 1), proc.stderr
+    assert elapsed < 15, f"took {elapsed:.1f}s"
+
+
+def test_an_alias_dag_in_a_config_reason_is_refused(tmp_path: Path) -> None:
+    config = tmp_path / "cfg.yml"
+    config.write_text(
+        _alias_dag(22, "rules:\n  CL-0002:\n    enabled: false\n    reason: *l22\n"),
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigError, match="must be a scalar"):
+        load_config(config)
+
+
+# --- Repeated work over one document -------------------------------------
+
+
+def test_split_lines_is_memoized_per_document() -> None:
+    """Each fixer asks for the same lines; re-splitting made collect_edits O(n^2)."""
+    text = "services:\n  web:\n    image: nginx:1.27\n"
+    assert split_lines(text) is split_lines(text)
+
+
+def test_split_lines_still_answers_correctly_for_a_different_document() -> None:
+    assert split_lines("a\nb\n") == ["a\n", "b\n"]
+    assert split_lines("c\nd\n") == ["c\n", "d\n"]
+
+
+def test_extends_targets_is_memoized_per_document() -> None:
+    data, _lines = loads(
+        "services:\n"
+        "  base:\n    image: nginx:1.27\n"
+        "  web:\n    extends:\n      service: base\n"
+    )
+    first = extends_targets(data)
+    assert extends_targets(data) is first
+    assert first == {"base"}
+
+
+def test_a_deep_alias_dag_with_extends_resolves_quickly() -> None:
+    """`_merge_extends` re-walked a shared subtree once per path: 805 B -> 5.4 s."""
+    source = _alias_dag(
+        18,
+        "services:\n"
+        "  base:\n    image: nginx:1.27\n    cap_add: *l18\n"
+        "  web:\n    extends:\n      service: base\n",
+    )
+    start = time.perf_counter()
+    loads(source)
+    assert time.perf_counter() - start < 10
+
+
+# --- Bounded regex scanning ----------------------------------------------
+
+
+def test_a_long_connection_string_is_not_scanned_quadratically() -> None:
+    from compose_lint.rules.CL0021_connection_string_credentials import (
+        _find_inline_credential,
+    )
+
+    start = time.perf_counter()
+    for size in (20_000, 40_000, 80_000):
+        _find_inline_credential("a" * size + "@")
+    assert time.perf_counter() - start < 5
+
+
+def test_an_ordinary_connection_string_still_fires() -> None:
+    data, lines = loads(
+        "services:\n"
+        "  web:\n"
+        "    image: nginx:1.27\n"
+        "    environment:\n"
+        "      DATABASE_URL: postgres://user:hunter2@db:5432/app\n"
+    )
+    ids = {f.rule_id for f in run_rules(data, lines)}
+    assert "CL-0021" in ids
+
+
+# --- Output that a consumer will actually accept --------------------------
+
+
+def test_sarif_is_truncated_and_says_so(tmp_path: Path) -> None:
+    lines = [
+        "services:",
+        "  base: &b",
+        "    image: nginx:latest",
+        "    privileged: true",
+    ]
+    for i in range(1500):
+        lines += [f"  s{i}:", "    <<: *b"]
+    target = tmp_path / "amp.yml"
+    target.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    proc = _run(["check", "--format", "sarif", str(target)], tmp_path, timeout=180)
+
+    # GitHub Code Scanning rejects a document over 10 MB outright, so an
+    # uncapped one produces no alerts at all.
+    assert len(proc.stdout) < 10 * 1024 * 1024, f"{len(proc.stdout)} bytes"
+
+    doc = json.loads(proc.stdout)
+    run = doc["runs"][0]
+    assert len(run["results"]) == MAX_SARIF_RESULTS
+    invocation = run["invocations"][0]
+    assert invocation["executionSuccessful"] is False
+    assert any(
+        "omitted" in n["message"]["text"]
+        for n in invocation["toolExecutionNotifications"]
+    )
+    # A gate must not read success from a knowingly incomplete artifact.
+    assert proc.returncode == 2
+
+
+def test_an_ordinary_run_is_not_truncated(tmp_path: Path) -> None:
+    target = tmp_path / "docker-compose.yml"
+    target.write_text(
+        "services:\n  web:\n    image: nginx:latest\n    privileged: true\n",
+        encoding="utf-8",
+    )
+    proc = _run(["check", "--format", "sarif", str(target)], tmp_path)
+    doc = json.loads(proc.stdout)
+    invocation = doc["runs"][0]["invocations"][0]
+    assert invocation["executionSuccessful"] is True
+    assert "toolExecutionNotifications" not in invocation
+    assert proc.returncode == 1
+
+
+def test_a_malformed_document_is_still_a_compose_error() -> None:
+    with pytest.raises(ComposeError):
+        loads("services:\n  web:\n    image: [\n")


### PR DESCRIPTION
Resolves nine findings from a [VulnHunter](https://github.com/capitalone/vulnhunter) security audit of this repository (tracked internally as VULN-004, 012, 016, 021, 022, 026, 031, 032, 035). Two more from that group — VULN-013 and 014 — were already closed by the interpolation cap in #550, confirmed by re-running their tests.

They share a shape: input that parses in milliseconds and then costs seconds or gigabytes downstream, while producing **no finding and exiting 0** — so nothing in the output signals it.

## Measured

Service count vs wall clock, before and after:

```
services     check              fix                 sarif
     100   0.08s              0.14s → 0.11s       0.13s → 0.10s
     800   0.21s              2.67s → 0.65s       2.37s → 0.36s
  growth   1.6x/doubling      3.3x → 2.1x         3.4x → 1.7x
```

`check` was always linear; `fix` and `sarif` were approaching quadratic and are now linear. The audit's own DoS suite runs in **14.6s**, down from 225s+.

## What was wrong

- **Reading a path that is not a bounded regular file.** `.exists()` is true of a FIFO and of `/dev/zero`, and a repository can commit a *symlink* to either — it survives clone and checkout, and the runner resolves it. One hung the job forever; the other allocated until the runner died. Both loaders now check the resolved file's shape first, with the descriptor opened `O_NONBLOCK` — a plain `open()` on a FIFO blocks **before** any check can run, which is the whole trick — and the read bounded at 8 MB.

- **`str()` on a YAML container.** Aliases share nodes by reference, so a 22-level doubling chain is under 1 KB on disk and 22 nodes in memory, but `str()` serializes it as a *tree*: 4M elements from one call. Eleven rule sinks and three config fields did that to whatever the document handed them. They now refuse a container — a list is not a capability, a port, a mount spec, or a suppression reason.

- **Repeated work over one document.** `extends_targets` walked every service once per *finding*; `_merge_extends` re-walked a shared alias subtree once per path through the DAG (805 B → 5.4 s). Both memoized.

- **Quadratic scanning.** CL-0021's userinfo pattern retried from every offset (20 KB → 1.1 s, 40 KB → 4.1 s). Quantifiers bounded, scalar capped.

- **The edit-conflict check** compared every pair of fix units. It now sweeps spans sorted by offset and stops once a later span begins past the current one's end.

- **SARIF a consumer would reject.** 1,500 aliased services in 29 KB produced a document over GitHub Code Scanning's 10 MB ceiling — and an artifact that large is *rejected*, so the run showed **no alerts at all**. That is the same false-clean as producing nothing.

## A regression of mine, named

Profiling found the dominant cost was `split_lines` — **802 calls, 2.24s of a 2.58s run** — re-splitting the whole document once per fixer.

That O(n²) shape predates me (each fixer already called `text.splitlines(keepends=True)`), but it was cheap at C speed. Replacing it with a pure-Python scan in #547's line-space fix is what made it expensive. I introduced that, and it is fixed here two ways: memoized per document, and given a C-speed fast path for text containing none of the five characters `str.splitlines()` breaks on and PyYAML does not. Equivalence of the fast path against the manual scan was fuzzed over 4,000 random strings drawn from the full break alphabet — 0 mismatches.

## Behavior change

**No findings, exit codes or errors change across the 5,417-file corpus.**

Two user-visible changes, both on input that previously misbehaved:

| | before | after |
|---|---|---|
| Compose file / config that is a FIFO, device or >8 MB | hang or OOM | clean error, exit 2, batch continues |
| a run producing >5,000 findings in SARIF | >10 MB document, rejected by GitHub | capped, omission stated, exit 2 |

The SARIF cap is the one to weigh: a run with more than 5,000 findings now exits 2 with a truncated document instead of exiting 1 with one the consumer drops. `--format json` is uncapped. 5,000 was chosen from measurement — results serialize at ~1.2 KB each, so this lands around 5–6 MB against a 10 MB ceiling.

Config `reason:`/`severity:` given a list or mapping is now a `ConfigError` rather than a stringified container.

Semver: **minor**.

## Tests

26 new tests in `tests/test_resource_bounds.py`, structural wherever possible rather than timed — a wall-clock threshold is the flakiest thing to put in CI, so timing is used only where it is the honest measure, with bounds loose enough that a 4x-per-doubling defect is still separated by orders of magnitude. Both directions are covered: FIFOs and devices refused, but a symlink to a real Compose file still followed; containers refused, but scalars unchanged; SARIF truncated when it must be, untouched when it need not be.

Full suite 1701 passed / 6 skipped; `ruff check`, `ruff format --check`, `mypy src/` clean.
