### PR TITLE
Grant the verify-tag caller job contents: read

### DIFF
--- a/.github/workflows/publish-channel.yml
+++ b/.github/workflows/publish-channel.yml
@@ -24,6 +24,11 @@ jobs:
   # signature — so the emergency path was the weaker one, which is exactly
   # backwards for an escape hatch that ships with the same credentials.
   verify-tag:
+    # Granted here for the same reason as in publish.yml: the called workflow
+    # cannot hold more than this job was given, and the workflow default is
+    # deny-all, so omitting this stops the run before any job starts.
+    permissions:
+      contents: read
     uses: ./.github/workflows/verify-tag.yml
     with:
       tag: ${{ inputs.tag }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,15 @@ jobs:
     # Extracted to a reusable workflow so publish-channel.yml calls the *same*
     # gate rather than keeping a copy that drifted (it omitted the signature
     # check entirely). See .github/workflows/verify-tag.yml for what it asserts.
+    #
+    # The grant has to be made here, not just in the called workflow. A called
+    # workflow's jobs cannot hold more than the calling job was given, and this
+    # workflow's deny-all default (`permissions: {}`) applies to the call. Its
+    # job asks for `contents: read` to check out the repo, so without this the
+    # run fails to start with "requesting 'contents: read', but is only allowed
+    # 'contents: none'" — before any job exists to report it.
+    permissions:
+      contents: read
     uses: ./.github/workflows/verify-tag.yml
     with:
       tag: ${{ github.ref_name }}


### PR DESCRIPTION
Pushing the `v0.18.0` tag failed to start `publish.yml`:

> Error calling workflow `.../verify-tag.yml`. The nested job 'verify-tag' is requesting `contents: read`, but is only allowed `contents: none`.

## Cause

`publish.yml` and `publish-channel.yml` both default to `permissions: {}` and declared no `permissions:` on the job that calls `verify-tag.yml`, so the call carried a deny-all token. A called workflow's jobs cannot hold more than the calling job was given, and `verify-tag.yml`'s job asks for `contents: read` to check out the repo — so the run was rejected before any job existed.

The gate was extracted to a reusable workflow in #559 and no release has been cut since, so neither caller had ever been exercised by a tag push.

## Why nothing caught it

- `actionlint` does not model permission inheritance across a workflow call, so the workflow-lint gate stayed green.
- A `startup_failure` produces **zero jobs**, no check-runs, no annotations and no log archive (`/logs` 404s), and neither REST nor GraphQL exposes the reason — it exists only as UI text on the run page.

## Fix

Grant `contents: read` on both calling jobs — exactly equal to what the callee requests, so the deny-all default still holds everywhere else.

## Release impact

None published. The failed run executed no jobs, so TestPyPI was never contacted and **0.18.0 is not burned**. After this merges, `v0.18.0` gets deleted and re-pushed at the new `main`.