### PR TITLE
Grade the [Unreleased] shape on the PR that changes it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,6 +526,24 @@ jobs:
           fi
           echo "Found matching CHANGELOG section for ${head_version}."
 
+      # The [Unreleased] *shape* is graded on the PR that changes it, not
+      # only at release-prep dispatch (#593): #590 landed an unrecognised
+      # heading on fully green CI and cost the first 0.19.0 dispatch,
+      # because the check lived only in release-prep.yml. Same script as
+      # release-prep, minus --require-content — a PR that adds no
+      # user-facing entry is legitimate; an empty section at release time
+      # is not.
+      - name: Validate [Unreleased] shape when CHANGELOG.md changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if ! git diff --name-only "${BASE_SHA}" "${HEAD_SHA}" | grep -q '^CHANGELOG.md$'; then
+            echo "CHANGELOG.md not touched; nothing to validate."
+            exit 0
+          fi
+          python3 scripts/check_changelog_unreleased.py
+
   dco:
     name: Developer Certificate of Origin
     runs-on: ubuntu-24.04

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -72,77 +72,14 @@ jobs:
       #   - 0.18.0: it carried two "### Security" and two "### Fixed" blocks
       #     with "### Changed" between them, so renaming the header would have
       #     shipped the duplicates inside [0.18.0].
-      # The changelog-gate job catches neither: it only asserts a section
-      # exists for the bumped version, which a renamed-but-malformed section
-      # satisfies. Check here, before anything is modified, so a bad changelog
-      # costs nothing but a re-dispatch.
+      # The changelog-gate job runs the same script (without
+      # --require-content) on every PR touching CHANGELOG.md, so shape
+      # breakage is normally caught on the PR that introduces it (#593);
+      # this dispatch-time run is the last line of defence and the only
+      # place emptiness is an error. Check here, before anything is
+      # modified, so a bad changelog costs nothing but a re-dispatch.
       - name: Validate CHANGELOG [Unreleased] section
-        run: |
-          python - <<'PY'
-          import pathlib, re, sys
-
-          # Keep a Changelog's order, with this repo's "Upgrading" preamble
-          # first and its "Known limitations" postscript last. Both are local
-          # conventions that predate this check: "Upgrading from 0.15.x" and
-          # "Upgrading from 0.16.x" already shipped inside released sections,
-          # and "Known limitations" landed in #590. Normalise the versioned
-          # "Upgrading from X.Y.x" spelling to the bare key so the ordering
-          # comparison below sees one heading, not an unknown one.
-          ORDER = [
-              "Upgrading", "Added", "Changed", "Deprecated", "Removed",
-              "Fixed", "Security", "Known limitations",
-          ]
-
-          def key(heading: str) -> str:
-              return "Upgrading" if re.fullmatch(r"Upgrading(\s+from\s+.+)?", heading) else heading
-
-          lines = pathlib.Path("CHANGELOG.md").read_text(encoding="utf-8").splitlines()
-          start = next((i for i, ln in enumerate(lines) if ln.startswith("## [Unreleased]")), None)
-          if start is None:
-              sys.exit("::error::No '## [Unreleased]' section in CHANGELOG.md")
-          end = next(
-              (i for i in range(start + 1, len(lines)) if lines[i].startswith("## [")),
-              len(lines),
-          )
-
-          # A '###' inside a fenced block is sample text, not a section heading.
-          headings: list[str] = []
-          fenced = has_content = False
-          for line in lines[start + 1 : end]:
-              if re.match(r"^(```|~~~)", line.strip()):
-                  fenced = not fenced
-              if not fenced and line.startswith("### "):
-                  headings.append(line[4:].strip())
-                  continue
-              if line.strip():
-                  has_content = True
-
-          if not has_content:
-              sys.exit(
-                  "::error::[Unreleased] is empty. This workflow only renames the "
-                  "header, so releasing now would ship a blank section and blank "
-                  "GitHub Release notes. Author the entries first — `git log "
-                  "v<PREV>..HEAD` lists what landed."
-              )
-
-          if dupes := sorted({h for h in headings if headings.count(h) > 1}):
-              sys.exit(
-                  f"::error::[Unreleased] has duplicate sections: {dupes}. Merge each "
-                  "pair into one before releasing, or the duplicates ship inside the "
-                  "release section."
-              )
-
-          if unknown := [h for h in headings if key(h) not in ORDER]:
-              sys.exit(f"::error::[Unreleased] has unrecognised sections: {unknown}. Expected some of {ORDER}.")
-
-          if [ORDER.index(key(h)) for h in headings] != sorted(ORDER.index(key(h)) for h in headings):
-              sys.exit(
-                  f"::error::[Unreleased] sections are out of order: {headings}. "
-                  f"Expected: {[h for h in ORDER if h in headings]}"
-              )
-
-          print("[Unreleased] OK:", ", ".join(headings) or "(no subsections)")
-          PY
+        run: python scripts/check_changelog_unreleased.py --require-content
 
       # Delegate to the same script a maintainer runs by hand, so there is one
       # definition of "what a version bump is". This workflow used to

