### PR TITLE
Smoke test the fix round trip on LF and CRLF inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1089,6 +1089,41 @@ jobs:
       - name: Validate each runtime rule's premise against a live container
         run: python scripts/validate_rule_premises.py
 
+  # `fix` is the only mode that writes to a user's files, and until #611 it
+  # was the only mode no workflow ran. The failure modes that matter live in
+  # the round trip rather than in any single function — 0.20.0 shipped one:
+  # the line-inserting fixers spliced bare-LF lines into CRLF files, and the
+  # mixed-endings result made every line of the user's next diff light up.
+  # Nothing in the parsed tree is wrong in that file, so `verify_apply`'s
+  # in-process re-run (which already covers convergence and "no new finding")
+  # cannot see it. The script closes the loop on disk and hands the result to
+  # `docker compose config` — a consumer that is not our own mental model.
+  # Docker is preinstalled on the runners, as `rule-premises` already relies
+  # on; the script fails closed if it is ever absent rather than skipping.
+  fix-smoke:
+    name: Smoke test fix round trip
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements.lock
+      - name: Install the pinned runtime closure and the working tree
+        run: |
+          pip install --require-hashes -r requirements.lock
+          pip install --no-deps -e .
+      - name: fix --apply survives a round trip on LF and CRLF inputs
+        run: python scripts/smoke_fix_roundtrip.py
+
   # Developer-machine legs (macOS/Windows) for the two modes that run off
   # this repo's CI platform: the CLI and the pre-commit hook. Defined in
   # os-smoke.yml so the weekly scheduled run and this PR gate share one
@@ -1137,6 +1172,7 @@ jobs:
       - docker-smoke
       - action-smoke
       - precommit-smoke
+      - fix-smoke
       - rule-premises
       - os-smoke
     if: always()

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -41,6 +41,7 @@ cancels in-progress runs when you push new commits to the same PR.
 | `dockerfile-digests`      | Fails if any `FROM @sha256:` in the Dockerfile is a per-arch manifest instead of an index |
 | `docker-smoke`            | Builds `linux/amd64` from the Dockerfile and runs it against fixtures (only when build inputs change) |
 | `action-smoke`            | Runs `./action.yml` against clean and insecure fixtures; asserts exit codes               |
+| `fix-smoke`               | `fix --apply` round trip on LF and CRLF copies of the insecure fixture — result parses, `docker compose config` accepts it, endings stay uniform, no new finding, idempotent |
 | `rule-premises`           | Runs `scripts/validate_rule_premises.py` in a live container to prove each rule's premise  |
 | `version-consistency`     | Fails if `pyproject.toml` and `src/compose_lint/__init__.py` disagree on the version      |
 | `changelog-gate`          | If a PR bumps the `version`, `CHANGELOG.md` must have a matching `## [X.Y.Z]` section     |

