### PR TITLE
Split CL-0021 userinfo and nested defaults at substitution depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,38 @@ Compose then ships nothing.
 
 ### Fixed
 
+- **Nested interpolation defaults resolve the way Compose resolves them.**
+  `${A:-x${B:-y}z}` was rewritten by a single regex pass whose default group
+  stopped at the *first* `}` — the inner one — so
+  `${DB_URL:-postgres://u:${PW:-s3cret}@db/x}` normalized to
+  `postgres://u:${PW:-s3cret@db/x}`, a string Compose never ships, with the
+  userinfo boundary moved and the brace relocated past the host. Every rule
+  reads the normalized document, so the corruption reached bind sources
+  (`${GOPATH:-${HOME}/go}/pkg/mod/cache`) as well as the credential rules. 98
+  values across 34 corpus files are written this way. Resolution is now
+  innermost-first with balanced brace counting, checked against
+  `docker compose config` on Compose 5.4.0 with no `.env`:
+
+  | written | shipped | before |
+  |---|---|---|
+  | `${A:-front-${B:-back}-tail}` | `front-back-tail` | `front-${B:-back-tail}` |
+  | `${OUTER:-postgres://u:${IN:-pw}@db/x}` | `postgres://u:pw@db/x` | `postgres://u:${IN:-pw@db/x}` |
+  | `${CONF:-{"a":1}}` | `{"a":1}` | `{"a":1}` |
+
+  Nesting is bounded at 32 levels, deeper values being left as written: because
+  resolution recurses per level, `${A:-` repeated 1,200 times — 7 KB, under
+  `MAX_SCAN_LEN` — otherwise exhausted the interpreter stack and the parser
+  reported that as a usage error, so a 7 KB scalar turned a clean lint into
+  exit 2.
+
+  Measured over the 5,417-file corpus: **5 files (0.09%) change findings and
+  none go from pass to fail.** Two stop failing at the default `--fail-on high`,
+  each losing a single CL-0021 false positive; one drops a CL-0020 on
+  `MINIO_ROOT_PASSWORD: ${S3_SECRET_ACCESS_KEY:-${S3_SECRET_KEY:-}}`, which
+  Compose ships empty; and one file's five `${IMG:-repo/app:${TAG:-latest}}`
+  images move from CL-0019 to CL-0004 at the same MEDIUM severity, because the
+  tag now resolves to the mutable `latest` rather than to an opaque reference.
+
 - **`init` no longer writes a config that does not parse.** A service name
   carrying a newline produced a `.compose-lint.yml` with a bare line break
   inside a mapping key — and `init` reported success writing it, so every later

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,15 @@ Compose then ships nothing.
 
 ### Fixed
 
+- **CL-0021 no longer reports a connection string whose credential is entirely
+  a variable reference.** The `user:password@` split ran on the first `:`,
+  which for `postgresql://${DB_USER:?error}:${DB_PASSWORD:?error}@db/x` lands
+  inside the substitution — leaving a "password" of `?error}:${DB_PASSWORD:?error}`,
+  which is not wholly a reference and so read as a shipped literal. The split
+  now happens at substitution depth zero, the same thing `parser` already did
+  for short-syntax volumes, and each half is length-bounded rather than
+  relying on a regex quantifier to bound it.
+
 - **Nested interpolation defaults resolve the way Compose resolves them.**
   `${A:-x${B:-y}z}` was rewritten by a single regex pass whose default group
   stopped at the *first* `}` — the inner one — so

