### PR TITLE
Classify the IPv4-mapped wildcard without the interpreter's help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CL-0005 now flags `::ffff:0.0.0.0` on every supported interpreter.** The
+  IPv4-mapped spelling of the unspecified address was classified by
+  `ipaddress.is_unspecified`, whose handling of IPv4-mapped addresses varies
+  with the CPython build — so a port published on all interfaces was reported
+  on some hosts and missed on others, with no way for a user to tell which
+  they had. The mapping is now unwrapped explicitly. A compose file binding
+  `[::ffff:0.0.0.0]` that previously passed on macOS or Windows will now
+  correctly report CL-0005.
 - **GitHub Action: installing a just-released version no longer fails on
   PyPI index lag.** PyPI's JSON API sees a release within seconds of the
   publish, but the `/simple/` index pip resolves against can lag it by

--- a/src/compose_lint/rules/CL0005_unbound_ports.py
+++ b/src/compose_lint/rules/CL0005_unbound_ports.py
@@ -61,11 +61,22 @@ _WILDCARD_LITERALS = frozenset({"*"})
 def _is_wildcard_ip(value: str) -> bool:
     """Return True if the value publishes on all interfaces.
 
-    Tests the *address*, not its spelling. `ipaddress.is_unspecified` covers
-    every way of writing the all-zeroes address in either family, including the
-    IPv4-mapped IPv6 form; brackets are stripped first because the port syntax
-    wraps IPv6 literals in them. An unparseable value is not a wildcard — it is
-    either a hostname or junk, and guessing would invent a finding.
+    Tests the *address*, not its spelling: brackets are stripped first
+    because the port syntax wraps IPv6 literals in them, and every way of
+    writing the all-zeroes address in either family is then the same
+    address. An unparseable value is not a wildcard — it is either a
+    hostname or junk, and guessing would invent a finding.
+
+    The IPv4-mapped form (``::ffff:0.0.0.0``) is unwrapped here rather than
+    left to ``is_unspecified``. Whether that property sees through the
+    mapping depends on the interpreter: CPython grew the delegation late
+    and backported it unevenly, so on some builds in this project's
+    supported range ``ipaddress.ip_address("::ffff:0.0.0.0")`` reports
+    ``is_unspecified`` as False. Relying on it made CL-0005 miss a
+    published-on-all-interfaces port on those hosts and fire on others —
+    the same compose file graded differently by interpreter patch level,
+    which is the worst failure mode available to a security linter. Doing
+    the unwrap ourselves makes the classification ours on every host.
     """
     if not value:
         return True
@@ -75,9 +86,18 @@ def _is_wildcard_ip(value: str) -> bool:
     if candidate.startswith("[") and candidate.endswith("]"):
         candidate = candidate[1:-1]
     try:
-        return ipaddress.ip_address(candidate).is_unspecified
+        address = ipaddress.ip_address(candidate)
     except ValueError:
         return False
+    if address.is_unspecified:
+        return True
+    if isinstance(address, ipaddress.IPv6Address):
+        mapped = address.ipv4_mapped
+        # Only the mapped address being unspecified counts. ::ffff:127.0.0.1
+        # is a loopback bind wearing an IPv6 spelling, not a wildcard.
+        if mapped is not None and mapped.is_unspecified:
+            return True
+    return False
 
 
 @register_rule

--- a/tests/test_normalized_classification.py
+++ b/tests/test_normalized_classification.py
@@ -69,7 +69,17 @@ WILDCARD_SPELLINGS = [
     "[::ffff:0.0.0.0]",
     "0000:0000:0000:0000:0000:0000:0000:0000",
 ]
-BOUND_SPELLINGS = ["127.0.0.1", "[::1]", "192.168.1.10", "10.0.0.1"]
+BOUND_SPELLINGS = [
+    "127.0.0.1",
+    "[::1]",
+    "192.168.1.10",
+    "10.0.0.1",
+    # An IPv4-mapped *bind* address. The wildcard check unwraps the mapping,
+    # so this is the case that proves the unwrap is not blanket "any mapped
+    # address is a wildcard".
+    "[::ffff:127.0.0.1]",
+    "[::ffff:192.168.1.10]",
+]
 
 
 @pytest.mark.parametrize("host_ip", WILDCARD_SPELLINGS)
@@ -88,7 +98,33 @@ def test_an_unparseable_host_is_not_treated_as_a_wildcard() -> None:
     assert _is_wildcard_ip("db.internal") is False
 
 
