### PR TITLE
Catch both ways a release can fail before the tag push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,15 +366,26 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
-      # Parse both versions structurally rather than by grep (#382): a commented
+      # Parse the versions structurally rather than by grep (#382): a commented
       # "# version = ..." above the real line, or reformatting, would fool
       # `grep '^version =' | head -1`. tomllib reads pyproject's [project].version
       # and ast reads __init__.py's __version__ assignment — deterministic, no
       # regex to drift.
-      - name: Compare pyproject.toml and __init__.py
+      #
+      # action.yml's DEFAULT_VERSION is the third source-of-truth string, and it
+      # was NOT checked here until 0.18.0 — so this job could report "Version
+      # strings in sync" while that one was a release behind, which is exactly
+      # what happened on the 0.18.0 prep PR. A check whose name overclaims is
+      # worse than no check: it was read as covering all of them.
+      # tests/test_action_contract.py asserts the same equality, but it lives in
+      # the `test` matrix, so it does not run when only a version file changes.
+      # DEFAULT_VERSION is a shell assignment inside a `run:` block, so it is
+      # matched by an anchored regex (PyYAML is not installed in this job, and a
+      # YAML parse would only get us to the same string).
+      - name: Compare pyproject.toml, __init__.py and action.yml
         run: |
           python - <<'PY'
-          import ast, pathlib, sys, tomllib
+          import ast, pathlib, re, sys, tomllib
 
           pyproject = tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"]
 
@@ -385,12 +396,19 @@ jobs:
               ) and isinstance(node.value, ast.Constant):
                   init = node.value.value
 
+          found = re.findall(r'^\s*DEFAULT_VERSION="([^"]*)"', pathlib.Path("action.yml").read_text(), re.M)
+          if len(found) != 1:
+              sys.exit(f"::error::Expected exactly one DEFAULT_VERSION in action.yml, found {len(found)}")
+          action = found[0]
+
           print(f"pyproject.toml: {pyproject}")
           print(f"__init__.py:    {init}")
-          if not pyproject or not init:
-              sys.exit("::error::Could not extract version from one or both files")
-          if pyproject != init:
-              sys.exit(f"::error::Version drift: pyproject.toml ({pyproject}) vs src/compose_lint/__init__.py ({init})")
+          print(f"action.yml:     {action}")
+          if not pyproject or not init or not action:
+              sys.exit("::error::Could not extract version from one or more files")
+          drift = {"pyproject.toml": pyproject, "src/compose_lint/__init__.py": init, "action.yml": action}
+          if len(set(drift.values())) != 1:
+              sys.exit("::error::Version drift: " + ", ".join(f"{k} ({v})" for k, v in drift.items()))
           PY
       # Self-referencing version pins in living docs (README integration
       # snippets, docs/hardening.md) must equal the current version. A

--- a/tests/test_release_layer.py
+++ b/tests/test_release_layer.py
@@ -192,3 +192,94 @@ def test_the_dockerhub_credential_is_only_read_by_first_party_code() -> None:
         # The token is passed as an input to the local composite action only.
         assert "secrets.DOCKERHUB_TOKEN" in line
     assert "uses: ./.github/actions/update-dockerhub-description" in raw
