### PR TITLE
Teach the changelog check the repo's own section vocabulary

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -81,8 +81,20 @@ jobs:
           python - <<'PY'
           import pathlib, re, sys
 
-          # Keep a Changelog's order, with this repo's "Upgrading" preamble first.
-          ORDER = ["Upgrading", "Added", "Changed", "Deprecated", "Removed", "Fixed", "Security"]
+          # Keep a Changelog's order, with this repo's "Upgrading" preamble
+          # first and its "Known limitations" postscript last. Both are local
+          # conventions that predate this check: "Upgrading from 0.15.x" and
+          # "Upgrading from 0.16.x" already shipped inside released sections,
+          # and "Known limitations" landed in #590. Normalise the versioned
+          # "Upgrading from X.Y.x" spelling to the bare key so the ordering
+          # comparison below sees one heading, not an unknown one.
+          ORDER = [
+              "Upgrading", "Added", "Changed", "Deprecated", "Removed",
+              "Fixed", "Security", "Known limitations",
+          ]
+
+          def key(heading: str) -> str:
+              return "Upgrading" if re.fullmatch(r"Upgrading(\s+from\s+.+)?", heading) else heading
 
           lines = pathlib.Path("CHANGELOG.md").read_text(encoding="utf-8").splitlines()
           start = next((i for i, ln in enumerate(lines) if ln.startswith("## [Unreleased]")), None)
@@ -120,10 +132,10 @@ jobs:
                   "release section."
               )
 
-          if unknown := [h for h in headings if h not in ORDER]:
+          if unknown := [h for h in headings if key(h) not in ORDER]:
               sys.exit(f"::error::[Unreleased] has unrecognised sections: {unknown}. Expected some of {ORDER}.")
 
-          if [ORDER.index(h) for h in headings] != sorted(ORDER.index(h) for h in headings):
+          if [ORDER.index(key(h)) for h in headings] != sorted(ORDER.index(key(h)) for h in headings):
               sys.exit(
                   f"::error::[Unreleased] sections are out of order: {headings}. "
                   f"Expected: {[h for h in ORDER if h in headings]}"


### PR DESCRIPTION
## Why

Cutting 0.19.0 failed at dispatch: release-prep's `[Unreleased]` validator (#568) rejected the changelog with

```
[Unreleased] has unrecognised sections: ['Known limitations'].
Expected some of ['Upgrading', 'Added', 'Changed', 'Deprecated', 'Removed', 'Fixed', 'Security']
```

`### Known limitations` was added one commit later in #590 to record the Windows bind-source limitation (#588). The validator landed in #568 and the heading in #590 — a day apart, and they never met, because **this check only runs when release-prep is dispatched, never on the PR that introduces the heading**. Both merged on green CI.

The same defect has a second, latent instance: `### Upgrading from 0.16.x` and `### Upgrading from 0.15.x` already shipped inside the 0.17.0 and 0.16.0 sections, but only the bare `Upgrading` is recognised. The next release to use the versioned spelling would have failed identically.

## What

- Add `Known limitations` to `ORDER` as a trailing section (it is a postscript, so it sorts last).
- Normalise `Upgrading from X.Y.x` → `Upgrading` for **both** the membership test and the ordering test, so the versioned form keeps its required first position.

Duplicate, empty, unknown and out-of-order detection are otherwise unchanged.

## Verification

The validator script was extracted verbatim from the workflow and run against real and synthetic changelogs:

| Case | Result |
|---|---|
| Real `[Unreleased]` (Added / Fixed / Known limitations) | PASS |
| `Upgrading from 0.16.x` + `Added` | PASS |
| Unknown section `Bogus` | REJECT |
| Out of order (`Fixed` before `Added`) | REJECT |
| `Known limitations` before `Added` | REJECT |
| Duplicate `Fixed` | REJECT |
| Empty `[Unreleased]` | REJECT |

`actionlint` clean.

Follow-up issues for running this check on PRs rather than only at dispatch will be filed separately.