### PR TITLE
Stop CL-0020 reading a token's lifetime as the token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,31 @@ Compose then ships nothing.
   for short-syntax volumes, and each half is length-bounded rather than
   relying on a regex quantifier to bound it.
 
+- **CL-0020 no longer reads a token's *lifetime* as the token.**
+  `JWT_ACCESS_TOKEN_EXPIRE_MINUTES: 30` matched on the `TOKEN` substring and
+  fired at `high` — a finding with no fix, since the value is a duration.
+  A key naming a quantity about the credential (`TTL`, `EXPIRE`, `EXPIRY`,
+  `VALIDITY`, `ROTATION`, `INTERVAL`, `RETENTION`, `_MINUTES`/`_DAYS`,
+  `MIN_LENGTH`, `MIN_CHAR`, `_LIMIT`, `_SIZE`, `POLICY`, plural `TOKENS`,
+  `_PORT`) is now exempt **when its value is also a bare quantity** (`30`,
+  `900s`, `30m`).
+
+  Both halves are required, and deliberately so. Exempting on the value alone
+  — the shape a bare integer suggests — would have reverted the numeric-secret
+  fix: `POSTGRES_PASSWORD: 1234` is a weak credential and must keep firing.
+  Exempting on the key alone would skip `AUTH_TOKENS: your_token_here`.
+
+  Measured over the 5,417-file corpus: **30 findings removed across 18 files,
+  every one a knob; all 40 numeric-valued credentials kept; no other rule's
+  output changes.** Three files stop failing at the default `--fail-on high`,
+  having failed only on this. This class grew with the interpolation change
+  above — `TOKEN_TTL: ${TTL:-60}` resolves to `60` and began firing where the
+  unresolved reference had not.
+
+  Four knob keys holding non-quantity values still fire (a banned-password
+  *list filename*, a `5/hour` rate, an arithmetic expression, a placeholder
+  token); judging those needs the content scanner this rule declines to be.
+
 - **Nested interpolation defaults resolve the way Compose resolves them.**
   `${A:-x${B:-y}z}` was rewritten by a single regex pass whose default group
   stopped at the *first* `}` — the inner one — so

--- a/docs/rules/CL-0020.md
+++ b/docs/rules/CL-0020.md
@@ -35,6 +35,9 @@ Exemptions (key matches a credential pattern but the rule does **not** fire):
 - Keys ending in `_FILE` — this is the secrets-mount convention (`POSTGRES_PASSWORD_FILE: /run/secrets/db_password`), the *fix*, not the bug.
 - Keys containing `ALLOW_EMPTY_` or `RANDOM_` — image-startup boolean toggles (`MYSQL_ALLOW_EMPTY_PASSWORD: "yes"`, `MYSQL_RANDOM_ROOT_PASSWORD: "yes"`).
 - Values that are exactly `yes`, `no`, `true`, `false`, `on`, `off`, `0`, or `1` (case-insensitive) — boolean flags.
+- Keys that name a **quantity about** the credential — a lifetime, size, limit or policy knob (`TTL`, `TIMEOUT`, `EXPIRE`, `EXPIRY`, `VALIDITY`, `LIFETIME`, `ROTATION`, `INTERVAL`, `RETENTION`, `_SECONDS`/`_MINUTES`/`_HOURS`/`_DAYS`, `MIN_LENGTH`, `MIN_CHAR`, `_LIMIT`, `_SIZE`, `POLICY`, plural `TOKENS`, `_PORT`) — **and** whose value is a bare quantity (`30`, `1.5`, `900s`, `30m`). `JWT_ACCESS_TOKEN_EXPIRE_MINUTES: 30` is a duration, not a token.
+
+    Both halves are required. On the key alone, `AUTH_TOKENS: your_token_here` would be skipped; on the value alone, `DB_PASSWORD: 12345678` would be — and a weak numeric password is exactly the finding. So `PASSWORD_RESET_TOKEN_TTL: 900` is exempt while `SECRET_KEY: 12345` fires.
 - Empty values (`PASSWORD: ""` — env unset, not a credential).
 - Values Compose ships as empty — made only of references with no default (`${DB_PASSWORD}`, or `"${DB_PASSWORD}"` in a list-form entry, where the quotes are literal characters). The credential is parameterized and sourced from process env, the documented secure-ish pattern.
 

