### PR TITLE
Exercise every action.yml input in the action-smoke job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -746,7 +746,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -785,6 +785,128 @@ jobs:
         if: steps.insecure.outcome != 'failure'
         run: |
           echo "::error::Expected action to fail on insecure fixture, got '${{ steps.insecure.outcome }}'"
+          exit 1
+
+      # Everything below exercises the inputs the clean/insecure pair does
+      # not (issue #574). action.yml's composite shell is the most intricate
+      # in the repo, and its documented bug history — $GITHUB_OUTPUT newline
+      # forgery, `find -print0` path handling, the 0-byte-SARIF upload — all
+      # lived in code paths those two steps never run. The static assertions
+      # in tests/test_action_contract.py execute the step scripts in
+      # isolation but cannot catch a wiring bug between steps or in the
+      # `with:`→env plumbing, so every input gets at least one live
+      # `uses: ./` run here.
+
+      - name: Prepare pattern fixtures (spaced path + .git decoy)
+        run: |
+          set -euo pipefail
+          mkdir -p "pattern smoke"
+          cp tests/smoke/clean.yml "pattern smoke/pattern smoke fixture.yml"
+          # An insecure copy under .git/: if discovery stops pruning .git,
+          # the step below lints it and fails.
+          cp tests/smoke/insecure.yml ".git/pattern smoke fixture.yml"
+
+      # A pass here is meaningful on three axes: zero matches would exit 2
+      # (fail-closed), a mangled spaced path would exit 2 (file not found),
+      # and a linted .git decoy would exit 1. Only "found the spaced clean
+      # file, skipped .git" is green. `verbose` rides along for input
+      # coverage.
+      - name: Pattern discovery handles spaces and prunes .git
+        uses: ./
+        with:
+          pattern: "pattern smoke fixture.yml"
+          fail-on: high
+          verbose: "true"
+          version: latest
+
+      - name: Zero-match pattern must fail closed
+        id: zero-match
+        continue-on-error: true
+        uses: ./
+        with:
+          pattern: "matches-nothing-*.yml"
+          version: latest
+
+      - name: Assert zero-match run failed
+        if: steps.zero-match.outcome != 'failure'
+        run: |
+          echo "::error::Expected fail-closed exit on zero matched files, got '${{ steps.zero-match.outcome }}'"
+          exit 1
+
+      - name: Zero match with allow-no-files opts out
+        uses: ./
+        with:
+          pattern: "matches-nothing-*.yml"
+          allow-no-files: "true"
+          version: latest
+
+      # tests/smoke/insecure.yml's only at-or-above-high finding is CL-0002
+      # (privileged), so disabling it must flip the gate to a pass. If a new
+      # rule starts flagging the fixture at high+, this step fails — update
+      # the config below alongside the fixture. `skip-suppressed` and
+      # `quiet` ride along for input coverage.
+      - name: Prepare a config that suppresses the insecure finding
+        run: |
+          set -euo pipefail
+          printf 'rules:\n  CL-0002:\n    enabled: false\n    reason: "smoke: prove config pass-through flips the gate"\n' \
+            > smoke-config.yml
+
+      - name: Config pass-through flips the insecure outcome
+        uses: ./
+        with:
+          files: tests/smoke/insecure.yml
+          fail-on: high
+          config: smoke-config.yml
+          skip-suppressed: "true"
+          quiet: "true"
+          version: latest
+
+      # `upload-sarif: false` keeps the Code Scanning upload out of the
+      # smoke: this job holds no `security-events: write` (fork PRs never
+      # can), and fixture findings must not land in the repo's alerts.
+      - name: SARIF file is written without uploading
+        id: sarif
+        uses: ./
+        with:
+          files: tests/smoke/sarif-shape.yml
+          fail-on: critical
+          sarif-file: smoke-results.sarif
+          upload-sarif: "false"
+          version: latest
+
+      - name: Assert SARIF artifact exists and output is set
+        env:
+          SARIF_WRITTEN: ${{ steps.sarif.outputs.sarif-written }}
+        run: |
+          set -euo pipefail
+          if [ ! -s smoke-results.sarif ]; then
+            echo "::error::smoke-results.sarif is missing or empty"
+            exit 1
+          fi
+          python3 -c 'import json; json.load(open("smoke-results.sarif"))'
+          if [ "$SARIF_WRITTEN" != "true" ]; then
+            echo "::error::sarif-written output was '$SARIF_WRITTEN', expected 'true'"
+            exit 1
+          fi
+
+      # The documented `files:` contract is a space-separated list; a
+      # newline in it must be refused loudly (it could forge output records
+      # when filenames crossed $GITHUB_OUTPUT, and still means a malformed
+      # list today).
+      - name: Newline in files must be refused
+        id: newline
+        continue-on-error: true
+        uses: ./
+        with:
+          files: |
+            tests/smoke/clean.yml
+            tests/smoke/insecure.yml
+          version: latest
+
+      - name: Assert newline run failed
+        if: steps.newline.outcome != 'failure'
+        run: |
+          echo "::error::Expected rejection of a files list containing a newline, got '${{ steps.newline.outcome }}'"
           exit 1
 
   # The pre-commit arm of the integration-surface smoke set. `action-smoke`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- GitHub Action: `upload-sarif` input (default `"true"`). Set to `"false"` to
+  write the file requested via `sarif-file` without uploading it to GitHub
+  Code Scanning — for runners without Code Scanning (Forgejo) or jobs that
+  lack the `security-events: write` permission the upload needs.
+- GitHub Action: `sarif-written` output — `"true"` when the SARIF file was
+  written and non-empty, empty otherwise.
+
 ## [0.18.0] - 2026-08-14
 
 ### Upgrading

