### PR TITLE
Widen the coverage matrix to arm64, the Python floor, and the one-shot runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -696,13 +696,35 @@ jobs:
   # `docker-smoke` job is the first thing to notice. amd64-only to keep
   # the gate cheap; the release pipeline covers multi-arch.
   docker-smoke:
-    name: Smoke test Dockerfile (amd64)
+    name: Smoke test Dockerfile (${{ matrix.arch }})
     # Build inputs are detected centrally by the `changes` job (the `docker`
     # group: Dockerfile, .dockerignore, the runtime/build lockfiles,
     # pyproject.toml, src/). On push, that group is always true.
     needs: changes
     if: needs.changes.outputs.docker == 'true'
-    runs-on: ubuntu-24.04
+    # arm64 used to appear only in publish.yml, so an arm64-specific image
+    # regression was caught *after* the irreversible trigger — the tag is
+    # pushed, TestPyPI has consumed the version, and the only way out is a
+    # new patch release (#613). The image ships multi-arch, so both arches
+    # are release surfaces and both belong on the PR path.
+    #
+    # `ubuntu-24.04-arm` is a native GitHub-hosted runner and free for
+    # public repos, so this costs wall-clock rather than money, and it runs
+    # in parallel with the amd64 leg. Native also means no QEMU, which is
+    # what made an arm64 PR leg expensive before these runners existed.
+    # The same platform/runner pairing is already used by publish.yml's
+    # docker-build and docker-smoke.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 10
     permissions:
       contents: read
@@ -715,11 +737,14 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           load: true
           tags: composelint/compose-lint:pr-smoke
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Scope the layer cache per arch. A shared scope has the two legs
+          # writing the same `mode=max` cache concurrently, where each can
+          # evict the other's layers — turning a cache into a coin flip.
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,scope=${{ matrix.arch }},mode=max
       - name: Clean fixture exits 0
         run: |
           cat > /tmp/clean.yml <<'YAML'

--- a/.github/workflows/marketplace-smoke.yml
+++ b/.github/workflows/marketplace-smoke.yml
@@ -56,26 +56,22 @@ env:
   CL_RELEASE_TAG: v0.20.0
 
 jobs:
-  marketplace-smoke:
-    name: Smoke test published action
+  # This workflow's whole point is to run moments after a publish — the
+  # pin-bump merge is its trigger — and that is exactly when PyPI's /simple/
+  # index has not caught up with the JSON API yet. Every job below that
+  # resolves compose-lint from PyPI waits on this one (#612).
+  #
+  # It was a step inside marketplace-smoke when it landed; the one-shot job
+  # below is a second consumer, and duplicating a retry loop is how two
+  # copies start drifting toward the weaker one. The extra runner spin-up
+  # buys a failure that names itself in the job list instead of hiding in
+  # another job's step log.
+  pypi-propagated:
+    name: Release is visible on PyPI's index
     runs-on: ubuntu-24.04
     timeout-minutes: 5
-    permissions:
-      contents: read
+    permissions: {}
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      # This workflow's whole point is to run moments after a publish — the
-      # pin-bump merge is its trigger — and that is exactly when PyPI's
-      # /simple/ index has not caught up with the JSON API yet. The action
-      # steps below install `compose-lint==<the release>` from inside the
-      # published action, so the retry that now lives in action.yml only
-      # protects releases cut *after* this lands. Gate here as well, because
-      # the useful part is the diagnosis: without it the failure surfaces as
-      # `Process completed with exit code 1` on a workflow line, which is
-      # what made the 0.20.0 occurrence (#612) look like a real regression.
       - name: Wait for the release to reach PyPI's /simple/ index
         run: |
           set -euo pipefail
@@ -99,6 +95,18 @@ jobs:
             echo "Attempt ${attempt}: ${version} not on the /simple/ index yet; sleeping 20s..."
             sleep 20
           done
+
+  marketplace-smoke:
+    name: Smoke test published action
+    needs: pypi-propagated
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Clean fixture should pass
         uses: tmatens/compose-lint@86aa003f03ac82a3c2544cc35eac56aff8be769e # v0.20.0