--- a/src/compose_lint/rules/CL0020_credential_env_keys.py
+++ b/src/compose_lint/rules/CL0020_credential_env_keys.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, Any
 
 from compose_lint._scalar import as_scalar_text
@@ -64,6 +65,66 @@ _FLAG_KEY_FRAGMENTS = (
 # Compared case-insensitively against the trimmed value.
 _FLAG_VALUES = frozenset({"yes", "no", "true", "false", "0", "1", "on", "off"})
 
+# Exemption: keys that carry a credential-shaped substring but name a
+# *quantity* about the credential — a lifetime, size, limit or policy knob —
+# rather than the credential itself (issue #561):
+# `JWT_ACCESS_TOKEN_EXPIRE_MINUTES: 30` is a duration, not a token.
+#
+# Deliberately conjunctive with _QUANTITY_VALUE_RE below: a knob-shaped key is
+# exempt only when its value is *also* a bare quantity. Exempting on the value
+# alone would revert issue #277 F7 (`DB_PASSWORD: 12345678` must keep firing —
+# a weak numeric password is the finding), and exempting on the key alone would
+# skip `AUTH_TOKENS: your_token_here`. Fragments are corpus-derived: over the
+# 5,417-file corpus this pair removes 30 findings, every one a knob, and keeps
+# all 40 numeric-valued credentials.
+_QUANTITY_KEY_FRAGMENTS = (
+    # Lifetime / rotation.
+    "TTL",
+    "TIMEOUT",
+    "EXPIRE",
+    "EXPIRY",
+    "EXPIRATION",
+    "VALIDITY",
+    "LIFETIME",
+    "MAX_AGE",
+    "MAXAGE",
+    "ROTATION",
+    "INTERVAL",
+    "RETENTION",
+    "DURATION",
+    # Explicit time units.
+    "_SECONDS",
+    "_SECS",
+    "_MINUTES",
+    "_MINS",
+    "_HOURS",
+    "_DAYS",
+    "_MS",
+    # Size / length / limit / policy knobs.
+    "MIN_LENGTH",
+    "MINLENGTH",
+    "MAX_LENGTH",
+    "MAXLENGTH",
+    "MIN_CHAR",
+    "MINCHAR",
+    "_LIMIT",
+    "_SIZE",
+    "REQUIREMENTS",
+    "POLICY",
+    "_BONUS",
+    # Plural TOKENS counts an LLM's units of text, not credentials
+    # (OPENAI_MAX_TOKENS, SUMMARY_MAX_TOKENS).
+    "TOKENS",
+)
+
+# Suffix-anchored so PASSPORT_SECRET is not read as a port number.
+_QUANTITY_KEY_SUFFIXES = ("_PORT",)
+
+# A bare number, optionally carrying a time unit (`30`, `1.5`, `900s`, `30m`,
+# `500ms`). Anything else — a placeholder, a filename, a rate like `5/hour` —
+# is not a quantity and the rule still fires.
+_QUANTITY_VALUE_RE = re.compile(r"^\d+(\.\d+)?(ms|s|m|h|d)?$", re.IGNORECASE)
+
 
 def _matches_credential_pattern(key_upper: str) -> bool:
     """Return True if the key name matches a credential-shaped pattern."""
@@ -77,6 +138,25 @@ def _is_exempt_key(key_upper: str) -> bool:
     if key_upper.endswith(_FILE_SUFFIX):
         return True
     return any(fragment in key_upper for fragment in _FLAG_KEY_FRAGMENTS)
+
+
+def _is_quantity_knob(key_upper: str, raw: Any) -> bool:
+    """Return True for a quantity-shaped key holding a quantity-shaped value.
+
+    Both halves are required: `PASSWORD_TTL: 900` is a lifetime, while
+    `DB_PASSWORD: 12345678` (no knob word) and `AUTH_TOKENS: your_token_here`
+    (not a quantity) are credentials and keep firing. See issue #561.
+    """
+    if isinstance(raw, bool):
+        return False
+    text = as_scalar_text(raw) if isinstance(raw, (int, float)) else raw
+    if not isinstance(text, str):
+        return False
+    if not _QUANTITY_VALUE_RE.match(text.strip()):
+        return False
+    if any(fragment in key_upper for fragment in _QUANTITY_KEY_FRAGMENTS):
+        return True
+    return any(key_upper.endswith(suffix) for suffix in _QUANTITY_KEY_SUFFIXES)
 
 
 def _is_literal_credential_value(raw: Any) -> bool:
@@ -155,9 +235,13 @@ class CredentialEnvKeysRule(BaseRule):
                 "`/proc/<pid>/environ`, `docker compose config`, process "
                 "listings, and CI logs. Compose's `secrets:` primitive "
                 "materializes credentials as files under /run/secrets/ and "
-                "does not appear in any of those surfaces. This rule is a "
-                "naming-convention check, not a content scanner — it does "
-                "not inspect the value for secret-like entropy or formats."
+                "does not appear in any of those surfaces. A key naming a "
+                "quantity about the credential (a lifetime, size, limit or "
+                "policy knob) whose value is also a bare quantity is exempt: "
+                "TOKEN_TTL_MINUTES: 30 is a duration, not a token. This rule "
+                "is a naming-convention check, not a content scanner — it "
+                "does not inspect the value for secret-like entropy or "
+                "formats."
             ),
             severity=Severity.HIGH,
             references=[OWASP_REF, COMPOSE_SECRETS_REF],
