### PR TITLE
Keep Windows' platform variables in the tests' subprocess environment

### DIFF
--- a/tests/_cli_env.py
+++ b/tests/_cli_env.py
@@ -1,0 +1,59 @@
+"""A portable environment for the tests that spawn the CLI.
+
+Several suites run ``python -m compose_lint`` as a subprocess with an
+environment built from scratch rather than inherited, so a stray
+``NO_COLOR``/``PYTHONPATH`` on a developer's machine cannot change what
+the test observes. The dict those suites used was POSIX-shaped —
+``PATH="/usr/bin:/bin"`` and nothing else — which is inert on Windows
+right up until it isn't:
+
+    Fatal Python error: _Py_HashRandomization_Init: failed to get random
+    numbers to initialize Python
+    Python runtime state: preinitialized
+
+CPython 3.10 seeds hash randomization on Windows through
+``CryptAcquireContext``, which locates the crypto provider relative to
+``%SystemRoot%``. Drop that variable and the interpreter dies before it
+runs a line of our code — every such test failing with exit 1 and no
+output. 3.11+ moved to ``BCryptGenRandom``, which does not consult the
+environment, which is why this only ever broke a Windows leg pinned to
+the 3.10 floor (#613).
+
+Keep the environment minimal; keep the handful of variables Windows
+treats as part of the platform rather than as configuration.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Not a wishlist: SystemRoot is the one that breaks interpreter startup,
+# and the rest are what Windows expects any child process to be handed.
+# Spelled uppercase because Windows resolves environment names
+# case-insensitively (and os.environ upper-cases its keys there anyway), so
+# SYSTEMROOT and SystemRoot are the same variable to the child process.
+_WINDOWS_PLATFORM_VARS = (
+    "SYSTEMROOT",
+    "SYSTEMDRIVE",
+    "COMSPEC",
+    "PATHEXT",
+    "TEMP",
+    "TMP",
+)
+
+
+def cli_env(**overrides: str) -> dict[str, str]:
+    """Minimal, isolated environment for a compose-lint subprocess."""
+    env = {"PATH": "/usr/bin:/bin"}
+    if sys.platform == "win32":
+        env["PATH"] = os.environ.get("PATH", "")
+        env.update(
+            {
+                name: os.environ[name]
+                for name in _WINDOWS_PLATFORM_VARS
+                if name in os.environ
+            }
+        )
+    env.update(overrides)
+    return env

--- a/tests/test_assurance.py
+++ b/tests/test_assurance.py
@@ -20,6 +20,7 @@ from compose_lint import cli
 from compose_lint.config import ConfigError, load_config
 from compose_lint.engine import run_rules
 from compose_lint.parser import loads
+from tests._cli_env import cli_env
 
 _PRIVILEGED = "services:\n  web:\n    image: nginx:1.27\n    privileged: true\n"
 _FIXABLE = (
@@ -174,11 +175,10 @@ def test_the_override_is_visible_in_every_output_format(tmp_path: Path) -> None:
             text=True,
             encoding="utf-8",
             cwd=tmp_path,
-            env={
-                "PYTHONPATH": str(Path(__file__).resolve().parent.parent / "src"),
-                "PATH": "/usr/bin:/bin",
-                "NO_COLOR": "1",
-            },
+            env=cli_env(
+                PYTHONPATH=str(Path(__file__).resolve().parent.parent / "src"),
+                NO_COLOR="1",
+            ),
             timeout=120,
         ).stdout
 

--- a/tests/test_cli_env.py
+++ b/tests/test_cli_env.py
@@ -1,0 +1,47 @@
+"""The CLI-subprocess environment must stay isolated *and* startable.
+
+Two properties in tension. Isolation is why the environment is built from
+scratch instead of inherited. Startability is what that cost on Windows:
+without ``SystemRoot`` CPython 3.10 cannot seed hash randomization and
+dies at preinitialization, so every test using it failed with exit 1 and
+no output at all (#613's 3.10 Windows leg found this).
+
+A regression in either direction is silent — one lets the developer's
+shell leak into assertions, the other only shows up on one OS at one
+Python version — so both get pinned here.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from tests._cli_env import cli_env
+
+
+def test_the_environment_stays_minimal() -> None:
+    """Isolation is the reason this env is constructed rather than inherited."""
+    env = cli_env(PYTHONPATH="/x", NO_COLOR="1")
+    assert env["PYTHONPATH"] == "/x"
+    assert env["NO_COLOR"] == "1"
+    # Nothing that would let an ambient setting change what a test observes.
+    for leaked in ("COMPOSE_LINT_CONFIG", "PYTHONWARNINGS", "PYTHONSTARTUP"):
+        assert leaked not in env
+
+
+def test_overrides_win() -> None:
+    assert cli_env(PATH="/only/here")["PATH"] == "/only/here"
+
+
+def test_windows_keeps_what_the_interpreter_needs_to_start() -> None:
+    """``SYSTEMROOT`` is not configuration; it is how Windows finds the CSP."""
+    env = cli_env(PYTHONPATH="/x")
+    if sys.platform != "win32":
+        # The POSIX baseline stays deliberately bare.
+        assert env["PATH"] == "/usr/bin:/bin"
+        return
+    assert "SYSTEMROOT" in env, (
+        "dropping SystemRoot makes CPython 3.10 fail at preinitialization with "
+        "_Py_HashRandomization_Init, before any compose-lint code runs"
+    )
+    assert env["SYSTEMROOT"] == os.environ["SYSTEMROOT"]

--- a/tests/test_exit_code_contract.py
+++ b/tests/test_exit_code_contract.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 
 from compose_lint.config import ConfigError, load_config
 from compose_lint.parser import ComposeError, loads
+from tests._cli_env import cli_env
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -53,11 +54,7 @@ def _run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
         capture_output=True,
         text=True,
         encoding="utf-8",
-        env={
-            "PYTHONPATH": str(REPO_ROOT / "src"),
-            "PATH": "/usr/bin:/bin",
-            "NO_COLOR": "1",
-        },
+        env=cli_env(PYTHONPATH=str(REPO_ROOT / "src"), NO_COLOR="1"),
         timeout=180,
     )
 

