### PR TITLE
Stop the release layer having a weaker path than its main one

### DIFF
--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -12,6 +12,18 @@ name: Docker Hub description (manual)
 # secrets are repo-level, so the job reads them directly. Reuses the same
 # first-party composite action as publish.yml, so no third-party code holds the
 # delete-capable PAT.
+#
+# Because the secrets are repo-level, nothing scopes them to a ref — so the
+# checkout below is pinned to the default branch rather than to the dispatched
+# ref. `workflow_dispatch` can name any ref, and `uses: ./…` resolves the
+# composite action out of the *workspace*: without the pin, whoever dispatches
+# chooses the code that reads a Read+Write+Delete token. The pin means a
+# dispatch can choose only *when* this runs, not *what* runs.
+#
+# The remaining half of that gap is not fixable in this file: it needs a
+# `dockerhub-description` environment whose deployment-branch policy allows only
+# the default branch, holding the Docker Hub secrets so they leave repo scope.
+# See docs/RELEASING.md.
 
 on:
   workflow_dispatch:
@@ -27,6 +39,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # Not the dispatched ref — see the note at the top of this file.
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
       - uses: ./.github/actions/update-dockerhub-description
         with:

--- a/.github/workflows/publish-channel.yml
+++ b/.github/workflows/publish-channel.yml
@@ -19,7 +19,17 @@ on:
 permissions: {}
 
 jobs:
+  # The same gate publish.yml uses. This workflow used to carry its own copy
+  # that checked the tag was annotated and reachable but never verified its
+  # signature — so the emergency path was the weaker one, which is exactly
+  # backwards for an escape hatch that ships with the same credentials.
+  verify-tag:
+    uses: ./.github/workflows/verify-tag.yml
+    with:
+      tag: ${{ inputs.tag }}
+
   publish-pypi:
+    needs: verify-tag
     if: inputs.channel == 'pypi'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -38,20 +48,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.tag }}
           persist-credentials: false
-      - name: Verify tag is annotated and reachable from main
-        env:
-          TAG: ${{ inputs.tag }}
-        run: |
-          obj_type=$(git cat-file -t "${TAG}")
-          if [ "${obj_type}" != "tag" ]; then
-            echo "::error::${TAG} is a ${obj_type}, expected an annotated tag"
-            exit 1
-          fi
-          tag_commit=$(git rev-parse "${TAG}^{commit}")
-          if ! git merge-base --is-ancestor "${tag_commit}" origin/main; then
-            echo "::error::${TAG} commit ${tag_commit} is not reachable from origin/main"
-            exit 1
-          fi
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
@@ -136,6 +132,7 @@ jobs:
   # Hub on a single approval. Single-arch (amd64) keeps the smoke cheap —
   # multi-arch is still covered by the real build-docker matrix below.
   docker-smoke:
+    needs: verify-tag
     if: inputs.channel == 'docker'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -147,20 +144,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.tag }}
           persist-credentials: false
