### PR TITLE
Open files without O_NONBLOCK where the platform lacks it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Action: `sarif-written` output — `"true"` when the SARIF file was
   written and non-empty, empty otherwise.
 
+### Fixed
+
+- **Windows: every invocation crashed with `AttributeError: module 'os' has
+  no attribute 'O_NONBLOCK'` in 0.18.0.** The bounded-read hardening opened
+  files with the POSIX-only `O_NONBLOCK` flag (its FIFO-open-blocking rationale
+  does not exist on Windows). File opens now apply `O_NONBLOCK` only where the
+  platform has it, and add Windows' `O_BINARY` so CRT newline translation
+  cannot corrupt reads that ask for the file's real bytes. Found by the new
+  macOS/Windows CI smoke on its first run.
+
 ## [0.18.0] - 2026-08-14
 
 ### Upgrading

--- a/src/compose_lint/_safe_read.py
+++ b/src/compose_lint/_safe_read.py
@@ -58,8 +58,16 @@ def read_text_bounded(
     any check can run. It has no effect on a regular file. Symlinks are
     deliberately followed — a symlink to a real Compose file is ordinary, and
     it is the resolved target's shape that matters.
+
+    Both extra flags are POSIX-vs-Windows conditional, hence the ``getattr``:
+    Windows has no ``O_NONBLOCK`` — and no FIFO whose open would block this
+    way, so nothing is lost — and referencing it unconditionally crashed every
+    file read on Windows in 0.18.0. ``O_BINARY`` exists only on Windows, where
+    omitting it makes the CRT translate newlines *under* the text layer below,
+    silently breaking the ``newline=""`` real-bytes contract.
     """
-    fd = os.open(path, os.O_RDONLY | os.O_NONBLOCK)
+    flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_BINARY", 0)
+    fd = os.open(path, flags)
     try:
         info = os.fstat(fd)
         if not stat.S_ISREG(info.st_mode):


### PR DESCRIPTION
First catch from the new OS smoke (#584, ref #572), and it's severe: **compose-lint 0.18.0 is completely broken on Windows** — the bounded-read hardening (#558) opens every file with the POSIX-only `os.O_NONBLOCK`, which doesn't exist there, so every invocation dies with `AttributeError: module 'os' has no attribute 'O_NONBLOCK'` before reading a byte. Both Windows pytest collection errors in the first smoke run trace to this one line.

Fix: apply the flag via `getattr(os, "O_NONBLOCK", 0)` — Windows also has no FIFO whose open would block this way, so nothing is lost — and add `O_BINARY` the same way, since without it the Windows CRT translates newlines *beneath* the `fdopen` text layer and would silently break the `newline=""` real-bytes contract.

CHANGELOG Fixed entry included; worth noting this makes a prompt release more attractive, since 0.18.0 is the version Windows users currently get from PyPI.

No dedicated unit test: the failure is platform-conditional and the Windows leg of `os-smoke.yml` (which exercises the full suite plus the hook) is the honest regression net — it goes from collection-interrupt to green with this change. Linux gates all pass (ruff, mypy strict, 1789 tests, format).