@@ -179,6 +263,8 @@ class CredentialEnvKeysRule(BaseRule):
             if not _matches_credential_pattern(key_upper):
                 continue
             if _is_exempt_key(key_upper):
+                continue
+            if _is_quantity_knob(key_upper, raw):
                 continue
             if not _is_literal_credential_value(raw):
                 continue

--- a/tests/test_CL0020.py
+++ b/tests/test_CL0020.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from compose_lint.models import Finding, Severity
 from compose_lint.parser import load_compose, loads
 from compose_lint.rules.CL0020_credential_env_keys import CredentialEnvKeysRule
@@ -188,6 +190,79 @@ class TestCredentialEnvKeysRule:
         # would be skipped because the literal-value check requires str.
         findings = self._check("skip_yaml_bool_value")
         assert findings == []
+
+    # ---- Exemptions: quantity knobs (issue #561) ----
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "JWT_ACCESS_TOKEN_EXPIRE_MINUTES",
+            "JWT_REFRESH_TOKEN_EXPIRE_DAYS",
+            "ACCESS_TOKEN_EXPIRE_MINUTES",
+            "DEEPFENCE_ACCESS_TOKEN_EXPIRY_MINUTES",
+            "WF_AUTH_TOKEN_TTL_MINUTES",
+            "PASSWORD_RESET_TOKEN_TTL",
+            "PASSWORD_CHANGE_TICKET_TTL_SECONDS",
+            "GF_AUTH_TOKEN_ROTATION_INTERVAL_MINUTES",
+            "JWT__REFRESHTOKENEXPIRATIONDAYS",
+            "TOKENVALIDITYMAX",
+            "TOKEN_USAGE_RETENTION",
+            "OPENAI_MAX_TOKENS",
+            "SUMMARY_MAX_TOKENS",
+            "CHATGPT2API_THREAD_TOKENS",
+            "DEFAULT_TOKEN_LIMIT",
+            "OLLAMA_MODEL_TOKEN_LIMIT",
+            "INDEXING_MAX_SEGMENTATION_TOKENS_LENGTH",
+            "PASSWORDMINCHAR",
+            "USER_PASSWORD_MIN_LENGTH",
+            "USER_PASSWORD_REQUIREMENTS",
+            "OCIS_PASSWORD_POLICY_MIN_CHARACTERS",
+            "TOKEN_SIGNUP_BONUS",
+            "SECRET_PORT",
+            "SECRET_FILE_SIZE",
+            "SECRET_MAX_TEXT_SIZE",
+        ],
+    )
+    def test_exempt_quantity_knob_keys(self, key: str) -> None:
+        # A lifetime/size/policy knob is not the credential it is named after.
+        # Every key here is a real corpus false positive from issue #561.
+        assert self._check_key(key, "30") == []
+
+    @pytest.mark.parametrize(
+        "value", ["30", "1.5", "900s", "500ms", "30m", "24h", "7d"]
+    )
+    def test_exempt_quantity_knob_value_forms(self, value: str) -> None:
+        assert self._check_key("TOKEN_TTL", value) == []
+
+    def test_knob_key_with_interpolated_default_is_exempt(self) -> None:
+        # The parser resolves `${WF_TTL:-60}` to 60 before the rule runs, so
+        # the defaulted form must be exempt exactly like the bare literal —
+        # this is the form that grading defaults newly surfaced.
+        assert self._check_key("WF_AUTH_TOKEN_TTL_MINUTES", '"${WF_TTL:-60}"') == []
+
+    @pytest.mark.parametrize(
+        ("key", "value"),
+        [
+            # Value is a quantity but the key names the credential itself.
+            ("DB_PASSWORD", "12345678"),
+            ("POSTGRES_PASSWORD", "1234"),
+            ("SECRET_KEY", "12345"),
+            ("DB_PASS", "1234"),
+            # Key is knob-shaped but the value is not a quantity.
+            ("AUTH_TOKENS", "your_token_here"),
+            ("TOKEN_TTL", "hunter2"),
+            ("PASSWORD_RESET_REQUEST_THROTTLE_RATE", '"5/hour"'),
+        ],
+    )
+    def test_quantity_exemption_needs_both_halves(self, key: str, value: str) -> None:
+        # Exempting on either half alone would lose a real finding: a weak
+        # numeric password (issue #277 F7) or a literal token.
+        assert len(self._check_key(key, value)) == 1
+
+    def test_passport_secret_is_not_read_as_a_port(self) -> None:
+        # _PORT is suffix-anchored: PASSPORT_SECRET contains "PORT" but the
+        # key does not end in it, so the credential still fires.
+        assert len(self._check_key("PASSPORT_SECRET", "12345")) == 1
 
     # ---- Variable-substitution skips ----
 