-      - name: Verify tag is annotated and reachable from main
-        env:
-          TAG: ${{ inputs.tag }}
-        run: |
-          obj_type=$(git cat-file -t "${TAG}")
-          if [ "${obj_type}" != "tag" ]; then
-            echo "::error::${TAG} is a ${obj_type}, expected an annotated tag"
-            exit 1
-          fi
-          tag_commit=$(git rev-parse "${TAG}^{commit}")
-          if ! git merge-base --is-ancestor "${tag_commit}" origin/main; then
-            echo "::error::${TAG} commit ${tag_commit} is not reachable from origin/main"
-            exit 1
-          fi
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Build image for testing
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,48 +35,12 @@ jobs:
   #      from a commit they control. Adding/rotating signing keys is a
   #      maintainer action documented in GOVERNANCE.md.
   verify-tag:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 3
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Assert annotated tag and reachable from main
-        env:
-          TAG: ${{ github.ref_name }}
-        run: |
-          obj_type=$(git cat-file -t "${TAG}")
-          if [ "${obj_type}" != "tag" ]; then
-            echo "::error::${TAG} is a ${obj_type}, expected an annotated tag (git tag -s/-a)"
-            exit 1
-          fi
-          tag_commit=$(git rev-parse "${TAG}^{commit}")
-          if ! git merge-base --is-ancestor "${tag_commit}" origin/main; then
-            echo "::error::${TAG} commit ${tag_commit} is not reachable from origin/main"
-            exit 1
-          fi
-          echo "Tag ${TAG} is annotated and reachable from origin/main (commit ${tag_commit})."
-      - name: Verify SSH signature against allowed_signers
-        env:
-          TAG: ${{ github.ref_name }}
-        run: |
-          # `git verify-tag` exits non-zero on any signature problem
-          # (missing, malformed, signed by an unknown key, signed by a
-          # key not authorized for the "git" namespace). The
-          # allowedSignersFile must be an absolute path.
-          allowed="${GITHUB_WORKSPACE}/.github/allowed_signers"
-          if [ ! -s "${allowed}" ]; then
-            echo "::error::${allowed} is missing or empty — cannot verify tag signature"
-            exit 1
-          fi
-          if ! git -c "gpg.ssh.allowedSignersFile=${allowed}" tag -v "${TAG}"; then
-            echo "::error::${TAG} signature did not verify against .github/allowed_signers"
-            echo "::error::If a maintainer's key was rotated, update .github/allowed_signers in a PR before tagging."
-            exit 1
-          fi
+    # Extracted to a reusable workflow so publish-channel.yml calls the *same*
+    # gate rather than keeping a copy that drifted (it omitted the signature
+    # check entirely). See .github/workflows/verify-tag.yml for what it asserts.
+    uses: ./.github/workflows/verify-tag.yml
+    with:
+      tag: ${{ github.ref_name }}
 
   build:
     needs: verify-tag
@@ -280,18 +244,34 @@ jobs:
             requirements.lock
             requirements-dev.lock
             requirements-build.lock
+      - name: Install the dependency closure from the hash-pinned lock
+        # The dependencies must not come from TestPyPI. `-i` makes an index
+        # *primary*, and pip then prefers the highest version across every
+        # configured index — so with TestPyPI primary, anyone who claims
+        # `pyyaml` there at a higher version supplies code into this job. The
+        # TestPyPI namespace is open to any account, which makes that a
+        # register-and-wait attack rather than a compromise.
+        #
+        # Installing the closure first, from hashes, means the step below has
+        # nothing left to resolve.
+        run: pip install --require-hashes -r requirements.lock
+
       - name: Install from TestPyPI and verify version
         # TestPyPI's JSON API sees a new release within seconds of the
         # publish step, but the /simple/ index pip uses can lag by
         # minutes. A fixed sleep has flaked mid-release before (0.3.6),
         # so retry the install with backoff until the index catches up
         # or we hit ~2 minutes of attempts.
+        #
+        # `--no-deps` is what keeps TestPyPI scoped to the one artifact under
+        # test: it is the only thing that legitimately lives there, and its
+        # dependencies are already installed above.
         run: |
           version="${GITHUB_REF_NAME#v}"
           for attempt in 1 2 3 4 5 6; do
             if pip install \
+                --no-deps \
                 -i https://test.pypi.org/simple/ \
-                --extra-index-url https://pypi.org/simple/ \
                 "compose-lint==${version}"; then
               break
             fi