--- a/scripts/check_changelog_unreleased.py
+++ b/scripts/check_changelog_unreleased.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Validate the shape of CHANGELOG.md's ``[Unreleased]`` section.
+
+One definition, two call sites (#593):
+
+- ci.yml's ``changelog-gate`` job runs it on every PR that touches
+  CHANGELOG.md, so a duplicate, unknown, or out-of-order section is caught
+  on the PR that introduces it — #590 landed ``### Known limitations`` on
+  fully green CI and cost the first 0.19.0 release-prep dispatch, because
+  this check only existed inside release-prep.yml's heredoc.
+- release-prep.yml runs it with ``--require-content`` as the last line of
+  defence before the section is renamed into the release. The emptiness
+  rule stays dispatch-only: a PR that adds no user-facing entry is
+  legitimate, an empty section at release time is not (0.17.0 nearly
+  shipped blank notes).
+
+release-prep.yml only *renames* ``[Unreleased]`` -> ``[X.Y.Z]``; it never
+authors or reorders entries, so whatever shape the section is in is what
+ships — in the GitHub Release notes too.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+# Keep a Changelog's order, with this repo's "Upgrading" preamble first and
+# its "Known limitations" postscript last. Both are local conventions that
+# predate this check: "Upgrading from 0.15.x"/"0.16.x" already shipped
+# inside released sections, and "Known limitations" landed in #590. The
+# versioned "Upgrading from X.Y.x" spelling is normalised to the bare key so
+# the ordering comparison sees one heading, not an unknown one.
+ORDER = [
+    "Upgrading",
+    "Added",
+    "Changed",
+    "Deprecated",
+    "Removed",
+    "Fixed",
+    "Security",
+    "Known limitations",
+]
+
+
+def _key(heading: str) -> str:
+    if re.fullmatch(r"Upgrading(\s+from\s+.+)?", heading):
+        return "Upgrading"
+    return heading
+
+
+def validate(text: str, *, require_content: bool) -> str | None:
+    """Return an error message, or ``None`` when the section is well-formed."""
+    lines = text.splitlines()
+    start = next(
+        (i for i, ln in enumerate(lines) if ln.startswith("## [Unreleased]")), None
+    )
+    if start is None:
+        return "No '## [Unreleased]' section in CHANGELOG.md"
+    end = next(
+        (i for i in range(start + 1, len(lines)) if lines[i].startswith("## [")),
+        len(lines),
+    )
+
+    # A '###' inside a fenced block is sample text, not a section heading.
+    headings: list[str] = []
+    fenced = has_content = False
+    for line in lines[start + 1 : end]:
+        if re.match(r"^(```|~~~)", line.strip()):
+            fenced = not fenced
+        if not fenced and line.startswith("### "):
+            headings.append(line[4:].strip())
+            continue
+        if line.strip():
+            has_content = True
+
+    if require_content and not has_content:
+        return (
+            "[Unreleased] is empty. release-prep only renames the header, so "
+            "releasing now would ship a blank section and blank GitHub Release "
+            "notes. Author the entries first — `git log v<PREV>..HEAD` lists "
+            "what landed."
+        )
+
+    if dupes := sorted({h for h in headings if headings.count(h) > 1}):
+        return (
+            f"[Unreleased] has duplicate sections: {dupes}. Merge each pair "
+            "into one, or the duplicates ship inside the release section."
+        )
+
+    if unknown := [h for h in headings if _key(h) not in ORDER]:
+        return (
+            f"[Unreleased] has unrecognised sections: {unknown}. "
+            f"Expected some of {ORDER}."
+        )
+
+    indices = [ORDER.index(_key(h)) for h in headings]
+    if indices != sorted(indices):
+        expected = [h for h in ORDER if h in {_key(x) for x in headings}]
+        return (
+            f"[Unreleased] sections are out of order: {headings}. Expected: {expected}"
+        )
+
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--file",
+        default="CHANGELOG.md",
+        type=pathlib.Path,
+        help="changelog to validate (default: CHANGELOG.md)",
+    )
+    parser.add_argument(
+        "--require-content",
+        action="store_true",
+        help="also fail when [Unreleased] is empty (release-prep only)",
+    )
+    args = parser.parse_args()
+
+    text = args.file.read_text(encoding="utf-8")
+    error = validate(text, require_content=args.require_content)
+    if error is not None:
+        print(f"::error::{error}")
+        return 1
+    print("[Unreleased] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_changelog_shape.py
+++ b/tests/test_changelog_shape.py
@@ -1,0 +1,85 @@
+"""The [Unreleased] shape rules that gate PRs and release-prep (#593).
+
+``scripts/check_changelog_unreleased.py`` is the single definition used by
+both ci.yml's changelog-gate and release-prep.yml. These are the first
+tests the shape rules have had: before extraction they lived in a workflow
+heredoc, where verifying a change meant regex-extracting the script and
+running it by hand against synthetic changelogs.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_spec = importlib.util.spec_from_file_location(
+    "check_changelog_unreleased",
+    REPO_ROOT / "scripts" / "check_changelog_unreleased.py",
+)
+assert _spec is not None and _spec.loader is not None
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+validate = _mod.validate
+
+
+def _doc(body: str) -> str:
+    return f"# Changelog\n\n## [Unreleased]\n{body}\n## [0.19.0] - 2026-08-18\n"
+
+
+def test_a_well_formed_section_passes() -> None:
+    body = "\n### Added\n\n- a thing\n\n### Fixed\n\n- a fix\n"
+    assert validate(_doc(body), require_content=True) is None
+
+
+def test_the_real_changelog_passes() -> None:
+    text = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert validate(text, require_content=False) is None
+
+
+def test_missing_unreleased_section_fails() -> None:
+    error = validate("# Changelog\n\n## [0.19.0]\n", require_content=False)
+    assert error is not None and "No '## [Unreleased]'" in error
+
+
+def test_empty_section_fails_only_when_content_is_required() -> None:
+    doc = _doc("\n")
+    assert validate(doc, require_content=False) is None
+    error = validate(doc, require_content=True)
+    assert error is not None and "empty" in error
+
+
+def test_duplicate_sections_fail() -> None:
+    body = "\n### Fixed\n\n- one\n\n### Changed\n\n- two\n\n### Fixed\n\n- three\n"
+    error = validate(_doc(body), require_content=True)
+    assert error is not None and "duplicate" in error and "Fixed" in error
+
+
+def test_an_unknown_heading_fails() -> None:
+    # The 0.19.0 dispatch failure before #591 taught the vocabulary; an
+    # actually-unknown heading must still be refused.
+    body = "\n### Awesome stuff\n\n- a thing\n"
+    error = validate(_doc(body), require_content=True)
+    assert error is not None and "unrecognised" in error
+
+
+def test_known_limitations_is_recognised_and_ordered_last() -> None:
+    body = "\n### Fixed\n\n- a fix\n\n### Known limitations\n\n- an edge\n"
+    assert validate(_doc(body), require_content=True) is None
+
+
+def test_out_of_order_sections_fail() -> None:
+    body = "\n### Fixed\n\n- a fix\n\n### Added\n\n- a thing\n"
+    error = validate(_doc(body), require_content=True)
+    assert error is not None and "out of order" in error
+
+
+def test_versioned_upgrading_heading_is_normalised() -> None:
+    body = "\n### Upgrading from 0.18.x\n\n- do this\n\n### Added\n\n- a thing\n"
+    assert validate(_doc(body), require_content=True) is None
+
+
+def test_a_heading_inside_a_fenced_block_is_ignored() -> None:
+    body = "\n### Added\n\n- a thing\n\n```markdown\n### Bogus\n```\n"
+    assert validate(_doc(body), require_content=True) is None


### PR DESCRIPTION
Closes #593, exactly as proposed:

- The validator is extracted verbatim from `release-prep.yml`'s heredoc into `scripts/check_changelog_unreleased.py` (same rules, same messages, including #591's vocabulary — `Known limitations`, versioned `Upgrading from X.Y.x` normalisation, fenced-block awareness).
- **Both call sites**: ci.yml's `changelog-gate` job now runs it on every PR that touches `CHANGELOG.md` (the #590 shape of failure gets caught on the PR that introduces it), and `release-prep.yml` calls the script with `--require-content` as the unchanged last line of defence.
- **The issue's caveat is honored**: the emptiness rule is dispatch-only via the flag — a PR adding no user-facing entry stays green; an empty section at release time still refuses.
- **First-ever tests for the shape rules** (`tests/test_changelog_shape.py`, 10 cases): pass shape, the real CHANGELOG.md, missing section, both emptiness modes, duplicates, unknown heading, `Known limitations` ordering, out-of-order detection, `Upgrading from X.Y.x` normalisation, fenced `###` exemption.

Verified live: bare mode passes on the current changelog; `--require-content` correctly exits 1 on the post-0.19.0 empty `[Unreleased]` (the 0.17.0 near-miss scenario). Full suite 1800 passed; ruff clean; both workflows parse.