### PR TITLE
Retry PyPI installs through index propagation

### DIFF
--- a/.github/workflows/marketplace-smoke.yml
+++ b/.github/workflows/marketplace-smoke.yml
@@ -48,6 +48,13 @@ on:
 
 permissions: {}
 
+# The release both jobs consume. Hoisted to workflow scope so the PyPI
+# propagation gate and the pre-commit rev read one pin; publish.yml's
+# bump-marketplace-smoke-pin seds this literal line, which does not care
+# where in the file it lives.
+env:
+  CL_RELEASE_TAG: v0.20.0
+
 jobs:
   marketplace-smoke:
     name: Smoke test published action
@@ -59,6 +66,39 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      # This workflow's whole point is to run moments after a publish — the
+      # pin-bump merge is its trigger — and that is exactly when PyPI's
+      # /simple/ index has not caught up with the JSON API yet. The action
+      # steps below install `compose-lint==<the release>` from inside the
+      # published action, so the retry that now lives in action.yml only
+      # protects releases cut *after* this lands. Gate here as well, because
+      # the useful part is the diagnosis: without it the failure surfaces as
+      # `Process completed with exit code 1` on a workflow line, which is
+      # what made the 0.20.0 occurrence (#612) look like a real regression.
+      - name: Wait for the release to reach PyPI's /simple/ index
+        run: |
+          set -euo pipefail
+          version="${CL_RELEASE_TAG#v}"
+          # PEP 691 JSON view of the same /simple/ index pip resolves against,
+          # so a hit here means pip can see the version — unlike the JSON API
+          # (/pypi/<name>/json), which goes live seconds after publish and
+          # would report ready while pip still 404s.
+          for attempt in 1 2 3 4 5 6; do
+            if curl -fsSL \
+                 -H 'Accept: application/vnd.pypi.simple.v1+json' \
+                 https://pypi.org/simple/compose-lint/ \
+               | jq -e --arg v "${version}" 'any(.versions[]; . == $v)' >/dev/null; then
+              echo "compose-lint ${version} is visible on the /simple/ index."
+              exit 0
+            fi
+            if [ "${attempt}" = 6 ]; then
+              echo "::error::compose-lint ${version} is still absent from PyPI's /simple/ index after 6 attempts over ~100s. Either the release never published, or propagation is unusually slow — re-run this workflow before treating it as a regression."
+              exit 1
+            fi
+            echo "Attempt ${attempt}: ${version} not on the /simple/ index yet; sleeping 20s..."
+            sleep 20
+          done
 
       - name: Clean fixture should pass
         uses: tmatens/compose-lint@86aa003f03ac82a3c2544cc35eac56aff8be769e # v0.20.0
@@ -93,11 +133,6 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
-    env:
-      # The release the hook is consumed at. Bumped alongside the action
-      # SHA by publish.yml's bump-marketplace-smoke-pin job, so the job
-      # runs against each new release automatically.
-      CL_RELEASE_TAG: v0.20.0
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **GitHub Action: installing a just-released version no longer fails on
+  PyPI index lag.** PyPI's JSON API sees a release within seconds of the
+  publish, but the `/simple/` index pip resolves against can lag it by
+  minutes — so `uses: tmatens/compose-lint@<sha>` pinned to a version
+  released moments earlier could fail with "No matching distribution
+  found". The action's install now retries with backoff for ~100s, and
+  says so if it gives up instead of leaving a bare non-zero exit.
+
 ## [0.20.0] - 2026-08-18
 
 ### Upgrading from 0.19.x

--- a/action.yml
+++ b/action.yml
@@ -87,15 +87,40 @@ runs:
         # if it drifts.
         DEFAULT_VERSION="0.20.0"
         if [ -z "$CL_VERSION" ]; then
-          pip install "compose-lint==${DEFAULT_VERSION}"
+          SPEC="compose-lint==${DEFAULT_VERSION}"
         elif [ "$CL_VERSION" = "latest" ]; then
           # Opt-in to tracking PyPI. Used by this repo's own smoke jobs, which
           # exist to catch drift between the source action and the published
           # package.
-          pip install compose-lint
+          SPEC="compose-lint"
         else
-          pip install "compose-lint==${CL_VERSION}"
+          SPEC="compose-lint==${CL_VERSION}"
         fi