--- a/.github/workflows/verify-tag.yml
+++ b/.github/workflows/verify-tag.yml
@@ -1,0 +1,79 @@
+name: Verify release tag
+
+# The one place a release tag is checked, called by every publish path.
+#
+# It used to be inlined in publish.yml, which meant publish-channel.yml — the
+# manual escape hatch — carried its own copy. That copy performed two of the
+# three checks and omitted the third, the signature verification, so a tag
+# signed by nobody in .github/allowed_signers could reach the credential-bearing
+# publish jobs. Duplicated security checks drift toward the weaker copy; one
+# definition cannot.
+#
+# The three checks, and why each exists:
+#   1. The tag is annotated. Releases are cut with `git tag -s`; a lightweight
+#      tag means something or someone pushed a malformed release tag.
+#   2. The tag commit is reachable from origin/main. Without this, a rogue tag
+#      pointed at an arbitrary commit outside main's merge history would still
+#      trigger a publish and ship whatever tree that commit has.
+#   3. The tag's SSH signature verifies against `.github/allowed_signers`. This
+#      is the cryptographic root of the Sigstore provenance chain — without it,
+#      an attacker with a stolen GitHub credential could trigger a release from
+#      a commit they control. Adding or rotating signing keys is a maintainer
+#      action documented in GOVERNANCE.md.
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: "Tag to verify (e.g. v1.2.3)"
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  verify-tag:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 3
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history so the reachability check below can see main.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Assert annotated tag and reachable from main
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          obj_type=$(git cat-file -t "${TAG}")
+          if [ "${obj_type}" != "tag" ]; then
+            echo "::error::${TAG} is a ${obj_type}, expected an annotated tag (git tag -s/-a)"
+            exit 1
+          fi
+          tag_commit=$(git rev-parse "${TAG}^{commit}")
+          if ! git merge-base --is-ancestor "${tag_commit}" origin/main; then
+            echo "::error::${TAG} commit ${tag_commit} is not reachable from origin/main"
+            exit 1
+          fi
+          echo "Tag ${TAG} is annotated and reachable from origin/main (commit ${tag_commit})."
+
+      - name: Verify SSH signature against allowed_signers
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          # `git verify-tag` exits non-zero on any signature problem (missing,
+          # malformed, signed by an unknown key, signed by a key not authorized
+          # for the "git" namespace). The allowedSignersFile must be absolute.
+          allowed="${GITHUB_WORKSPACE}/.github/allowed_signers"
+          if [ ! -s "${allowed}" ]; then
+            echo "::error::${allowed} is missing or empty — cannot verify tag signature"
+            exit 1
+          fi
+          if ! git -c "gpg.ssh.allowedSignersFile=${allowed}" tag -v "${TAG}"; then
+            echo "::error::${TAG} signature did not verify against .github/allowed_signers"
+            echo "::error::If a maintainer's key was rotated, update .github/allowed_signers in a PR before tagging."
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,47 @@ If a finding is genuinely parameterized in your deployment, that is what
 default (`${PW}` rather than `${PW:-hunter2}`) also stays exempt, because
 Compose then ships nothing.
 