@@ -183,5 +191,86 @@ jobs:
           git add -A
           if pre-commit run --all-files; then
             echo "::error::Expected the published hook to fail on the insecure fixture."
+            exit 1
+          fi
+
+  # README's Installation section offers two ad-hoc runners as first-class
+  # alternatives to `pip install`:
+  #
+  #     uvx compose-lint docker-compose.yml
+  #     pipx run compose-lint docker-compose.yml
+  #
+  # Every install in CI — ci.yml, publish.yml's testpypi-smoke,
+  # marketplace-smoke, os-smoke — went through `pip` (#613). The one
+  # adjacent case, testpypi-smoke's `pipx run --spec <local wheel>` (#575),
+  # deliberately hands pipx a *file* so TestPyPI is never configured as an
+  # index — so it exercises neither name resolution from PyPI nor uv at
+  # all. Console-script generation and isolated-environment layout differ
+  # enough between pip, pipx and uv that any one of them can break alone,
+  # and a broken `uvx compose-lint` is invisible to us until a user says so.
+  #
+  # Weekly rather than PR-time, alongside the other published-surface
+  # checks: what this can catch is a regression in the published artifact
+  # or in a third-party runner, neither of which a PR changes.
+  oneshot-runners-smoke:
+    name: Smoke test the advertised one-shot runners
+    needs: pypi-propagated
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # Exactly the two forms README advertises. `pipx install` /
+        # `uv tool install` are not tested because they are not offered —
+        # testing an install method we do not document would assert a
+        # contract with nobody on the other end.
+        include:
+          - runner: uvx
+            command: uvx compose-lint
+          - runner: pipx
+            command: pipx run compose-lint
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # pipx is preinstalled on ubuntu-24.04; uv is not.
+      - if: matrix.runner == 'uvx'
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      # The advertised form pins nothing — it resolves the newest release,
+      # which is what CL_RELEASE_TAG names both after a pin bump and on the
+      # weekly cron. Asserting they agree is what makes this job meaningful
+      # between releases: a yanked release, or a resolver that starts
+      # preferring something older, shows up here as a mismatch rather than
+      # as a silent pass on the wrong version.
+      - name: Resolves the current release
+        env:
+          CL_RUN: ${{ matrix.command }}
+        run: |
+          set -euo pipefail
+          expected="compose-lint ${CL_RELEASE_TAG#v}"
+          actual="$(${CL_RUN} --version)"
+          echo "Expected: ${expected}"
+          echo "Actual:   ${actual}"
+          if [ "${actual}" != "${expected}" ]; then
+            echo "::error::${CL_RUN} resolved '${actual}', expected '${expected}'"
+            exit 1
+          fi
+
+      - name: Clean fixture exits 0
+        env:
+          CL_RUN: ${{ matrix.command }}
+        run: ${CL_RUN} tests/smoke/clean.yml
+
+      - name: Insecure fixture exits 1
+        env:
+          CL_RUN: ${{ matrix.command }}
+        run: |
+          exit_code=0
+          ${CL_RUN} tests/smoke/insecure.yml || exit_code=$?
+          if [ "${exit_code}" -ne 1 ]; then
+            echo "::error::Expected exit code 1 from ${CL_RUN}, got ${exit_code}"
             exit 1
           fi

--- a/.github/workflows/os-smoke.yml
+++ b/.github/workflows/os-smoke.yml
@@ -48,15 +48,27 @@ permissions: {}
 
 jobs:
   test:
