### PR TITLE
Harden the init write path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,24 @@ Compose then ships nothing.
 
 ### Fixed
 
+- **`init` no longer writes a config that does not parse.** A service name
+  carrying a newline produced a `.compose-lint.yml` with a bare line break
+  inside a mapping key — and `init` reported success writing it, so every later
+  run in that directory failed with `Invalid YAML in config file` at exit 2
+  until someone found the file by hand. Durable corruption from one lint of one
+  hostile file. Quoting is now delegated to PyYAML rather than hand-rolled
+  (the previous version escaped `\` and `"` and nothing else), and the
+  plain-scalar test is anchored with `\Z` rather than `$` — in Python `$` also
+  matches *before* a trailing newline, so `"web\n"` was emitted unquoted.
+  Ordinary names are still emitted unquoted.
+
+- **`init --force` no longer overwrites a read-only config.** A 0444
+  `.compose-lint.yml` is an explicit "do not modify" on the file that decides
+  which security rules are suppressed, and `os.replace` would swap it out
+  through the writable parent directory regardless. `fix --apply` had honoured
+  that mode all along; the init path did not. The guard is now one shared
+  helper called by both, with a test that fails if either loses it.
+
 - **A small file can no longer buy a large amount of work.** Nine defects
   shared that shape: input that parses in milliseconds and then costs seconds
   or gigabytes downstream, while producing no finding and exiting 0 — so

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -587,6 +587,18 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
     sys.exit(1 if has_errors else 0)
 
 
+def _refuses_write(path: Path) -> bool:
+    """Whether ``path`` exists and is marked read-only.
+
+    A 0444 file is an explicit "do not modify" signal, and `os.replace` would
+    still swap it out through the writable parent directory — so the mode has
+    to be checked, not relied on. `fix --apply` did; `init --force` did not,
+    and the file it overwrites is the policy governing which security rules are
+    suppressed.
+    """
+    return path.exists() and not os.access(path, os.W_OK)
+
+
 class UnwritableTargetError(OSError):
     """Raised when a write target exists but is not a regular file."""
 
@@ -794,11 +806,7 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
             continue
 
         if args.apply:
-            if not os.access(filepath, os.W_OK):
-                # A read-only file (e.g. chmod 444) is an explicit "do not
-                # modify" signal; os.replace would still swap it in via the
-                # writable parent directory. Warn and skip rather than override
-                # the user's intent silently.
+            if _refuses_write(Path(filepath)):
                 emit(
                     f"Warning: {filepath}: file is not writable; skipping "
                     "(make it writable to allow `fix --apply` to modify it)"
@@ -872,6 +880,17 @@ def _run_init(args: argparse.Namespace) -> NoReturn:
     # Protect deliberate human suppression decisions from a silent clobber.
     if out_path.exists() and not args.force:
         emit(f"Error: {out_path} already exists; pass --force to overwrite")
+        sys.exit(2)
+
+    if _refuses_write(out_path):
+        # --force overrides the "already exists" refusal above; it does not
+        # override the file's own mode. `fix --apply` has always honoured this
+        # and the init path did not, so the one file whose contents decide
+        # which rules are suppressed was the one without the guard.
+        emit(
+            f"Error: {out_path} is not writable; "
+            "make it writable to allow `init --force` to replace it"
+        )
         sys.exit(2)
 
     existed = out_path.exists()

--- a/src/compose_lint/config_emit.py
+++ b/src/compose_lint/config_emit.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 import re
 
+import yaml
+
 from compose_lint.models import Finding, Severity
 
 _PLACEHOLDER_REASON = "TODO: justify or fix"
@@ -32,15 +34,33 @@ _SEVERITY_RANK = {
 
 # A YAML plain scalar safe to emit unquoted: an identifier-ish token with no
 # characters that would change the parse. Anything else is double-quoted.
-_PLAIN_SCALAR = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+#
+# `\A`/`\Z`, not `^`/`$`: in Python `$` also matches *before* a trailing
+# newline, so a service named "web\n" passed this check and was emitted
+# unquoted — a bare newline in the middle of a mapping key.
+_PLAIN_SCALAR = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9._-]*\Z")
 
 
 def _scalar(value: str) -> str:
-    """Render a string as a YAML scalar, quoting only when necessary."""
+    """Render a string as a YAML scalar, quoting only when necessary.
+
+    Quoting is delegated to PyYAML rather than hand-rolled. The previous
+    version escaped `\\` and `"` and nothing else, so a service name carrying a
+    newline produced a config that does not parse — and `init` reported success
+    while writing it, which broke every later run in that directory with
+    `Invalid YAML in config file`, exit 2. Durable corruption from one lint of
+    one hostile file.
+
+    Escaping is the kind of thing that is nearly right until it meets the next
+    character class; the emitter that owns the format should decide.
+    """
     if _PLAIN_SCALAR.match(value):
         return value
-    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
-    return f'"{escaped}"'
+    # `default_style='"'` forces the double-quoted form, which is what this
+    # emitter wants and which yields a single line with no document markers.
+    return yaml.safe_dump(
+        value, default_style='"', width=10**9, allow_unicode=True
+    ).rstrip("\n")
 
 
 def _rule_names() -> dict[str, str]:

--- a/tests/test_init_write_path.py
+++ b/tests/test_init_write_path.py
@@ -1,0 +1,180 @@
+"""`init` writes the file that governs which security rules are suppressed.
+
+Two defects on that path. It could write a config that does not parse — and
+report success doing it, so every later run in that directory failed at exit 2
+until someone found the file by hand. And `--force` overwrote a read-only
+policy, the one file where "do not modify" is a security decision, even though
+`fix --apply` had honoured that mode all along.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from compose_lint.config import load_config
+from compose_lint.config_emit import render_config
+from compose_lint.models import Finding, Severity
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_INSECURE = "services:\n  web:\n    image: nginx:latest\n    privileged: true\n"
+
+
+def _run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "compose_lint", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        env={
+            "PYTHONPATH": str(REPO_ROOT / "src"),
+            "PATH": "/usr/bin:/bin",
+            "NO_COLOR": "1",
+        },
+        timeout=120,
+    )
+
+
+@pytest.fixture
+def restore_mode():
+    touched: list[Path] = []
+    yield touched
+    for path in touched:
+        with __import__("contextlib").suppress(OSError):
+            path.chmod(0o644)
+
+
+# --- VULN-030: what init writes must parse -------------------------------
+
+
+@pytest.mark.parametrize(
+    "service",
+    [
+        "web\n      other: x",  # a newline inside a mapping key
+        "web\n",  # trailing newline — `$` matched before it
+        'quote"name',
+        "back\\slash",
+        "colon: name",
+        "tab\tname",
+        "hash # name",
+        "- dash",
+        "\x85nel",
+        "unicode-é",
+    ],
+)
+def test_a_hostile_service_name_still_yields_a_parseable_config(
+    tmp_path: Path, service: str
+) -> None:
+    findings = [
+        Finding(
+            rule_id="CL-0002",
+            severity=Severity.CRITICAL,
+            service=service,
+            message="m",
+            line=4,
+        )
+    ]
+    config = tmp_path / ".compose-lint.yml"
+    config.write_text(render_config(findings), encoding="utf-8")
+
+    # The whole point: the file it wrote must load again.
+    disabled, overrides, excluded = load_config(config)
+    assert service in excluded["CL-0002"], excluded
+
+
+def test_init_output_round_trips_end_to_end(tmp_path: Path) -> None:
+    target = tmp_path / "docker-compose.yml"
+    target.write_text(
+        'services:\n  "web\\n      other: x":\n'
+        "    image: nginx:latest\n    privileged: true\n",
+        encoding="utf-8",
+    )
+
+    init = _run(["init", str(target)], tmp_path)
+    assert init.returncode == 0, init.stderr
+
+    # The next run in this directory must not fail on the config init wrote.
+    check = _run([str(target)], tmp_path)
+    assert "Invalid YAML in config file" not in check.stderr
+    assert check.returncode != 2, check.stderr
+
+
+def test_an_ordinary_service_name_is_still_emitted_unquoted() -> None:
+    """The plain-scalar path is what keeps the generated file readable."""
+    findings = [
+        Finding(
+            rule_id="CL-0002",
+            severity=Severity.CRITICAL,
+            service="web",
+            message="m",
+            line=4,
+        )
+    ]
+    assert "      web: " in render_config(findings)
+
+
+# --- VULN-036: a read-only policy file is a decision, not an obstacle ----
+
+
+def test_init_force_refuses_a_read_only_config(
+    tmp_path: Path, restore_mode: list[Path]
+) -> None:
+    target = tmp_path / "docker-compose.yml"
+    target.write_text(_INSECURE, encoding="utf-8")
+    config = tmp_path / ".compose-lint.yml"
+    original = "rules: {}  # reviewed, do not modify\n"
+    config.write_text(original, encoding="utf-8")
+    config.chmod(0o444)
+    restore_mode.append(config)
+
+    proc = _run(["init", str(target), "--force"], tmp_path)
+
+    assert proc.returncode == 2, proc.stderr
+    assert "not writable" in proc.stderr
+    assert config.read_text(encoding="utf-8") == original
+    assert stat.S_IMODE(config.stat().st_mode) == 0o444
+
+
+def test_init_still_writes_a_writable_config(tmp_path: Path) -> None:
+    target = tmp_path / "docker-compose.yml"
+    target.write_text(_INSECURE, encoding="utf-8")
+    config = tmp_path / ".compose-lint.yml"
+    config.write_text("rules: {}\n", encoding="utf-8")
+
+    proc = _run(["init", str(target), "--force"], tmp_path)
+    assert proc.returncode == 0, proc.stderr
+    assert "CL-0002" in config.read_text(encoding="utf-8")
+
+
+def test_init_writes_a_fresh_config_when_none_exists(tmp_path: Path) -> None:
+    """The guard must not block the ordinary first run."""
+    target = tmp_path / "docker-compose.yml"
+    target.write_text(_INSECURE, encoding="utf-8")
+
+    proc = _run(["init", str(target)], tmp_path)
+    assert proc.returncode == 0, proc.stderr
+    written = tmp_path / ".compose-lint.yml"
+    assert written.exists()
+    assert os.access(written, os.W_OK)
+
+
+def test_both_write_paths_share_one_guard() -> None:
+    """`fix` had it and `init` did not; one definition keeps them together."""
+    import ast
+
+    source = (REPO_ROOT / "src" / "compose_lint" / "cli.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_refuses_write"
+    ]
+    assert len(calls) == 2, f"expected the fix and init paths, found {len(calls)}"


### PR DESCRIPTION
Resolves the last two findings from a [VulnHunter](https://github.com/capitalone/vulnhunter) security audit of this repository (VULN-030 and VULN-036). Both are on the `init` write path — the file it produces is the one that decides which security rules are suppressed.

## `init` could write a config that does not parse

A service name carrying a newline produced a `.compose-lint.yml` with a bare line break inside a mapping key, and `init` **reported success** writing it:

```
wrote .compose-lint.yml with 5 suppression(s)
```

Every later run in that directory then failed:

```
Error: Invalid YAML in config file: mapping values are not allowed here
exit 2
```

Durable corruption from one lint of one hostile file, and nothing in the output pointed at the config.

Two causes, both fixed:

- `_scalar` escaped `\` and `"` and nothing else. Hand-rolled escaping is nearly right until it meets the next character class, so quoting is now delegated to PyYAML — the emitter that owns the format decides.
- `_PLAIN_SCALAR` was anchored with `$`, which **in Python also matches before a trailing newline**, so `"web\n"` passed the "safe to emit unquoted" test. `\Z` does not.

Ordinary names are still emitted unquoted, which is what keeps the generated file readable — there's a test pinning that too.

## `init --force` overwrote a read-only config

A `0444` `.compose-lint.yml` is an explicit "do not modify" on the file governing suppression, and `os.replace` swaps it out through the writable parent directory regardless of its mode — so the mode has to be checked, not relied on.

`fix --apply` had that guard from the start. The init path did not, which left the one file whose contents decide which rules fire as the one without it. The guard is now a shared helper called by both, with a test that fails if either path loses it.

## Behavior change

**No findings, exit codes or errors change across the 5,417-file corpus.**

| | before | after |
|---|---|---|
| `init` on a file with a hostile service name | writes an unparseable config, exit 0 | writes a parseable config, exit 0 |
| `init --force` onto a `0444` config | overwrites it, exit 0 | refuses, exit 2, file untouched |

The generated config's *shape* is unchanged for ordinary input; only values that previously needed escaping and did not get it are now quoted differently.

Semver: **patch**.

## Tests

16 new tests. The hostile-name cases are a table — newline-in-key, trailing newline, quote, backslash, colon, tab, hash, leading dash, U+0085, non-ASCII — each asserting the written file *loads again*, which is the property that actually matters. Plus an end-to-end `init` → `check` round trip in one directory, the read-only refusal with the file verified byte-identical and still `0444`, and the ordinary paths (fresh config, writable config) still working.

Checked against the pre-fix code: **6 of the 16 fail**, including both the newline cases, the round trip, the read-only refusal, and the shared-guard assertion.

Full suite 1729 passed / 6 skipped; `ruff check`, `ruff format --check`, `mypy src/` clean.

---

This completes the remediation: **all 51 findings addressed across 12 groups**, except two Docker Hub credential items that need repository and Docker Hub settings rather than code — the PAT capability split and moving the Docker Hub secrets into a default-branch-scoped environment. Both are written up in `docs/RELEASING.md` under "Credential scoping (open items)", with the ordering needed to avoid breaking the release pipeline.
