### PR TITLE
Fix the OS smoke legs' two environment failures

### DIFF
--- a/.github/workflows/os-smoke.yml
+++ b/.github/workflows/os-smoke.yml
@@ -14,9 +14,12 @@ name: OS smoke (macOS/Windows)
 # is signal to triage, not a blocked PR.
 #
 # The pre-commit steps mirror ci.yml's `precommit-smoke` with one
-# portability change: throwaway repos live in `mktemp -d` (POSIX-style in
-# every bash, including Git Bash on Windows) rather than
-# `${{ runner.temp }}`, whose Windows backslash form fights shell quoting.
+# portability change: throwaway repos are created with `mktemp -d` under
+# RUNNER_TEMP (converted to POSIX form via cygpath where that exists).
+# The base directory matters on Windows: the workspace lives on D: while
+# the default temp dir is on C:, and pre-commit's try-repo computes a
+# relative path between the two — os.path.relpath cannot cross drives
+# and crashes. Keeping the throwaway on the workspace drive avoids it.
 on:
   workflow_dispatch:
   schedule:
@@ -96,7 +99,9 @@ jobs:
       - name: Clean stack with a config present should pass
         run: |
           set -euo pipefail
-          SMOKE="$(mktemp -d)"
+          TMPBASE="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+          command -v cygpath >/dev/null 2>&1 && TMPBASE="$(cygpath -u "$TMPBASE")"
+          SMOKE="$(mktemp -d -p "$TMPBASE")"
           cp tests/smoke/clean.yml "$SMOKE/docker-compose.yml"
           printf 'rules:\n  CL-0004:\n    enabled: false\n    reason: "smoke"\n' \
             > "$SMOKE/.compose-lint.yml"
@@ -119,7 +124,9 @@ jobs:
       - name: Insecure stack should fail the hook
         run: |
           set -euo pipefail
-          SMOKE="$(mktemp -d)"
+          TMPBASE="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+          command -v cygpath >/dev/null 2>&1 && TMPBASE="$(cygpath -u "$TMPBASE")"
+          SMOKE="$(mktemp -d -p "$TMPBASE")"
           cp tests/smoke/insecure.yml "$SMOKE/docker-compose.yml"
           git -C "$SMOKE" init -q
           git -C "$SMOKE" add -A

--- a/tests/test_action_contract.py
+++ b/tests/test_action_contract.py
@@ -49,6 +49,22 @@ def _step(name: str) -> dict[str, Any]:
     raise AssertionError(f"no step named {name!r}")
 
 
+def _bash_major() -> int:
+    try:
+        out = subprocess.run(
+            ["bash", "-c", "echo ${BASH_VERSINFO[0]}"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        ).stdout.strip()
+        return int(out)
+    except (OSError, ValueError):
+        return 0
+
+
+_BASH_MAJOR = _bash_major()
+
+
 def _run_step(
     name: str,
     env: dict[str, str],
@@ -57,6 +73,16 @@ def _run_step(
     extra_path: Path | None = None,
 ) -> tuple[int, str, str]:
     """Execute a step's `run:` body the way the runner would."""
+    if _BASH_MAJOR < 4:
+        # The scripts target the GitHub runner's bash (5.x) and use
+        # bash-4 features (`mapfile`). macOS ships bash 3.2, which fails
+        # them for reasons the action never sees in production — every
+        # `runs-on` that executes action.yml provides a modern bash. The
+        # static assertions below still run everywhere.
+        pytest.skip(
+            "action.yml step scripts need bash >= 4 "
+            f"(this platform has {_BASH_MAJOR or 'no bash'})"
+        )
     script = _step(name)["run"]
     path = f"{VENV_BIN}:{os.environ.get('PATH', '')}"
     if extra_path is not None:


### PR DESCRIPTION
Ref #572 — triage of the first macOS/Windows smoke run's failures. Three legs went red; one was a real product bug (#585, Windows `O_NONBLOCK`), and these are the other two, both environment issues in the harness/tests rather than in compose-lint:

- **macOS pytest**: the action-contract tests execute `action.yml`'s step scripts with the local bash; macOS ships bash 3.2 (no `mapfile`), so the four tests touching the lint step failed with `command not found` / exit 127. The scripts target the GitHub runner's bash 5 — every `runs-on` that actually executes the action provides one — so `_run_step` now skips under bash < 4 with the version in the skip reason. All static assertions (parse-level pins) still run on every platform.
- **Windows pre-commit**: `pre-commit try-repo` computes a relative path between the throwaway repo and the hook repo, and `os.path.relpath` cannot cross drive letters — bare `mktemp -d` lands on C: while the workspace is on D:, crashing with `ValueError: path is on mount 'D:', start on mount 'C:'`. The throwaway repos now go under `RUNNER_TEMP` (same drive as the workspace), converted to POSIX form via `cygpath` where it exists; no behavior change on macOS/Linux.

After this and #585 merge, I'll dispatch the OS smoke and confirm all four legs go green — that's the acceptance for this triage round. Linux gates pass locally (contract tests, ruff, YAML).