+### Security
+
+- **The release layer no longer has a weaker path than its main one.**
+
+  - **One tag gate, called by both publish paths.** `publish.yml` verified
+    three things about a release tag: annotated, reachable from `main`, and
+    signed by a key in `.github/allowed_signers`. `publish-channel.yml` — the
+    manual escape hatch, which ships with the same credentials — carried its
+    own copy that did the first two and omitted the third, so a tag signed by
+    nobody could reach the publishing jobs. The signature check is the
+    cryptographic root of the Sigstore provenance chain. It now lives once, in
+    a reusable `verify-tag.yml` that both paths call, and every
+    credential-bearing job depends on it. A test walks the `needs:` graph and
+    fails if any job touching a publishing credential does not reach the gate.
+  - **The release smoke no longer resolves dependencies from TestPyPI.** `-i`
+    makes an index *primary*, and pip then prefers the highest version across
+    all configured indexes — so with TestPyPI primary, anyone who claims a
+    dependency name in that open namespace at a higher version supplies code
+    into the release. The closure is now installed from the hash-pinned lock
+    first, and TestPyPI is used only with `--no-deps` for the one artifact
+    under test. Verified against a local squat: PyYAML resolves from the lock,
+    not the planted 99.0.0. A test fails any workflow `pip install` that reads
+    from a non-default index without `--no-deps`.
+  - **The manual Docker Hub description sync runs default-branch code.**
+    `workflow_dispatch` can name any ref and `uses: ./…` runs whatever is in
+    the workspace, so the dispatcher chose the code that reads a
+    Read+Write+Delete token. The checkout is pinned to the default branch: a
+    dispatch now chooses when it runs, not what runs.
+  - **The corpus report escapes third-party repository and path strings.**
+    They come from code-search results over arbitrary public repositories, and
+    only a path's *basename* is filtered when fetching — so a directory
+    component could contain `|`, backticks and HTML, forge extra columns, and
+    write rows that looked like compose-lint's own findings. Backticks are
+    replaced rather than escaped, because Markdown does not honour backslash
+    escapes inside a code span.
+
+  Two related items need repository and Docker Hub settings rather than code,
+  and are written up in `docs/RELEASING.md`: moving the Docker Hub secrets into
+  a default-branch-scoped environment, and splitting the single
+  Read+Write+Delete PAT into read, write and admin tokens.
+
 ### Fixed
 
 - **A small file can no longer buy a large amount of work.** Nine defects

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -374,6 +374,53 @@ After approval, `publish` and `docker-publish` run in parallel.
   Delete the tag and re-push it as a signed tag from your workstation
   (see "Tag and release" above).
 
