### PR TITLE
Smoke the published pre-commit hook from its release tag, weekly

### DIFF
--- a/.github/workflows/marketplace-smoke.yml
+++ b/.github/workflows/marketplace-smoke.yml
@@ -1,19 +1,24 @@
 name: Marketplace smoke test
 
-# Manually-triggered end-to-end test of the published action as it
-# appears on the GitHub Marketplace. Unlike the `action-smoke` job in
-# ci.yml (which uses `./` — the local action.yml in this repo), this
-# workflow consumes `tmatens/compose-lint@<tag>` the same way an
-# external user would. It catches regressions that only show up at
-# the Marketplace boundary: a missing tag, a broken published
-# action.yml, a PyPI outage, etc.
+# End-to-end tests of the *published* integration surfaces. Unlike the
+# smoke jobs in ci.yml (which use `./` and `try-repo` — the working
+# tree), the jobs here consume what a user consumes: the action as
+# `tmatens/compose-lint@<sha>` from the Marketplace, and the pre-commit
+# hook as `repo: https://github.com/tmatens/compose-lint` at a release
+# tag. They catch regressions that only show up at the publish
+# boundary: a missing or broken tag, a packaging regression, a broken
+# published action.yml, a PyPI outage, etc.
 #
 # Auto-triggers on push-to-main that touches this file — i.e., when
 # the `bump-marketplace-smoke-pin` PR from publish.yml merges, the
-# smoke runs against the newly-pinned SHA without a manual click.
+# smoke runs against the newly-pinned release without a manual click.
 # `release: published` would fire before the pin bump lands, smoking
 # the *previous* release; gating on the pin-bump merge avoids that.
-# Also triggerable manually from Actions tab for ad-hoc re-verification.
+# Also triggerable manually from Actions tab for ad-hoc re-verification,
+# and weekly on a schedule: a regression that develops *between*
+# releases (a yanked dependency, a resolver change, a PyPI- or
+# GitHub-side issue) is otherwise invisible until a user's workflow
+# breaks (issue #570).
 #
 # When cutting a new release, bump the commit SHA on the two
 # `uses:` lines below (and the trailing `# vX.Y.Z` comment so a
@@ -36,6 +41,10 @@ on:
     branches: [main]
     paths:
       - .github/workflows/marketplace-smoke.yml
+  schedule:
+    # Weekly re-verification of both published surfaces. Failures email
+    # the workflow author (see docs/CI.md "Where findings land").
+    - cron: "13 9 * * 1"
 
 permissions: {}
 
@@ -70,3 +79,74 @@ jobs:
         run: |
           echo "::error::Expected action to fail on insecure fixture, got '${{ steps.insecure.outcome }}'"
           exit 1
+
+  # The pre-commit arm of the published-surface smoke (issue #570).
+  # Consumers pin `repo: https://github.com/tmatens/compose-lint` at a
+  # release tag and pre-commit builds the hook environment from that
+  # tag — a boundary ci.yml's `precommit-smoke` (`try-repo` against the
+  # working tree) never crosses. This is the same blind spot the action
+  # surface had through 0.3.x, and issue #465 established that
+  # pre-commit is the mode where untested gaps reach users first.
+  precommit-published-smoke:
+    name: Smoke test published pre-commit hook
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    env:
+      # The release the hook is consumed at. Bumped alongside the action
+      # SHA by publish.yml's bump-marketplace-smoke-pin job, so the job
+      # runs against each new release automatically.
+      CL_RELEASE_TAG: v0.18.0
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements-dev.lock
+      - name: Install pinned dev env
+        run: pip install --require-hashes -r requirements-dev.lock
+
+      # Same one-source-of-truth contract as every other smoke job: the
+      # shared tests/smoke/ fixtures define what "clean" and "insecure"
+      # mean, and each case builds a throwaway repo around them.
+      - name: Clean fixture should pass via the published hook
+        env:
+          SMOKE: ${{ runner.temp }}/published-pass
+        run: |
+          set -euo pipefail
+          mkdir -p "$SMOKE"
+          cp tests/smoke/clean.yml "$SMOKE/docker-compose.yml"
+          printf 'repos:\n  - repo: https://github.com/tmatens/compose-lint\n    rev: %s\n    hooks:\n      - id: compose-lint\n' \
+            "$CL_RELEASE_TAG" > "$SMOKE/.pre-commit-config.yaml"
+          cd "$SMOKE"
+          git init -q
+          git add -A
+          pre-commit run --all-files --verbose 2>&1 | tee out.txt
+          # A hook that matched no files "passes" trivially. Assert it ran.
+          if grep -q "no files to check" out.txt; then
+            echo "::error::Hook selected no files — the smoke test proved nothing."
+            exit 1
+          fi
+          grep -q "docker-compose.yml" out.txt \
+            || { echo "::error::Hook did not receive docker-compose.yml"; exit 1; }
+
+      - name: Insecure fixture should fail via the published hook
+        env:
+          SMOKE: ${{ runner.temp }}/published-fail
+        run: |
+          set -euo pipefail
+          mkdir -p "$SMOKE"
+          cp tests/smoke/insecure.yml "$SMOKE/docker-compose.yml"
+          printf 'repos:\n  - repo: https://github.com/tmatens/compose-lint\n    rev: %s\n    hooks:\n      - id: compose-lint\n' \
+            "$CL_RELEASE_TAG" > "$SMOKE/.pre-commit-config.yaml"
+          cd "$SMOKE"
+          git init -q
+          git add -A
+          if pre-commit run --all-files; then
+            echo "::error::Expected the published hook to fail on the insecure fixture."
+            exit 1
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -897,6 +897,13 @@ jobs:
           sed -i -E \
             "s|uses: tmatens/compose-lint@[0-9a-f]+ # v[0-9.]+|uses: tmatens/compose-lint@${SHA} # v${version}|g" \
             "${targets[@]}"