-@pytest.mark.parametrize("host_ip", ["[::0]", "[0:0:0:0:0:0:0:0]", "[::ffff:0.0.0.0]"])
+@pytest.mark.parametrize(
+    "host_ip", ["[::ffff:0.0.0.0]", "[::ffff:0:0]", "::ffff:0.0.0.0"]
+)
+def test_the_ipv4_mapped_wildcard_does_not_depend_on_the_interpreter(
+    host_ip: str,
+) -> None:
+    """``::ffff:0.0.0.0`` is the unspecified address in an IPv6 spelling.
+
+    ``_is_wildcard_ip`` used to hand this to ``ipaddress.is_unspecified``,
+    whose treatment of IPv4-mapped addresses depends on the CPython build:
+    the macOS and Windows 3.10 legs reported False while 3.13 reported
+    True, so the same compose file was graded differently by interpreter
+    patch level and CL-0005 silently missed a port published on all
+    interfaces. Assert the classification directly — it is ours now.
+    """
+    assert _is_wildcard_ip(host_ip) is True, host_ip
+
+
+@pytest.mark.parametrize("host_ip", ["[::ffff:127.0.0.1]", "[::ffff:10.0.0.1]"])
+def test_an_ipv4_mapped_bind_address_is_still_not_a_wildcard(host_ip: str) -> None:
+    """The unwrap must not turn every mapped address into a finding."""
+    assert _is_wildcard_ip(host_ip) is False, host_ip
+
+
+@pytest.mark.parametrize(
+    "host_ip", ["[::0]", "[0:0:0:0:0:0:0:0]", "[::ffff:0.0.0.0]", "[::ffff:0:0]"]
+)
 def test_ipv6_wildcard_spellings_fire_cl0005(host_ip: str) -> None:
     source = (
         "services:\n  web:\n    image: nginx:1.25\n"


### PR DESCRIPTION
A false negative in CL-0005, found by the macOS/Windows Python 3.10 legs added
in #617 — on their first run. Not a CI problem: a real defect the existing
matrix could not see.

## What happens

`_is_wildcard_ip` handed `::ffff:0.0.0.0` — the IPv4-mapped spelling of the
unspecified address — to `ipaddress.is_unspecified`. That property's treatment
of IPv4-mapped addresses depends on the CPython build. Verified: 3.13.13 reports
`is_unspecified=True` (despite `int(addr) == 281470681743360`, i.e. it is
special-casing the mapping), while the macOS and Windows 3.10 runners report
`False`.

So:

```yaml
ports:
  - "[::ffff:0.0.0.0]:8080:80"   # published on all interfaces
```

is flagged on some hosts and **silently missed on others**, with nothing in the
output to tell a user which kind of host they are on. The function's docstring
already claimed the IPv4-mapped form was covered — on those builds it was not.

Same compose file, different verdict by interpreter patch level, in the direction
of a **false negative**. That is the worst failure mode available to a security
linter: a clean report that isn't.

## The fix

Unwrap `ipv4_mapped` ourselves and test the address behind it, so the
classification doesn't depend on the interpreter. Only a mapped address that is
*itself* unspecified counts — `::ffff:127.0.0.1` is a loopback bind wearing an
IPv6 spelling, not a wildcard.

Verified in both directions locally:

| input | result |
|---|---|
| `[::ffff:0.0.0.0]`, `::ffff:0:0` | wildcard |
| `[::ffff:127.0.0.1]`, `::ffff:192.168.1.10` | not a wildcard |
| `0.0.0.0`, `[::]`, `` (empty) | wildcard |
| `[::1]`, `127.0.0.1`, `localhost` | not a wildcard |

## Tests

The existing parametrized case asserted `[::ffff:0.0.0.0]` was a wildcard and
passed on 3.13 by accident. Added alongside it:

- the mapped-unspecified spellings asserted directly, with the interpreter
  dependency written down so the next person doesn't reintroduce it
- IPv4-mapped **bind** addresses in `BOUND_SPELLINGS`, which is what stops the
  unwrap being a blanket "any mapped address is a wildcard"
- `[::ffff:0:0]` added to the end-to-end CL-0005 firing cases

`ruff`, `mypy --strict`, `pytest` (1831 passed, 6 skipped) green.

## Note on sequencing

**#617 is red until this lands** — its new 3.10 legs are what surfaced this, and
they will keep failing until the bug is fixed. Merge this first, then #617
rebases green. This PR stands on its own regardless: the defect is real on
today's `main`, on any macOS or Windows host running Python 3.10.

**Not verified from here:** I could not install CPython 3.10 in this container
(the interpreter download host isn't in the egress allowlist), so the 3.10
behaviour is established from the CI logs rather than reproduced locally. The
fix removes the dependency on that property entirely, so it is version-invariant
by construction — but #617's legs are what will confirm it.
