### PR TITLE
Document the Windows bind-source resolution limitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   redirected output is UTF-8 everywhere. Also found by the macOS/Windows
   smoke.
 
+### Known limitations
+
+- **On Windows hosts, bind-source path resolution uses the host's path
+  semantics**, so the climb-to-root detections (CL-0001, CL-0025) can miss
+  findings that the same file produces on Linux/macOS, and a bind source
+  containing `${VAR:?err}` can surface an OS error. Tracked in
+  [#588](https://github.com/tmatens/compose-lint/issues/588). Linting the
+  same files on Linux CI is unaffected.
+
 ## [0.18.0] - 2026-08-14
 
 ### Upgrading

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -72,6 +72,18 @@ Two things are never reused or quietly repurposed:
 - **Exit-code meanings** — `0` / `1` / `2` keep their meanings; adding a new
   non-zero code is a MAJOR change.
 
+## Operating systems
+
+Linux is the fully gated platform: every PR runs the complete suite there
+across all supported Python versions. macOS and Windows are exercised by a
+separate smoke workflow (pytest plus the pre-commit hook, currently at one
+Python version) that runs on every merge and weekly, but does not yet gate
+merges. Known platform limitation: on Windows hosts, bind-source path
+resolution uses host path semantics, so the climb-to-root detections
+(CL-0001, CL-0025) can miss findings there — see
+[#588](https://github.com/tmatens/compose-lint/issues/588). The GitHub
+Action and the Docker image are Linux by construction and unaffected.
+
 ## Python versions
 
 Supported CPython versions track upstream: a version is added to the matrix


### PR DESCRIPTION
Ref #588. Pre-release documentation: 0.19.0's notes fix two Windows crashes, which makes Windows usable for the first time — so the remaining known gap there gets stated instead of implied away (the same don't-document-what-isn't-tested principle as everything else this week, pointed the other direction).

- CHANGELOG Unreleased gains a **Known limitations** entry: Windows bind-source resolution uses host path semantics, the climb-to-root detections (CL-0001/CL-0025) can miss findings there, `${VAR:?err}` sources can surface an OS error; tracked in #588; Linux CI unaffected.
- `docs/compatibility.md` gains an **Operating systems** section saying precisely what is gated (Linux, full matrix, every PR), what is smoked non-gating (macOS/Windows via `os-smoke.yml`), and the known Windows edge.

Docs-only; changelog-gate does not fire (no version bump). This is the last item before the 0.19.0 release, which will be driven from claude-station.