--- a/README.md
+++ b/README.md
@@ -417,7 +417,10 @@ releases. Denying everything at the workflow level and granting the two scopes
 the job actually uses keeps a compromised dependency in this job from reaching
 anything else.
 
-Drop `security-events: write` if you are not uploading SARIF.
+Drop `security-events: write` if you are not uploading SARIF. To write the
+SARIF file without the Code Scanning upload — for example to attach it as a
+build artifact instead — set `upload-sarif: "false"` alongside `sarif-file`
+(and drop the scope).
 
 Or install from PyPI directly:
 

--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,21 @@ inputs:
       CLI itself exits 2 in that case.
     required: false
     default: "false"
+  upload-sarif:
+    description: >-
+      Upload the written SARIF file to GitHub Code Scanning. Set to "false"
+      to only write the file — for runners without Code Scanning (Forgejo)
+      or jobs that lack the `security-events: write` permission the upload
+      needs.
+    required: false
+    default: "true"
+
+outputs:
+  sarif-written:
+    description: >-
+      "true" when the file requested via `sarif-file` was written and
+      non-empty; empty otherwise.
+    value: ${{ steps.lint.outputs.sarif-written }}
 
 runs:
   using: "composite"
@@ -234,7 +249,7 @@ runs:
       # Gated on the file actually having been written, not on `always()`.
       # `always()` uploaded whatever was at the path even when the lint step
       # had failed before producing a document.
-      if: inputs.sarif-file != '' && !cancelled() && steps.lint.outputs.sarif-written == 'true'
+      if: inputs.sarif-file != '' && inputs.upload-sarif == 'true' && !cancelled() && steps.lint.outputs.sarif-written == 'true'
       uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         sarif_file: ${{ inputs.sarif-file }}

--- a/tests/test_action_contract.py
+++ b/tests/test_action_contract.py
@@ -284,6 +284,32 @@ def test_upload_is_gated_on_the_file_being_written(ws: Path) -> None:
     assert "always()" not in condition, condition
 
 
+def test_upload_can_be_switched_off(ws: Path) -> None:
+    """`upload-sarif: false` must skip the Code Scanning upload.
+
+    Runners without Code Scanning (Forgejo) and jobs without
+    `security-events: write` — every fork PR — need the SARIF file without
+    the upload; ci.yml's action-smoke relies on this to exercise
+    `sarif-file` live.
+    """
+    action = _action()
+    upload = action["inputs"]["upload-sarif"]
+    assert upload["default"] == "true", "uploading must stay the default"
+    condition = str(_step("Upload SARIF")["if"])
+    assert "inputs.upload-sarif == 'true'" in condition, condition
+
+
+def test_sarif_written_is_a_declared_output(ws: Path) -> None:
+    """Callers assert on `sarif-written`; composite steps are private.
+
+    A composite action exposes a step's outputs only through a declared
+    `outputs:` mapping — dropping it would silently break every workflow
+    gating on the output, including ci.yml's action-smoke.
+    """
+    value = _action()["outputs"]["sarif-written"]["value"]
+    assert "steps.lint.outputs.sarif-written" in value, value
+
+
 # --- VULN-041: the SARIF path is a write target ---------------------------
 
 


### PR DESCRIPTION
Closes #574.

`action-smoke` only ever ran the `files:` + `fail-on:` path, so the most intricate shell in the repo — the code paths where the newline-forgery, `-print0`, and 0-byte-SARIF bugs actually lived — had no live execution. This extends the job so **every input in action.yml is exercised by at least one `uses: ./` step**:

- **`pattern:`** against a spaced path (`pattern smoke/pattern smoke fixture.yml`) with an insecure decoy planted under `.git/`. Because discovery fails closed, a green run proves three things at once: the pattern matched (zero matches → exit 2), the spaced path survived intact (mangled path → exit 2), and `.git` was pruned (linted decoy → exit 1). `verbose:` rides along.
- **Zero-match fail-closed** (`continue-on-error` + outcome assertion) and the **`allow-no-files: true`** opt-out. Exit-2 semantics of the closed path stay pinned at the script level by `test_action_contract.py`.
- **`config:`** that disables CL-0002 — the insecure fixture's only ≥high finding (verified against 0.18.0) — asserting the verdict flips to pass. `skip-suppressed:` and `quiet:` ride along; a comment notes the deliberate coupling if a future rule flags the fixture at high+.
- **`sarif-file:`** against `tests/smoke/sarif-shape.yml` at `fail-on: critical`, asserting the file exists, is non-empty, parses as JSON, and the action's `sarif-written` output is `"true"`.
- **`files:` containing a newline** (YAML block scalar) asserted to be refused.

Two small contract additions were needed to exercise `sarif-file:` live, both pinned by new contract tests and noted in the CHANGELOG Unreleased section:

- **`upload-sarif:` input** (default `"true"`, so behavior is unchanged for existing consumers). The smoke passes `"false"` because the job holds no `security-events: write` — fork PRs never can — and fixture findings must not land in the repo's Code Scanning alerts. It's independently useful for Forgejo consumers (no Code Scanning) and artifact-only SARIF use; README's Action section documents it.
- **`sarif-written` output** declared in `outputs:` — composite step outputs are invisible to callers unless mapped, so the issue's asserted output needed the declaration.

Kept `marketplace-smoke.yml` to its thin clean/insecure pair per the issue — the contract detail belongs in the PR gate.

Verified locally: full pytest (1787 passed), ruff clean, and the pattern/spaces/.git-prune scenario executed end-to-end through the real action.yml step scripts in a sandbox (count=1, only the spaced clean file selected, lint exit 0).