### PR TITLE
Gate PRs on the macOS and Windows smoke legs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1089,6 +1089,24 @@ jobs:
       - name: Validate each runtime rule's premise against a live container
         run: python scripts/validate_rule_premises.py
 
+  # Developer-machine legs (macOS/Windows) for the two modes that run off
+  # this repo's CI platform: the CLI and the pre-commit hook. Defined in
+  # os-smoke.yml so the weekly scheduled run and this PR gate share one
+  # definition. `workflows` is in the condition alongside `code` because a
+  # PR editing os-smoke.yml should exercise the workflow it edits.
+  #
+  # The `permissions` block below is not decoration: a called workflow's
+  # jobs cannot hold more than the calling job was granted, and both jobs
+  # in os-smoke.yml request `contents: read` to check out. Dropping this
+  # makes the whole run fail as `startup_failure` before any job starts
+  # (the 0.18.0 release blocker); tests/test_release_layer.py guards it.
+  os-smoke:
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.workflows == 'true'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/os-smoke.yml
+
   # Single rollup job for branch protection. Required-status-checks should
   # point at this job name instead of the individual ci.yml job names, so
   # adding/renaming/removing jobs doesn't require a protection-rule edit.
@@ -1120,6 +1138,7 @@ jobs:
       - action-smoke
       - precommit-smoke
       - rule-premises
+      - os-smoke
     if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 1

--- a/.github/workflows/os-smoke.yml
+++ b/.github/workflows/os-smoke.yml
@@ -6,12 +6,20 @@ name: OS smoke (macOS/Windows)
 # path handling (backslashes, drive letters), pre-commit's hook-environment
 # build, and Windows console encodings.
 #
-# Deliberately NOT part of ci.yml / the `ci-ok` merge gate — this is the
-# staged rollout: run on every merge to code paths plus weekly, absorb the
-# OS-specific triage out-of-band (failures email like the other scheduled
-# workflows), and promote the legs into `ci-ok` once they have stayed
-# green long enough to trust in the merge path. Until then a red run here
-# is signal to triage, not a blocked PR.
+# Promoted into the merge gate (issue #572's third acceptance criterion):
+# `ci.yml` calls this workflow on PRs that touch code, and `ci-ok` gates on
+# the result. The `workflow_call` trigger below is that entry point. The
+# soak behind the promotion is narrow and worth stating plainly — the four
+# failures were the rollout commits themselves (#584-#587, which is what
+# the legs were for), and every run from `d757ee3` on has been green, but
+# that is 9 runs inside a single day, not weeks of history. If Windows
+# turns out to flake in the merge path, the honest fix is to quarantine
+# the flaky leg here, not to widen `ci-ok`'s pass condition.
+#
+# The other triggers stay: the weekly cron catches drift that arrives with
+# no PR at all — a yanked dependency, a resolver change, a runner-image
+# update — which a merge gate structurally cannot see, and `push: main`
+# keeps covering merges that bypassed the PR path.
 #
 # The pre-commit steps mirror ci.yml's `precommit-smoke` with one
 # portability change: throwaway repos are created with `mktemp -d` under
@@ -21,6 +29,7 @@ name: OS smoke (macOS/Windows)
 # relative path between the two — os.path.relpath cannot cross drives
 # and crashes. Keeping the throwaway on the workspace drive avoids it.
 on:
+  workflow_call:
   workflow_dispatch:
   schedule:
     - cron: "27 10 * * 1"


### PR DESCRIPTION
Closes the third acceptance criterion of #572, which I left unmet when I closed that issue: the macOS/Windows legs ran only after merge and weekly, so the platforms that produced three shipped crashes (#585, #587, #588) were gating nothing.

**What changes**

- `os-smoke.yml` gains a `workflow_call` trigger. Its `workflow_dispatch`, weekly `schedule`, and `push: main` triggers all stay — drift that arrives with no PR at all (a yanked dependency, a resolver change, a runner-image update) is invisible to a merge gate, so the cron is not redundant with it.
- `ci.yml` calls it as the `os-smoke` job when `changes.outputs.code` or `changes.outputs.workflows` is true, and `ci-ok` now needs that job. `workflows` is in the condition so a PR editing `os-smoke.yml` exercises the workflow it edits.

Branch protection points only at `ci-ok`, so no protection-rule edit is needed.

**The permissions block is load-bearing.** The calling job grants `contents: read` because a called workflow's jobs cannot hold more than the caller was given, and both jobs in `os-smoke.yml` request it to check out. Dropping it fails the entire run as `startup_failure` before any job starts — the 0.18.0 release blocker. `tests/test_release_layer.py::test_a_called_workflow_is_granted_what_its_jobs_request` walks every `uses: ./.github/workflows/` call and catches this; `actionlint` does not model permission inheritance across a workflow call, so the test is the only guard.

**Cost.** ~2 min wall-clock for all four legs, in parallel with the existing suite, and the repo is public so the runners are free. Path-gated, so docs-only PRs skip it and `ci-ok` counts `skipped` as a pass. Note that lockfile PRs do **not** skip it — `code`'s filter matches `requirements*.lock` — which is the behavior you want: the locks are compiled `--universal`, so a dependency bump is exactly the change that can break on macOS or Windows alone. It does mean Renovate PRs now wait on these legs.

**Soak, stated honestly.** `os-smoke` has 13 runs, 4 failed. All four failures are the rollout commits themselves (#584–#587) — finding those was the point. Every run from `d757ee3` onward is green, but that is 9 runs inside a single day, not weeks of history. If Windows flakes in the merge path, the fix is to quarantine the flaky leg, not to widen `ci-ok`'s pass condition; the workflow header says so.

Verified locally: `actionlint` clean, `tests/test_release_layer.py` 16 passed.