### PR TITLE
Prove GitHub ingests the SARIF we emit

### DIFF
--- a/.github/workflows/sarif-ingestion.yml
+++ b/.github/workflows/sarif-ingestion.yml
@@ -1,0 +1,95 @@
+name: SARIF ingestion
+
+# Proves GitHub accepts the SARIF compose-lint emits (issue #610).
+#
+# `tests/test_sarif.py` asserts the document's shape against the same
+# mental model that produced it, and no job anywhere ingested a
+# compose-lint SARIF into Code Scanning — `ci.yml`'s action smoke sets
+# `upload-sarif: "false"` deliberately, and the only `upload-sarif` calls
+# in the repo carry Scorecard, Docker Scout and CodeQL output. So the
+# rejections that are invisible to a shape assertion — a duplicate
+# `ruleId`, an out-of-range region, a missing `artifactLocation` base, a
+# `level` GitHub does not accept — surfaced first in a *consumer's* job.
+# `upload-sarif` became a first-class input in 0.19.0, which makes the
+# upload path more of a surface, not less.
+#
+# Not on the PR gate, for three reasons rather than one:
+#   1. Fork PRs can never hold `security-events: write` (the same reason
+#      action-smoke passes `upload-sarif: "false"`), so the job would be
+#      structurally unavailable on exactly the contributions least likely
+#      to have been checked locally.
+#   2. It would push deliberately-insecure fixture findings into this
+#      repo's alert set on every PR.
+#   3. What it can catch is a change in our SARIF or in GitHub's
+#      acceptance of it — the first is caught post-merge one commit later,
+#      the second has no PR to attach to at all.
+# Its own workflow rather than a job in ci.yml so `security-events: write`
+# is scoped to one file that does nothing else.
+on:
+  push:
+    branches: [main]
+    paths:
+      - src/compose_lint/formatters/**
+      - src/compose_lint/attack.py
+      - src/compose_lint/rules/**
+      - src/compose_lint/models.py
+      - tests/smoke/**
+      - action.yml
+      - scripts/verify_sarif_ingestion.py
+      - .github/workflows/sarif-ingestion.yml
+  workflow_dispatch:
+  schedule:
+    # GitHub can tighten SARIF acceptance with no change on our side, and
+    # that has no commit to hang off. Same reasoning as marketplace-smoke's
+    # weekly re-verification of published surfaces (#570).
+    - cron: "41 11 * * 1"
+
+permissions: {}
+
+jobs:
+  ingest:
+    name: GitHub ingests our SARIF
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # All three fixtures together, so the document carries several
+      # artifactLocations, all three SARIF levels, and a suppression — the
+      # constructs a single-file probe would never produce.
+      #
+      # The config keeps the lint itself at exit 0, so a failed upload is the
+      # only thing that can turn this job red; it explains itself, and
+      # tests/test_sarif_ingestion_probe.py holds this step to that contract
+      # at PR time.
+      - name: Upload the probe SARIF to Code Scanning
+        uses: ./
+        with:
+          files: tests/smoke/insecure.yml tests/smoke/sarif-shape.yml tests/smoke/clean.yml
+          config: tests/smoke/sarif-probe-config.yml
+          fail-on: critical
+          sarif-file: sarif-ingestion-probe.sarif
+          upload-sarif: "true"
+          version: latest
+
+      # An accepted POST is not ingestion. `upload-sarif` waits for
+      # processing, but a document that lands with every result discarded
+      # still passes that step.
+      - name: Assert the results actually landed
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/verify_sarif_ingestion.py verify
+
+      # `always()`: the probe cleans up after a failed assertion too,
+      # otherwise a red run leaves the fixture findings behind precisely
+      # when nobody is looking for them.
+      - name: Remove the probe's alerts
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/verify_sarif_ingestion.py cleanup

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -21,6 +21,30 @@ per-channel publish contract see [`DISTRIBUTION.md`](DISTRIBUTION.md).
 | `marketplace-smoke.yml`   | Push to `main` touching the file + manual + weekly cron | Verifies the published action and pre-commit hook end-to-end |
 | `forgejo-smoke.yml`       | Push to `main` touching the harness + manual + weekly cron | Runs README's Forgejo snippet on a live containerized Forgejo |
 | `os-smoke.yml`            | Called by `ci.yml` on PRs touching code + push to `main` + manual + weekly cron | pytest + pre-commit hook on macOS and Windows — **gates via `ci-ok`** |
+| `sarif-ingestion.yml`     | Push to `main` touching SARIF inputs + manual + weekly cron | Uploads a probe SARIF to Code Scanning and asserts GitHub ingested it — then deletes its own alerts |
+
+
+### Why SARIF ingestion is not a PR check
+
+`ci.yml`'s action smoke passes `upload-sarif: "false"` on purpose, so
+nothing on the PR path ingests a compose-lint SARIF into Code Scanning.
+SARIF rejections are schema- and semantics-level — a duplicate `ruleId`,
+an out-of-range region, a `level` GitHub does not accept — and none of
+them are visible to a shape assertion written against the same mental
+model that produced the file. They surface in the *consumer's* job.
+
+`sarif-ingestion.yml` closes that (#610) off the PR path deliberately:
+fork PRs can never hold `security-events: write`, and a PR-time job would
+push deliberately-insecure fixture findings into this repo's alert set on
+every run. Post-merge and weekly also matches what it can actually catch
+— GitHub tightening SARIF acceptance has no PR to attach to.
+
+The probe deletes its own analysis afterwards, so the fixtures' findings
+do not linger in Code Scanning. The parts that *can* be checked on the PR
+are: `tests/test_sarif_ingestion_probe.py` asserts the probe's lint still
+exits 0 (so only an upload failure can fail that job) and that the
+document still carries several artifact locations, more than one `level`,
+a suppression, and no duplicate `ruleId`.
 
 ---
 

--- a/scripts/verify_sarif_ingestion.py
+++ b/scripts/verify_sarif_ingestion.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Prove GitHub actually ingested a compose-lint SARIF (#610).
+
+``tests/test_sarif.py`` asserts the document's shape against the same
+mental model that produced it. SARIF rejections are the failures that
+model cannot see: a duplicate ``ruleId``, an out-of-range region, a
+missing ``artifactLocation`` base, a ``level`` GitHub does not accept.
+Those surface in the *consumer's* job — historically a user's workflow,
+which is the worst place to learn about it.
+
+``upload-sarif`` failing is the first half of the proof, and it is the
+half the workflow gets for free. This script is the second half: an
+accepted POST is not ingestion. It waits for an analysis attributed to
+this run's commit and asserts it produced results, then that alerts are
+actually queryable.
+
+``cleanup`` is the other half of being a good citizen. The findings come
+from fixtures that are deliberately insecure, and this repo already
+refuses to let them near its alert set — ``ci.yml``'s action smoke sets
+``upload-sarif: "false"`` for exactly that reason. So the probe deletes
+its own analysis afterwards rather than leaving fixture findings in the
+repo's Code Scanning.
+
+Usage:
+    python scripts/verify_sarif_ingestion.py verify
+    python scripts/verify_sarif_ingestion.py cleanup
+
+Reads GITHUB_TOKEN, GITHUB_REPOSITORY, GITHUB_REF, GITHUB_SHA.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+API = "https://api.github.com"
+TOOL = "compose-lint"
+
+TOKEN = os.environ["GITHUB_TOKEN"]
+REPO = os.environ["GITHUB_REPOSITORY"]
+REF = os.environ["GITHUB_REF"]
+SHA = os.environ["GITHUB_SHA"]
+
+
+def call(method: str, path: str, *, params: dict[str, str] | None = None) -> object:
+    url = f"{API}{path}"
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
+    req = urllib.request.Request(url, method=method)
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("Authorization", f"Bearer {TOKEN}")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        body = resp.read()
+    return json.loads(body) if body else None
+
+
+def our_analyses() -> list[dict[str, object]]:
+    """Analyses this run produced — matched on tool *and* commit."""
+    try:
+        found = call(
+            "GET",
+            f"/repos/{REPO}/code-scanning/analyses",
+            params={"tool_name": TOOL, "ref": REF, "per_page": "100"},
+        )
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return []
+        raise
+    assert isinstance(found, list)
+    return [a for a in found if a.get("commit_sha") == SHA]
+
+
+def verify() -> int:
+    # `upload-sarif` waits for processing, so an analysis should already
+    # exist; alert indexing can still trail it by a few seconds.
+    analyses: list[dict[str, object]] = []
+    for attempt in range(1, 7):
+        analyses = our_analyses()
+        if analyses:
+            break
+        print(f"Attempt {attempt}: no compose-lint analysis for {SHA[:8]} yet; sleeping 10s...")
+        time.sleep(10)
+
+    if not analyses:
+        print(
+            f"::error::GitHub accepted the upload but produced no compose-lint "
+            f"analysis for {SHA} on {REF} after ~60s. The POST succeeding is not "
+            f"ingestion — this is the failure mode the job exists to catch."
+        )
+        return 1
+
+    total = sum(int(a.get("results_count") or 0) for a in analyses)
+    for a in analyses:
+        print(
+            f"analysis {a['id']}: category={a.get('category')!r} "
+            f"results={a.get('results_count')} warning={a.get('warning')!r}"
+        )
+    if total == 0:
+        print(
+            "::error::The analysis ingested with zero results. The probe fixtures "
+            "produce findings, so an empty analysis means GitHub discarded every "
+            "result — a semantic rejection that does not fail the upload step."
+        )
+        return 1
+
+    alerts = call(
+        "GET",
+        f"/repos/{REPO}/code-scanning/alerts",
+        params={"tool_name": TOOL, "ref": REF, "per_page": "100"},
+    )
+    assert isinstance(alerts, list)
+    if not alerts:
+        print(
+            "::error::The analysis reports results but no alert is queryable for "
+            f"tool_name={TOOL}. Ingestion did not complete."
+        )
+        return 1
+
+    rules = sorted({str(a["rule"]["id"]) for a in alerts})
+    print(f"\nGitHub ingested {total} result(s); {len(alerts)} alert(s) queryable.")
+    print(f"Rules that survived ingestion: {', '.join(rules)}")
+    return 0
+
+
+def cleanup() -> int:
+    """Delete this run's analyses so fixture findings do not linger."""
+    remaining = our_analyses()
+    if not remaining:
+        print("No probe analysis to clean up.")
+        return 0
+
+    deleted = 0
+    for analysis in remaining:
+        # Belt and braces before a destructive call on a security surface:
+        # the query already filters by tool, and this refuses anything that
+        # is not ours even if that filter ever changes meaning.
+        name = str((analysis.get("tool") or {}).get("name", ""))
+        if name != TOOL or analysis.get("commit_sha") != SHA:
+            print(f"::warning::refusing to delete analysis {analysis['id']} (tool={name!r})")
+            continue
+        try:
+            call(
+                "DELETE",
+                f"/repos/{REPO}/code-scanning/analyses/{analysis['id']}",
+                params={"confirm_delete": "true"},
+            )
+            deleted += 1
+        except urllib.error.HTTPError as exc:
+            print(
+                f"::warning::could not delete analysis {analysis['id']} "
+                f"(HTTP {exc.code}). Delete it by hand, or the insecure fixtures' "
+                f"findings stay in this repo's Code Scanning alerts."
+            )
+            return 0
+
+    print(f"Deleted {deleted} probe analysis/analyses.")
+    return 0
+
+
+if __name__ == "__main__":
+    mode = sys.argv[1] if len(sys.argv) > 1 else ""
+    if mode == "verify":
+        sys.exit(verify())
+    if mode == "cleanup":
+        sys.exit(cleanup())
+    print(f"usage: {sys.argv[0]} verify|cleanup", file=sys.stderr)
+    sys.exit(2)

--- a/tests/smoke/sarif-probe-config.yml
+++ b/tests/smoke/sarif-probe-config.yml
@@ -1,0 +1,18 @@
+# Config for the SARIF ingestion probe (.github/workflows/sarif-ingestion.yml).
+#
+# The probe's lint must exit 0, so that a failed upload is the *only* thing
+# that can turn that job red. `continue-on-error` on the action step would be
+# the obvious way to tolerate a non-zero lint — and it would swallow exactly
+# the failure the job exists to detect.
+#
+# tests/smoke/insecure.yml's only critical finding is CL-0002, so disabling it
+# puts every remaining finding below `--fail-on critical`. Suppression is not a
+# workaround here: a disabled rule still emits a suppressed result carrying a
+# `justification`, which is one more SARIF construct GitHub has to accept.
+#
+# tests/test_sarif_ingestion_probe.py holds this to that contract, so a new
+# critical rule fails on the PR that adds it rather than a week later.
+rules:
+  CL-0002:
+    enabled: false
+    reason: "SARIF ingestion probe: keeps the lint exit 0 so only an upload failure fails the job"

--- a/tests/test_sarif_ingestion_probe.py
+++ b/tests/test_sarif_ingestion_probe.py
@@ -1,0 +1,108 @@
+"""The SARIF ingestion probe must keep failing for one reason only (#610).
+
+`.github/workflows/sarif-ingestion.yml` uploads a compose-lint SARIF to
+Code Scanning so that a document GitHub rejects fails *our* run instead of
+a consumer's. That only works if the lint itself exits 0 — otherwise the
+action step goes red on findings, and the obvious fix (`continue-on-error`)
+would swallow the upload failure the job exists to detect.
+
+That contract depends on the fixtures and the rule set, both of which
+change. A new critical-severity rule flagging any probe fixture breaks it,
+and the workflow runs post-merge and weekly, so the breakage would surface
+a week after the PR that caused it. These tests move that signal onto the
+PR, and read the workflow rather than a copy of it so the two cannot drift.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "sarif-ingestion.yml"
+
+
+def _upload_step() -> dict[str, Any]:
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["ingest"]["steps"]
+    for step in steps:
+        if step.get("uses") == "./":
+            return step
+    raise AssertionError("no `uses: ./` step in the ingestion workflow")
+
+
+def _probe_args() -> tuple[list[str], str, str]:
+    with_ = _upload_step()["with"]
+    return with_["files"].split(), with_["config"], with_["fail-on"]
+
+
+def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "compose_lint", *args],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def test_the_probe_lint_exits_zero() -> None:
+    """A non-zero lint makes the upload assertion unreadable.
+
+    If this fails because a new rule flags a probe fixture at critical,
+    the fix is to extend tests/smoke/sarif-probe-config.yml — never to add
+    `continue-on-error` to the workflow step.
+    """
+    files, config, fail_on = _probe_args()
+    proc = _run(["check", "--config", config, "--fail-on", fail_on, *files])
+    assert proc.returncode == 0, (
+        "the SARIF ingestion probe's lint must exit 0 so that only an upload "
+        f"failure can fail that job; got {proc.returncode}\n"
+        f"{proc.stdout}\n{proc.stderr}"
+    )
+
+
+def test_the_probe_sarif_stays_worth_uploading() -> None:
+    """A probe that degrades to one trivial result stops proving anything.
+
+    The rejections this job exists to catch are constructs: several
+    artifactLocations, more than one `level`, a suppression's
+    `justification`. A document carrying none of them can be accepted while
+    a real one is not.
+    """
+    files, config, fail_on = _probe_args()
+    proc = _run(
+        ["check", "--config", config, "--fail-on", fail_on, "--format", "sarif", *files]
+    )
+    assert proc.returncode == 0, proc.stderr
+    run = json.loads(proc.stdout)["runs"][0]
+    results = run["results"]
+
+    assert results, "the probe produced no SARIF results"
+
+    locations = {
+        r["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
+        for r in results
+    }
+    assert len(locations) > 1, (
+        f"probe covers one artifact only ({locations}); a missing "
+        "artifactLocation base would not show up"
+    )
+    assert len({r["level"] for r in results}) > 1, (
+        "probe exercises a single SARIF level; a level GitHub rejects would not show up"
+    )
+    assert any(r.get("suppressions") for r in results), (
+        "probe carries no suppressed result, so its `justification` construct "
+        "is never ingested"
+    )
+
+    rule_ids = [rule["id"] for rule in run["tool"]["driver"]["rules"]]
+    assert len(rule_ids) == len(set(rule_ids)), (
+        f"duplicate ruleId in the probe document: {sorted(rule_ids)} — GitHub "
+        "rejects these, and it would be found in the consumer's job"
+    )


### PR DESCRIPTION
Closes #610.

No job anywhere ingested a compose-lint SARIF into GitHub Code Scanning.
`tests/test_sarif.py` asserts the document's shape against the same mental model
that produced it; `ci.yml`'s action smoke sets `upload-sarif: "false"`
deliberately; and the only `upload-sarif` calls in the repo carry Scorecard,
Docker Scout and CodeQL output. So the rejections a shape assertion structurally
cannot see — a duplicate `ruleId`, an out-of-range region, a missing
`artifactLocation` base, a `level` GitHub does not accept — surfaced first in a
*consumer's* job.

## The two decisions the issue left open

**Where: off the PR gate**, in its own workflow (push-to-`main` on SARIF-relevant
paths, weekly, dispatchable). Three reasons, only one of which the issue named:

1. Fork PRs can never hold `security-events: write` — the same reason
   `action-smoke` passes `upload-sarif: "false"` — so the job would be
   structurally unavailable on exactly the contributions least likely to have
   been checked locally.
2. A PR-time job would push deliberately-insecure fixture findings into this
   repo's alert set on every run.
3. What it can catch is a change in our SARIF (caught post-merge, one commit
   later) or a change in *GitHub's acceptance of it* — and the latter has no PR
   to attach to at all.

Its own workflow rather than a job in `ci.yml`, so `security-events: write` is
scoped to one file that does nothing else.

**What it asserts: ingestion, not the POST.** `upload-sarif` waits for
processing, but a document that lands with every result discarded still passes
that step. `scripts/verify_sarif_ingestion.py` waits for an analysis attributed
to *this run's commit*, asserts it produced results, and asserts alerts are
queryable via `GET /code-scanning/alerts?tool_name=compose-lint`.

## Two things worth calling out

**The `continue-on-error` trap.** The insecure fixture exits 1, so the natural
way to write this job is `continue-on-error: true` on the action step — which
would swallow the upload failure the job exists to detect. Instead the probe
config disables CL-0002 (the fixtures' only critical finding), putting everything
below `--fail-on critical` so the lint exits 0 and **a failed upload is the only
thing that can turn the job red**. Suppression isn't a workaround here: a
disabled rule still emits a suppressed result carrying a `justification`, which
is one more SARIF construct GitHub has to accept.

**The probe cleans up after itself.** This repo already refuses to let fixture
findings near its alert set. So the run deletes its own analysis afterwards
(`if: always()`, filtered on both `tool_name` and `commit_sha`, and refusing
anything that isn't ours). Cleanup failure warns rather than fails — the
ingestion assertion has already passed by then, and a red run would misreport
SARIF validity — but it names exactly what to delete by hand.

## What's checked on the PR

The probe's contract decays silently: a new critical-severity rule flagging any
probe fixture breaks it, and the workflow runs post-merge and weekly, so that
would surface a week after the PR that caused it.
`tests/test_sarif_ingestion_probe.py` reads the workflow (not a copy of it) and
holds the probe to exiting 0, and to a document still worth uploading — more than
one artifact location, more than one `level`, a suppression present, no duplicate
`ruleId`.

Probe document verified locally: 13 results across 3 files, 27 rules declared,
all three levels, 1 suppressed result, no duplicate rule ids, exit 0.

`ruff`, `mypy --strict`, `pytest` (1817 passed, 6 skipped), `actionlint` all green.

## Not verified — needs a live run

**The actual upload has never executed.** It cannot run from a PR (that is the
whole design), and this container has no way to POST to Code Scanning. So the
first real exercise of `upload-sarif: "true"` → ingestion → cleanup is the
push-to-`main` run when this merges, or a `workflow_dispatch` on the branch.

Concretely unproven until then: that GitHub accepts this document at all (the
thing the issue is about), that alerts become queryable inside the ~60s poll
window, and that the analysis-deletion call behaves as documented. **Worth
watching that first run rather than assuming it green** — and if the SARIF turns
out to be rejected, that is the issue doing its job, not this PR failing.