--- a/scripts/smoke_fix_roundtrip.py
+++ b/scripts/smoke_fix_roundtrip.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""End-to-end smoke for ``compose-lint fix`` — the one mode that writes.
+
+``fix`` is covered by unit tests but was invoked by no workflow (#611).
+That matters more here than for ``check``: a ``check`` bug prints
+something wrong, a ``fix`` bug corrupts a file the user then commits.
+
+``fix.verify_apply`` already re-runs the engine on the *candidate string*
+before writing, so convergence and "no new finding" are enforced
+in-process. What no test crossed is the boundary after that: the bytes
+that reach disk, and whether anything other than compose-lint accepts
+them. 0.20.0 shipped exactly one bug of that shape — the line-inserting
+fixers spliced bare-LF lines into CRLF files, and the mixed-endings
+result made every line of the user's next diff light up. Nothing in the
+parsed tree is wrong in that file; only the bytes are.
+
+So this closes the loop where a user stands:
+
+1. copy the canonical insecure fixture to a scratch dir
+2. ``fix --apply`` it
+3. the result still parses as YAML, and ``docker compose config``
+   accepts it — an external consumer, not our own mental model
+4. line endings are still uniform and still the input's convention
+5. re-lint: no finding appeared that was not there before, some finding
+   went away, and ``fix`` offers nothing further (every claim it made is
+   discharged)
+6. a second ``--apply`` is byte-identical — idempotent
+
+The whole loop runs twice, once on an LF copy and once on a CRLF copy,
+because CRLF is a supported input shape with a known past failure.
+
+Usage:
+    python scripts/smoke_fix_roundtrip.py [--allow-missing-docker]
+
+``docker compose config`` is required by default: a smoke that silently
+drops its only external validator reads as "covered" when it is not. The
+flag exists for local runs on hosts without Docker, and CI never passes
+it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+FIXTURE = REPO / "tests" / "smoke" / "insecure.yml"
+
+failures: list[str] = []
+
+
+def fail(variant: str, message: str) -> None:
+    failures.append(f"[{variant}] {message}")
+    print(f"::error::[{variant}] {message}")
+
+
+def run(args: list[str], cwd: pathlib.Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, cwd=cwd, capture_output=True, text=True, timeout=120)
+
+
+def lint(path: pathlib.Path) -> set[tuple[str, str]]:
+    """Every finding as ``(rule_id, service)``, at the lowest threshold.
+
+    ``--fail-on low`` keeps the comparison over the whole finding set
+    rather than the gate's slice: a fix that traded a HIGH for a LOW
+    would otherwise pass unnoticed.
+    """
+    proc = run(
+        [
+            sys.executable,
+            "-m",
+            "compose_lint",
+            "check",
+            "--fail-on",
+            "low",
+            "--format",
+            "json",
+            str(path.name),
+        ],
+        cwd=path.parent,
+    )
+    if proc.returncode not in (0, 1):
+        raise SystemExit(
+            f"check exited {proc.returncode} (expected 0 or 1)\n{proc.stderr}"
+        )
+    payload = json.loads(proc.stdout)
+    return {(f["rule_id"], f["service"]) for f in payload["findings"]}
+
+
+def newline_report(raw: bytes) -> tuple[int, int, int]:
+    """``(lf_total, crlf, lone_cr)`` for a file's raw bytes."""
+    lf_total = raw.count(b"\n")
+    crlf = raw.count(b"\r\n")
+    lone_cr = raw.count(b"\r") - crlf
+    return lf_total, crlf, lone_cr
+
+
+def check_endings(variant: str, raw: bytes, want_crlf: bool) -> None:
+    lf_total, crlf, lone_cr = newline_report(raw)
+    if lone_cr:
+        fail(variant, f"{lone_cr} lone CR byte(s) in the fixed file")
+    if want_crlf and crlf != lf_total:
+        fail(
+            variant,
+            f"mixed line endings after fix: {crlf} CRLF vs {lf_total} total "
+            "line breaks — inserted lines did not adopt the file's convention",
+        )
+    if not want_crlf and crlf:
+        fail(variant, f"{crlf} CRLF ending(s) introduced into an LF file")
+
+
+def smoke(variant: str, want_crlf: bool, require_docker: bool) -> None:
+    print(f"\n=== fix round trip: {variant} ===")
+    with tempfile.TemporaryDirectory() as tmp:
+        work = pathlib.Path(tmp)
+        target = work / "docker-compose.yml"
+        # Normalise before building the variant. The repo has no
+        # .gitattributes, so Git for Windows checks this fixture out with
+        # CRLF under its default core.autocrlf=true — which made the "LF"
+        # copy CRLF on the Windows leg, and the CRLF copy `\r\r\n`. Reading
+        # the checkout verbatim would test the runner's git config rather
+        # than compose-lint, in opposite directions per platform.
+        source = FIXTURE.read_bytes().replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+        target.write_bytes(source.replace(b"\n", b"\r\n") if want_crlf else source)
+        original = target.read_bytes()
+        check_endings(f"{variant} (input)", original, want_crlf)
+        if failures:
+            raise SystemExit(
+                "the scratch copy did not have the endings this variant is "
+                "about to assert on — normalisation is broken, and the smoke "
+                "would be testing the checkout rather than fix"
+            )
+
+        before = lint(target)
+        if not before:
+            raise SystemExit(
+                "the insecure fixture produced no findings — the smoke would "
+                "prove nothing; fixture and rules have drifted apart"
+            )
+
+        applied = run(
+            [sys.executable, "-m", "compose_lint", "fix", "--apply", target.name],
+            cwd=work,
+        )
+        print((applied.stdout + applied.stderr).strip() or "(no output)")
+        if applied.returncode != 0:
+            fail(variant, f"fix --apply exited {applied.returncode}\n{applied.stderr}")
+            return
+
+        fixed = target.read_bytes()
+        if fixed == original:
+            raise SystemExit(
+                "fix --apply changed nothing on the canonical insecure fixture — "
+                "the smoke would prove nothing; if a fixer was removed on "
+                "purpose, point this script at a fixture that still has one"
+            )
+
+        # 3. Still Compose, judged by something that is not us.
+        try:
+            import yaml
+
+            yaml.safe_load(fixed.decode("utf-8"))
+        except Exception as exc:  # noqa: BLE001 - any parse failure is the finding
+            fail(variant, f"fixed file does not parse as YAML: {exc}")
+            return
+
+        if shutil.which("docker") is None:
+            if require_docker:
+                fail(
+                    variant,
+                    "docker is not available; `docker compose config` is this "
+                    "smoke's only external validator. Pass "
+                    "--allow-missing-docker to run the rest locally.",
+                )
+            else:
+                print("::notice::docker absent — SKIPPED `docker compose config`")
+        else:
+            cfg = run(["docker", "compose", "-f", target.name, "config"], cwd=work)
+            if cfg.returncode != 0:
+                fail(
+                    variant,
+                    "`docker compose config` rejected the fixed file:\n"
+                    f"{cfg.stderr.strip()}",
+                )
+
+        # 4. The bytes, not just the tree.
+        check_endings(variant, fixed, want_crlf)
+
+        # 5. Findings moved the right way.
+        after = lint(target)
+        introduced = after - before
+        if introduced:
+            fail(variant, f"fix introduced new finding(s): {sorted(introduced)}")
+        if not (before - after):
+            fail(
+                variant, f"fix removed no finding (before == after == {sorted(after)})"
+            )
+
+        # Every claim discharged: a remaining auto-fixable finding would
+        # still be offered here. Derived rather than a hardcoded rule
+        # list, so a new fixer does not need this script updated.
+        #
+        # The *diff* is the signal, and it is on stdout — `fix` puts its
+        # data there and its human summary on stderr (AGENTS.md), so an
+        # empty stdout is exactly "nothing left to fix". Asserting on the
+        # summary string instead would silently stop matching the day
+        # that wording changes.
+        residual = run(
+            [sys.executable, "-m", "compose_lint", "fix", target.name], cwd=work
+        )
+        if residual.stdout.strip():
+            fail(
+                variant,
+                "fix still offers changes after --apply:\n"
+                f"{residual.stdout.strip()}\n{residual.stderr.strip()}",
+            )
+
+        # 6. Idempotent.
+        again = run(
+            [sys.executable, "-m", "compose_lint", "fix", "--apply", target.name],
+            cwd=work,
+        )
+        if again.returncode != 0:
+            fail(variant, f"second fix --apply exited {again.returncode}")
+        elif target.read_bytes() != fixed:
+            fail(variant, "second fix --apply changed the file again — not idempotent")
+
+        print(
+            f"[{variant}] removed {sorted(before - after)}; {len(after)} finding(s) remain"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--allow-missing-docker",
+        action="store_true",
+        help="downgrade a missing docker to a skip (local runs only; CI must not)",
+    )
+    args = parser.parse_args()
+
+    for variant, want_crlf in (("LF", False), ("CRLF", True)):
+        smoke(variant, want_crlf, require_docker=not args.allow_missing_docker)
+
+    if failures:
+        print(f"\n{len(failures)} failure(s):")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print("\nfix round trip OK on both line-ending conventions.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_smoke_fix_roundtrip.py
+++ b/tests/test_smoke_fix_roundtrip.py
@@ -1,0 +1,136 @@
+"""Guard the guard for the ``fix`` round-trip smoke (#611).
+
+The smoke's job is to fail when ``fix`` corrupts a file. A smoke that
+cannot fail is worse than none — it reports coverage it does not have —
+so the two detectors that carry the weight here are exercised against
+inputs that must trip them.
+
+The line-ending detector gets the closest attention: mixed endings are
+the shape 0.20.0 actually shipped, and the parsed tree of such a file is
+perfectly correct, so nothing above the byte level notices.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "smoke_fix_roundtrip.py"
+
+
+def _load() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("smoke_fix_roundtrip", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def smoke() -> ModuleType:
+    module = _load()
+    module.failures.clear()
+    return module
+
+
+def test_mixed_endings_are_caught(smoke: ModuleType) -> None:
+    """The 0.20.0 bug: bare-LF lines spliced into a CRLF file."""
+    mixed = b"services:\r\n  app:\r\n    read_only: true\n"
+    smoke.check_endings("CRLF", mixed, want_crlf=True)
+    assert smoke.failures, "mixed endings must be reported"
+    assert "mixed line endings" in smoke.failures[0]
+
+
+def test_uniform_crlf_passes(smoke: ModuleType) -> None:
+    smoke.check_endings("CRLF", b"services:\r\n  app:\r\n", want_crlf=True)
+    assert not smoke.failures
+
+
+def test_uniform_lf_passes(smoke: ModuleType) -> None:
+    smoke.check_endings("LF", b"services:\n  app:\n", want_crlf=False)
+    assert not smoke.failures
+
+
+def test_crlf_leaking_into_an_lf_file_is_caught(smoke: ModuleType) -> None:
+    """The mirror-image splice, which is just as wrong."""
+    smoke.check_endings("LF", b"services:\n  app:\r\n", want_crlf=False)
+    assert smoke.failures
+    assert "CRLF ending(s) introduced" in smoke.failures[0]
+
+
+def test_a_lone_cr_is_caught(smoke: ModuleType) -> None:
+    """A CR that is not part of a line ending is the smuggling shape."""
+    smoke.check_endings("LF", b"services:\r  app:\n", want_crlf=False)
+    assert smoke.failures
+    assert "lone CR" in smoke.failures[0]
+
+
+def test_the_loop_is_immune_to_how_git_checked_the_fixture_out(
+    smoke: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The repo has no .gitattributes, so the fixture's endings vary by host.
+
+    Git for Windows' default ``core.autocrlf=true`` hands the checkout a
+    CRLF copy of a file that is LF in the repo. Read verbatim, the "LF"
+    variant would then be CRLF and the "CRLF" variant ``\r\r\n`` — so the
+    smoke would be asserting on the runner's git config rather than on
+    ``fix``, in opposite directions per platform. That is not theoretical:
+    it failed the windows-2025 leg on this branch's first run.
+    """
+    crlf_checkout = tmp_path / "insecure.yml"
+    crlf_checkout.write_bytes(
+        smoke.FIXTURE.read_bytes().replace(b"\r\n", b"\n").replace(b"\n", b"\r\n")
+    )
+    monkeypatch.setattr(smoke, "FIXTURE", crlf_checkout)
+
+    smoke.smoke("LF", want_crlf=False, require_docker=False)
+    smoke.smoke("CRLF", want_crlf=True, require_docker=False)
+    assert not smoke.failures, smoke.failures
+
+
+def test_missing_docker_fails_closed_by_default(tmp_path: Path) -> None:
+    """The only external validator must not drop silently.
+
+    A smoke that skips ``docker compose config`` and still reports green
+    claims coverage it does not have, so absent Docker is an error unless
+    the caller opts out. CI never opts out.
+    """
+    empty_bin = tmp_path / "emptybin"
+    empty_bin.mkdir()
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PATH": str(empty_bin)},
+        timeout=300,
+    )
+    assert proc.returncode != 0
+    assert "docker is not available" in proc.stdout
+
+
+def test_missing_docker_can_be_downgraded_for_local_runs(tmp_path: Path) -> None:
+    """...and the rest of the loop still runs, so local dev is not blocked."""
+    empty_bin = tmp_path / "emptybin"
+    empty_bin.mkdir()
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--allow-missing-docker"],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PATH": str(empty_bin)},
+        timeout=300,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "SKIPPED `docker compose config`" in proc.stdout
+    # Both conventions were actually exercised, not just declared.
+    assert "fix round trip: LF" in proc.stdout
+    assert "fix round trip: CRLF" in proc.stdout