+## Credential scoping (open items)
+
+Two hardening steps live in GitHub and Docker Hub settings, not in this
+repository, so they cannot be landed by a PR. Both are recorded here rather
+than left implicit — the workflow side of each is already in place.
+
+### A `dockerhub-description` environment
+
+`dockerhub-description.yml` is dispatched manually and reads the Docker Hub
+credential. Its checkout is pinned to the default branch, so a dispatcher
+cannot choose the code that runs — but the secrets are still **repo-level**,
+which means nothing scopes them to a ref.
+
+To close the rest:
+
+1. Create an environment named `dockerhub-description`.
+2. Set its deployment-branch policy to the default branch only. (The existing
+   `dockerhub` environment is tags-only, which is why this job could not simply
+   reuse it.)
+3. Move `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` into it, removing them from
+   repo scope.
+4. Add `environment: dockerhub-description` to the job, and required reviewers
+   if you want a human gate.
+
+Until step 3, a repo-level secret is readable by any workflow in the
+repository, so steps 1–2 alone change nothing.
+
+### Split the Docker Hub PAT by capability
+
+One `Read, Write, Delete` PAT is referenced by every Docker Hub job, including
+read-only ones (`docker-smoke`, `scout`, `report`). A leak from any of them
+carries delete capability for the whole namespace — the scope of the credential
+is set by the single most privileged consumer.
+
+Mint three tokens and route them by need:
+
+| Token | Scope | Used by |
+|---|---|---|
+| `DOCKERHUB_TOKEN_READ` | Read | `docker-smoke`, `scout`, `report` |
+| `DOCKERHUB_TOKEN_WRITE` | Read, Write | the four build/publish jobs |
+| `DOCKERHUB_TOKEN_ADMIN` | Read, Write, Delete | the two `dockerhub-description` jobs only |
+
+The ADMIN token should live in the `dockerhub-description` environment above,
+so the other jobs cannot reference it even by name. Renaming the secrets is a
+breaking change to the release pipeline, so do it in one pass: add the new
+secrets first, land the workflow change, then revoke the old PAT.
+
 ## Why this checklist exists
 
 - Three version strings (`pyproject.toml`, `__init__.py`, and `action.yml`'s

--- a/scripts/corpus/run.py
+++ b/scripts/corpus/run.py
@@ -132,6 +132,31 @@ def load_index() -> dict[str, dict]:
     return out
 
 
+def md_cell(value: object) -> str:
+    """Escape a third-party string for one Markdown table cell or code span.
+
+    `repo` and `path` come from the corpus index, whose values are GitHub
+    code-search results over arbitrary public repositories. Only the *basename*
+    of a path is filtered when fetching, so a directory component can legally
+    contain `|`, backticks and HTML — enough to close the cell, forge extra
+    columns, and write rows that look like compose-lint's own findings. The
+    report is read as evidence about the corpus, so a falsified row is the whole
+    impact.
+
+    A backtick is *replaced*, not escaped. Several of these values are rendered
+    inside a code span, and Markdown does not honour backslash escapes there —
+    ``\\``` still closes the span, so escaping would leave the injection intact
+    while looking handled. Substituting a similar-looking character cannot.
+
+    The rest are backslash-escaped, backslash itself first so the others are not
+    double-escaped. Newlines become spaces because a table cell cannot hold one.
+    """
+    text = str(value).replace("`", "ˋ")  # U+02CB MODIFIER LETTER GRAVE
+    for char in ("\\", "|", "<", ">"):
+        text = text.replace(char, "\\" + char)
+    return text.replace("\r", " ").replace("\n", " ")
+
+
 def summarize(run_dir: Path, results: list[dict], index: dict[str, dict], started_at: str, elapsed: float) -> None:
     total = len(results)
     parse_errors = [r for r in results if r.get("error") == "usage_or_parse"]
@@ -225,7 +250,10 @@ def summarize(run_dir: Path, results: list[dict], index: dict[str, dict], starte
             sev = rule_severity.get(rid, "?")
             impact = SEVERITY_WEIGHT.get(sev, 0) * files_per_rule[rid]
             ex = rule_examples.get(rid, [])
-            ex_str = ", ".join(f"{repo}#{path}:{line}" for repo, path, line in ex[:1])
+            ex_str = ", ".join(
+                f"{md_cell(repo)}#{md_cell(path)}:{md_cell(line)}"
+                for repo, path, line in ex[:1]
+            )
             lines.append(f"| `{rid}` | {sev} | {n} | {files_per_rule[rid]} | {impact} | {ex_str} |")
     else:
         lines.append("_No findings._")
@@ -256,13 +284,19 @@ def summarize(run_dir: Path, results: list[dict], index: dict[str, dict], starte
     for r in parse_errors[:10]:
         meta = index.get(r["content_hash"], {})
         msg = (r.get("stderr") or "").splitlines()[0] if r.get("stderr") else ""
-        lines.append(f"- `{meta.get('repo','?')}` / `{meta.get('path','?')}` — {msg[:200]}")
+        lines.append(
+            f"- `{md_cell(meta.get('repo', '?'))}` / "
+            f"`{md_cell(meta.get('path', '?'))}` — {md_cell(msg[:200])}"
+        )
 
     if crashes:
         lines += ["", "## Crashes / unexpected errors", ""]
         for r in crashes[:20]:
             meta = index.get(r["content_hash"], {})
-            lines.append(f"- `{meta.get('repo','?')}` / `{meta.get('path','?')}` — {r.get('error')}")
+            lines.append(
+                f"- `{md_cell(meta.get('repo', '?'))}` / "
+                f"`{md_cell(meta.get('path', '?'))}` — {md_cell(r.get('error'))}"
+            )
 
     lines += [
         "",

--- a/tests/test_release_layer.py
+++ b/tests/test_release_layer.py
@@ -1,0 +1,194 @@
+"""The release layer must not be the weak path.
+
+Publishing is where this repo's credentials and its provenance chain live, so a
+check that exists on the normal path and not on the emergency one is worse than
+having neither: the escape hatch is the path taken under pressure.
+
+These assert on the workflow files themselves. They cannot run a release, so
+they check the properties a release depends on — that every credential-bearing
+job transitively reaches the tag gate, that the gate is defined once, and that
+no workflow resolves dependencies from an index it does not pin.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+# Anything that reaches a publishing credential, a signing key, or the registry.
+_CREDENTIAL_MARKERS = (
+    "DOCKERHUB_TOKEN",
+    "gh-action-pypi-publish",
+    "cosign sign",
+    "cosign attest",
+)
+
+
+def _load(name: str) -> dict[str, Any]:
+    return yaml.safe_load((WORKFLOWS / name).read_text(encoding="utf-8"))
+
+
+def _needs(job: dict[str, Any]) -> list[str]:
+    needs = job.get("needs", [])
+    return [needs] if isinstance(needs, str) else list(needs)
+
+
+def _reaches(jobs: dict[str, Any], start: str, target: str) -> bool:
+    """Whether ``start`` transitively depends on ``target``."""
+    seen: set[str] = set()
+    stack = list(_needs(jobs.get(start, {})))
+    while stack:
+        name = stack.pop()
+        if name == target:
+            return True
+        if name in seen or name not in jobs:
+            continue
+        seen.add(name)
+        stack.extend(_needs(jobs[name]))
+    return False
+
+
+def _credential_jobs(name: str) -> list[str]:
+    """Jobs in a workflow that touch a publishing credential or signing key."""
+    doc = _load(name)
+    raw = (WORKFLOWS / name).read_text(encoding="utf-8")
+    # Split the raw text per job so a marker is attributed to the job it is in.
+    found = []
+    for job_name in doc["jobs"]:
+        pattern = rf"^  {re.escape(job_name)}:$"
+        match = re.search(pattern, raw, re.MULTILINE)
+        assert match, job_name
+        start = match.start()
+        nxt = re.search(r"^  [A-Za-z0-9_-]+:$", raw[match.end() :], re.MULTILINE)
+        end = match.end() + nxt.start() if nxt else len(raw)
+        body = raw[start:end]
+        if any(marker in body for marker in _CREDENTIAL_MARKERS):
+            found.append(job_name)
+    return found
+
+
+# --- The gate is defined once -------------------------------------------
+
+
+def test_the_tag_gate_is_a_reusable_workflow() -> None:
+    doc = _load("verify-tag.yml")
+    # YAML 1.1 resolves the bare key `on` to the boolean True — the same
+    # coercion CL-0002 has to handle for `privileged: on`.
+    triggers = doc.get("on", doc.get(True))
+    assert "workflow_call" in triggers
+    assert "tag" in triggers["workflow_call"]["inputs"]
+
+
+def test_the_gate_performs_all_three_checks() -> None:
+    """The copy in publish-channel.yml did two of three; that is what drifted."""
+    raw = (WORKFLOWS / "verify-tag.yml").read_text(encoding="utf-8")
+    assert "git cat-file -t" in raw, "annotated-tag check missing"
+    assert "merge-base --is-ancestor" in raw, "reachable-from-main check missing"
+    assert "tag -v" in raw, "signature verification missing"
+    assert "allowedSignersFile" in raw
+
+
+@pytest.mark.parametrize("workflow", ["publish.yml", "publish-channel.yml"])
+def test_publish_paths_call_the_shared_gate(workflow: str) -> None:
+    jobs = _load(workflow)["jobs"]
+    assert "verify-tag" in jobs, f"{workflow} has no verify-tag job"
+    assert jobs["verify-tag"].get("uses", "").endswith("verify-tag.yml"), (
+        f"{workflow} defines its own gate instead of calling the shared one"
+    )
+
+
+@pytest.mark.parametrize("workflow", ["publish.yml", "publish-channel.yml"])
+def test_no_workflow_reimplements_the_signature_check(workflow: str) -> None:
+    """One definition cannot drift; two copies drift toward the weaker one."""
+    raw = (WORKFLOWS / workflow).read_text(encoding="utf-8")
+    assert "allowedSignersFile" not in raw, (
+        f"{workflow} carries its own signature check — call verify-tag.yml"
+    )
+
+
+# --- Every credential-bearing job is behind it ---------------------------
+
+
+@pytest.mark.parametrize("workflow", ["publish.yml", "publish-channel.yml"])
+def test_credential_jobs_depend_on_the_tag_gate(workflow: str) -> None:
+    jobs = _load(workflow)["jobs"]
+    offenders = [
+        name
+        for name in _credential_jobs(workflow)
+        if not _reaches(jobs, name, "verify-tag")
+    ]
+    assert not offenders, (
+        f"{workflow}: these jobs reach a publishing credential without "
+        f"depending on verify-tag: {offenders}"
+    )
+
+
+def test_the_credential_marker_scan_finds_something() -> None:
+    """Guard the guard: an empty scan would make the test above vacuous."""
+    assert _credential_jobs("publish.yml"), "no credential-bearing jobs detected"
+
+
+# --- No unpinned resolution from an index we do not control --------------
+
+
+def test_no_workflow_resolves_dependencies_from_an_unpinned_index() -> None:
+    """`-i` makes an index *primary*, and pip prefers the highest version found.
+
+    With TestPyPI primary, anyone who claims a dependency name there at a higher
+    version supplies code into the job — and that namespace is open to any
+    account. An install from such an index is only safe with ``--no-deps``,
+    which scopes it to the one artifact under test.
+    """
+    offenders: list[str] = []
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        # Join shell line-continuations first: a `pip install \` command spans
+        # several lines, and matching per line would read only the first of
+        # them — which silently makes this whole check vacuous.
+        flat_file = re.sub(r"\\\s*\n\s*", " ", path.read_text(encoding="utf-8"))
+        for line in flat_file.splitlines():
+            if "pip install" not in line:
+                continue
+            uses_index = "-i http" in line or "--index-url" in line
+            if uses_index and "--no-deps" not in line:
+                offenders.append(f"{path.name}: {' '.join(line.split())[:110]}")
+    assert not offenders, (
+        "pip install resolving from a non-default index without --no-deps:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+# --- A dispatch must not choose the code that reads a credential ---------
+
+
+def test_the_dockerhub_description_dispatch_is_pinned_to_the_default_branch() -> None:
+    """`workflow_dispatch` can name any ref, and `uses: ./…` runs workspace code.
+
+    The Docker Hub secrets here are repo-level, so nothing scopes them to a ref.
+    Pinning the checkout means a dispatcher chooses only *when* this runs, not
+    *what* runs with a Read+Write+Delete token.
+    """
+    jobs = _load("dockerhub-description.yml")["jobs"]
+    checkout = next(
+        step
+        for step in jobs["dockerhub-description"]["steps"]
+        if str(step.get("uses", "")).startswith("actions/checkout")
+    )
+    assert checkout["with"]["ref"] == "${{ github.event.repository.default_branch }}"
+
+
+def test_the_dockerhub_credential_is_only_read_by_first_party_code() -> None:
+    """The token must not be handed to a third-party action."""
+    raw = (WORKFLOWS / "dockerhub-description.yml").read_text(encoding="utf-8")
+    for line in raw.splitlines():
+        if "DOCKERHUB_TOKEN" not in line:
+            continue
+        # The token is passed as an input to the local composite action only.
+        assert "secrets.DOCKERHUB_TOKEN" in line
+    assert "uses: ./.github/actions/update-dockerhub-description" in raw


### PR DESCRIPTION
Resolves three findings from a [VulnHunter](https://github.com/capitalone/vulnhunter) security audit of this repository (VULN-043, 046, 047), plus the code half of a fourth (VULN-044). **VULN-045 and the remainder of 044 need repository and Docker Hub settings and cannot land in a PR** — both are written up in `docs/RELEASING.md`.

## The escape hatch was the weak path

`publish.yml` verified three things about a release tag: annotated, reachable from `main`, and signed by a key in `.github/allowed_signers`. `publish-channel.yml` — the manual escape hatch, which ships with the same credentials — carried its own copy that did the first two and **omitted the third**.

So a tag signed by nobody could reach the publishing jobs, on the path taken under pressure. The signature check is the cryptographic root of the Sigstore provenance chain.

The gate now lives once, in a reusable `verify-tag.yml` that both paths call. Duplicated security checks drift toward the weaker copy; one definition cannot. A test walks the `needs:` graph and fails if any job touching a publishing credential does not transitively reach the gate.

## Dependency confusion in the release smoke

`-i` makes an index **primary**, and pip then prefers the highest version across every configured index. With TestPyPI primary, anyone who claims a dependency name in that open namespace at a higher version supplies code into the release smoke — which feeds the release gate.

The closure now comes from the hash-pinned lock first, and TestPyPI is used only with `--no-deps` for the one artifact under test.

Verified against a local squat rather than by reading the flags — built a "TestPyPI" holding `pyyaml 99.0.0` alongside the artifact, then ran the new sequence:

```
local TestPyPI holds: ['compose_lint-9.9.9-...whl', 'pyyaml-99.0.0-...whl']
resolved pyyaml: ['PyYAML==6.0.3']
SQUATTED 99.0.0 installed? False
```

## Two smaller ones

**The manual Docker Hub sync ran the dispatcher's code.** `workflow_dispatch` can name any ref and `uses: ./…` runs whatever is in the workspace, so whoever dispatched chose the code that reads a Read+Write+Delete token. The checkout is pinned to the default branch — a dispatch now chooses *when* it runs, not *what* runs.

**The corpus report escapes third-party repo/path strings.** They come from code searches over arbitrary public repositories, and only a path's *basename* is filtered when fetching, so a directory component could carry `|`, backticks and HTML. Before: the attacker row had 13 columns against a 7-column header, with a forged Impact value and live HTML. After: 8 and 8, no forged cell, no HTML.

One correction worth noting: my first version backslash-escaped backticks. **Markdown does not honour backslash escapes inside a code span**, so `` `repo\`` `` still breaks out — escaping would have left the injection intact while looking handled. Backticks are now *replaced* (U+02CB), which cannot break out.

## What is NOT fixed here

- **VULN-045** — one `Read, Write, Delete` PAT is referenced by every Docker Hub job including read-only ones, so a leak from any carries delete capability for the whole namespace. Fixing it means minting three tokens and renaming secrets, which breaks the pipeline if done in the wrong order. `docs/RELEASING.md` has the table and the ordering.
- **VULN-044, remainder** — the checkout pin above is half of it. The other half is moving the Docker Hub secrets into a `dockerhub-description` environment scoped to the default branch, so they leave repo scope. Steps are in `docs/RELEASING.md`; I did **not** add an `environment:` declaration for an environment that does not exist yet, because a workflow naming an unconfigured environment reads as protected while protecting nothing.

## Verification

I cannot run a release, so the tests assert the properties a release depends on, and I checked each against the pre-fix files:

| test | catches |
|---|---|
| both publish paths call the shared gate | ✅ fails on old `publish.yml` *and* `publish-channel.yml` |
| no workflow reimplements the signature check | ✅ fails on old `publish.yml` |
| credential jobs reach the gate | ✅ fails on old `publish-channel.yml` |
| no unpinned index resolution | ✅ fails on old `publish.yml` |

That last one needed fixing twice: my first regex's greedy `[^\n]*` ate the shell line-continuation, so it read only `if pip install \` and passed against the vulnerable file. It now joins continuations first. A lint that cannot fail is worse than no lint.

Exploit tests: 043, 044, 047 no longer reproduce. 045 still does (expected — settings). 046's test hardcodes the old flag shape rather than reading `publish.yml`, so it cannot see the fix; the squat experiment above is the evidence instead.

## Behavior change

No linting behavior changes — `src/` is untouched, so no corpus impact. The release pipeline gains a job (`verify-tag`) on both paths and installs the locked closure before the TestPyPI step. `scripts/` is not shipped in the wheel.

Semver: **patch**.

Full suite 1713 passed / 6 skipped; `ruff check`, `ruff format --check`, `mypy src/` clean; all four workflows parse.