+
+        # PyPI's JSON API sees a release within seconds of the publish, but the
+        # /simple/ index pip resolves against can lag it by minutes. That race
+        # is not hypothetical here: it failed this repo's own marketplace-smoke
+        # minutes after the 0.20.0 publish (#612), and publish.yml's
+        # testpypi-smoke has carried the same backoff since 0.3.6 for the same
+        # reason on TestPyPI.
+        #
+        # A consumer hits it the moment they pin a just-released version — the
+        # pinned-by-default behaviour above makes that the normal case, not an
+        # edge one — so the retry belongs in the action rather than only in our
+        # workflow. The cost is that a genuinely wrong version now takes ~100s
+        # to fail instead of failing at once; the final message names both
+        # possibilities so that wait is not a mystery.
+        for attempt in 1 2 3 4 5 6; do
+          if pip install "$SPEC"; then
+            exit 0
+          fi
+          if [ "$attempt" = 6 ]; then
+            echo "::error::Could not install '${SPEC}' after 6 attempts over ~100s. Either the version does not exist, or it was released moments ago and PyPI's /simple/ index has not propagated yet."
+            exit 1
+          fi
+          echo "Attempt ${attempt} failed; sleeping 20s for PyPI /simple/ index propagation..."
+          sleep 20
+        done
 
     - name: Find Compose files
       id: find-files

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -237,6 +237,19 @@ recursion guard), so it would land with zero checks and sit blocked
 until someone closed and reopened it. Authoring it as the PAT user makes
 the required checks run automatically.
 