### PR DESCRIPTION
Closes #611.

`fix` is the only mode that writes to a user's files, and `grep -rn "compose-lint
fix" .github/workflows/` returned nothing. A `check` bug prints something wrong;
a `fix` bug corrupts a compose file the user then commits.

## What was actually missing

Worth stating precisely, because less was missing than the issue assumed —
and what remained is the part that bit us.

`fix.verify_apply` already re-runs the engine on the **candidate string** before
anything is written, and enforces structure-preserved, converges, and no-new-finding
(ADR-014). So the issue's steps 4 and 5 are covered in-process today.

What nothing crossed is the boundary *after* that: the bytes that reach disk, and
whether anything other than compose-lint accepts them. 0.20.0 shipped exactly that
bug — the line-inserting fixers spliced bare-LF lines into CRLF files, and the
mixed-endings result made every line of the user's next diff light up. **That
file's parsed tree is entirely correct**, so no check above the byte level can see
it, `verify_apply` included.

That reprioritised the loop. `docker compose config` (step 3) is in, as the
external validator, but it is not what would have caught the CRLF bug — YAML
tolerates both endings and Compose would have accepted that file happily. The
assertion that actually catches it is that endings stay **uniform and the input's
convention**, which is why the loop runs on a CRLF copy as a first-class case
rather than as the issue's optional extra.

