### PR TITLE
Cover the one-shot and module entrypoints

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -309,6 +309,24 @@ jobs:
             echo "::error::Expected exit code 1, got ${exit_code}"
             exit 1
           fi
+      - name: Smoke test — one-shot pipx run from the wheel
+        # `pipx run compose-lint` / `uvx compose-lint` is the standard way
+        # to run a linter ad hoc without installing it, and the README
+        # documents it — so it gets executed against the release artifact
+        # here (#575). The wheel is fetched from TestPyPI explicitly
+        # (--no-deps, exact version, index already warm from the install
+        # step above) and handed to pipx as a file, so TestPyPI is never
+        # configured as an index — same register-and-wait reasoning as the
+        # install step. pipx builds an ephemeral env and resolves PyYAML
+        # from real PyPI, exactly what a consumer's one-shot run does.
+        # pipx is preinstalled on ubuntu-24.04 runners; uv is not, and the
+        # two one-shot paths share these mechanics.
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          pip download --no-deps -d "${RUNNER_TEMP}/oneshot" \
+            -i https://test.pypi.org/simple/ "compose-lint==${version}"
+          pipx run --spec "${RUNNER_TEMP}"/oneshot/*.whl \
+            compose-lint tests/smoke/clean.yml
 
   # Build the image natively on each target arch and run the fixture battery.
   # Emulated arm64 via QEMU crashes on Debian apt-get, and a single-arch smoke

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ Use it if you ship Compose to production, want defense in depth in a homelab, or
 pip install compose-lint
 ```
 
+Or run it ad hoc without installing anything:
+
+```bash
+uvx compose-lint docker-compose.yml        # or: pipx run compose-lint docker-compose.yml
+```
+
 That resolves the newest release at install time. For a reproducible install (CI, production tooling), pin the version and install the dependency set from the repo's hash-pinned lockfile, which release automation keeps current:
 
 ```bash

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,6 +58,23 @@ class TestCLI:
         assert result.returncode == 1
         assert "CL-0002" in result.stdout
 
+    def test_module_entrypoint_matches_the_console_script(self) -> None:
+        """``python -m compose_lint`` and ``compose-lint`` are one surface.
+
+        Every other test here runs the module form; the console script is
+        what pip installs. Both must route through ``cli.main``'s
+        ``sys.exit`` — a ``__main__.py`` that swallowed ``SystemExit`` or
+        dropped argv handling would drift silently (#575).
+        """
+        script = Path(sys.executable).with_name("compose-lint")
+        if not script.exists():  # pragma: no cover - env without the script
+            pytest.skip("console script not installed next to the interpreter")
+        args = ("--format", "json", "--", str(FIXTURES / "insecure_privileged.yml"))
+        module = run_cli(*args)
+        console = subprocess.run([str(script), *args], capture_output=True, text=True)
+        assert module.returncode == console.returncode == 1
+        assert json.loads(module.stdout) == json.loads(console.stdout)
+
     def test_bare_invocation_still_lints(self) -> None:
         # The argv shim must keep `compose-lint <file>` working as `check`.
         bare = run_cli(str(FIXTURES / "insecure_privileged.yml"))


### PR DESCRIPTION
Closes #575.

All three parts of the issue, with one correction to its premise: `tests/test_cli.py`'s `run_cli` already invokes everything as `python -m compose_lint`, so the module entrypoint is far from untested — the uncovered edge was its *equivalence* with the console script pip installs. The new test runs both entrypoints on the same fixture and asserts identical exit code and identical JSON stdout, pinning `__main__.py` against drift (swallowed `SystemExit`, dropped argv handling). It skips gracefully if no console script sits next to the interpreter.

The one-shot path is now executed against the release artifact in `publish.yml`'s `testpypi-smoke`: the exact wheel is downloaded from TestPyPI (`--no-deps`, index already warm from the install step, and TestPyPI is never handed over as an index — same register-and-wait reasoning as the existing steps) and run via `pipx run --spec <wheel>` against the clean fixture, resolving PyYAML from real PyPI the way a consumer's one-shot run does. The runner-image choice is deliberate: pipx 1.16 is preinstalled on ubuntu-24.04 runners, uv is not (checked the runner-images manifest), and `uvx`/`pipx run` share the ephemeral-env mechanics under test.

With the smoke in place, README's Installation section documents `uvx compose-lint docker-compose.yml` / `pipx run compose-lint` per the issue's ordering (document only what's tested).

Verified locally: the exact pipx one-shot commands against the real published 0.18.0 wheel (clean exits 0, insecure exits 1), full `tests/test_cli.py` (72 passed) including the new equivalence test, ruff clean, publish.yml parses. Note the new publish.yml step itself can only run for real during the next release pipeline.