### PR TITLE
Respect a CRLF file's line endings in fix diffs and applies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`fix` now respects a CRLF file's line endings end to end.** The
+  line-inserting fixers spliced bare-LF lines into CRLF files, shipping a
+  mixed-endings result that editors and VCS `autocrlf` flag on every line;
+  inserted text now adopts the file's dominant ending. And the dry-run diff
+  no longer renders every line of a CRLF file with a trailing `\u000d`
+  escape — a CR that is part of the line-ending convention is not content,
+  while a *lone* CR (the smuggling shape the output sanitizer exists for)
+  still surfaces escaped.
 - **Windows lint hosts no longer miss climb-to-root bind mounts.** A
   `..`-climb source resolved with Windows path semantics never matched the
   whole-root (CL-0001) and root-equivalent (CL-0025) claims — the known

--- a/src/compose_lint/fix.py
+++ b/src/compose_lint/fix.py
@@ -14,7 +14,8 @@ and :func:`render_file_diff` turns the result into the dry-run unified diff.
 from __future__ import annotations
 
 import difflib
-from dataclasses import dataclass, field
+import re
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any
 
 from compose_lint._lines import line_starts, split_lines
@@ -310,6 +311,27 @@ def _coordinate_security_opt(
     return _FixUnit([*cl0003, *cl0009], [edit], caveat_rule_id="CL-0009")
 
 
+def _dominant_newline(text: str) -> str:
+    """The line ending spliced-in fix text should use: the file's dominant one.
+
+    Fixers build replacements with bare ``\n``. Splicing that into a CRLF
+    file shipped a mixed-endings result — original lines ``\r\n``, inserted
+    lines ``\n`` — which editors and VCS autocrlf setups flag on every line
+    (#601).
+    """
+    crlf = text.count("\r\n")
+    return "\r\n" if crlf > text.count("\n") - crlf else "\n"
+
+
+def _adapted_to_newline(edit: TextEdit, newline: str) -> TextEdit:
+    if newline == "\n" or "\n" not in edit.replacement:
+        return edit
+    # Only bare LFs adapt: a replacement can embed kept original content that
+    # already carries the file's endings, and doubling those CRs would corrupt
+    # the very lines the fix promised not to touch.
+    return replace(edit, replacement=re.sub("(?<!\r)\n", newline, edit.replacement))
+
+
 def collect_edits(
     findings: Iterable[Finding],
     data: dict[str, Any],
@@ -415,16 +437,18 @@ def collect_edits(
                 refused.add(b_unit)
 
     result = FixResult()
+    newline = _dominant_newline(text)
     seen_caveats: set[tuple[str, str]] = set()
     for index, (unit, _spans) in enumerate(spanned):
         if index in refused:
             result.manual.extend(unit.findings)
             continue
+        edits = [_adapted_to_newline(edit, newline) for edit in unit.edits]
         result.fixed.extend(unit.findings)
-        result.edits.extend(unit.edits)
+        result.edits.extend(edits)
         for finding in unit.findings:
-            result.fixed_edits.append((finding, unit.edits))
-        for edit in unit.edits:
+            result.fixed_edits.append((finding, edits))
+        for edit in edits:
             if not edit.caveat:
                 continue
             key = (unit.caveat_rule_id, edit.caveat)
@@ -468,6 +492,12 @@ def render_file_diff(
         fromfile=sanitize_line(path),
         tofile=sanitize_line(path),
     ):
+        if raw_line.endswith("\r\n"):
+            # A trailing CR is the file's line-ending convention, not content;
+            # sanitizing it rendered every line of a CRLF file's diff with a
+            # \u000d escape (#601). A CR anywhere *else* is still escaped
+            # below — that embedded shape is what sanitize guards against.
+            raw_line = raw_line[:-2] + "\n"
         line = sanitize(raw_line)
         # Header lines (`---`/`+++`/`@@`) always end in a newline; only a final
         # content line can lack one. Re-terminate it and add the git sentinel.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -529,6 +529,33 @@ _BARE_SERVICE = "services:\n  web:\n    image: nginx:1.27\n"
 class TestFixSubcommand:
     """Tests for the `fix` subcommand (ADR-014, promoted in 0.11.0)."""
 
+    def test_apply_inserts_new_lines_with_the_files_crlf_endings(
+        self, tmp_path: Path
+    ) -> None:
+        # The #515 regression test below covers in-line edits; this covers
+        # the line-*inserting* fixers, which spliced bare-LF lines into a
+        # CRLF file and shipped a mixed-endings result that editors and
+        # autocrlf flag on every line (#601).
+        target = tmp_path / "docker-compose.yml"
+        with open(target, "w", newline="\r\n", encoding="utf-8") as fh:
+            fh.write("services:\n  web:\n    image: nginx:1.27\n")
+        result = run_cli("fix", "--apply", str(target))
+        assert result.returncode == 0, result.stderr
+        raw = target.read_bytes()
+        crlf = raw.count(b"\r\n")
+        assert crlf > 3, raw  # fixes were inserted, as CRLF
+        assert raw.count(b"\n") == crlf, raw  # and not one lone LF remains
+
+    def test_dry_run_diff_of_a_crlf_file_carries_no_cr_escapes(
+        self, tmp_path: Path
+    ) -> None:
+        target = tmp_path / "docker-compose.yml"
+        with open(target, "w", newline="\r\n", encoding="utf-8") as fh:
+            fh.write("services:\n  web:\n    image: nginx:1.27\n")
+        result = run_cli("fix", str(target))
+        assert "+    read_only: true" in result.stdout
+        assert "\\u000d" not in result.stdout, result.stdout
+
     def test_dry_run_prints_diff_to_stdout(self, tmp_path: Path) -> None:
         f = tmp_path / "docker-compose.yml"
         f.write_text(_BARE_SERVICE)

--- a/tests/test_fix.py
+++ b/tests/test_fix.py
@@ -878,3 +878,30 @@ def test_verify_apply_flags_new_finding(tmp_path: Path) -> None:
     assert msg is not None
     assert "introduces a new finding" in msg
     assert "CL-0002" in msg
+
+
+# --- #601: line endings are content the fix must respect ------------------
+
+
+def test_dominant_newline_prefers_the_majority() -> None:
+    from compose_lint.fix import _dominant_newline
+
+    assert _dominant_newline("a\nb\n") == "\n"
+    assert _dominant_newline("a\r\nb\r\n") == "\r\n"
+    assert _dominant_newline("a\r\nb\r\nc\n") == "\r\n"
+    assert _dominant_newline("a\r\nb\nc\n") == "\n"
+    assert _dominant_newline("") == "\n"
+
+
+def test_render_diff_escapes_a_lone_cr_but_not_crlf_endings() -> None:
+    # A trailing CR that is part of a CRLF ending is the file's line-ending
+    # convention, not content — it no longer renders as an escape. A *lone*
+    # CR (splitlines treats it as its own terminator) is the smuggling shape
+    # the sanitizer exists for and still surfaces as \\u000d.
+    from compose_lint.fix import render_file_diff
+
+    original = 'a: 1\r\nb: "x\rY"\r\n'
+    patched = 'a: 2\r\nb: "x\rY"\r\n'
+    out = render_file_diff("f.yml", original, patched, [])
+    assert 'b: "x\\u000d' in out, out  # the lone CR stays visible
+    assert "1\\u000d" not in out and "2\\u000d" not in out, out


### PR DESCRIPTION
Closes #601. Investigation-first, as the issue asked — and the empirical pass sharpened both halves:

- **`--apply` was worse than "unverified": it produced *mixed* endings.** The read/write layers already preserve original bytes (#515's regression test covers in-line edits like the ports fixer), but line-*inserting* fixers splice bare-LF replacements — one apply on a CRLF file yielded 3 CRLF + 3 lone-LF lines. `collect_edits` now adapts replacements to the file's dominant ending (majority rule on mixed files), with a `(?<!\r)` lookbehind so kept original content embedded in a replacement is never double-CR'd. Adapting at collection time keeps apply, the diff, and SARIF `artifactChanges` describing identical bytes.
- **Diff rendering**: a CR that's part of a CRLF terminator is line-ending convention, not content — `render_file_diff` strips it before sanitizing, so CRLF files' diffs are escape-free. A *lone* CR (which `splitlines` treats as its own terminator — the actual smuggling shape) still surfaces as `\u000d`, pinned by test.

Verified live: the exact reproduction from the Windows triage now shows `u000d count: 0` in dry-run and `CRLF=6, loneLF=0` after apply. Full suite 1808 passed; ruff/mypy/format clean; changelog shape gate passes. The OS smoke's Windows leg re-validates on merge.