### PR TITLE
Correct the CL-0016 comment about SYSLOG coverage

### DIFF
--- a/src/compose_lint/rules/CL0016_dangerous_devices.py
+++ b/src/compose_lint/rules/CL0016_dangerous_devices.py
@@ -40,8 +40,11 @@ CIS_REF = (
 # create the container at all (and CONFIG_DEVKMEM is off on modern kernels).
 #
 # /dev/kmsg stays despite needing CAP_SYSLOG on this host: dmesg_restrict is a
-# *host* sysctl whose upstream default is 0, where the read needs no capability
-# — and no rule flags SYSLOG, so nothing else covers it.
+# *host* sysctl whose upstream default is 0, where the read needs no capability.
+# CL-0030 now flags a SYSLOG grant, but that is the capability axis and this is
+# the device axis: a file whose only mention of kernel logs is /dev/kmsg carries
+# no cap_add for CL-0030 to see, so dropping the device here would leave the
+# upstream-default case ungraded.
 _DANGEROUS_DEVICE_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"^/dev/sd[a-z]"), "/dev/sd* — SCSI/SATA block device"),
     (re.compile(r"^/dev/nvme"), "/dev/nvme* — NVMe block device"),


### PR DESCRIPTION
`CL0016_dangerous_devices.py` justified keeping `/dev/kmsg` partly with "and no rule flags SYSLOG, so nothing else covers it". CL-0030 has flagged a SYSLOG `cap_add` since 0.17.0, so as written the comment tells a future reader the device entry is now redundant.

It isn't — but the real reason is a different one, and worth writing down: CL-0030 iterates `cap_add` (`_caps.iter_cap_add`), so a compose file that mounts `/dev/kmsg` and adds no capability gives it nothing to see. The two rules sit on different axes, and the upstream-default case (`dmesg_restrict=0`, where the read needs no capability at all) is only covered by the device entry.

Comment only — no behavior change, no finding moves.