### PR TITLE
Validate the changelog and bump every version string in release prep

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -1,12 +1,13 @@
 name: Release prep
 
 # Maintainer-triggered. Opens the "Prepare X.Y.Z release" PR for you:
-# bumps pyproject.toml + src/compose_lint/__init__.py, bumps the
-# self-referencing version pins in README.md + docs/ that the
-# version-consistency job enforces (#443), renames the CHANGELOG
-# [Unreleased] section to [X.Y.Z] - <today>, inserts a fresh empty
-# [Unreleased] above it, updates the CHANGELOG compare-link footer,
-# commits on a release/X.Y.Z branch, and opens a PR against main.
+# validates the CHANGELOG [Unreleased] section, bumps the source-of-truth
+# version strings via scripts/bump-version.sh, bumps the self-referencing
+# version pins in README.md + docs/ that the version-consistency job
+# enforces (#443), renames the CHANGELOG [Unreleased] section to
+# [X.Y.Z] - <today>, inserts a fresh empty [Unreleased] above it, updates
+# the CHANGELOG compare-link footer, commits on a release/X.Y.Z branch,
+# and opens a PR against main.
 #
 # The signed annotated tag is NOT created here. After the PR merges,
 # run `git tag -s vX.Y.Z -m "compose-lint X.Y.Z" && git push origin vX.Y.Z`
@@ -62,19 +63,87 @@ jobs:
             exit 1
           fi
 
-      - name: Bump pyproject.toml
-        env:
-          VERSION: ${{ inputs.version }}
+      # release-prep.yml only *renames* [Unreleased] -> [X.Y.Z]; it never
+      # authors or reorders entries, so whatever shape the section is in when
+      # this runs is what ships — in the GitHub Release notes too. Two shapes
+      # have reached a release candidate:
+      #   - 0.17.0: [Unreleased] was empty while eleven PRs had landed, which
+      #     would have shipped a blank section and blank release notes.
+      #   - 0.18.0: it carried two "### Security" and two "### Fixed" blocks
+      #     with "### Changed" between them, so renaming the header would have
+      #     shipped the duplicates inside [0.18.0].
+      # The changelog-gate job catches neither: it only asserts a section
+      # exists for the bumped version, which a renamed-but-malformed section
+      # satisfies. Check here, before anything is modified, so a bad changelog
+      # costs nothing but a re-dispatch.
+      - name: Validate CHANGELOG [Unreleased] section
         run: |
-          sed -i -E "s/^version = \"[^\"]+\"/version = \"${VERSION}\"/" pyproject.toml
-          grep -E '^version = ' pyproject.toml
+          python - <<'PY'
+          import pathlib, re, sys
 
-      - name: Bump src/compose_lint/__init__.py
+          # Keep a Changelog's order, with this repo's "Upgrading" preamble first.
+          ORDER = ["Upgrading", "Added", "Changed", "Deprecated", "Removed", "Fixed", "Security"]
+
+          lines = pathlib.Path("CHANGELOG.md").read_text(encoding="utf-8").splitlines()
+          start = next((i for i, ln in enumerate(lines) if ln.startswith("## [Unreleased]")), None)
+          if start is None:
+              sys.exit("::error::No '## [Unreleased]' section in CHANGELOG.md")
+          end = next(
+              (i for i in range(start + 1, len(lines)) if lines[i].startswith("## [")),
+              len(lines),
+          )
+
+          # A '###' inside a fenced block is sample text, not a section heading.
+          headings: list[str] = []
+          fenced = has_content = False
+          for line in lines[start + 1 : end]:
+              if re.match(r"^(```|~~~)", line.strip()):
+                  fenced = not fenced
+              if not fenced and line.startswith("### "):
+                  headings.append(line[4:].strip())
+                  continue
+              if line.strip():
+                  has_content = True
+
+          if not has_content:
+              sys.exit(
+                  "::error::[Unreleased] is empty. This workflow only renames the "
+                  "header, so releasing now would ship a blank section and blank "
+                  "GitHub Release notes. Author the entries first — `git log "
+                  "v<PREV>..HEAD` lists what landed."
+              )
+
+          if dupes := sorted({h for h in headings if headings.count(h) > 1}):
+              sys.exit(
+                  f"::error::[Unreleased] has duplicate sections: {dupes}. Merge each "
+                  "pair into one before releasing, or the duplicates ship inside the "
+                  "release section."
+              )
+
+          if unknown := [h for h in headings if h not in ORDER]:
+              sys.exit(f"::error::[Unreleased] has unrecognised sections: {unknown}. Expected some of {ORDER}.")
+
+          if [ORDER.index(h) for h in headings] != sorted(ORDER.index(h) for h in headings):
+              sys.exit(
+                  f"::error::[Unreleased] sections are out of order: {headings}. "
+                  f"Expected: {[h for h in ORDER if h in headings]}"
+              )
+
+          print("[Unreleased] OK:", ", ".join(headings) or "(no subsections)")
+          PY
+
+      # Delegate to the same script a maintainer runs by hand, so there is one
+      # definition of "what a version bump is". This workflow used to
+      # reimplement the bumps with its own `sed` calls, and when #554 added
+      # action.yml's DEFAULT_VERSION as a fourth version string it taught the
+      # script, RELEASING.md and a new contract test about it — but not this
+      # workflow. The 0.18.0 prep PR therefore bumped three of the four and
+      # failed its own required check. A future version string added to the
+      # script is now picked up here for free.
+      - name: Bump version strings
         env:
           VERSION: ${{ inputs.version }}