+          # The published pre-commit hook is consumed at a release tag, not
+          # a SHA (that is how consumers pin it); bump its rev in the same
+          # follow-up PR so precommit-published-smoke runs against each new
+          # release automatically.
+          sed -i -E \
+            "s|CL_RELEASE_TAG: v[0-9.]+|CL_RELEASE_TAG: ${TAG}|" \
+            .github/workflows/marketplace-smoke.yml
           if git diff --quiet "${targets[@]}"; then
             echo "no_changes=1" >> "$GITHUB_ENV"
             echo "::notice::action pins already point at ${SHA}; nothing to do."

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -18,7 +18,7 @@ per-channel publish contract see [`DISTRIBUTION.md`](DISTRIBUTION.md).
 | `publish.yml`             | `v*` tag push                              | Release pipeline — see `RELEASING.md`                  |
 | `release-prep.yml`        | Manual (`workflow_dispatch`, maintainer)   | Opens the "Prepare X.Y.Z release" PR                   |
 | `publish-channel.yml`     | Manual (`workflow_dispatch`, maintainer)   | Emergency single-channel publish                       |
-| `marketplace-smoke.yml`   | Push to `main` touching the file + manual  | Verifies the published Marketplace action end-to-end   |
+| `marketplace-smoke.yml`   | Push to `main` touching the file + manual + weekly cron | Verifies the published action and pre-commit hook end-to-end |
 
 ---
 
@@ -292,18 +292,24 @@ should leave a paper trail.
 
 ### `marketplace-smoke.yml`
 
-Verifies the published GitHub Action as it appears on the Marketplace —
-consumes `tmatens/compose-lint@<tag>` the same way an external user
-would. Unlike `ci.yml`'s `action-smoke` job (which uses the local
-`action.yml` at `./`), this catches regressions at the Marketplace
-boundary: a missing tag, a broken published `action.yml`, a PyPI outage
-during install.
+Verifies the published integration surfaces the way an external user
+consumes them: the GitHub Action as `tmatens/compose-lint@<sha>` from
+the Marketplace, and the pre-commit hook as
+`repo: https://github.com/tmatens/compose-lint` pinned at a release tag
+(the `precommit-published-smoke` job, added for issue #570). Unlike
+`ci.yml`'s `action-smoke` and `precommit-smoke` jobs (which use the
+working tree via `./` and `try-repo`), these catch regressions at the
+publish boundary: a missing or broken tag, a packaging regression, a
+broken published `action.yml`, a PyPI outage during install.
 
 Auto-runs on push to `main` that touches `marketplace-smoke.yml` — i.e.,
