### PR TITLE
Record accepted Code Scanning findings in-repo

### DIFF
--- a/docs/security-exceptions.md
+++ b/docs/security-exceptions.md
@@ -1,0 +1,20 @@
+# Accepted security findings
+
+GitHub keys a Code Scanning dismissal to the alert's *location fingerprint*,
+so an accepted finding "resurfaces" as a fresh, undismissed alert whenever
+edits above it move the line — Scorecard alert #81, dismissed *won't fix* in
+May 2026, came back as alert #101 in August after unrelated `publish.yml`
+edits shifted its line (#594). Dismissals are therefore not a durable
+record; this file is.
+
+**How the release preflight uses it:** the code-scanning sweep (Step 0 of
+the release process) matches each open alert against the rows below on
+**rule + file + message** — never on alert number or line. A matched alert
+is previously accepted: re-dismiss it in the UI citing this file, and
+proceed. An alert with no row here is a real finding — fix it forward, or
+add a row via a reviewed PR recording why it cannot be fixed and what
+compensates.
+
+| Rule | File | Message | Why it cannot be fixed | Compensating control | History |
+| ---- | ---- | ------- | ---------------------- | -------------------- | ------- |
+| Scorecard `PinnedDependenciesID` | `.github/workflows/publish.yml` | `pipCommand not pinned by hash` | The `testpypi-smoke` retry loop installs the wheel that was built and uploaded to TestPyPI moments earlier in the same workflow run; that wheel's hash does not exist when the workflow source is written. | Post-install integrity is verified via Sigstore in `verify-release-signatures`. | Accepted 2026-05-21 (alert #81); resurfaced by line movement and re-accepted 2026-08-17 (alert #101). |


### PR DESCRIPTION
Closes #594 via its preferred option 1: `docs/security-exceptions.md` is the durable, fingerprint-proof record of accepted findings — rule, file, message, why unfixable, compensating control, dismissal history — seeded with the one current entry (Scorecard `PinnedDependenciesID` on `publish.yml`'s `testpypi-smoke`, Sigstore-compensated).

The sweep procedure itself lives in the `release-compose-lint` skill (dad/agent_skills), so its Step 0 is being updated in a companion PR there: match open alerts against this file on **rule + file + message** (never alert number or line), treat a match as previously-accepted needing only a re-dismissal citing this file, and only escalate unmatched alerts.

Option 3 (runtime hash-pinning the TestPyPI install) deliberately not taken: it removes the finding but adds machinery to a pipeline path CI can't exercise pre-release, for a check Sigstore already compensates — the issue ranked it last for the same reason.

**One manual step remains that automation can't do** (no code-scanning write on the PAT): re-dismiss alert [#101](https://github.com/tmatens/compose-lint/security/code-scanning/101) as *won't fix* with a rationale pointing at `docs/security-exceptions.md`.