### PR DESCRIPTION
Closes the CL-0020 half of #561, the half #562 deferred.

`JWT_ACCESS_TOKEN_EXPIRE_MINUTES: 30` matched on the `TOKEN` substring and fired at `high` — a finding with no fix, since the value is a duration rather than a credential. It fails builds at the default `--fail-on high`, which makes it unactionable in the sense this project rules out.

## The fix is conjunctive

A key naming a *quantity about* the credential — `TTL`, `TIMEOUT`, `EXPIRE`, `EXPIRY`, `VALIDITY`, `ROTATION`, `INTERVAL`, `RETENTION`, `_SECONDS`/`_MINUTES`/`_HOURS`/`_DAYS`, `MIN_LENGTH`, `MIN_CHAR`, `_LIMIT`, `_SIZE`, `POLICY`, plural `TOKENS`, `_PORT` — is exempt **only when the value is also a bare quantity** (`30`, `1.5`, `900s`, `30m`).

The issue suggested the value half alone ("a bare integer is not a credential"). That would revert #277 F7, where numeric values are coerced to text specifically so `POSTGRES_PASSWORD: 1234` keeps firing — and the issue's own caveat ("some real secrets are numeric") is what makes it unsafe. The key half alone would skip `AUTH_TOKENS: your_token_here`.

| | knob key | non-knob key |
|---|---|---|
| **quantity value** | `PASSWORD_RESET_TOKEN_TTL: 900` — exempt | `SECRET_KEY: 12345` — fires |
| **other value** | `AUTH_TOKENS: your_token_here` — fires | `DB_PASSWORD: hunter2` — fires |

## Corpus measurement

Full engine diff over the 5,417-file corpus, before vs after:

- **30 findings removed across 18 files**, every one a knob (durations, LLM `MAX_TOKENS` counts, password-policy minimums)
- **all 40 numeric-valued credentials kept** (`POSTGRES_PASSWORD: 1234`, `MYSQL_ROOT_PASSWORD: 123456`, `ENCRYPTION_KEY: 000…0`, `SECRET_KEY: 12345`)
- **no other rule's output changes**, none added
- 3 files stop failing at the default `--fail-on high`, having failed only on this

## Why in this release

The `${VAR:-default}` resolution change already in `[Unreleased]` grows this class: `WF_AUTH_TOKEN_TTL_MINUTES: "${WF_TTL:-60}"` resolves to `60` and began firing where the unresolved reference had not. Verified against `v0.17.0`: the interpolated form was clean there and fires on current `main`. Shipping 0.18.0 without this would widen a known false positive.

## Known gap

Four knob keys holding non-quantity values still fire — a banned-password *list filename*, a `5/hour` rate, an arithmetic expression, a placeholder token. Judging those requires inspecting value content, which this rule deliberately does not do.

## Tests

35 new cases: every corpus key that changes verdict, the value forms, the interpolated-default form, both-halves-required pairs, and `PASSPORT_SECRET` proving `_PORT` stays suffix-anchored.