-when `bump-marketplace-smoke-pin`'s PR lands — so the freshly-pinned
-SHA is verified without a manual step. Also triggerable from the
-Actions tab for ad-hoc re-verification (e.g., to confirm the listing
-still works weeks after release).
+when `bump-marketplace-smoke-pin`'s PR lands (it bumps both the action
+SHA pins and the pre-commit `CL_RELEASE_TAG` rev) — so the
+freshly-pinned release is verified without a manual step. Also
+triggerable from the Actions tab for ad-hoc re-verification, and runs
+weekly on a schedule so a regression that develops *between* releases
+(a yanked dependency, a resolver change, a registry-side issue) is
+noticed before a user's workflow breaks.
 
 ---
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -226,11 +226,13 @@ five before opening the bump PR.
       rewritten. Verify rather than re-do — if the prep PR is green and
       the follow-up PR touches `README.md`, this item is satisfied.
 - [ ] `.github/workflows/marketplace-smoke.yml` — two
-      `uses: tmatens/compose-lint@<sha> # vX.Y.Z` lines. Automated by
-      the same `bump-marketplace-smoke-pin` job as the README pin above:
-      it resolves `git rev-parse vX.Y.Z^{commit}` **after** the signed
-      tag is pushed and opens the follow-up PR for you. Review and merge
-      that PR; only bump by hand if the job failed.
+      `uses: tmatens/compose-lint@<sha> # vX.Y.Z` lines plus the
+      `CL_RELEASE_TAG: vX.Y.Z` env the published pre-commit smoke
+      consumes. Automated by the same `bump-marketplace-smoke-pin` job
+      as the README pin above: it resolves
+      `git rev-parse vX.Y.Z^{commit}` **after** the signed tag is
+      pushed and opens the follow-up PR for you. Review and merge that
+      PR; only bump by hand if the job failed.
 
 Verify the first three match:
 
@@ -322,9 +324,11 @@ After approval, `publish` and `docker-publish` run in parallel.
 - [ ] **Marketplace smoke test pin bump** — `publish.yml`'s
       `bump-marketplace-smoke-pin` job (runs after `create-release`)
       opens a follow-up PR with the new SHA in both
-      `uses: tmatens/compose-lint@<sha> # vX.Y.Z` lines. Review and
-      squash-merge, then trigger **Actions → Marketplace smoke test →
-      Run workflow** to verify the published Action end-to-end.
+      `uses: tmatens/compose-lint@<sha> # vX.Y.Z` lines and the new
+      tag in the `CL_RELEASE_TAG` env of the published pre-commit
+      smoke. Merging it auto-triggers the workflow, which verifies the
+      published Action and pre-commit hook end-to-end (it can also be
+      re-run from **Actions → Marketplace smoke test**).
 - [ ] **Docker Hub overview sync** — runs automatically in
       `publish.yml`'s `dockerhub-description` job after `docker-publish`,
       via the first-party composite action at


### PR DESCRIPTION
Closes #570.

Implements all three parts of the issue:

1. **`precommit-published-smoke` job** in `marketplace-smoke.yml`, next to the action leg. It writes a real `.pre-commit-config.yaml` pinning `repo: https://github.com/tmatens/compose-lint` at the released tag, runs `pre-commit run --all-files` in throwaway repos against the shared `tests/smoke/` fixtures (clean passes with the selected-no-files guard from `precommit-smoke`, insecure must fail), installing everything hash-pinned from `requirements-dev.lock` like the ci.yml twin.
2. **Pin-bump wiring**: the tag lives in a single `CL_RELEASE_TAG` job env, and `publish.yml`'s `bump-marketplace-smoke-pin` sed now rewrites it alongside the two action SHA pins. Verified by running the exact sed commands against the edited file: both `uses:` lines and the rev all land on the new release.
3. **Weekly `schedule:`** (`13 9 * * 1`) on `marketplace-smoke.yml`, covering both published legs between releases — previously the workflow fired only on pin-bump merge and manual dispatch.

`docs/CI.md` (workflow table + section) and `docs/RELEASING.md` (both pin-bump bullets) updated to describe the new leg and the automated rev bump.

Verified locally: the exact consumer flow — `pre-commit` building the hook env from the *published* v0.18.0 tag over the network — passes on the clean fixture (with the file demonstrably selected) and exits 1 on the insecure fixture. Note this PR touches only workflows + docs, so ci.yml's `changes` filter skips the code jobs and the new job itself first runs when this merges: the push to main touches `marketplace-smoke.yml`, which auto-triggers the workflow — I'll verify that run after merge.