-    name: pytest (${{ matrix.os }})
+    name: pytest (${{ matrix.os }}, py${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     permissions:
       contents: read
+    # 3.10 is the `requires-python` floor and, until #613, was tested only
+    # on Linux — while the OS legs ran only 3.13. That left the realistic
+    # worst case uncovered: an old Python on Windows. It is also the leg
+    # most likely to differ, because what varies across these platforms is
+    # `pathlib`/`os` behavior and that is exactly where the floor is
+    # furthest from the version the ubuntu matrix's other legs pin.
+    #
+    # Deliberately the floor and the ceiling, not the full 3.10-3.14 range
+    # the ubuntu matrix runs: the versions in between differ from their
+    # neighbours far less than either end differs from the other, so they
+    # would buy little for 6 more jobs on two of the slowest runners.
     strategy:
       fail-fast: false
       matrix:
         os: [macos-15, windows-2025]
+        python-version: ["3.10", "3.13"]
     defaults:
       run:
         shell: bash
@@ -66,7 +78,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.13"
+          python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: |
             requirements.lock
@@ -80,6 +92,11 @@ jobs:
           pip install --no-deps -e .
       - run: pytest
 
+  # Stays on one Python: what this leg exercises is pre-commit's
+  # hook-environment build and the OS's path/console handling, neither of
+  # which is a function of the interpreter version the way the pytest leg
+  # is. It is also the slower of the two jobs — it builds an environment
+  # per run — so doubling it buys the least and costs the most.
   precommit-smoke:
     name: pre-commit hook (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -18,9 +18,9 @@ per-channel publish contract see [`DISTRIBUTION.md`](DISTRIBUTION.md).
 | `publish.yml`             | `v*` tag push                              | Release pipeline — see `RELEASING.md`                  |
 | `release-prep.yml`        | Manual (`workflow_dispatch`, maintainer)   | Opens the "Prepare X.Y.Z release" PR                   |
 | `publish-channel.yml`     | Manual (`workflow_dispatch`, maintainer)   | Emergency single-channel publish                       |
-| `marketplace-smoke.yml`   | Push to `main` touching the file + manual + weekly cron | Verifies the published action and pre-commit hook end-to-end |
+| `marketplace-smoke.yml`   | Push to `main` touching the file + manual + weekly cron | Verifies the published action, pre-commit hook, and the `uvx`/`pipx run` one-shot forms end-to-end |
 | `forgejo-smoke.yml`       | Push to `main` touching the harness + manual + weekly cron | Runs README's Forgejo snippet on a live containerized Forgejo |
-| `os-smoke.yml`            | Called by `ci.yml` on PRs touching code + push to `main` + manual + weekly cron | pytest + pre-commit hook on macOS and Windows — **gates via `ci-ok`** |
+| `os-smoke.yml`            | Called by `ci.yml` on PRs touching code + push to `main` + manual + weekly cron | pytest (3.10 and 3.13) + pre-commit hook on macOS and Windows — **gates via `ci-ok`** |
 | `sarif-ingestion.yml`     | Push to `main` touching SARIF inputs + manual + weekly cron | Uploads a probe SARIF to Code Scanning and asserts GitHub ingested it — then deletes its own alerts |
 
 
@@ -63,7 +63,7 @@ cancels in-progress runs when you push new commits to the same PR.
 | `dependency-review`       | Blocks PRs adding deps with known high-severity CVEs or disallowed licenses               |
 | `actionlint`              | Lints every workflow under `.github/workflows/` (embeds shellcheck for `run:` blocks)     |
 | `dockerfile-digests`      | Fails if any `FROM @sha256:` in the Dockerfile is a per-arch manifest instead of an index |
-| `docker-smoke`            | Builds `linux/amd64` from the Dockerfile and runs it against fixtures (only when build inputs change) |
+| `docker-smoke`            | Builds `linux/amd64` **and `linux/arm64`** from the Dockerfile on native runners and runs each against fixtures (only when build inputs change) |
 | `action-smoke`            | Runs `./action.yml` against clean and insecure fixtures; asserts exit codes               |
 | `fix-smoke`               | `fix --apply` round trip on LF and CRLF copies of the insecure fixture — result parses, `docker compose config` accepts it, endings stay uniform, no new finding, idempotent |
 | `rule-premises`           | Runs `scripts/validate_rule_premises.py` in a live container to prove each rule's premise  |
@@ -267,9 +267,9 @@ so the smoke runs against the release just cut. It also means the smoke
 runs minutes after the publish, inside the window where PyPI's JSON API
 already shows the release but the `/simple/` index pip resolves against
 does not. That race failed the 0.20.0 run ([#612]), so two things now
-absorb it: `marketplace-smoke.yml` gates its action steps on the version
-being visible on `/simple/`, and `action.yml`'s install retries with
-backoff for ~100s. A propagation delay therefore costs wall-clock, not a
+absorb it: `marketplace-smoke.yml`'s `pypi-propagated` job gates every
+PyPI-consuming job on the version being visible on `/simple/`, and
+`action.yml`'s install retries with backoff for ~100s. A propagation delay therefore costs wall-clock, not a
 red run, and if it does exhaust the retries the message says so instead
 of `Process completed with exit code 1`.
 


### PR DESCRIPTION
Closes #613.

Three gaps between what CI covers and how compose-lint is actually consumed.
Filed and fixed together because they are one decision — how wide the matrix
should be — not three.

## 1. arm64 at PR time

`ci.yml`'s `docker-smoke` built `linux/amd64` only; arm64 appeared only in
`publish.yml`. So an arm64-specific image regression was caught **after** the
irreversible trigger — tag pushed, TestPyPI has consumed the version, and the
only way out is a new patch release. The image ships multi-arch, so both arches
are release surfaces and both belong on the PR path.

`docker-smoke` becomes the same `platform`/`runner` `include:` matrix
`publish.yml` already uses. `ubuntu-24.04-arm` is native and free for public
repos, the two legs run in parallel, and the existing `changes.outputs.docker`
path-gate is untouched — so this costs wall-clock on build-input changes only.

One thing worth flagging that the issue didn't raise: the gha layer cache is now
**scoped per arch**. Two legs writing one `mode=max` scope concurrently can evict
each other's layers, which turns the cache into a coin flip rather than a speedup.

## 2. The Python floor on the OS legs

`os-smoke.yml` ran 3.13 on both OSes while 3.10 — the `requires-python` floor —
was tested only on Linux. The pytest leg now runs **the floor and the ceiling**
(3.10 and 3.13), which is 2 extra jobs.

Deliberately not the full 3.10–3.14 range: the versions in between differ from
their neighbours far less than either end differs from the other, so they'd buy
little for 6 more jobs on the two slowest runners. `precommit-smoke` stays
single-version — it exercises pre-commit's environment build and the OS's
path/console handling, neither of which is a function of interpreter version,
and it's the slower job.

## 3. The advertised one-shot runners

`README.md:42` offers `uvx compose-lint <file>` and `pipx run compose-lint
<file>` beside pip, and every install in CI went through pip.

Worth correcting one thing in the issue: `pipx` is *not* entirely untested —
`testpypi-smoke` runs `pipx run --spec <local wheel>` (#575). But it deliberately
hands pipx a **file** so TestPyPI is never configured as an index, which means it
exercises neither PyPI name resolution nor uv at all. The advertised forms are a
genuinely different surface, so the new job runs exactly those two forms and
nothing else — `pipx install` / `uv tool install` aren't tested because they
aren't offered, and asserting a contract nobody is on the other end of is noise.

Weekly, alongside the other published-surface checks. Each leg asserts the runner
resolves the *current* release, which is what makes it meaningful between
releases: a yank, or a resolver that starts preferring something older, shows up
as a mismatch rather than a green pass on the wrong version.

## Also here

The PyPI propagation gate from #615 is promoted from a step inside
`marketplace-smoke` to its own `pypi-propagated` job, now that the one-shot job
is a second consumer. Two copies of a retry loop drift toward the weaker one, and
a named job puts the failure in the job list instead of inside another job's step log.

## Verification

`uvx compose-lint` checked live against real PyPI from this container rather than
assumed: `--version` → `compose-lint 0.20.0` (exact match with the asserted
string), clean fixture → 0, insecure fixture → 1.

`actionlint` clean on all workflows; `ruff`, `mypy --strict`, `pytest` (1815
passed, 6 skipped) green.

**Not verified locally:** `pipx` is not installed in this container, so that
matrix leg runs for the first time on the weekly cron or a manual dispatch — it
is not on the PR path. Same for the arm64 build, which needs a GitHub-hosted arm
runner; this PR touches `ci.yml` but not Dockerfile inputs, so `docker-smoke` is
path-gated *off* here. **Both are worth a manual `workflow_dispatch` of
`marketplace-smoke.yml`, and a trivial Dockerfile-touching PR, before trusting
them.**