-        run: |
-          sed -i -E "s/^__version__ = \"[^\"]+\"/__version__ = \"${VERSION}\"/" src/compose_lint/__init__.py
-          grep '__version__' src/compose_lint/__init__.py
+        run: scripts/bump-version.sh "${VERSION}"
 
       # The version-consistency job's "self-referencing version pins" step
       # (#443) requires every `compose-lint==X.Y.Z`,
@@ -190,14 +259,24 @@ jobs:
           mv CHANGELOG.md.new CHANGELOG.md
           grep -E "^\[Unreleased\]: |^\[${VERSION}\]: " CHANGELOG.md
 
+      # All four source-of-truth strings, not just the two this workflow used
+      # to write. A miss here is a red required check on the PR at best, and at
+      # worst — for action.yml's DEFAULT_VERSION — an Action that installs a
+      # different linter than the one its SHA pins.
       - name: Verify versions match
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           pyproject=$(grep -E '^version = ' pyproject.toml | head -1 | cut -d'"' -f2)
           init=$(grep '__version__' src/compose_lint/__init__.py | head -1 | cut -d'"' -f2)
-          if [ "${pyproject}" != "${init}" ] || [ "${pyproject}" != "${{ inputs.version }}" ]; then
-            echo "::error::Post-bump version mismatch: pyproject=${pyproject}, init=${init}, input=${{ inputs.version }}"
-            exit 1
-          fi
+          action=$(grep -E '^[[:space:]]*DEFAULT_VERSION="' action.yml | head -1 | cut -d'"' -f2)
+          echo "pyproject=${pyproject} init=${init} action.yml=${action} input=${VERSION}"
+          for got in "${pyproject}" "${init}" "${action}"; do
+            if [ "${got}" != "${VERSION}" ]; then
+              echo "::error::Post-bump version mismatch: pyproject=${pyproject}, init=${init}, action.yml=${action}, input=${VERSION}"
+              exit 1
+            fi
+          done
 
       - name: Commit, push, open PR
         env:
@@ -211,7 +290,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "${branch}"
-          # `-u` stages every tracked file the steps above modified — the two
+          # `-u` stages every tracked file the steps above modified — the three
           # version files, CHANGELOG.md, and whichever README/docs carried a
           # self-referencing pin. Listing paths explicitly would silently drop
           # a pin in a doc added later, which is the failure #443 guards

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -158,6 +158,12 @@ version number.
       against the bullets in `[Unreleased]` and backfill the gaps in a
       separate chore PR before dispatching `release-prep.yml`. (0.5.2
       tripped on this — four merged PRs had no changelog entries.)
+
+      `release-prep.yml` now refuses to run on a `[Unreleased]` that is
+      empty, has duplicate `###` sections, or orders them outside Keep a
+      Changelog — the three shapes that have reached a release candidate.
+      **That checks shape, not completeness:** it cannot know a PR went
+      undocumented, so the cross-check above is still yours to do.
 - [ ] `.vex/compose-lint.openvex.json` is current: any new pip (or other
       stripped-component) CVE that a scanner now reports against the image
       is either covered by an existing `not_affected` statement with
@@ -173,12 +179,22 @@ version number.
 
 ## Bump the version
 
-compose-lint declares the version in **four** places that must stay
+compose-lint declares the version in **five** places that must stay
 in sync. Missing any one of them is a release-blocker — check all
