### PR TITLE
Never let a bypassed pip shim reach the real environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,14 @@ of code:
 pytest --cov=compose_lint --cov-report=term-missing --cov-fail-under=80
 ```
 
+On hosts where `/tmp` is mounted `noexec` (hardened containers), point
+pytest's temp directory somewhere executable first — the action-contract
+tests run shim executables from it and will skip otherwise:
+
+```bash
+TMPDIR=$HOME/.pytest-tmp pytest --basetemp=$HOME/.pytest-tmp/bt
+```
+
 ## Code standards
 
 - **Python 3.10+** required. Don't use syntax or stdlib features added after

--- a/tests/test_action_contract.py
+++ b/tests/test_action_contract.py
@@ -84,6 +84,8 @@ def _run_step(
             f"(this platform has {_BASH_MAJOR or 'no bash'})"
         )
     script = _step(name)["run"]
+    if extra_path is not None:
+        _require_exec(extra_path)
     path = f"{VENV_BIN}:{os.environ.get('PATH', '')}"
     if extra_path is not None:
         path = f"{extra_path}:{path}"
@@ -93,6 +95,11 @@ def _run_step(
         "GITHUB_OUTPUT": str(outputs),
         "GITHUB_WORKSPACE": str(workspace),
         "RUNNER_TEMP": str(workspace / "_temp"),
+        # Even a bypassed shim must never reach the network: a real pip
+        # running here installs a published compose-lint over the editable
+        # checkout under test (#595). With no index, that becomes a loud
+        # local failure instead of silent environment corruption.
+        "PIP_NO_INDEX": "1",
         **env,
     }
     (workspace / "_temp").mkdir(exist_ok=True)
@@ -105,6 +112,30 @@ def _run_step(
         timeout=180,
     )
     return proc.returncode, proc.stdout, proc.stderr
+
+
+def _require_exec(shim_dir: Path) -> None:
+    """Skip when ``shim_dir`` cannot execute files (a ``noexec`` tmpdir).
+
+    PATH resolution silently passes over a non-executable entry, so on a
+    host with ``/tmp`` mounted ``noexec`` the *real* tool runs instead of
+    the shim. For the pip shim that meant a live network install replacing
+    the editable checkout with a published compose-lint — corrupting every
+    subsequent test run in a way that reads like source breakage (#595).
+    Never fall through: probe an exec here and skip with the remedy.
+    """
+    probe = shim_dir / "exec-probe"
+    probe.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    probe.chmod(0o755)
+    try:
+        subprocess.run([str(probe)], check=True, timeout=10)
+    except OSError:
+        pytest.skip(
+            f"{shim_dir} cannot execute files (noexec tmpdir?) — set TMPDIR "
+            "to an exec-capable directory, see CONTRIBUTING.md"
+        )
+    finally:
+        probe.unlink()
 
 
 def _outputs(path: Path) -> dict[str, str]:


### PR DESCRIPTION
Closes #595.

Defense in depth, per the issue's suggestions — three layers, each independently sufficient:

1. **Exec probe**: `_run_step` now proves the shim directory can execute files before running any step that depends on a shim, and `pytest.skip`s with the remedy (`TMPDIR` to an exec-capable dir) when it can't — a `noexec` tmpdir becomes a named skip, never a silent fall-through to the real tool. (The issue's first suggestion — invoking the shim by absolute path — doesn't apply here: the script under test is `action.yml`'s verbatim `run:` body calling bare `pip`, so the guard has to sit on the environment instead.)
2. **`PIP_NO_INDEX=1`** in every `_run_step` environment: even a bypassed shim can't reach PyPI, so the worst case is a loud local failure rather than the editable checkout being replaced by a published package.
3. **CONTRIBUTING.md** documents the `TMPDIR=$HOME/.pytest-tmp` workaround for hardened hosts.

Empirical verification (no noexec mount exists on this machine, so the mechanisms were verified directly): a non-executable probe raises `PermissionError` (an `OSError`, exactly what the guard catches), and `PIP_NO_INDEX=1 pip download compose-lint==0.16.0` fails with "no matching distribution" — the silent-install path is dead. Contract tests: 19 passed; ruff clean. The affected host (claude-station's hardened container) re-validates the skip path on its next preflight.