### PR TITLE
Reconfigure stdio to UTF-8 so Windows pipes can carry the report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   platform has it, and add Windows' `O_BINARY` so CRT newline translation
   cannot corrupt reads that ask for the file's real bytes. Found by the new
   macOS/Windows CI smoke on its first run.
+- **Windows: any run with findings crashed with `UnicodeEncodeError`.**
+  Windows pipes and redirected files inherit the locale code page (usually
+  cp1252), which cannot encode the report's ⚠/·/│ characters. The CLI now
+  reconfigures stdout/stderr to UTF-8 when they aren't already — a no-op on
+  every other platform and on interactive Windows consoles — so piped and
+  redirected output is UTF-8 everywhere. Also found by the macOS/Windows
+  smoke.
 
 ## [0.18.0] - 2026-08-14
 

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import io
 import json
 import os
 import stat
@@ -340,8 +341,29 @@ def _normalize_argv(argv: list[str]) -> list[str]:
     return ["check", *argv]
 
 
+def _utf8_stdio() -> None:
+    """Make stdout/stderr UTF-8 on Windows, matching every other platform.
+
+    Windows pipes and redirected files inherit the locale code page
+    (typically cp1252), which cannot encode the characters this tool
+    prints — the ⚠/· verdict marks and the │/─ excerpt gutters — so any
+    run with findings died with UnicodeEncodeError instead of a report.
+    Interactive consoles are unaffected: modern Python drives them through
+    the wide-character API and they are already UTF-8-capable, so this
+    only changes what lands in pipes and files — where UTF-8 is what the
+    other platforms (and PEP 686's direction) already produce.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        if isinstance(stream, io.TextIOWrapper) and stream.encoding.lower() not in (
+            "utf-8",
+            "utf8",
+        ):
+            stream.reconfigure(encoding="utf-8")
+
+
 def main(argv: list[str] | None = None) -> NoReturn:
     """Main entry point for the CLI."""
+    _utf8_stdio()
     parser = _build_parser()
     raw = sys.argv[1:] if argv is None else argv
     args = parser.parse_args(_normalize_argv(raw))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import stat
 import subprocess
 import sys
@@ -57,6 +58,33 @@ class TestCLI:
         result = run_cli("check", str(FIXTURES / "insecure_privileged.yml"))
         assert result.returncode == 1
         assert "CL-0002" in result.stdout
+
+    def test_findings_survive_a_cp1252_stdio(self) -> None:
+        """A narrow stdio encoding must not crash the report.
+
+        Windows pipes inherit the locale code page (cp1252), which cannot
+        encode the ⚠/·/│ characters the text report uses — every run with
+        findings died with UnicodeEncodeError there. The CLI reconfigures
+        its stdio to UTF-8; PYTHONIOENCODING=cp1252 reproduces the Windows
+        condition on any platform.
+        """
+        env = {**os.environ, "PYTHONIOENCODING": "cp1252"}
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "compose_lint",
+                str(FIXTURES / "insecure_privileged.yml"),
+            ],
+            capture_output=True,
+            env=env,
+        )
+        stdout = result.stdout.decode("utf-8")
+        assert result.returncode == 1, result.stderr.decode("utf-8", "replace")
+        assert "CL-0002" in stdout
+        # The excerpt gutter is the exact character the Windows crash died
+        # on; its presence proves the output is real UTF-8, not degraded.
+        assert "│" in stdout
 
     def test_module_entrypoint_matches_the_console_script(self) -> None:
         """``python -m compose_lint`` and ``compose-lint`` are one surface.


### PR DESCRIPTION
Second product bug from the OS smoke's Windows leg (ref #572, follow-up to #585): **any run with findings crashed on Windows with `UnicodeEncodeError`** — pipes and redirected files inherit cp1252, which can't encode the report's `⚠`/`·`/`│` characters. This is what killed the Windows pre-commit smoke (`'charmap' codec can't encode character '│'`) and explains the bulk of the 54 Windows pytest failures (clean files "exiting 1", findings missing from output — the process was dying mid-print).

Fix: `main()` reconfigures stdout/stderr to UTF-8 when they're `TextIOWrapper`s with a narrower encoding. No-op on Linux/macOS and on interactive Windows consoles (wide-char API); piped/redirected Windows output becomes UTF-8 — the bytes every other platform already produces, and PEP 686's direction.

The regression test reproduces the Windows condition cross-platform with `PYTHONIOENCODING=cp1252` and asserts the gutter character arrives intact — **verified failing before the fix** (with the exact production error) and passing after. Full gates green (ruff, mypy strict, 1790 tests).

After this merges I'll dispatch the OS smoke again; the expected residue is the POSIX-only test tail (`mkfifo`, chmod semantics, Linux-image Docker pulls), which gets skip guards in a follow-up informed by that run.