-four before opening the bump PR.
+five before opening the bump PR.
 
 - [ ] `pyproject.toml` — `version = "X.Y.Z"` under `[project]`
 - [ ] `src/compose_lint/__init__.py` — `__version__ = "X.Y.Z"`
+- [ ] `action.yml` — `DEFAULT_VERSION="X.Y.Z"` in the install step. This
+      is the package the Action installs when a consumer does not pass
+      `version:`, so a stale one means a SHA-pinned `uses:` silently
+      installs a different linter than the action it pinned.
+      Automated: `release-prep.yml` calls `scripts/bump-version.sh`,
+      which rewrites this alongside the two above, and
+      `tests/test_action_contract.py` fails the PR if they disagree.
+      It was omitted from this list when #554 introduced it, and
+      `release-prep.yml` did not bump it either — so the 0.18.0 prep PR
+      failed its own required check and needed a hand-pushed commit.
 - [ ] `README.md` + `docs/hardening.md` — version references in
       copy-paste integration snippets. All need bumping each release;
       otherwise users land on a stale version (v0.14.0 shipped with all
@@ -216,11 +232,12 @@ four before opening the bump PR.
       tag is pushed and opens the follow-up PR for you. Review and merge
       that PR; only bump by hand if the job failed.
 
-Verify the first two match:
+Verify the first three match:
 
 ```bash
 grep -E '^version' pyproject.toml
 grep __version__ src/compose_lint/__init__.py
+grep DEFAULT_VERSION= action.yml
 ```
 
 The `marketplace-smoke.yml` bump has to land *after* the release


### PR DESCRIPTION
Both failures below were hit while cutting 0.18.0. Neither is reachable by CI, because `release-prep.yml` only runs when a release is dispatched.

## 1. One definition of a version bump

`release-prep.yml` reimplemented the bump with its own `sed` calls, so "what a version bump is" had two definitions — the workflow's and `scripts/bump-version.sh`'s. When #554 introduced `action.yml`'s `DEFAULT_VERSION` as a fourth version string, it taught the script, `docs/RELEASING.md` and a new contract test about it, **but not this workflow**. The 0.18.0 prep PR bumped three of four and failed its own required check; the fix had to be pushed onto the release branch by hand.

Now it calls the script, so a version string added there is picked up by the release for free.

Two related gaps closed:
- **`Verify versions match` only checked pyproject + `__init__`** — it could not see the string that was missed. Now checks all three, and fails the *dispatch* rather than the PR.
- **`RELEASING.md`'s "Bump the version" checklist never listed `action.yml`.** It claimed four places and enumerated the other four, so following the checklist exactly still missed it.

## 2. Validate `[Unreleased]` before touching anything

The section is renamed, never authored or reordered, so its shape at dispatch is the shape that ships — including into the GitHub Release notes. Two bad shapes have reached a release candidate:

- **0.17.0** — empty while eleven PRs had landed. Would have shipped a blank section and blank release notes.
- **0.18.0** — two `### Security` and two `### Fixed` blocks with `### Changed` between them; renaming the header would have shipped the duplicates inside `[0.18.0]`. Needed manual PR #564.

`changelog-gate` catches neither: it only asserts a section exists for the bumped version, which a renamed-but-malformed section satisfies.

The check runs before any file is modified, so a bad changelog costs a re-dispatch and nothing else. **It checks shape, not completeness** — it cannot know a PR went undocumented, so the `RELEASING.md` cross-check still stands. That limit is stated in the docs rather than left implied.

## Verification

The validator was extracted from the workflow and run against real changelog states, so the test can't drift from the shipped code:

| Input | Result |
|---|---|
| `894e3e2` current main (post-release, empty) | ✅ rejected — empty |
| `1ac9451` pre-#564 (the real 0.18.0 duplicates) | ✅ rejected — `duplicate sections: ['Fixed', 'Security']` |
| `3d2968c` post-#564 (tidied, pre-bump) | ✅ accepted — `Upgrading, Changed, Fixed, Security` |
| synthetic: Security before Changed | ✅ rejected — out of order |
| synthetic: `### Fixed` inside a code fence | ✅ accepted — fenced headings are not sections |
| synthetic: `### Fixxed` | ✅ rejected — unrecognised |

The fenced-block case matters: a naive scan reads sample markdown in a fenced block as a real heading and reports a phantom duplicate.

`scripts/bump-version.sh 0.99.0` was also run locally and confirmed to rewrite all three strings; `actionlint` is clean.