### PR TITLE
Bump marketplace-smoke pin to v0.19.0

### DIFF
--- a/.github/workflows/marketplace-smoke.yml
+++ b/.github/workflows/marketplace-smoke.yml
@@ -61,7 +61,7 @@ jobs:
           persist-credentials: false
 
       - name: Clean fixture should pass
-        uses: tmatens/compose-lint@f11d751f71aef2bcbaa61f682f6456c3c97f95bf # v0.18.0
+        uses: tmatens/compose-lint@79fa86c6d6792a85e27367f34b8c4337578f4021 # v0.19.0
         with:
           files: tests/smoke/clean.yml
           fail-on: high
@@ -69,7 +69,7 @@ jobs:
       - name: Insecure fixture should fail
         id: insecure
         continue-on-error: true
-        uses: tmatens/compose-lint@f11d751f71aef2bcbaa61f682f6456c3c97f95bf # v0.18.0
+        uses: tmatens/compose-lint@79fa86c6d6792a85e27367f34b8c4337578f4021 # v0.19.0
         with:
           files: tests/smoke/insecure.yml
           fail-on: high
@@ -97,7 +97,7 @@ jobs:
       # The release the hook is consumed at. Bumped alongside the action
       # SHA by publish.yml's bump-marketplace-smoke-pin job, so the job
       # runs against each new release automatically.
-      CL_RELEASE_TAG: v0.18.0
+      CL_RELEASE_TAG: v0.19.0
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ jobs:
       security-events: write  # upload the SARIF to Code Scanning
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: tmatens/compose-lint@f11d751f71aef2bcbaa61f682f6456c3c97f95bf # v0.18.0
+      - uses: tmatens/compose-lint@79fa86c6d6792a85e27367f34b8c4337578f4021 # v0.19.0
         with:
           sarif-file: results.sarif
 ```


### PR DESCRIPTION
**Post-tag follow-up.** This PR was opened automatically by `publish.yml` *after*:

- Tag `v0.19.0` was pushed and triggered the Publish workflow
- TestPyPI + Docker smoke tests passed
- The `release-gate` environment was approved
- `publish` (PyPI) and `docker-publish` (Docker Hub) both succeeded
- `create-release` created the GitHub Release `v0.19.0`

So the pinned SHA `79fa86c6d6792a85e27367f34b8c4337578f4021` is guaranteed to correspond to a release that actually shipped through every channel.

Bumps the pin in `.github/workflows/marketplace-smoke.yml` **and** the copy-paste GitHub Action snippet in `README.md` — both use the `@<sha> # vX.Y.Z` form that CI cannot check pre-tag.

**After merging this PR**, trigger **Actions → Marketplace smoke test → Run workflow** to verify the published Action end-to-end against the new tag.
