### PR TITLE
Resolve bind sources with deploy-host-independent segment math

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bind-source resolution is now lexical segment math in POSIX notation on
+  every platform (ADR-023): findings assert facts about the document that
+  hold on any plausible deploy host, instead of borrowing the linting
+  machine's path semantics. On Linux/macOS behavior is unchanged (verified:
+  zero findings changed across the 5,417-file corpus). On Windows lint
+  hosts, resolved relative sources are now spelled `/`-rooted, and `~`
+  sources are left as written rather than expanded against a Windows home
+  that is no proxy for a POSIX deploy home.
+
+### Fixed
+
+- **Windows lint hosts no longer miss climb-to-root bind mounts.** A
+  `..`-climb source resolved with Windows path semantics never matched the
+  whole-root (CL-0001) and root-equivalent (CL-0025) claims — the known
+  limitation shipped in 0.19.0's notes (#588). Climbs now saturate at the
+  root of whatever filesystem contains the compose file and are claimed on
+  every platform.
+
 ## [0.19.0] - 2026-08-18
 
 ### Added

--- a/docs/adr/023-deploy-host-independent-claims.md
+++ b/docs/adr/023-deploy-host-independent-claims.md
@@ -1,0 +1,62 @@
+# ADR-023: Claims Are Deploy-Host-Independent
+
+**Status:** Accepted
+
+**Context:** A compose file is routinely linted on a machine that is not the
+machine it deploys to — a Windows or macOS laptop editing files headed for a
+Linux server, a CI runner linting a checkout that production deploys from a
+different path. The deploy target is not present in the document, so any
+lint-host context that leaks into a finding is an unstated guess about it.
+
+The codebase already followed this principle in four places, each chosen
+deliberately: `${VAR:-default}` interpolations resolve to the no-`.env`
+shipped value and never read the linting machine's environment;
+`include:`/cross-file `extends:` are refused loudly as coverage gaps rather
+than resolved through the lint host's filesystem; bind-source resolution is
+lexical, never following the lint host's symlinks (verified against Compose
+29.4.3); and `~user` sources are left unclaimed rather than asserting a path
+from the linting user's environment for another account's home.
+
+One layer violated it: `_resolved_bind_source` did its relative and `~` math
+through the host's path semantics (`os.path.join`/`normpath`/`expanduser`).
+Issue #588 surfaced the consequence when the OS smoke first ran on Windows:
+a `..`-climb resolved to `C:\` instead of `/`, so the climb-to-root claims
+(CL-0001 whole-root, CL-0025 root-equivalent) — the linter's highest-severity
+territory — silently failed to fire. Silent false negatives are the worst
+failure mode a security linter has. The same host-semantics assumption was
+also wrong in the mirror direction: Windows path math describes a deployment
+that never happens when the file deploys to Linux.
+
+**Decision:** A finding must be true of the *document* on any plausible
+deploy host. Concretely:
+
+1. **Resolution is lexical segment math in POSIX notation on every
+   platform** (`_lexical_join`): `..` saturates at the anchor of whatever
+   filesystem contains the compose file — `/` on a POSIX host, the drive or
+   UNC share root on Windows — and the result is spelled `/`-rooted either
+   way, because "climbs to the root of the containing filesystem" is the
+   deploy-host-independent fact the rules grade. On POSIX lint hosts the
+   output is byte-identical to the previous `normpath(join(...))` behavior
+   (verified: zero findings changed over the 5,417-file corpus).
+2. **Lint-host context may serve only as a *declared proxy*, never as an
+   undeclared input.** Two proxies exist and are documented at their sites:
+   the compose file's position on the linting machine stands in for its
+   deploy position (CL-0013's `/home` membership), and on POSIX lint hosts
+   the linting user's home stands in for the deploying user's (`~`
+   expansion). Where a proxy has no sensible value — a Windows home for a
+   POSIX deploy home — nothing is claimed rather than something wrong.
+3. **Future rules inherit the test:** a rule that would read the lint
+   host's environment, check whether a bind source exists on disk, or
+   follow document references through the lint host's filesystem is
+   claiming a deploy-host fact it cannot know. Such context is admissible
+   only as a new declared proxy or an explicit opt-in flag.
+
+**Consequences:** Windows lint hosts regain the climb-to-root claims and
+produce the same `/`-rooted notation as every other platform (a visible
+output change for relative sources on Windows, shipped pre-1.0 while the
+machine-readable output contract is still open to change — ADR-015). Tilde
+sources are claimed only on POSIX lint hosts. The `/home`-membership proxy
+keeps its known imprecision (lint position ≠ deploy position) as an accepted,
+documented trade-off. Out of scope: presentation and operational host context
+(color env vars, SARIF artifact URIs, config discovery, `fix` writing files)
+— the ADR governs claims, not I/O.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -78,11 +78,13 @@ Linux is the fully gated platform: every PR runs the complete suite there
 across all supported Python versions. macOS and Windows are exercised by a
 separate smoke workflow (pytest plus the pre-commit hook, currently at one
 Python version) that runs on every merge and weekly, but does not yet gate
-merges. Known platform limitation: on Windows hosts, bind-source path
-resolution uses host path semantics, so the climb-to-root detections
-(CL-0001, CL-0025) can miss findings there — see
-[#588](https://github.com/tmatens/compose-lint/issues/588). The GitHub
-Action and the Docker image are Linux by construction and unaffected.
+merges. Bind-source resolution is deploy-host-independent
+([ADR-023](adr/023-deploy-host-independent-claims.md)): findings are facts
+about the document, not the linting machine, so the climb-to-root
+detections fire on every platform. One platform difference remains by
+design: `~` bind sources are claimed only on POSIX lint hosts, where the
+linting user's home is a sensible proxy for the deploying user's. The
+GitHub Action and the Docker image are Linux by construction.
 
 ## Python versions
 

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os.path
 import re
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Any
 
 import yaml
@@ -662,7 +662,45 @@ def _resolve_in_file_extends(data: dict[str, Any]) -> None:
         services[name] = _resolve(name, ())
 
 
-def _resolved_bind_source(source: str, base_dir: Path) -> str | None:
+# Whether this lint host can stand in for a POSIX deploy host's home
+# directory (ADR-023). Module-level so tests can exercise the non-POSIX
+# branch from any platform.
+_POSIX_LINT_HOST = os.name == "posix"
+
+
+def _lexical_join(base_dir: PurePath, source: str) -> str:
+    """Join ``source`` onto ``base_dir`` lexically, in POSIX notation.
+
+    Claims are deploy-host-independent (ADR-023), so the math is done on
+    path *segments*, never through the lint host's path semantics. On a
+    POSIX lint host the result is byte-identical to
+    ``os.path.normpath(os.path.join(base_dir, source))`` — the behavior
+    verified against Docker Compose 29.4.3. On Windows the drive or UNC
+    anchor is dropped and the result is still ``/``-rooted: a climb that
+    saturates the anchor names ``/`` — the root of whatever filesystem
+    contains the compose file at deploy time, which is the fact the rules
+    grade (the deploy host may be the Windows machine itself, where that
+    root is the containing drive or share, or a Linux host the file is
+    headed for, where it is ``/``).
+
+    Compose sources use ``/`` separators on every platform, so tokens are
+    split on ``/`` only; ``..`` saturates at the root, as ``normpath``
+    does.
+    """
+    segments: list[str] = []
+    base_tokens = base_dir.parts[1:] if base_dir.is_absolute() else base_dir.parts
+    for token in (*base_tokens, *source.split("/")):
+        if token in ("", "."):
+            continue
+        if token == "..":
+            if segments:
+                segments.pop()
+            continue
+        segments.append(token)
+    return "/" + "/".join(segments)
+
+
+def _resolved_bind_source(source: str, base_dir: PurePath) -> str | None:
     """The host path a relative or ``~`` bind source names, else ``None``.
 
     Compose resolves a relative source (``./x``, ``../x``, ``.``, ``..``)
@@ -670,6 +708,15 @@ def _resolved_bind_source(source: str, base_dir: Path) -> str | None:
     ``~`` to the invoking user's home. Both verified against Docker Compose
     (29.4.3): a long-syntax bind with twelve ``..`` segments mounted the host
     root filesystem, and ``~:/probe`` mounted the home directory.
+
+    Resolution is lexical segment math in POSIX notation on every platform
+    (ADR-023): what a source names is a fact about the *document*, not about
+    the machine that happens to be linting it — the same file is routinely
+    linted on a laptop and deployed on a server. Only the ``~`` expansion
+    consults the lint host, as a declared proxy (the linting user's home
+    stands in for the deploying user's), and only on a POSIX lint host —
+    a Windows home is no proxy for a POSIX deploy home, so there the
+    source is left as written and nothing is claimed.
 
     ``~user`` is deliberately left as written, but *not* because Compose
     ignores it. Measured against Docker Compose 29.4.3: Compose strips the
@@ -682,7 +729,8 @@ def _resolved_bind_source(source: str, base_dir: Path) -> str | None:
     claimed for it.
 
     Anything else — an absolute path, a named volume, an unresolved
-    ``${VAR}`` — is returned as ``None`` and left exactly as written.
+    ``${VAR}``, a relative source with no absolute ``base_dir`` to resolve
+    against — is returned as ``None`` and left exactly as written.
     """
     # Resolve "${VAR:-default}" first, so the shapes below see the path the
     # file actually ships. The two compose: "${DATA:-./data}" is a relative
@@ -696,11 +744,13 @@ def _resolved_bind_source(source: str, base_dir: Path) -> str | None:
         # None (nothing to rewrite); the substitution still has to be applied.
         return resolved if resolved is not None else substituted
     if source.startswith("~"):
-        if source == "~" or source.startswith("~/"):
+        if (source == "~" or source.startswith("~/")) and _POSIX_LINT_HOST:
             return os.path.normpath(os.path.expanduser(source))
         return None
     if source in {".", ".."} or source.startswith(("./", "../")):
-        return os.path.normpath(os.path.join(base_dir, source))
+        if not base_dir.is_absolute():
+            return None
+        return _lexical_join(base_dir, source)
     return None
 
 

--- a/tests/test_bind_source_resolution.py
+++ b/tests/test_bind_source_resolution.py
@@ -12,8 +12,8 @@ bind spelled that way produced a clean pass.
 from __future__ import annotations
 
 import os
+import re
 import shutil
-import sys
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -23,15 +23,10 @@ import pytest
 from compose_lint.engine import run_rules
 from compose_lint.parser import load_compose, loads
 
-# Bind-source resolution does its lexical math with the host's path
-# semantics, which is wrong on Windows: climb-to-root claims (CL-0001,
-# CL-0025) are silently missed and `${VAR:?err}`-shaped sources raise
-# WinError 123. Tracked in #588 — removing this skip is that issue's
-# acceptance criterion.
-pytestmark = pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="bind-source resolution assumes POSIX path semantics (#588)",
-)
+# Resolution is lexical segment math in POSIX notation on every platform
+# (ADR-023), so this module runs on every OS. Only the ``~`` expansion is
+# lint-host-dependent — a declared POSIX-only proxy — so only the tilde
+# cases carry a platform gate.
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -68,6 +63,13 @@ def base_dir(request: pytest.FixtureRequest, tmp_path: Path) -> Iterator[Path]:
         yield root
     finally:
         shutil.rmtree(root, ignore_errors=True)
+
+
+def _fixture_dir_name(source: str) -> str:
+    # Windows forbids ':' and '?' in filenames; the WinError 123 the
+    # unsanitized names raised was mistaken for a product bug when this
+    # module first ran there (#588).
+    return re.sub(r"[^A-Za-z0-9._-]", "_", source)
 
 
 def _write(base_dir: Path, body: str) -> Path:
@@ -121,6 +123,7 @@ def test_a_benign_relative_source_is_not_flagged(base_dir: Path) -> None:
     assert _mount_findings(path) == {}
 
 
+@pytest.mark.skipif(os.name != "posix", reason="tilde proxy is POSIX-only (ADR-023)")
 def test_tilde_expands_to_the_home_directory(base_dir: Path) -> None:
     # Verified: Compose mounts $HOME for a "~" source. Under /home, that is
     # CL-0013's.
@@ -189,6 +192,7 @@ def test_a_project_data_dir_under_home_is_not_user_data(base_dir: Path) -> None:
         assert _mount_findings(path) == {}, source
 
 
+@pytest.mark.skipif(os.name != "posix", reason="tilde proxy is POSIX-only (ADR-023)")
 def test_a_tilde_credential_dir_is_still_claimed(base_dir: Path) -> None:
     # Narrowing /home must not lose the real disclosures. "~/.ssh" expands to
     # $HOME/.ssh, which is a credential directory whatever sits below it.
@@ -215,7 +219,8 @@ def test_a_symlinked_directory_resolves_lexically(tmp_path: Path) -> None:
 
     data, _ = load_compose(link / "docker-compose.yml")
     # Lexical: parent of the *link* path, not of its target.
-    assert data["services"]["svc"]["volumes"] == [f"{tmp_path}/marker:/m"]
+    expected = "/" + "/".join(tmp_path.parts[1:]) + "/marker:/m"
+    assert data["services"]["svc"]["volumes"] == [expected]
 
 
 def test_loads_without_a_base_dir_leaves_sources_as_written() -> None:
@@ -236,7 +241,7 @@ def test_an_interpolated_default_resolves_to_its_default(base_dir: Path) -> None
         "${DOCKER_SOCKET_PATH-/var/run/docker.sock}",
     ):
         path = _write(
-            base_dir / source.replace("$", "").replace("{", "").replace("}", "")[:20],
+            base_dir / _fixture_dir_name(source),
             f'services:\n  svc:\n    image: nginx\n    volumes: ["{source}:/s"]\n',
         )
         assert _mount_findings(path).get("svc") == {"CL-0001"}, source
@@ -264,7 +269,7 @@ def test_a_reference_without_a_default_is_still_left_alone(base_dir: Path) -> No
     # file, and guessing one would invent a finding.
     for source in ("${UNSET}", "${REQUIRED:?boom}", "$BARE"):
         path = _write(
-            base_dir / source.replace("$", "").replace("{", "").replace("}", "")[:16],
+            base_dir / _fixture_dir_name(source),
             f'services:\n  svc:\n    image: nginx\n    volumes: ["{source}:/s"]\n',
         )
         data, _ = load_compose(path)
@@ -295,3 +300,67 @@ def test_an_escaped_dollar_is_not_a_substitution(base_dir: Path) -> None:
     )
     data, _ = load_compose(path)
     assert data["services"]["svc"]["volumes"] == ["pa$$w0rd_vol:/d"]
+
+
+# --- ADR-023: resolution must not depend on the lint host -----------------
+
+
+@pytest.mark.skipif(os.name != "posix", reason="normpath is the POSIX oracle")
+def test_lexical_join_matches_normpath_on_posix() -> None:
+    # The segment math must be byte-identical to the os.path behavior the
+    # Compose 29.4.3 observations were made against.
+    from compose_lint.parser import _lexical_join
+
+    cases = [
+        ("/a/b", "./data"),
+        ("/a/b", "../.."),
+        ("/a/b", CLIMB),
+        ("/a/b", f"{CLIMB}/etc"),
+        ("/a/b", "."),
+        ("/a", ".."),
+        ("/a/b/../c", "./x"),  # an unnormalized base collapses too
+        ("/a/b", "..//x/./y"),
+        ("/", "./x"),
+    ]
+    for base, source in cases:
+        expected = os.path.normpath(os.path.join(base, source))
+        assert _lexical_join(Path(base), source) == expected, (base, source)
+
+
+def test_lexical_join_is_anchor_relative_for_windows_bases() -> None:
+    # A climb saturates at the anchor of whatever filesystem holds the
+    # compose file — drive or UNC share — and is spelled "/", the
+    # deploy-generic root the rules grade. Runs on every platform via
+    # PureWindowsPath.
+    from pathlib import PureWindowsPath
+
+    from compose_lint.parser import _lexical_join
+
+    base = PureWindowsPath("D:/proj/stack")
+    assert _lexical_join(base, CLIMB) == "/"
+    assert _lexical_join(base, f"{CLIMB}/etc") == "/etc"
+    assert _lexical_join(base, "./data") == "/proj/stack/data"
+    unc = PureWindowsPath("//server/share/proj")
+    assert _lexical_join(unc, CLIMB) == "/"
+
+
+def test_a_relative_base_dir_claims_nothing() -> None:
+    # Without an absolute base there is no fact to claim; leaving the
+    # source as written beats inventing a rooted path.
+    from compose_lint.parser import _resolved_bind_source
+
+    assert _resolved_bind_source("./x", Path("rel/dir")) is None
+
+
+def test_tilde_is_left_alone_off_posix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The home proxy is declared POSIX-only (ADR-023): a Windows home is no
+    # stand-in for a POSIX deploy home, so nothing is claimed there.
+    monkeypatch.setattr("compose_lint.parser._POSIX_LINT_HOST", False)
+    path = _write(
+        tmp_path,
+        'services:\n  svc:\n    image: nginx\n    volumes: ["~/.ssh:/keys"]\n',
+    )
+    data, _ = load_compose(path)
+    assert data["services"]["svc"]["volumes"] == ["~/.ssh:/keys"]


### PR DESCRIPTION
Closes #588 — via the decision walked through with the maintainer: claims must be true of the *document* on any plausible deploy host, since lint host ≠ deploy host in both directions (Windows laptop → Linux server, and local Docker Desktop).

**What changed:**
- `_lexical_join`: segment math in POSIX notation on every platform. `..` saturates at the anchor of the containing filesystem (`/`, drive, or UNC share) and emits `/`-rooted output either way — so the climb-to-root claims (CL-0001/CL-0025) fire on every platform, and rule matching needed zero changes.
- `~` expansion stays as a **declared proxy, POSIX lint hosts only**; on Windows nothing is claimed rather than something wrong. A relative `base_dir` (unreachable from the CLI) now claims nothing instead of writing an unrooted path.
- **ADR-023** records the principle, its four existing precedents in this codebase, the two declared proxies, and the test future rules inherit (no lint-host env reads, no source-exists checks, no reference-following as claims).
- CHANGELOG (Changed + Fixed — 0.19.0's known limitation is resolved) and `docs/compatibility.md` updated; the bind-source test module's win32 skip is **removed** (that was #588's stated acceptance criterion).

**Verification:**
- **Corpus diff: 0 of 5,417 files changed findings** (base=main vs branch, in-process, (rule, severity, service) tuples) — POSIX behavior is byte-identical.
- Property test pins `_lexical_join` against the `normpath` oracle on POSIX, including unnormalized bases; Windows anchor behavior (drive + UNC) is unit-tested from any platform via `PureWindowsPath`.
- Full suite 1804 passed; ruff/mypy/format clean; the new changelog shape gate passes on its own entry.
- Merging touches `src/`+`tests/`, so the OS smoke auto-runs on main — its Windows leg executes this module un-skipped for the first time, which is the live platform validation.

**Issue-record correction:** #588's `WinError 123` claim was a mis-RCA — the error came from *test fixture directory names* carrying `:` (from `${VAR:-...}` spellings), not from the product; resolution is purely lexical and touches no filesystem. Fixture names are sanitized here, and no speculative product crash-guard was added.