--- a/tests/test_harness_end_of_options.py
+++ b/tests/test_harness_end_of_options.py
@@ -26,6 +26,8 @@ from typing import Any
 import pytest
 import yaml
 
+from tests._cli_env import cli_env
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 _COMPOSE = (
@@ -103,7 +105,7 @@ def test_double_dash_is_what_changes_the_verdict(tmp_path: Path) -> None:
             capture_output=True,
             text=True,
             encoding="utf-8",
-            env={"PYTHONPATH": str(REPO_ROOT / "src"), "PATH": "/usr/bin:/bin"},
+            env=cli_env(PYTHONPATH=str(REPO_ROOT / "src")),
             timeout=120,
         )
 
@@ -141,7 +143,7 @@ def test_flags_after_a_positional_still_work(tmp_path: Path, argv: list[str]) ->
         capture_output=True,
         text=True,
         encoding="utf-8",
-        env={"PYTHONPATH": str(REPO_ROOT / "src"), "PATH": "/usr/bin:/bin"},
+        env=cli_env(PYTHONPATH=str(REPO_ROOT / "src")),
         timeout=120,
     )
     assert proc.returncode == 0, proc.stderr

--- a/tests/test_init_write_path.py
+++ b/tests/test_init_write_path.py
@@ -20,6 +20,7 @@ import pytest
 from compose_lint.config import load_config
 from compose_lint.config_emit import render_config
 from compose_lint.models import Finding, Severity
+from tests._cli_env import cli_env
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -32,11 +33,7 @@ def _run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
         cwd=cwd,
         capture_output=True,
         text=True,
-        env={
-            "PYTHONPATH": str(REPO_ROOT / "src"),
-            "PATH": "/usr/bin:/bin",
-            "NO_COLOR": "1",
-        },
+        env=cli_env(PYTHONPATH=str(REPO_ROOT / "src"), NO_COLOR="1"),
         timeout=120,
     )
 

