### PR TITLE
Claim tilde bind sources by spelling on every platform

### DIFF
--- a/docs/adr/023-deploy-host-independent-claims.md
+++ b/docs/adr/023-deploy-host-independent-claims.md
@@ -39,12 +39,18 @@ deploy host. Concretely:
    output is byte-identical to the previous `normpath(join(...))` behavior
    (verified: zero findings changed over the 5,417-file corpus).
 2. **Lint-host context may serve only as a *declared proxy*, never as an
-   undeclared input.** Two proxies exist and are documented at their sites:
-   the compose file's position on the linting machine stands in for its
-   deploy position (CL-0013's `/home` membership), and on POSIX lint hosts
-   the linting user's home stands in for the deploying user's (`~`
-   expansion). Where a proxy has no sensible value — a Windows home for a
-   POSIX deploy home — nothing is claimed rather than something wrong.
+   undeclared input.** One proxy remains, documented at its site: the
+   compose file's position on the linting machine stands in for its deploy
+   position (CL-0013's `/home` membership). Where a proxy has no sensible
+   value, nothing is claimed rather than something wrong.
+
+   *Amended (#602):* the second original proxy — expanding `~` against the
+   linting user's home, POSIX lint hosts only — is retired. `~` sources are
+   left as written on every platform and CL-0013 claims the *spelling*
+   (`~/.ssh` is the deploying user's credential directory, whoever that
+   is), which is strictly stronger: reports stop asserting a lint-host
+   username, and the claims fire identically on every lint platform.
+   Verified: zero findings changed across the 5,417-file corpus.
 3. **Future rules inherit the test:** a rule that would read the lint
    host's environment, check whether a bind source exists on disk, or
    follow document references through the lint host's filesystem is

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -81,10 +81,10 @@ Python version) that runs on every merge and weekly, but does not yet gate
 merges. Bind-source resolution is deploy-host-independent
 ([ADR-023](adr/023-deploy-host-independent-claims.md)): findings are facts
 about the document, not the linting machine, so the climb-to-root
-detections fire on every platform. One platform difference remains by
-design: `~` bind sources are claimed only on POSIX lint hosts, where the
-linting user's home is a sensible proxy for the deploying user's. The
-GitHub Action and the Docker image are Linux by construction.
+detections fire on every platform, and `~` bind sources are claimed by
+their spelling — the deploying user's home, whoever that is — identically
+everywhere. The GitHub Action and the Docker image are Linux by
+construction.
 
 ## Python versions
 

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os.path
 import re
 from pathlib import Path, PurePath
 from typing import Any
@@ -662,12 +661,6 @@ def _resolve_in_file_extends(data: dict[str, Any]) -> None:
         services[name] = _resolve(name, ())
 
 
-# Whether this lint host can stand in for a POSIX deploy host's home
-# directory (ADR-023). Module-level so tests can exercise the non-POSIX
-# branch from any platform.
-_POSIX_LINT_HOST = os.name == "posix"
-
-
 def _lexical_join(base_dir: PurePath, source: str) -> str:
     """Join ``source`` onto ``base_dir`` lexically, in POSIX notation.
 
@@ -712,11 +705,11 @@ def _resolved_bind_source(source: str, base_dir: PurePath) -> str | None:
     Resolution is lexical segment math in POSIX notation on every platform
     (ADR-023): what a source names is a fact about the *document*, not about
     the machine that happens to be linting it — the same file is routinely
-    linted on a laptop and deployed on a server. Only the ``~`` expansion
-    consults the lint host, as a declared proxy (the linting user's home
-    stands in for the deploying user's), and only on a POSIX lint host —
-    a Windows home is no proxy for a POSIX deploy home, so there the
-    source is left as written and nothing is claimed.
+    linted on a laptop and deployed on a server. ``~`` sources are left as
+    written on every platform: whose home ``~`` names is a deploy-host fact,
+    and the rules claim the *spelling* instead (``~/.ssh`` is the deploying
+    user's credential directory, whoever that is — see CL-0013), which made
+    the old expand-against-the-linting-user proxy unnecessary (#602).
 
     ``~user`` is deliberately left as written, but *not* because Compose
     ignores it. Measured against Docker Compose 29.4.3: Compose strips the
@@ -744,9 +737,7 @@ def _resolved_bind_source(source: str, base_dir: PurePath) -> str | None:
         # None (nothing to rewrite); the substitution still has to be applied.
         return resolved if resolved is not None else substituted
     if source.startswith("~"):
-        if (source == "~" or source.startswith("~/")) and _POSIX_LINT_HOST:
-            return os.path.normpath(os.path.expanduser(source))
-        return None
+        return None  # claimed by spelling in the rules, never expanded (#602)
     if source in {".", ".."} or source.startswith(("./", "../")):
         if not base_dir.is_absolute():
             return None

--- a/src/compose_lint/rules/CL0013_sensitive_mount.py
+++ b/src/compose_lint/rules/CL0013_sensitive_mount.py
@@ -125,6 +125,28 @@ _HOME_CREDENTIAL_DIRS: frozenset[str] = frozenset(
 )
 
 
+def _match_tilde_home(normalized: str) -> str | None:
+    """The deploy-user home path a ``~`` source exposes, or ``None``.
+
+    ``~`` names the *deploying* user's home, whoever that turns out to be, so
+    the claim is made on the spelling itself (ADR-023, #602) instead of the
+    old expansion against the linting user — which asserted a lint-host
+    username in reports and existed only on POSIX lint hosts. The same depth
+    rule as :func:`_match_home_tree` applies: the whole home or a known
+    credential directory is a disclosure; ``~/data`` is the project idiom and
+    is not. ``~user`` spellings are never claimed (see the parser's note on
+    what Compose actually does with them).
+    """
+    if normalized == "~":
+        return "~"
+    if not normalized.startswith("~/"):
+        return None
+    first = normalized[2:].split("/", 1)[0]
+    if first in _HOME_CREDENTIAL_DIRS:
+        return "~/" + first
+    return None
+
+
 def _match_home_tree(normalized: str) -> str | None:
     """The home path this mount exposes, or ``None``.
 
@@ -187,8 +209,10 @@ class SensitiveMountRule(BaseRule):
             if normalized in _INERT_DEVICES:
                 continue  # a bit bucket discloses nothing
 
-            matched = match_prefix(mount.host_path, _EXPOSED_PATHS) or _match_home_tree(
-                normalized
+            matched = (
+                match_prefix(mount.host_path, _EXPOSED_PATHS)
+                or _match_home_tree(normalized)
+                or _match_tilde_home(normalized)
             )
             reason = "exposes host kernel interfaces, devices or user data"
             if matched is None and not claims_host_path(mount.host_path):

--- a/src/compose_lint/rules/_mounts.py
+++ b/src/compose_lint/rules/_mounts.py
@@ -21,9 +21,12 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
 # Matches host:container or host:container:mode in short syntax. The host group
-# allows a bare "/" (root mount) by using `*` instead of `+`.
+# allows a bare "/" (root mount) by using `*` instead of `+`. A leading ``~``
+# is a host path too — Compose expands it at deploy time — and became visible
+# here when the parser stopped expanding it against the linting user (#602);
+# a named volume cannot begin with ``~``, so the shapes stay disjoint.
 _SHORT_VOLUME_RE = re.compile(
-    r"^(?P<host>/[^:]*):(?P<container>[^:]+)(?::(?P<mode>[^:]+))?"
+    r"^(?P<host>(?:/|~)[^:]*):(?P<container>[^:]+)(?::(?P<mode>[^:]+))?"
 )
 
 
@@ -169,7 +172,7 @@ def iter_bind_mounts(
             vtype = volume.get("type")
             if not isinstance(source, str):
                 continue
-            if vtype == "bind" or source.startswith("/"):
+            if vtype == "bind" or source.startswith(("/", "~")):
                 host_path = source
                 read_only = as_bool(volume.get("read_only")) is True
             elif source in named_binds:

--- a/tests/test_CL0013.py
+++ b/tests/test_CL0013.py
@@ -295,3 +295,42 @@ class TestScopedAlternatives:
             assert self._check(path)[0].fix.endswith(
                 "Full guide: compose-lint --explain CL-0013"
             ), path
+
+
+class TestTildeShapeClaims:
+    """``~`` sources are claimed by spelling, on every platform (#602).
+
+    Whose home ``~`` names is a deploy-host fact, so the parser leaves the
+    source as written and this rule matches the shape itself — the same depth
+    rule as the ``/home`` tree: the whole home or a known credential directory
+    is a disclosure, a project directory under it is not.
+    """
+
+    def _check(self, volume: str) -> list:
+        from compose_lint.rules.CL0013_sensitive_mount import SensitiveMountRule
+
+        data, lines = loads(
+            f'services:\n  a:\n    image: x\n    volumes:\n      - "{volume}"\n'
+        )
+        return list(SensitiveMountRule().check("a", data["services"]["a"], data, lines))
+
+    def test_whole_home_is_claimed(self) -> None:
+        findings = self._check("~:/probe")
+        assert len(findings) == 1
+        assert "'~'" in findings[0].message
+
+    def test_credential_dir_is_claimed_with_descent(self) -> None:
+        for volume in ("~/.ssh:/keys", "~/.aws/config:/cfg", "~/.ssh/:/keys"):
+            findings = self._check(volume)
+            assert len(findings) == 1, volume
+            assert findings[0].severity == Severity.HIGH
+
+    def test_a_project_dir_under_home_is_not_claimed(self) -> None:
+        # The commonest benign idiom must stay clean, exactly as it does for
+        # a resolved /home/<user>/project path.
+        assert self._check("~/data:/data") == []
+
+    def test_tilde_user_is_never_claimed(self) -> None:
+        # See the parser's ~user note: Compose never resolves another
+        # account's home, so no claim can be honest.
+        assert self._check("~someone/.ssh:/keys") == []

--- a/tests/test_bind_source_resolution.py
+++ b/tests/test_bind_source_resolution.py
@@ -123,17 +123,17 @@ def test_a_benign_relative_source_is_not_flagged(base_dir: Path) -> None:
     assert _mount_findings(path) == {}
 
 
-@pytest.mark.skipif(os.name != "posix", reason="tilde proxy is POSIX-only (ADR-023)")
-def test_tilde_expands_to_the_home_directory(base_dir: Path) -> None:
-    # Verified: Compose mounts $HOME for a "~" source. Under /home, that is
-    # CL-0013's.
-    home = os.path.expanduser("~")
+def test_tilde_is_left_as_written(base_dir: Path) -> None:
+    # Whose home "~" names is a deploy-host fact; the spelling is claimed by
+    # the rules instead of being expanded against the linting user (#602),
+    # so reports no longer assert a lint-host username and behave the same
+    # on every platform.
     path = _write(
         base_dir,
         'services:\n  svc:\n    image: nginx\n    volumes: ["~/.ssh:/keys"]\n',
     )
     data, _ = load_compose(path)
-    assert data["services"]["svc"]["volumes"] == [f"{home}/.ssh:/keys"]
+    assert data["services"]["svc"]["volumes"] == ["~/.ssh:/keys"]
 
 
 def test_tilde_user_is_left_alone(base_dir: Path) -> None:
@@ -192,16 +192,15 @@ def test_a_project_data_dir_under_home_is_not_user_data(base_dir: Path) -> None:
         assert _mount_findings(path) == {}, source
 
 
-@pytest.mark.skipif(os.name != "posix", reason="tilde proxy is POSIX-only (ADR-023)")
 def test_a_tilde_credential_dir_is_still_claimed(base_dir: Path) -> None:
-    # Narrowing /home must not lose the real disclosures. "~/.ssh" expands to
-    # $HOME/.ssh, which is a credential directory whatever sits below it.
+    # Narrowing /home must not lose the real disclosures: "~/.ssh" is the
+    # deploying user's credential directory whoever that is, claimed by
+    # spelling on every platform (#602).
     path = _write(
         base_dir,
         'services:\n  svc:\n    image: nginx\n    volumes: ["~/.ssh:/keys"]\n',
     )
-    if _HOME_IS_UNDER_HOME:
-        assert _mount_findings(path).get("svc") == {"CL-0013"}
+    assert _mount_findings(path).get("svc") == {"CL-0013"}
 
 
 def test_a_symlinked_directory_resolves_lexically(tmp_path: Path) -> None:
@@ -352,15 +351,11 @@ def test_a_relative_base_dir_claims_nothing() -> None:
     assert _resolved_bind_source("./x", Path("rel/dir")) is None
 
 
-def test_tilde_is_left_alone_off_posix(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    # The home proxy is declared POSIX-only (ADR-023): a Windows home is no
-    # stand-in for a POSIX deploy home, so nothing is claimed there.
-    monkeypatch.setattr("compose_lint.parser._POSIX_LINT_HOST", False)
+def test_a_whole_home_mount_is_claimed(tmp_path: Path) -> None:
+    # "~:/probe" mounts the deploying user's entire home (verified against
+    # Compose 29.4.3, which mounts $HOME for it).
     path = _write(
         tmp_path,
-        'services:\n  svc:\n    image: nginx\n    volumes: ["~/.ssh:/keys"]\n',
+        'services:\n  svc:\n    image: nginx\n    volumes: ["~:/probe"]\n',
     )
-    data, _ = load_compose(path)
-    assert data["services"]["svc"]["volumes"] == ["~/.ssh:/keys"]
+    assert _mount_findings(path).get("svc") == {"CL-0013"}


### PR DESCRIPTION
Closes #602 — the ADR-023 follow-up, resolving its three design questions:

1. **The expansion rewrite retires entirely** (Q1: yes). The parser leaves `~` sources as written on every platform; parsed output is now platform-identical and reports stop asserting a lint-host username. The pre-1.0 output-change window applies (ADR-015), and the **corpus diff is zero across all 5,417 files** — shape claims reproduce the proxy's (rule, severity, service) coverage exactly; only finding message text changes for tilde sources (`'~/.ssh' (under ~/.ssh)` instead of a materialized `/home/<user>/...`).
2. **Whole-home and generic claims are preserved** (Q2): `~:/probe` claims the deploying user's entire home; `~/data` stays clean under the same depth exemption as `/home/<user>/project`; the credential table (`.ssh`, `.docker`, `.aws`, `.kube`, `.gnupg`) matches by first segment with descent.
3. **`~user` stays unclaimed** (Q3), per the parser's observed-Compose note.

Mechanically: the short-syntax regex and long-syntax inference now recognise a leading `~` as a host path (Compose treats it as one; named volumes can't begin with `~`, so the shapes stay disjoint), and CL-0013 gains `_match_tilde_home` mirroring `_match_home_tree`'s depth rule. ADR-023 is amended in place: the home proxy is retired, the `/home`-position proxy remains the one declared proxy; `docs/compatibility.md`'s platform note is updated accordingly.

Tests: the bind-source tilde tests lose their POSIX gates (they now assert identical behavior everywhere), and CL-0013 gains a shape-claim class covering all four acceptance shapes. Full suite 1808 passed; gates clean. The OS smoke's Windows leg validates the every-platform acceptance on merge.