### PR TITLE
Run README's Forgejo snippet against a live Forgejo in CI

### DIFF
--- a/.github/workflows/forgejo-smoke.yml
+++ b/.github/workflows/forgejo-smoke.yml
@@ -1,0 +1,44 @@
+name: Forgejo smoke test
+
+# Executes README's Forgejo Actions snippet — extracted from README.md
+# verbatim at runtime — against a live, containerized Forgejo + act_runner
+# stack (issue #573). GitHub-hosted CI cannot *be* a Forgejo runner, but
+# it can host one: scripts/forgejo_smoke.py boots the stack in
+# tests/forgejo_smoke/, pushes a repo whose workflow is the snippet,
+# dispatches it, requires success, and asserts README's
+# "Verified on Forgejo X, runner Y" claim against the live versions.
+#
+# Triggers: weekly (a Forgejo-side or PyPI-side breakage between releases
+# should be noticed before a user reports it), on pushes touching the
+# harness (including Renovate bumps of the Forgejo/runner images — a
+# version bump re-proves the snippet and forces the README claim to move
+# in the same PR), and manually. Deliberately NOT on README PRs: the
+# release-prep PR bumps the snippet's compose-lint pin to a version PyPI
+# does not have yet, which would fail here spuriously mid-release; the
+# post-release weekly run covers the new pin instead.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "43 9 * * 1"
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/forgejo-smoke.yml
+      - tests/forgejo_smoke/**
+      - scripts/forgejo_smoke.py
+
+permissions: {}
+
+jobs:
+  forgejo-smoke:
+    name: README Forgejo snippet runs on a live Forgejo
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Boot Forgejo, run the snippet, verify the README claim
+        run: python3 scripts/forgejo_smoke.py

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ jobs:
         run: compose-lint --fail-on high
 ```
 
-Forgejo has no SARIF UI today — `--format sarif` still produces a valid document, but there's no security-tab equivalent to render it. Verified on Forgejo 15.0.2, runner 12.9.0, July 2026.
+Forgejo has no SARIF UI today — `--format sarif` still produces a valid document, but there's no security-tab equivalent to render it. Verified on Forgejo 16.0.2, runner 13.0.0 — this exact snippet is executed against a live Forgejo weekly by the [forgejo-smoke workflow](.github/workflows/forgejo-smoke.yml), which fails if this line and the versions it ran on disagree.
 
 ### SARIF output
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -19,6 +19,7 @@ per-channel publish contract see [`DISTRIBUTION.md`](DISTRIBUTION.md).
 | `release-prep.yml`        | Manual (`workflow_dispatch`, maintainer)   | Opens the "Prepare X.Y.Z release" PR                   |
 | `publish-channel.yml`     | Manual (`workflow_dispatch`, maintainer)   | Emergency single-channel publish                       |
 | `marketplace-smoke.yml`   | Push to `main` touching the file + manual + weekly cron | Verifies the published action and pre-commit hook end-to-end |
+| `forgejo-smoke.yml`       | Push to `main` touching the harness + manual + weekly cron | Runs README's Forgejo snippet on a live containerized Forgejo |
 
 ---
 
@@ -310,6 +311,27 @@ triggerable from the Actions tab for ad-hoc re-verification, and runs
 weekly on a schedule so a regression that develops *between* releases
 (a yanked dependency, a resolver change, a registry-side issue) is
 noticed before a user's workflow breaks.
+
+### `forgejo-smoke.yml`
+
+Proves README's Forgejo Actions snippet — and its "Verified on Forgejo X,
+runner Y" claim — empirically (issue #573). GitHub-hosted CI cannot *be*
+a Forgejo runner, but it can host one: `scripts/forgejo_smoke.py` boots a
+throwaway Forgejo + act_runner stack
+(`tests/forgejo_smoke/compose-forgejo-smoke.yml`), extracts the snippet
+from `README.md` **verbatim** at runtime (documented and tested cannot
+drift — they are one string), pushes a repo whose workflow is that
+snippet with the shared clean fixture as its compose file, dispatches it,
+and requires success. It then asserts the README's verified-on versions
+against the live instance and runner, so bumping the harness images
+without moving the claim (or vice versa) fails the run.
+
+Runs weekly, on pushes to `main` touching the harness — which includes
+Renovate bumps of the Forgejo/runner images, so each Forgejo release
+re-proves the snippet — and manually. Deliberately not on README PRs:
+the release-prep PR bumps the snippet's `compose-lint==X.Y.Z` pin before
+that version exists on PyPI, which would fail spuriously; the weekly run
+covers the new pin after release instead.
 
 ---
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -329,6 +329,12 @@ After approval, `publish` and `docker-publish` run in parallel.
       smoke. Merging it auto-triggers the workflow, which verifies the
       published Action and pre-commit hook end-to-end (it can also be
       re-run from **Actions → Marketplace smoke test**).
+- [ ] **Forgejo snippet with the new pin** — optional: the README
+      snippet's `compose-lint==X.Y.Z` pin (bumped by release-prep) gets
+      its first live execution on the next weekly `forgejo-smoke.yml`
+      run; dispatch **Actions → Forgejo smoke test** to verify it
+      immediately instead. (It deliberately doesn't run pre-release —
+      the new version isn't on PyPI yet.)
 - [ ] **Docker Hub overview sync** — runs automatically in
       `publish.yml`'s `dockerhub-description` job after `docker-publish`,
       via the first-party composite action at

--- a/scripts/forgejo_smoke.py
+++ b/scripts/forgejo_smoke.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Execute README's Forgejo Actions snippet against a live Forgejo (#573).
+
+README promises a working Forgejo integration and closes with a
+"Verified on Forgejo X, runner Y" line. A documented snippet without a
+test is a promise we can't keep, so this script makes the claim
+empirical, end to end:
+
+1. Extract the snippet from README.md *verbatim* — the tested thing and
+   the documented thing cannot drift, because they are one string.
+2. Boot a throwaway Forgejo + act_runner stack
+   (tests/forgejo_smoke/compose-forgejo-smoke.yml), bootstrap an admin
+   user, an API token, and a runner registration over the Forgejo CLI.
+3. Push a repo whose workflow *is* the snippet and whose
+   docker-compose.yml is the shared clean fixture, dispatch it, and
+   require the run to succeed. The clean fixture passes at the
+   snippet's `--fail-on high`, so a green run proves install + lint
+   actually happened on the Forgejo side.
+4. Assert README's "Verified on ..." versions match the *live* instance
+   and runner, so bumping the harness images without updating the claim
+   fails loudly (and vice versa).
+
+Run locally: python3 scripts/forgejo_smoke.py   (needs Docker + compose)
+In CI: the forgejo-smoke workflow, weekly and on harness changes.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import secrets
+import subprocess
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+COMPOSE_FILE = REPO_ROOT / "tests" / "forgejo_smoke" / "compose-forgejo-smoke.yml"
+README = REPO_ROOT / "README.md"
+CLEAN_FIXTURE = REPO_ROOT / "tests" / "smoke" / "clean.yml"
+
+HOST_PORT = os.environ.get("FORGEJO_SMOKE_PORT", "3000")
+API = f"http://localhost:{HOST_PORT}/api/v1"
+USER = "smoke"
+REPO = "snippet"
+SNIPPET_MARKER = "# .forgejo/workflows/validate.yml"
+VERIFIED_RE = re.compile(r"Verified on Forgejo ([0-9.]+), runner ([0-9.]+)")
+
+WAIT_API_SECONDS = 120
+WAIT_RUN_SECONDS = 420
+
+
+def log(msg: str) -> None:
+    print(msg, flush=True)
+
+
+def fail(msg: str) -> None:
+    print(f"::error::{msg}", flush=True)
+    raise SystemExit(1)
+
+
+def sh(
+    *args: str, echo: bool = True, capture: bool = False
+) -> subprocess.CompletedProcess[str]:
+    """Run a command; `echo=False` for argv carrying credentials."""
+    if echo:
+        log("+ " + " ".join(args))
+    return subprocess.run(list(args), check=True, capture_output=capture, text=True)
+
+
+def compose(*args: str, echo: bool = True, capture: bool = False):
+    return sh(
+        "docker", "compose", "-f", str(COMPOSE_FILE), *args, echo=echo, capture=capture
+    )
+
+
+def forgejo_cli(*args: str, echo: bool = True) -> str:
+    """Run the Forgejo CLI inside the server container (as the git user)."""
+    out = compose(
+        "exec", "-T", "-u", "1000", "forgejo", "forgejo", *args, echo=echo, capture=True
+    )
+    return out.stdout.strip()
+
+
+def api(
+    method: str,
+    path: str,
+    token: str | None = None,
+    body: dict[str, Any] | None = None,
+) -> tuple[int, Any]:
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(API + path, method=method, data=data)
+    if token:
+        req.add_header("Authorization", "token " + token)
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read()
+            return resp.status, (json.loads(raw) if raw else None)
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode(errors="replace")
+    except OSError as e:
+        # URLError, plus raw socket errors (connection refused/reset while
+        # the instance is still booting) — callers treat 0 as "not up yet".
+        return 0, str(e)
+
+
+def extract_snippet() -> str:
+    text = README.read_text(encoding="utf-8")
+    blocks = re.findall(
+        rf"```yaml\n({re.escape(SNIPPET_MARKER)}\n.*?)```", text, re.DOTALL
+    )
+    if len(blocks) != 1:
+        fail(
+            f"expected exactly one README code fence starting with "
+            f"'{SNIPPET_MARKER}', found {len(blocks)}"
+        )
+    return blocks[0]
+
+
+def readme_verified_versions() -> tuple[str, str]:
+    matches = VERIFIED_RE.findall(README.read_text(encoding="utf-8"))
+    if len(matches) != 1:
+        fail("expected exactly one 'Verified on Forgejo X, runner Y' README line")
+    return matches[0]
+
+
+def wait_for_api() -> str:
+    deadline = time.monotonic() + WAIT_API_SECONDS
+    while time.monotonic() < deadline:
+        status, body = api("GET", "/version")
+        if status == 200:
+            return str(body["version"])
+        time.sleep(2)
+    fail(f"Forgejo API did not come up within {WAIT_API_SECONDS}s")
+    raise AssertionError  # unreachable
+
+
+def main() -> None:
+    snippet = extract_snippet()
+    log(f"README snippet extracted ({len(snippet.splitlines())} lines).")
+    claimed_forgejo, claimed_runner = readme_verified_versions()
+
+    password = secrets.token_urlsafe(18)
+    exit_code = 0
+    try:
+        compose("up", "-d", "--quiet-pull", "forgejo")
+        live_version = wait_for_api()
+        log(f"Forgejo up: {live_version}")
+
+        forgejo_cli(
+            "admin",
+            "user",
+            "create",
+            "--admin",
+            "--username",
+            USER,
+            "--password",
+            password,
+            "--email",
+            "smoke@example.invalid",
+            echo=False,
+        )
+        token = forgejo_cli(
+            "admin",
+            "user",
+            "generate-access-token",
+            "--username",
+            USER,
+            "--token-name",
+            "smoke",
+            "--scopes",
+            "all",
+            "--raw",
+            echo=False,
+        ).splitlines()[-1]
+        runner_token = forgejo_cli("actions", "generate-runner-token", echo=False)
+        # Mask both in Actions logs; they are sandbox-scoped but tidy is tidy.
+        for value in (token, runner_token):
+            log(f"::add-mask::{value}")
+
+        os.environ["RUNNER_TOKEN"] = runner_token
+        compose("up", "-d", "runner")
+
+        status, body = api(
+            "POST",
+            "/user/repos",
+            token,
+            {"name": REPO, "default_branch": "main", "auto_init": False},
+        )
+        if status != 201:
+            fail(f"repo creation failed ({status}): {body}")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            work = Path(tmp)
+            wf = work / ".forgejo" / "workflows" / "validate.yml"
+            wf.parent.mkdir(parents=True)
+            wf.write_text(snippet, encoding="utf-8")
+            (work / "docker-compose.yml").write_text(
+                CLEAN_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8"
+            )
+            g = (
+                "git",
+                "-C",
+                str(work),
+                "-c",
+                "user.name=smoke",
+                "-c",
+                "user.email=smoke@example.invalid",
+            )
+            sh(*g, "init", "-q", "-b", "main")
+            sh(*g, "add", "-A")
+            sh(*g, "commit", "-q", "--no-gpg-sign", "-m", "snippet under test")
+            push_url = f"http://{USER}:{token}@localhost:{HOST_PORT}/{USER}/{REPO}.git"
+            sh(*g, "push", "-q", push_url, "main", echo=False)
+        log("Snippet repo pushed.")
+
+        status, body = api(
+            "POST",
+            f"/repos/{USER}/{REPO}/actions/workflows/validate.yml/dispatches",
+            token,
+            {"ref": "main"},
+        )
+        if status not in (200, 204):
+            fail(f"workflow dispatch failed ({status}): {body}")
+        log("Workflow dispatched; waiting for the run...")
+
+        deadline = time.monotonic() + WAIT_RUN_SECONDS
+        outcome = None
+        while time.monotonic() < deadline:
+            status, body = api("GET", f"/repos/{USER}/{REPO}/actions/tasks", token)
+            if status == 200 and body.get("workflow_runs"):
+                states = {r["status"] for r in body["workflow_runs"]}
+                if states & {"failure", "cancelled"}:
+                    outcome = "failure"
+                    break
+                if states == {"success"}:
+                    outcome = "success"
+                    break
+            time.sleep(5)
+        if outcome != "success":
+            compose("logs", "--tail", "150", "runner")
+            fail(
+                "the README snippet did not complete successfully on the live "
+                f"Forgejo (outcome: {outcome or 'timeout'})"
+            )
+        log("Snippet workflow succeeded on the live Forgejo.")
+
+        # The claim must match what actually ran.
+        live_forgejo = live_version.split("+")[0]
+        runner_version_out = compose(
+            "exec", "-T", "runner", "forgejo-runner", "--version", capture=True
+        ).stdout.strip()
+        m = re.search(r"v?([0-9][0-9.]*)", runner_version_out)
+        live_runner = m.group(1) if m else runner_version_out
+        if (claimed_forgejo, claimed_runner) != (live_forgejo, live_runner):
+            fail(
+                "README's verified-on line is stale: claims Forgejo "
+                f"{claimed_forgejo} / runner {claimed_runner}, but this run "
+                f"used Forgejo {live_forgejo} / runner {live_runner}. Update "
+                "the README line (and the harness images if intended)."
+            )
+        log(
+            f"Verified on Forgejo {live_forgejo}, runner {live_runner} — "
+            "README claim matches the live run."
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"::error::command failed with exit {e.returncode}", flush=True)
+        exit_code = 1
+    finally:
+        compose("down", "-v", "--remove-orphans")
+    raise SystemExit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/forgejo_smoke/compose-forgejo-smoke.yml
+++ b/tests/forgejo_smoke/compose-forgejo-smoke.yml
@@ -1,0 +1,66 @@
+# Throwaway Forgejo + act_runner stack for the forgejo-smoke workflow
+# (issue #573): scripts/forgejo_smoke.py boots it, executes README's
+# Forgejo Actions snippet against it verbatim, and tears it down. This is
+# harness infrastructure, not a lint fixture — nothing in CI runs
+# compose-lint against this file (it would rightly object to the Docker
+# socket mount the runner needs to spawn job containers).
+#
+# The compose-* filename keeps both images under Renovate's
+# docker-compose manager, so digest bumps arrive automatically and a
+# Forgejo/runner version bump re-runs the harness when it merges (the
+# workflow triggers on pushes touching this file). The versions here are
+# what README's "Verified on ..." line claims: forgejo_smoke.py asserts
+# the claim against the *live* instance, so bumping an image without
+# updating the README fails the run.
+services:
+  forgejo:
+    image: codeberg.org/forgejo/forgejo:16.0.2@sha256:2fdfe28b5c68f82f49580e227b84e2afb43af0250e0631a54a386ef3b1d9b759
+    environment:
+      # Headless install: lock the installer and configure via env.
+      FORGEJO__security__INSTALL_LOCK: "true"
+      FORGEJO__database__DB_TYPE: sqlite3
+      # ROOT_URL must be resolvable from *job containers* (checkout clones
+      # from it), which is why everything joins the named network below
+      # and the runner config pins that network for job containers.
+      FORGEJO__server__DOMAIN: forgejo
+      FORGEJO__server__ROOT_URL: http://forgejo:3000/
+      FORGEJO__actions__ENABLED: "true"
+    ports:
+      # Bound to loopback: the orchestration script talks to the API from
+      # the host; nothing else should. The host port is overridable so the
+      # harness can run on machines where 3000 is taken (CI leaves the
+      # default).
+      - "127.0.0.1:${FORGEJO_SMOKE_PORT:-3000}:3000"
+    networks: [forgejo-smoke]
+
+  runner:
+    image: data.forgejo.org/forgejo/runner:13.0.0@sha256:7fb853bfe73c229be6349398359c0a7bd01fadfd17c106607b2221150b799ed2
+    # root so the runner can use the host Docker socket on the CI runner.
+    user: root
+    depends_on: [forgejo]
+    environment:
+      # Registration token minted by forgejo_smoke.py (via the Forgejo
+      # CLI) after the instance is up; passed through the environment so
+      # it never lands in a file or command line.
+      RUNNER_TOKEN: ${RUNNER_TOKEN:-}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./runner-config.yml:/config/config.yml:ro
+    working_dir: /data
+    # Retry registration until Forgejo is ready, then run the daemon. The
+    # `docker:` label maps the snippet's `runs-on: docker` to a Debian
+    # image with apt + root, matching what the snippet assumes (README
+    # documents the node-in-container requirement). Tag-pinned only: the
+    # label string is runner config Renovate cannot see, and a digest
+    # here would just go permanently stale.
+    command: >-
+      sh -c 'while ! forgejo-runner register --no-interactive
+      --instance http://forgejo:3000 --token "$$RUNNER_TOKEN"
+      --name smoke-runner --labels "docker:docker://node:24-bookworm";
+      do sleep 2; done &&
+      exec forgejo-runner --config /config/config.yml daemon'
+    networks: [forgejo-smoke]
+
+networks:
+  forgejo-smoke:
+    name: forgejo-smoke

--- a/tests/forgejo_smoke/runner-config.yml
+++ b/tests/forgejo_smoke/runner-config.yml
@@ -1,0 +1,6 @@
+# Minimal act_runner config for the forgejo-smoke harness. The one thing
+# that matters: job containers must join the harness network, or
+# `http://forgejo:3000` (the instance ROOT_URL the checkout action clones
+# from) does not resolve inside them. Everything else stays at defaults.
+container:
+  network: forgejo-smoke


### PR DESCRIPTION
Closes #573 — via **option 2, fully containerized in GitHub Actions** (direction recorded on the issue), chosen over the maintainer-operated instance: nothing to operate, and the guarantees come out stronger.

**How it works.** The new `forgejo-smoke.yml` workflow runs `scripts/forgejo_smoke.py`, which:

1. Extracts the Forgejo snippet from `README.md` **verbatim at runtime** (exactly one fenced block may match) — the documented snippet and the tested snippet are one string, so they cannot drift.
2. Boots a throwaway Forgejo 16.0.2 + forgejo-runner 13.0.0 stack (`tests/forgejo_smoke/compose-forgejo-smoke.yml`, digest-pinned; the `compose-*` filename keeps both images under Renovate's docker-compose manager, so **every Forgejo release bump re-proves the snippet** when it merges). Job containers join a named network so the instance `ROOT_URL` resolves from inside them.
3. Bootstraps admin/API-token/runner-registration over the Forgejo CLI, pushes a repo whose workflow *is* the snippet with the shared `tests/smoke/clean.yml` as its compose file, dispatches it, and requires the run to succeed.
4. Asserts README's "Verified on Forgejo X, runner Y" line against the **live** instance and runner versions — the claim and the harness can only move together, in the same PR.

**Triggers:** weekly cron, pushes to main touching the harness, manual dispatch. Deliberately *not* on README PRs: release-prep bumps the snippet's `compose-lint==X.Y.Z` pin before that version exists on PyPI, which would fail spuriously mid-release — RELEASING.md documents the post-release verification path (weekly run, or dispatch immediately).

**Empirically verified before landing**, on a real Docker host running the exact committed files:
- Full positive run: snippet executed green on live Forgejo 16.0.2 / runner 13.0.0 (runner registered, job container resolved the instance, checkout from code.forgejo.org, apt+pip install of published compose-lint, lint passed), version assertion matched, teardown clean.
- Negative run (insecure stack substituted): harness exited 1 with `::error::the README snippet did not complete successfully` and dumped the runner logs — a Forgejo-side breakage turns the workflow red rather than passing silently.
- One real bug found and fixed by iteration: raw socket resets during instance boot escaped the API helper's error handling.

Also updates the stale README claim (was 15.0.2/12.9.0, July 2026), adds the workflow to CI.md's table + a section, and the RELEASING.md post-release checklist item. Merging this PR touches the harness paths, so the workflow auto-runs on main immediately — that run is the live CI proof.