--- a/tests/test_output_sanitizing.py
+++ b/tests/test_output_sanitizing.py
@@ -24,6 +24,7 @@ from pathlib import Path
 import pytest
 
 from compose_lint._output import sanitize, sanitize_line
+from tests._cli_env import cli_env
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SRC = REPO_ROOT / "src" / "compose_lint"
@@ -39,11 +40,7 @@ def _run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
         cwd=cwd,
         capture_output=True,
         text=True,
-        env={
-            "PYTHONPATH": str(REPO_ROOT / "src"),
-            "PATH": "/usr/bin:/bin",
-            "NO_COLOR": "1",
-        },
+        env=cli_env(PYTHONPATH=str(REPO_ROOT / "src"), NO_COLOR="1"),
         timeout=120,
     )
 

--- a/tests/test_resource_bounds.py
+++ b/tests/test_resource_bounds.py
@@ -31,6 +31,7 @@ from compose_lint.config import ConfigError, load_config
 from compose_lint.engine import run_rules
 from compose_lint.formatters.sarif import MAX_SARIF_RESULTS
 from compose_lint.parser import ComposeError, loads
+from tests._cli_env import cli_env
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -42,11 +43,7 @@ def _run(args: list[str], cwd: Path, timeout: int = 120):
         capture_output=True,
         text=True,
         encoding="utf-8",
-        env={
-            "PYTHONPATH": str(REPO_ROOT / "src"),
-            "PATH": "/usr/bin:/bin",
-            "NO_COLOR": "1",
-        },
+        env=cli_env(PYTHONPATH=str(REPO_ROOT / "src"), NO_COLOR="1"),
         timeout=timeout,
     )
 


### PR DESCRIPTION
A pre-existing test-harness portability bug, found by the Windows Python 3.10 leg
added in #617 — its second finding, after #619.

## What happens

Six suites spawn `python -m compose_lint` as a subprocess with an environment
built **from scratch** rather than inherited, so a stray `NO_COLOR`/`PYTHONPATH`
on a developer's machine cannot change what a test observes. That's the right
instinct; the dict was just POSIX-shaped:

```python
env={"PYTHONPATH": ..., "PATH": "/usr/bin:/bin", "NO_COLOR": "1"}
```

On Windows that's inert — until Python 3.10:

```
Fatal Python error: _Py_HashRandomization_Init: failed to get random numbers
to initialize Python
Python runtime state: preinitialized
```

CPython 3.10 seeds hash randomization on Windows through `CryptAcquireContext`,
which locates the crypto provider relative to `%SystemRoot%`. Drop that variable
and the interpreter dies at preinitialization — before a line of compose-lint
runs. All **16** affected tests fail with exit 1 and no output, which reads like
the CLI broke rather than like the harness did.

3.11+ moved to `BCryptGenRandom`, which doesn't consult the environment. That's
why this survived: it needs Windows *and* the 3.10 floor, and until #617 nothing
ran that combination.

## The fix

One helper (`tests/_cli_env.py`) builds the subprocess environment: minimal
everywhere, plus the handful of variables Windows treats as part of the platform
rather than as configuration. All six call sites use it.

POSIX behaviour is unchanged — same bare `PATH=/usr/bin:/bin`, same isolation.
Names are spelled uppercase because Windows resolves environment names
case-insensitively (and `os.environ` upper-cases its keys there anyway).

## Tests

`tests/test_cli_env.py` pins both properties, because a regression in either
direction is silent — one lets the developer's shell leak into assertions, the
other only appears on one OS at one Python version.

`ruff`, `mypy --strict`, `pytest` (1836 passed, 6 skipped) green.

## Sequencing

**#617 stays red until this lands**, same as #619 before it. Merge order:
#619 (merged) → this → #617.

**Not verified from here:** I can't run Windows or install CPython 3.10 in this
container, so the diagnosis comes from the CI log and CPython's documented
change of RNG backend, not from a local reproduction. #617's Windows 3.10 leg is
what will confirm it — which is the point of adding that leg.