+Merging that PR is what triggers `marketplace-smoke.yml` — deliberately,
+so the smoke runs against the release just cut. It also means the smoke
+runs minutes after the publish, inside the window where PyPI's JSON API
+already shows the release but the `/simple/` index pip resolves against
+does not. That race failed the 0.20.0 run ([#612]), so two things now
+absorb it: `marketplace-smoke.yml` gates its action steps on the version
+being visible on `/simple/`, and `action.yml`'s install retries with
+backoff for ~100s. A propagation delay therefore costs wall-clock, not a
+red run, and if it does exhaust the retries the message says so instead
+of `Process completed with exit code 1`.
+
+[#612]: https://github.com/tmatens/compose-lint/issues/612
+
 ### Provisioning `MARKETPLACE_SMOKE_PAT`
 
 Create a **fine-grained personal access token**:

--- a/tests/test_action_contract.py
+++ b/tests/test_action_contract.py
@@ -460,6 +460,77 @@ def test_install_honours_an_explicit_version(ws: Path, outputs: Path) -> None:
     assert "compose-lint==0.16.0" in log.read_text(encoding="utf-8")
 
 
+def _failing_pip_shim(ws: Path, fail_times: int) -> tuple[Path, Path]:
+    """A ``pip`` that fails its first ``fail_times`` calls, then succeeds.
+
+    ``sleep`` is shimmed to a no-op alongside it so the retry loop's real
+    backoff runs at full speed here. Shimming the clock rather than
+    shortening it in ``action.yml`` keeps the published action's timing
+    honest — the test exercises the loop consumers actually get.
+    """
+    shim_dir = ws / "pipshim"
+    shim_dir.mkdir()
+    log = ws / "pip.log"
+    shim = shim_dir / "pip"
+    shim.write_text(
+        f"""#!/usr/bin/env bash
+printf "%s\\n" "$*" >> {log}
+attempts=$(wc -l < {log})
+if [ "$attempts" -le {fail_times} ]; then
+  echo "ERROR: No matching distribution found for compose-lint" >&2
+  exit 1
+fi
+""",
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+    noop_sleep = shim_dir / "sleep"
+    noop_sleep.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    noop_sleep.chmod(0o755)
+    return shim_dir, log
+
+
+def test_install_retries_a_lagging_index(ws: Path, outputs: Path) -> None:
+    """PyPI's /simple/ index lags a publish, so the first install can 404.
+
+    The race broke this repo's own marketplace-smoke minutes after the
+    0.20.0 publish (#612), and a consumer pinning a just-released version
+    hits the identical window — which the action's pinned-by-default
+    behaviour makes the normal case.
+    """
+    shim_dir, log = _failing_pip_shim(ws, fail_times=2)
+    _require_exec(shim_dir)
+    rc, _out, _err = _run_step(
+        "Install compose-lint", {"CL_VERSION": ""}, ws, outputs, extra_path=shim_dir
+    )
+    assert rc == 0, "a lagging index must be retried, not fatal"
+    attempts = log.read_text(encoding="utf-8").strip().splitlines()
+    assert len(attempts) == 3, f"expected 2 failures then a success, got {attempts}"
+    assert all("compose-lint==" in line for line in attempts)
+
+
+def test_install_gives_up_naming_index_propagation(ws: Path, outputs: Path) -> None:
+    """Retrying forever would just move the mystery; the message must land.
+
+    A bare `Process completed with exit code 1` is what made the 0.20.0
+    occurrence read as a regression instead of a propagation delay.
+    """
+    shim_dir, log = _failing_pip_shim(ws, fail_times=99)
+    _require_exec(shim_dir)
+    rc, out, err = _run_step(
+        "Install compose-lint",
+        {"CL_VERSION": "0.0.0"},
+        ws,
+        outputs,
+        extra_path=shim_dir,
+    )
+    assert rc != 0
+    assert len(log.read_text(encoding="utf-8").strip().splitlines()) == 6, (
+        "the loop must be bounded"
+    )
+    assert "propagat" in (out + err), "the failure must name the index lag"
+
+
 def test_the_default_pin_matches_the_package_version() -> None:
     """Drift here would ship an action that installs a different linter."""
     import re


### PR DESCRIPTION
Closes #612.

PyPI's JSON API sees a release within seconds of the publish, but the
`/simple/` index pip resolves against can lag it by minutes. The 0.20.0
marketplace-smoke ran inside that window and failed with `No matching
distribution found for compose-lint==0.20.0`. Nothing was wrong with the
release — a re-dispatch minutes later was green.

`publish.yml`'s `testpypi-smoke` has carried a backoff for exactly this since
0.3.6. This ports it, in both places the issue identified, because they cover
different failures:

**`action.yml` — option 2.** The install retries with backoff for ~100s. A
consumer pinning a just-released version hits the identical race, and the
action's pinned-by-default behaviour (0.19.0) makes that the normal case rather
than an edge one — so it belongs where every consumer gets it, not only in our
workflow. Cost: a genuinely wrong version now takes ~100s to fail instead of
failing at once. The final message names both possibilities so the wait isn't a
mystery.

**`marketplace-smoke.yml` — option 1.** Gates the action steps on the version
being visible on `/simple/` before invoking the published action. This is not
redundant with the above: the workflow consumes `tmatens/compose-lint@<sha>` at
the *previous* release, so the action-side retry only protects releases cut
after this lands. Its lasting value is the diagnosis — the 0.20.0 failure
surfaced as a bare `Process completed with exit code 1` pointing at a workflow
line, which is what made it read as a regression.

Checked against PyPI live rather than assumed: `/simple/compose-lint/` under
`Accept: application/vnd.pypi.simple.v1+json` returns a `versions` array
(34 entries, `0.20.0` present). That is the PEP 691 view of the same index pip
resolves against — unlike `/pypi/<name>/json`, which goes live seconds after
publish and would report ready while pip still 404s. The predicate is
`any(.versions[]; . == $v)` rather than `index($v)` so it doesn't depend on
`jq -e`'s treatment of a `0` index.

`CL_RELEASE_TAG` moves to workflow scope so the gate and the pre-commit rev
read one pin. `bump-marketplace-smoke-pin` seds that literal line and doesn't
care where in the file it sits — verified one occurrence remains.

## Tests

Two contract tests drive the real loop via a `pip` shim that fails N times then
succeeds. `sleep` is shimmed to a no-op alongside it, so the backoff runs at
full speed in the test without shortening the timing consumers actually get:

- a lagging index is retried, not fatal (2 failures → 3 calls → rc 0)
- the loop is bounded at 6 attempts and the failure names propagation

All four gates green locally: `ruff format --check`, `ruff check`, `mypy
--strict`, `pytest` (1815 passed, 6 skipped). `actionlint` clean across all
workflows.

## Not covered

The gate and the retry are both exercised only in the unit/shim layer here —
the real propagation window can only be observed during an actual release. The
next release is the first live test of the end-to-end path.