## The loop

`scripts/smoke_fix_roundtrip.py`, run on an LF and a CRLF copy of the canonical
insecure fixture:

1. copy fixture to a scratch dir, `fix --apply`
2. result parses as YAML, and `docker compose config` accepts it
3. line endings uniform, still the input's convention, no lone CR
4. re-lint: nothing appeared that was not there before, something went away
5. `fix` offers nothing further — every claim discharged
6. a second `--apply` is byte-identical

Two deliberate choices:

- **Step 5 is derived, not hardcoded.** It reads the dry-run *diff on stdout*
  being empty, so a new fixer needs no edit here. Note `fix` puts its diff on
  stdout and its human summary on stderr (AGENTS.md) — I had this backwards
  first, and asserting on the summary string would have made the check silently
  vacuous.
- **Docker is required by default**, `--allow-missing-docker` is for local runs
  and CI never passes it. A smoke that quietly drops its only external validator
  reports coverage it does not have.

New `fix-smoke` job in `ci.yml`, gated on `changes.outputs.code`, registered in
`ci-ok`. Docker is preinstalled on the runners, as `rule-premises` already relies on.

## Guard the guard

`tests/test_smoke_fix_roundtrip.py` trips each detector on input that must fail
it — including the exact mixed-endings shape 0.20.0 shipped, its mirror image, a
lone CR, and the fail-closed-without-Docker path. The script also hard-exits if
the fixture stops producing findings or if `fix` stops changing it, rather than
passing vacuously.

## Verification

All four gates green locally: `ruff format --check`, `ruff check`, `mypy
--strict`, `pytest` (1820 passed, 6 skipped). `actionlint` clean.

**Live gap:** this container has no Docker, so `docker compose config` is the one
step I could not execute — it is skipped locally and runs for the first time in
this PR's `fix-smoke` job. The CRLF preservation was verified here directly
against the real CLI (LF and CRLF both come out uniform).
