### PR TITLE
Pin the pre-commit user args: override contract in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -988,6 +988,66 @@ jobs:
             exit 1
           fi
 
+      # The two cases below exercise the user `args:` override contract
+      # (issue #571). `.pre-commit-hooks.yaml` ships `args: [--]`, and a
+      # consumer's own `args:` replaces that default entirely — the README
+      # tells them to end their list with `--`. `try-repo` cannot inject a
+      # consumer `args:`, so these cases write a real
+      # `.pre-commit-config.yaml` pinning this checkout at its own SHA,
+      # which also makes them the only PR-gate steps that install the hook
+      # the way a consumer does (from a rev, not the working tree).
+
+      # The clean fixture passes at the default high threshold (proved
+      # above) and carries two medium findings, so `--fail-on medium` must
+      # flip the hook to a failure. A pass here means the override was
+      # dropped; a failure without the threshold verdict means it failed
+      # for the wrong reason.
+      - name: User args override with trailing -- is honored
+        env:
+          SMOKE: ${{ runner.temp }}/args-override
+        run: |
+          set -euo pipefail
+          REV="$(git rev-parse HEAD)"
+          mkdir -p "$SMOKE"
+          cp tests/smoke/clean.yml "$SMOKE/docker-compose.yml"
+          printf 'repos:\n  - repo: %s\n    rev: %s\n    hooks:\n      - id: compose-lint\n        args: [--fail-on, medium, "--"]\n' \
+            "$GITHUB_WORKSPACE" "$REV" > "$SMOKE/.pre-commit-config.yaml"
+          cd "$SMOKE"
+          git init -q
+          git add -A
+          if pre-commit run --all-files 2>&1 | tee out.txt; then
+            echo "::error::Expected the --fail-on medium override to fail the clean fixture."
+            exit 1
+          fi
+          grep -q "at or above medium" out.txt \
+            || { echo "::error::Hook failed for a reason other than the overridden threshold."; exit 1; }
+
+      # A directory named `--config=cfgdir` is the manifest comment's
+      # attack shape: with the trailing `--` omitted, argparse absorbs the
+      # repository path as a --config flag. The pinned outcome is the loud
+      # failure observed live — exit 2, "Config file not found" — never a
+      # green run that skipped the file.
+      - name: Omitted trailing -- fails loudly, never silently passes
+        env:
+          SMOKE: ${{ runner.temp }}/args-no-separator
+        run: |
+          set -euo pipefail
+          REV="$(git rev-parse HEAD)"
+          mkdir -p "$SMOKE/--config=cfgdir"
+          cp tests/smoke/clean.yml "$SMOKE/--config=cfgdir/compose.yml"
+          cp tests/smoke/clean.yml "$SMOKE/docker-compose.yml"
+          printf 'repos:\n  - repo: %s\n    rev: %s\n    hooks:\n      - id: compose-lint\n        args: [--fail-on, medium]\n' \
+            "$GITHUB_WORKSPACE" "$REV" > "$SMOKE/.pre-commit-config.yaml"
+          cd "$SMOKE"
+          git init -q
+          git add -A
+          if pre-commit run --all-files 2>&1 | tee out.txt; then
+            echo "::error::A flag-shaped path with no -- must not produce a passing run."
+            exit 1
+          fi
+          grep -q "Config file not found" out.txt \
+            || { echo "::error::Expected the absorbed-path config error; the failure shape changed — re-pin it."; exit 1; }
+
   # Runtime arm of the rule-grounding bar: every rule that describes container
   # runtime state must demonstrate its premise against a live container (the
   # insecure state is the Docker default, or the flagged config produces the

--- a/tests/test_precommit.py
+++ b/tests/test_precommit.py
@@ -73,6 +73,24 @@ def test_manifest_declares_at_least_one_hook(hooks: list[dict[str, Any]]) -> Non
     assert hooks
 
 
+def test_default_args_end_with_the_option_terminator(
+    hooks: list[dict[str, Any]],
+) -> None:
+    """The trailing ``--`` keeps a flag-shaped repository path a path.
+
+    pre-commit runs ``entry + args + filenames``, so without the terminator
+    a path like ``--config=cfgdir/compose.yml`` is absorbed as a flag and
+    an attacker-authored policy is installed for the run. A user's own
+    ``args:`` replaces this default entirely; ci.yml's ``precommit-smoke``
+    pins both override shapes live.
+    """
+    for hook in hooks:
+        args = hook.get("args", [])
+        assert args and args[-1] == "--", (
+            f"hook '{hook['id']}' default args must end with '--'"
+        )
+
+
 def test_every_hook_declares_a_files_pattern(hooks: list[dict[str, Any]]) -> None:
     # pre-commit defaults an absent ``files`` to "", which matches every path
     # the ``types`` filter admits — every YAML file in the repo, for us.


### PR DESCRIPTION
Closes #571.

`precommit-smoke` only ever ran the manifest's default `args: [--]`, so the documented, security-relevant override contract — a consumer's `args:` replaces the default entirely, and must end with `--` — had never been executed, in either direction. Two new live cases in `ci.yml`:

- **Override with trailing `--` is honored**: `args: [--fail-on, medium, "--"]` against the clean fixture, which passes at the default `high` threshold (the existing steps prove that) and carries two medium findings — so the run must flip to a failure, asserted together with the `at or above medium` verdict so a wrong-reason failure can't masquerade as coverage.
- **Omitted `--` fails loudly**: plants the manifest comment's own attack shape — a directory named `--config=cfgdir` whose `compose.yml` path pre-commit passes as a filename — and pins the behavior observed live: argparse absorbs the path as `--config`, the CLI exits 2 with `Config file not found`, and the hook fails rather than silently passing while the file leaves the lint set. If the failure shape ever changes, the step says to re-pin it rather than green-lighting whatever happens.

Mechanics: `try-repo` cannot inject a consumer `args:`, so both cases write a real `.pre-commit-config.yaml` pinning `$GITHUB_WORKSPACE` at its own `git rev-parse HEAD` — a side benefit is these are now the only PR-gate steps that install the hook from a rev the way a consumer does (verified locally that pre-commit installs cleanly from a depth-1 source clone, matching the CI checkout).

One correction to the issue text: it assumed the insecure fixture has no critical findings, but CL-0002 (privileged) is CRITICAL — `--fail-on critical` fails on it either way, proving nothing. Hence the outcome flip is demonstrated on the clean fixture at a lowered threshold instead.

Plus the suggested one-line manifest guard in `tests/test_precommit.py`: every hook's default `args` must end with `--`.

Verified locally: both scenarios executed end-to-end through real `pre-commit run` in throwaway repos (exit 1 with the two medium findings; exit 2 with the absorbed-path config error), pytest and ruff clean.