--- a/docs/rules/CL-0021.md
+++ b/docs/rules/CL-0021.md
@@ -30,11 +30,12 @@ services:
       AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow  # fires
 ```
 
-The value-side regex matches any URI scheme (`[a-zA-Z][a-zA-Z0-9+.\-]*`) followed by `://user:password@`, where the password half ships a non-empty literal — that is, it is not made up solely of `${VAR}`/`$VAR` references Compose resolves to nothing (Compose's escaped literal dollar, `$$`, is data, not a substitution — `pa$$w0rd` fires). The username half may be empty: RFC 3986 §3.2.1 permits it, and `redis://:password@host` — the standard Redis URL form — still leaks the password, so it fires.
+Detection matches any URI scheme (`[a-zA-Z][a-zA-Z0-9+.\-]*`) followed by `://`, then splits the `user:password@` that follows at the first `:` and `@` that sit *outside* a `${...}` substitution — a plain split lands inside one, so `postgresql://${DB_USER:?error}:${DB_PASSWORD:?error}@db/x` would be read as a password of `?error}:${DB_PASSWORD:?error}` and reported as a literal even though the file ships no credential. A match requires the password half to ship a non-empty literal — that is, it is not made up solely of `${VAR}`/`$VAR` references Compose resolves to nothing (Compose's escaped literal dollar, `$$`, is data, not a substitution — `pa$$w0rd` fires). The username half may be empty: RFC 3986 §3.2.1 permits it, and `redis://:password@host` — the standard Redis URL form — still leaks the password, so it fires.
 
 Skipped:
 
 - Password half is made only of `${VAR}`/`$VAR` references with no default — Compose ships nothing there, so the credential is parameterized. (A `$`-valued *username* with a literal password still fires: the password leaks regardless. A password whose only dollars are `$$` escapes also fires — that is a literal `$` in the credential, not a substitution. A **defaulted** password such as `${DB_PASSWORD:-hunter2}` fires too: the default is what the file deploys.)
+- Both halves are references with no default (`postgresql://${DB_USER:?error}:${DB_PASSWORD:?error}@db/x`) — the same rule as above, once the split respects the substitution.
 - Userinfo password is empty (`scheme://user:@host`) — no credential to leak.
 - No userinfo at all (`scheme://host/path`) — nothing to flag.
 - Empty or non-string value.

--- a/src/compose_lint/rules/CL0021_connection_string_credentials.py
+++ b/src/compose_lint/rules/CL0021_connection_string_credentials.py
@@ -22,23 +22,80 @@ COMPOSE_SECRETS_REF = "https://docs.docker.com/reference/compose-file/secrets/"
 
 RFC3986_REF = "https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.1"
 
-# Match `scheme://user:password@` in any env value. The scheme follows
-# RFC 3986 §3.1 (alpha + alnum/+/-/.); user and password halves stop at
-# the structural separators (':', '/', '@', whitespace). The user half is
-# optional (`*`, not `+`): RFC 3986 §3.2.1 permits an empty username, and
-# `redis://:password@host` — the standard Redis URL form — must still fire
-# (issue #279 R2). The var-ref guard below filters out variable substitutions
-# in the password half.
-# Every quantifier is bounded. Unbounded, the engine retries the scheme from
-# each of n offsets and rescans the tail from each — O(n^2) on a value shaped
-# like `scheme://<many>:<many>` (20 KB took 1.1 s, 40 KB took 4.1 s). The
-# ceilings are far above any real URL: RFC 3986 schemes are a handful of
-# characters, and a userinfo half in the hundreds is already implausible.
-_URI_USERINFO_RE = re.compile(
-    r"(?P<scheme>[a-zA-Z][a-zA-Z0-9+.\-]{0,63})://"
-    r"(?P<user>[^:/@\s]{0,512}):"
-    r"(?P<password>[^@/\s]{1,512})@"
-)
+# Match the `scheme://` prefix of a URL in any env value, per RFC 3986 §3.1
+# (alpha + alnum/+/-/.). The quantifier is bounded: unbounded, the engine
+# retries the scheme from each of n offsets and rescans the tail from each —
+# O(n^2) on a value shaped like `scheme://<many>:<many>` (20 KB took 1.1 s,
+# 40 KB took 4.1 s). The ceiling is far above any real scheme, which is a
+# handful of characters.
+_URI_SCHEME_RE = re.compile(r"(?P<scheme>[a-zA-Z][a-zA-Z0-9+.\-]{0,63})://")
+
+# Ceiling on either half of the userinfo. A userinfo half in the hundreds is
+# already implausible, and the bound is what keeps the scan below linear in
+# the length of a value that never terminates its userinfo.
+_MAX_USERINFO_HALF = 512
+
+
+def _split_userinfo(value: str, start: int) -> tuple[str, str] | None:
+    """Split `user:password@` out of ``value[start:]``, ignoring ``${...}``.
+
+    Returns the two halves, or ``None`` when what follows ``scheme://`` is not
+    a userinfo at all — no ``:``, no terminating ``@``, or a ``/`` or
+    whitespace reaching one of those first (both are structural separators
+    that end the authority, so a credential cannot span them).
+
+    Splitting on the first ``:`` with a regex splits *inside* the substitution,
+    the same defect :func:`parser._split_short_volume` exists to avoid.
+    ``postgresql://${DB_USER:?error}:${DB_PASSWORD:?error}@postgres/db`` has
+    its first colon in the ``:?``, yielding a password of
+    ``?error}:${HELLO_DB_PASSWORD:?error}`` — not wholly a reference, so
+    :func:`ships_no_literal` called it a literal and the rule fired on a value
+    that ships no credential at all (1 corpus instance, issue #561). Both
+    halves are therefore delimited by scanning at substitution depth 0.
+
+    ``$$`` is Compose's escape for a literal dollar, consumed before
+    interpolation, so it never opens a substitution — ``pa$${x}w0rd`` is a
+    literal password, not a reference (issue #502).
+    """
+    depth = 0
+    colon = -1
+    i = start
+    # A userinfo cannot exceed both ceilings plus its ':' separator, so past
+    # that point no '@' can produce a match. Bailing keeps the scan bounded on
+    # a long value whose userinfo never terminates.
+    limit = min(len(value), start + 2 * _MAX_USERINFO_HALF + 2)
+    while i < limit:
+        ch = value[i]
+        if ch == "$" and i + 1 < len(value):
+            following = value[i + 1]
+            if following == "$":  # escaped literal dollar, not syntax
+                i += 2
+                continue
+            if following == "{":
+                depth += 1
+                i += 2
+                continue
+        if depth:
+            if ch == "}":
+                depth -= 1
+            i += 1
+            continue
+        if ch == "@":
+            if colon < 0:
+                return None  # no password half
+            user = value[start:colon]
+            password = value[colon + 1 : i]
+            if len(user) > _MAX_USERINFO_HALF:
+                return None
+            if not 1 <= len(password) <= _MAX_USERINFO_HALF:
+                return None
+            return user, password
+        if ch == "/" or ch.isspace():
+            return None  # authority ended before any userinfo did
+        if ch == ":" and colon < 0:
+            colon = i
+        i += 1
+    return None
 
 
 def _iter_env(env_block: Any) -> Iterator[tuple[str, Any, int | None]]:
@@ -71,12 +128,16 @@ def _find_inline_credential(value: str) -> tuple[str, str, str] | None:
     CL-0020 so both rules classify a password identically — in particular,
     Compose's escaped literal dollar (`$$`) is data, not a substitution, so
     `pa$$w0rd` still fires (issue #502).
+
+    An empty username is a match: RFC 3986 §3.2.1 permits one, and
+    `redis://:password@host` — the standard Redis URL form — must still fire
+    (issue #279 R2).
     """
-    # The pattern requires a terminating '@', so a value without one can never
-    # match. Bail before `finditer` runs: without this guard a value shaped like
-    # `scheme://<many chars>:<many chars>` with no '@' makes the password half
-    # rescan the whole tail from every offset — O(n^2) on attacker-controlled
-    # env values, a cheap DoS when sweeping untrusted compose files.
+    # A userinfo requires a terminating '@', so a value without one can never
+    # match. Bail before the scan runs: without this guard a value shaped like
+    # `scheme://<many chars>:<many chars>` with no '@' is walked from every
+    # `scheme://` offset — O(n^2) on attacker-controlled env values, a cheap
+    # DoS when sweeping untrusted compose files.
     if "@" not in value:
         return None
     if len(value) > MAX_SCAN_LEN:
@@ -84,9 +145,11 @@ def _find_inline_credential(value: str) -> tuple[str, str, str] | None:
         # bound anything on its own. A scalar this long is not a connection
         # string; scanning it is pure cost.
         return None
-    for m in _URI_USERINFO_RE.finditer(value):
-        user = m.group("user")
-        password = m.group("password")
+    for m in _URI_SCHEME_RE.finditer(value):
+        split = _split_userinfo(value, m.end())
+        if split is None:
+            continue
+        user, password = split
         if ships_no_literal(password):
             continue
         return m.group("scheme"), user, password

--- a/src/compose_lint/rules/_interpolation.py
+++ b/src/compose_lint/rules/_interpolation.py
@@ -25,12 +25,24 @@ _MAX_SCAN_LEN = MAX_SCAN_LEN
 # An active variable substitution ("${VAR}", "${VAR:-default}", "$VAR").
 _VAR_REF_RE = re.compile(r"\$\{[^}]+\}|\$[A-Za-z_][A-Za-z0-9_]*")
 
-# "${VAR:-default}" and "${VAR-default}". Compose distinguishes them -- ":-"
+# The head of a "${...}" interior: the name, and the operator that follows it.
+# ":-" and "-" introduce a default (Compose distinguishes them -- ":-"
 # substitutes when unset *or empty*, "-" only when unset -- but both yield the
-# same default for a file carrying no .env, which is the case being resolved.
-# Non-greedy up to the first "}", so a trailing literal survives:
-# "${DIR:-/srv}/data" -> "/srv/data".
-_VAR_DEFAULT_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*):?-([^}]*)\}")
+# same default for a file carrying no .env, which is the case being resolved).
+# ":?"/"?" and ":+"/"+" do not: they carry an error message or an alternate,
+# so a reference spelled with one has no default to resolve to.
+_REF_HEAD_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)(:?[-?+])?")
+
+_DEFAULT_OPERATORS = frozenset({":-", "-"})
+
+# How deep a chain of nested defaults will be resolved. Resolution recurses
+# into each default, so without a bound a scalar of `${A:-` repeated ~1,200
+# times -- 7 KB, under `MAX_SCAN_LEN` -- exhausts the interpreter stack, and
+# the parser turns that RecursionError into a usage error. A file that lints
+# clean today would exit 2 instead, which is the denial of service
+# `_limits.MAX_SCAN_LEN` exists to close, arriving by a different route. Real
+# files nest two or three deep; the deepest in a 5,417-file corpus is three.
+_MAX_NESTING = 32
 
 # A reference with no default: "${VAR}", "$VAR", "${VAR:?err}". Nothing to
 # resolve to, so a value containing one is left exactly as written.
@@ -72,6 +84,93 @@ def ships_no_literal(value: str) -> bool:
     return _VAR_NO_DEFAULT_RE.sub("", text) == ""
 
 
+def _matching_brace(value: str, start: int) -> int | None:
+    """Index of the ``}`` closing the ``{`` at ``start``, or ``None``.
+
+    Braces are counted whether or not a ``$`` precedes them, because a default
+    may contain a literal one: Compose resolves ``${CONF:-{"a":1}}`` to
+    ``{"a":1}``, which only balanced counting reproduces.
+    """
+    depth = 0
+    for i in range(start, len(value)):
+        char = value[i]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return i
+    return None
+
+
+def _resolve_defaults(value: str, depth: int = 0) -> str | None:
+    """Rewrite each ``${VAR:-default}`` to its default, innermost first.
+
+    A single regex pass cannot do this. With the default written ``[^}]*`` it
+    stops at the *first* ``}``, which for a nested reference is the inner one:
+    ``${DB_URL:-postgres://u:${PW:-s3cret}@db/x}`` resolved to
+    ``postgres://u:${PW:-s3cret@db/x}`` — a string Compose never ships, with
+    the userinfo boundary moved and the closing brace relocated past the host.
+    98 corpus values across 34 files are shaped this way, bind mount sources
+    (``${GOPATH:-${HOME}/go}/pkg/mod/cache``) among them, so the corruption
+    reached the host-path rules as well as the credential ones (issue #561).
+    Compose's own resolution was captured with ``docker compose config`` on a
+    file carrying no ``.env``:
+
+    ====================================  ==========================
+    written                               shipped
+    ====================================  ==========================
+    ``${A:-front-${B:-back}-tail}``       ``front-back-tail``
+    ``${CONF:-{"a":1}}``                  ``{"a":1}``
+    ====================================  ==========================
+
+    A reference with no default is copied through **as written** rather than
+    resolved or dropped, leaving :func:`substitute_defaults` to make the
+    not-knowable call on the whole value exactly as before. ``None`` means the
+    value nests deeper than ``_MAX_NESTING`` and is treated as unknowable for
+    the same reason -- returning the partially-resolved text would claim
+    Compose ships something it does not.
+    """
+    if depth > _MAX_NESTING:
+        return None
+    out: list[str] = []
+    i = 0
+    end = len(value)
+    while i < end:
+        char = value[i]
+        if char == "$" and i + 1 < end:
+            following = value[i + 1]
+            if following == "$":  # escaped literal dollar, not a reference
+                out.append("$$")
+                i += 2
+                continue
+            if following == "{":
+                close = _matching_brace(value, i + 1)
+                if close is not None:
+                    default = _default_of(value[i + 2 : close])
+                    if default is not None:
+                        resolved = _resolve_defaults(default, depth + 1)
+                        if resolved is None:
+                            return None
+                        out.append(resolved)
+                        i = close + 1
+                        continue
+                    out.append(value[i : close + 1])  # no default; as written
+                    i = close + 1
+                    continue
+        out.append(char)
+        i += 1
+    return "".join(out)
+
+
+def _default_of(interior: str) -> str | None:
+    """The default an interpolation interior carries, or ``None`` if it has none."""
+    head = _REF_HEAD_RE.match(interior)
+    if head is None or head.group(2) not in _DEFAULT_OPERATORS:
+        return None
+    return interior[head.end() :]
+
+
 def substitute_defaults(value: str) -> str | None:
     """Resolve ``${VAR:-default}`` to its default, or ``None`` if unresolvable.
 
@@ -95,7 +194,9 @@ def substitute_defaults(value: str) -> str | None:
     escaped = value.replace("$$", "")
     if not _VAR_REF_RE.search(escaped):
         return value  # nothing to substitute
-    resolved = _VAR_DEFAULT_RE.sub(lambda m: m.group(2), value)
+    resolved = _resolve_defaults(value)
+    if resolved is None:
+        return None  # nested deeper than we resolve -- not knowable
     if _VAR_NO_DEFAULT_RE.search(resolved.replace("$$", "")):
         return None  # a reference without a default remains -- not knowable
     return resolved

--- a/tests/test_CL0021.py
+++ b/tests/test_CL0021.py
@@ -115,6 +115,32 @@ class TestConnectionStringCredentialsRule:
         findings = self._check("list_form_skipped_when_var")
         assert findings == []
 
+    def test_skip_required_var_halves(self) -> None:
+        # `${VAR:?err}` has no default, so Compose ships both halves empty and
+        # the value carries no credential. Splitting the userinfo on the first
+        # ':' landed inside the substitution, making the password half
+        # `?error}:${DB_PASSWORD:?error}` — not wholly a reference, so it read
+        # as a literal and the rule fired (issue #561).
+        findings = self._check_inline(
+            '"postgresql://${DB_USER:?error}:${DB_PASSWORD:?error}@postgres/db"'
+        )
+        assert findings == []
+
+    def test_skip_required_var_password_only(self) -> None:
+        # Control, not a regression: only the password half carries the ':?',
+        # which the old split already handled (the userinfo separator came
+        # first). It pins the behavior the fix must not change.
+        findings = self._check_inline('"postgres://app:${DB_PASSWORD:?err}@db/app"')
+        assert findings == []
+
+    def test_detect_literal_password_after_required_var_user(self) -> None:
+        # Control on the other side: making the split substitution-aware must
+        # not start exempting a literal password behind a `:?` username
+        # (issue #277 F6).
+        findings = self._check_inline('"postgres://${DB_USER:?err}:hunter2@db/app"')
+        assert len(findings) == 1
+        assert findings[0].rule_id == "CL-0021"
+
     # ---- $$ escape: a literal dollar is not a substitution (issue #502) ----
 
     def test_detect_dollar_escaped_password_in_url(self) -> None:
@@ -216,3 +242,45 @@ class TestConnectionStringCredentialsRule:
         assert meta.id == "CL-0021"
         assert meta.severity == Severity.HIGH
         assert len(meta.references) >= 3
+
+
+def test_split_userinfo_ignores_substitutions() -> None:
+    # Unit-level counterpart to the rule tests above, mirroring
+    # `test_bind_source_resolution`'s coverage of `_split_short_volume`: the
+    # split must happen at substitution depth 0, so a ':' inside `${...}` —
+    # `:-`, `:?` or `:+` — is not the userinfo separator (issue #561).
+    from compose_lint.rules.CL0021_connection_string_credentials import (
+        _split_userinfo,
+    )
+
+    def split(value: str) -> tuple[str, str] | None:
+        scheme, _, rest = value.partition("://")
+        return _split_userinfo(value, len(scheme) + 3) if rest else None
+
+    assert split("postgres://${U:?e}:${P:?e}@db/x") == ("${U:?e}", "${P:?e}")
+    assert split("postgres://u:${P:+set}@db/x") == ("u", "${P:+set}")
+    assert split("postgres://u:p@db/x") == ("u", "p")
+    assert split("redis://:p@r:6379/0") == ("", "p")
+    # `$$` is a literal dollar, so it opens no substitution and the '}' that
+    # follows cannot close one.
+    assert split("postgres://u:pa$${x}w0rd@db/x") == ("u", "pa$${x}w0rd")
+    # Not a userinfo: no ':', no '@', or the authority ends first.
+    assert split("postgres://host/db") is None
+    assert split("postgres://u:p/db") is None
+    assert split("http://example.com/a:b@c") is None
+
+
+def test_split_userinfo_bounds_each_half() -> None:
+    # Both halves are capped, which is what keeps the scan bounded on a value
+    # whose userinfo never terminates.
+    from compose_lint.rules.CL0021_connection_string_credentials import (
+        _MAX_USERINFO_HALF,
+        _split_userinfo,
+    )
+
+    at_cap = f"x://{'u' * _MAX_USERINFO_HALF}:{'p' * _MAX_USERINFO_HALF}@db"
+    assert _split_userinfo(at_cap, 4) is not None
+    over_user = f"x://{'u' * (_MAX_USERINFO_HALF + 1)}:p@db"
+    assert _split_userinfo(over_user, 4) is None
+    over_password = f"x://u:{'p' * (_MAX_USERINFO_HALF + 1)}@db"
+    assert _split_userinfo(over_password, 4) is None

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -55,6 +55,74 @@ def test_reference_without_a_default_is_left_as_written() -> None:
     assert data["services"]["web"]["image"] == "nginx:${TAG}"
 
 
+@pytest.mark.parametrize(
+    "written,shipped",
+    [
+        # Captured with `docker compose config` on Docker Compose 5.4.0, in an
+        # empty directory with no `.env` and an empty environment. A single
+        # regex pass resolved the *outer* reference against the *inner* one's
+        # closing brace, producing text Compose never ships:
+        # `${OUTER:-postgresql://user:${INNER:-pw}@db/x}` became
+        # `postgresql://user:${INNER:-pw@db/x}`, moving the userinfo boundary
+        # and relocating the brace past the host (issue #561).
+        (
+            "${OUTER:-postgresql://user:${INNER:-placeholder}@db:5432/x}",
+            "postgresql://user:placeholder@db:5432/x",
+        ),
+        ("${A:-front-${B:-back}-tail}", "front-back-tail"),
+        # Three deep, the shape corpus files use for a compose-project path.
+        ("${A:-${B:-${C:-leaf}}}", "leaf"),
+        # A default may contain literal braces, so the closing one is found by
+        # balanced counting rather than by taking the first `}`. This row is a
+        # control: taking the first `}` also happened to land here, because the
+        # brace it dropped was re-added as a trailing literal. It pins what the
+        # balanced counting must not break.
+        ('${CONF:-{"a":1}}', '{"a":1}'),
+    ],
+)
+def test_nested_defaults_resolve_innermost_first(written: str, shipped: str) -> None:
+    assert substitute_defaults(written) == shipped
+
+
+def test_nested_reference_without_a_default_is_left_as_written() -> None:
+    """One un-defaulted reference anywhere makes the whole value unknowable.
+
+    Compose ships `${GOPATH:-${HOME}/go}/pkg/mod/cache` as `/go/pkg/mod/cache`
+    with an empty environment, but `$HOME` is set in every real one — so this
+    file does not determine the path, and resolving it would invent a finding.
+    Left as written, `ships_no_literal` still classifies it correctly.
+    """
+    assert substitute_defaults("${GOPATH:-${HOME}/go}/pkg/mod/cache") is None
+
+
+def test_nesting_deeper_than_the_bound_is_left_as_written() -> None:
+    """Resolution recurses per level, so the depth is what a scalar can buy.
+
+    Unbounded, `${A:-` repeated ~1,200 times — 7 KB, under `MAX_SCAN_LEN` —
+    exhausted the interpreter stack, and the parser reports a RecursionError as
+    a usage error: a file that lints clean would exit 2 instead. That is the
+    denial of service `_limits.MAX_SCAN_LEN` exists to close, reached by
+    recursion rather than by backtracking.
+    """
+    from compose_lint.rules._interpolation import _MAX_NESTING
+
+    at_bound = "${A:-" * _MAX_NESTING + "leaf" + "}" * _MAX_NESTING
+    assert substitute_defaults(at_bound) == "leaf"
+
+    too_deep = "${A:-" * 1200 + "leaf" + "}" * 1200
+    assert len(too_deep) < _MAX_SCAN_LEN, "must be under the size cap to prove anything"
+    assert substitute_defaults(too_deep) is None
+    # And it reaches the parser as a lintable document, not an exit-2 error.
+    data, _lines = loads(f"services:\n  web:\n    working_dir: '{too_deep}'\n")
+    assert data["services"]["web"]["working_dir"] == too_deep
+
+
+def test_operators_other_than_default_carry_no_default() -> None:
+    """`:?`/`?` take an error message and `:+`/`+` an alternate, not a default."""
+    for written in ("${A:?err}", "${A?err}", "${A:+alt}", "${A+alt}"):
+        assert substitute_defaults(written) is None, written
+
+
 def test_normalization_reaches_nested_lists_and_maps() -> None:
     data, _lines = loads(
         "services:\n"


### PR DESCRIPTION
Closes the CL-0021 half of #561.

## Two commits, because the first one uncovered the second

**`Split CL-0021 userinfo at substitution depth zero`** — the reported false positive. The `user:password@` split ran on the first `:`, which for `postgresql://${DB_USER:?error}:${DB_PASSWORD:?error}@db/x` lands *inside* the substitution, leaving a "password" of `?error}:${DB_PASSWORD:?error}` — not wholly a reference, so `ships_no_literal` read it as a shipped literal. `parser._split_short_volume` already exists for exactly this on short-syntax volumes; the userinfo now splits the same way, and each half is length-bounded directly rather than through a regex quantifier.

**`Resolve nested interpolation defaults the way Compose does`** — found by measuring the corpus diff, not by reading the rule. `_VAR_DEFAULT_RE`'s `([^}]*)` takes the *first* `}` as the closing brace, so a nested default resolved to text Compose never ships:

| written | shipped | before this PR |
|---|---|---|
| `${A:-front-${B:-back}-tail}` | `front-back-tail` | `front-${B:-back-tail}` |
| `${OUTER:-postgres://u:${IN:-pw}@db/x}` | `postgres://u:pw@db/x` | `postgres://u:${IN:-pw@db/x}` |
| `${CONF:-{"a":1}}` | `{"a":1}` | `{"a":1}` |

Every "shipped" cell was captured with `docker compose config` on Compose 5.4.0 in an empty directory with no `.env`, not reasoned from the substitution syntax.

Rules read the normalized document, so the corruption reached bind sources (`${GOPATH:-${HOME}/go}/pkg/mod/cache`) as well as the credential rules. 98 values across 34 corpus files are written this way.

**This is why the two ship together.** Landing the CL-0021 fix alone would have converted two of those corrupted strings from *accidental* true positives into false negatives on real literal credentials — both files ship a literal password once the nesting resolves correctly. Nothing but the corpus diff would have caught that; both files still fail overall on other findings.

## Nesting is bounded at 32 levels

Resolution recurses per level, so `${A:-` repeated 1,200 times — 7 KB, comfortably under `MAX_SCAN_LEN` — exhausted the interpreter stack, and the parser reports a `RecursionError` as a usage error. A file that lints clean would have exited 2 instead: the denial of service `_limits.py` exists to close, arriving by recursion rather than by backtracking. The deepest real nesting in the corpus is three.

## Corpus impact

**5 files of 5,417 (0.09%) change findings. None go from pass to fail**, so no `Upgrading` note is needed.

| change | files | what |
|---|---|---|
| CL-0021 removed | 3 | the false positives — 2 stop failing at `--fail-on high`, each losing only the FP |
| CL-0020 removed | 1 | `MINIO_ROOT_PASSWORD: ${S3_SECRET_ACCESS_KEY:-${S3_SECRET_KEY:-}}`, which Compose ships empty |
| CL-0019 → CL-0004 | 1 | five `${IMG:-repo/app:${TAG:-latest}}` images, same MEDIUM severity — the tag now resolves to `latest` rather than staying opaque |

## Tests

1741 passing (+12). The regression tests were each checked against the pre-fix tree; the ones that pass either way are labelled controls in-place rather than left to imply coverage they do not have. `236222a` passes the suite on its own, so the branch bisects.

## Not in this PR

The CL-0020 duration false positive, the other half of #561 (`JWT_ACCESS_TOKEN_EXPIRE_MINUTES: 30` fires on the literal too, 6 corpus instances, pre-existing) — independent of this change.