+
+
+# --- A called workflow gets what its jobs ask for ------------------------
+
+# GITHUB_TOKEN permission levels, ordered. Under an explicit `permissions:`
+# map, any scope not listed is `none` — that is what makes a deny-all default
+# and a partial map behave the same way for an unlisted scope.
+_LEVELS = {"none": 0, "read": 1, "write": 2}
+_LEVEL_NAME = {v: k for k, v in _LEVELS.items()}
+
+
+def _permission_levels(spec: Any) -> tuple[dict[str, int], int]:
+    """Explicit per-scope levels, and the level every unlisted scope gets."""
+    if spec == "read-all":
+        return {}, _LEVELS["read"]
+    if spec == "write-all":
+        return {}, _LEVELS["write"]
+    if isinstance(spec, dict):
+        return {k: _LEVELS[v] for k, v in spec.items()}, _LEVELS["none"]
+    raise AssertionError(f"unrecognised permissions form: {spec!r}")
+
+
+def _reusable_calls() -> list[tuple[str, str, str]]:
+    """(caller workflow, caller job, callee workflow) for every local call."""
+    calls = []
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        for job_name, job in (_load(path.name).get("jobs") or {}).items():
+            uses = str(job.get("uses", ""))
+            if uses.startswith("./.github/workflows/"):
+                calls.append((path.name, job_name, uses.rsplit("/", 1)[-1]))
+    return calls
+
+
+@pytest.mark.parametrize(("caller", "job_name", "callee"), _reusable_calls())
+def test_a_called_workflow_is_granted_what_its_jobs_request(
+    caller: str, job_name: str, callee: str
+) -> None:
+    """A called workflow's jobs cannot hold more than the calling job was given.
+
+    Ask for more and GitHub rejects the *whole run*: no job is created, so
+    there is no log, no annotation and no check-run to read — the reason exists
+    only as UI text on the run page. The v0.18.0 tag push died exactly this way.
+    ``publish.yml`` declared ``permissions: {}`` workflow-wide and nothing on
+    the job calling ``verify-tag.yml``, whose job asks for ``contents: read`` to
+    check out, so the release failed to start.
+
+    This is invisible to the other gates. ``actionlint`` does not model
+    permission inheritance across a workflow call, and the pipeline itself only
+    runs on a tag push — which is after the point of no return.
+    """
+    caller_doc = _load(caller)
+    caller_job = caller_doc["jobs"][job_name]
+    granted = caller_job.get("permissions", caller_doc.get("permissions"))
+    assert granted is not None, (
+        f"{caller}: job '{job_name}' calls {callee} but neither it nor the "
+        f"workflow declares `permissions:`, so the grant is whatever the "
+        f"repository default happens to be. Declare it explicitly."
+    )
+    granted_map, granted_default = _permission_levels(granted)
+
+    callee_doc = _load(callee)
+    for callee_job, spec in (callee_doc.get("jobs") or {}).items():
+        requested = spec.get("permissions", callee_doc.get("permissions"))
+        if requested is None:
+            continue
+        req_map, req_default = _permission_levels(requested)
+
+        short = []
+        if req_default > granted_default:
+            short.append(
+                f"unlisted scopes (needs {_LEVEL_NAME[req_default]}, "
+                f"granted {_LEVEL_NAME[granted_default]})"
+            )
+        for scope in sorted(set(req_map) | set(granted_map)):
+            needs = req_map.get(scope, req_default)
+            has = granted_map.get(scope, granted_default)
+            if needs > has:
+                short.append(
+                    f"{scope} (needs {_LEVEL_NAME[needs]}, granted {_LEVEL_NAME[has]})"
+                )
+
+        assert not short, (
+            f"{caller} job '{job_name}' does not grant {callee} job "
+            f"'{callee_job}' what it requests: {'; '.join(short)}. "
+            f"The run would fail to start with no job, log or annotation."
+        )
+
+
+def test_the_reusable_call_scan_finds_something() -> None:
+    """Guard the guard: an empty scan would make the check above vacuous."""
+    assert _reusable_calls(), "no reusable-workflow calls detected"


### PR DESCRIPTION
The release pipeline is the one path CI never runs — `publish.yml` only fires on a tag push, which is after the point of no return. Both defects that blocked 0.18.0 were statically detectable, and neither was detected. This adds the two checks that would have caught them on a PR.

## 1. A called workflow must be granted what its jobs request

A called workflow's jobs cannot hold more than the calling job was given. `publish.yml` declared `permissions: {}` workflow-wide and nothing on the job calling `verify-tag.yml`, whose job asks `contents: read` to check out — so pushing `v0.18.0` produced a `startup_failure`.

That failure mode is unusually expensive to diagnose: **zero jobs are created**, so there is no log, no annotation, and no check-run. `/logs` 404s and GraphQL reports `STARTUP_FAILURE` with nothing attached. The reason exists only as UI text on the run page, which the GitHub mobile app does not render either.

Nothing else covers this. `actionlint` does not model permission inheritance across a workflow call, so `Lint GitHub Actions workflows` stayed green on a workflow that could not start.

The new test walks every `uses: ./.github/workflows/` call and compares the caller's grant against each callee job's request, handling `read-all`/`write-all`, partial maps, and the rule that an unlisted scope under an explicit map is `none`.

**Verified against the real regression** — reverting the #566 fix and re-running produces GitHub's own wording:

```
AssertionError: publish.yml job 'verify-tag' does not grant verify-tag.yml job
'verify-tag' what it requests: contents (needs read, granted none).
The run would fail to start with no job, log or annotation.
```

A `test_the_reusable_call_scan_finds_something` guard keeps the check from going vacuous if the calls are ever restructured — same pattern as the existing credential-marker guard.

## 2. Make `Version strings in sync` actually cover the version strings

The `version-consistency` job compared `pyproject.toml` and `__init__.py` only, while reporting itself as **"Version strings in sync"**. So it passed on the 0.18.0 prep PR with `action.yml`'s `DEFAULT_VERSION` a release behind — and I read that green check as covering all of them before reading the diff. A check whose name overclaims is worse than no check.

`tests/test_action_contract.py` asserts the same equality, but it lives in the `test` matrix, which is path-filtered out when only a version file changes. This job is the fast, aptly-named one, so it should be authoritative.

Verified by extracting the step from `ci.yml` and running it against a synthetic stale state:

```
::error::Version drift: pyproject.toml (0.18.0), src/compose_lint/__init__.py (0.18.0), action.yml (0.17.0)
```

## Notes

`DEFAULT_VERSION` is a shell assignment inside a `run:` block, so it is matched by an anchored regex — PyYAML is not installed in that job, and a YAML parse would only get us to the same string. The step fails if it does not find exactly one, so a refactor that moves or duplicates it surfaces rather than silently matching the wrong one.

Full gate green locally: ruff, ruff format, mypy, 1785 passed / 6 skipped, `actionlint` clean.

Pairs with #568, which fixes the release-prep side. Independent — either can merge first.