### PR TITLE
Mount the shared smoke fixtures instead of inlining them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -745,43 +745,33 @@ jobs:
           # evict the other's layers — turning a cache into a coin flip.
           cache-from: type=gha,scope=${{ matrix.arch }}
           cache-to: type=gha,scope=${{ matrix.arch }},mode=max
+      # The shared fixtures, mounted read-only — same documents publish.yml's
+      # docker-smoke uses, and the same ones action-smoke, precommit-smoke and
+      # marketplace-smoke grade. These steps used to write their own heredoc
+      # copies, which is how the image ended up validated against the pre-0.3.x
+      # `clean` fixture (no `tmpfs:`) long after every other surface moved on.
+      # `:ro` because a linter must never be able to write to the file it is
+      # linting, least of all one in the checkout.
       - name: Clean fixture exits 0
         run: |
-          cat > /tmp/clean.yml <<'YAML'
-          services:
-            web:
-              image: nginx:1.27-alpine
-              ports:
-                - "127.0.0.1:8080:80"
-              security_opt:
-                - no-new-privileges:true
-              cap_drop:
-                - ALL
-              read_only: true
-          YAML
-          docker run --rm -v /tmp/clean.yml:/src/docker-compose.yml composelint/compose-lint:pr-smoke
+          docker run --rm \
+            -v "${PWD}/tests/smoke/clean.yml:/src/docker-compose.yml:ro" \
+            composelint/compose-lint:pr-smoke
       - name: Insecure fixture exits 1
         run: |
-          cat > /tmp/insecure.yml <<'YAML'
-          services:
-            app:
-              image: myapp:1.0
-              privileged: true
-          YAML
           exit_code=0
-          docker run --rm -v /tmp/insecure.yml:/src/docker-compose.yml composelint/compose-lint:pr-smoke || exit_code=$?
+          docker run --rm \
+            -v "${PWD}/tests/smoke/insecure.yml:/src/docker-compose.yml:ro" \
+            composelint/compose-lint:pr-smoke || exit_code=$?
           if [ "${exit_code}" -ne 1 ]; then
             echo "::error::Expected exit code 1, got ${exit_code}"
             exit 1
           fi
       - name: SARIF output is valid JSON
         run: |
-          cat > /tmp/test.yml <<'YAML'
-          services:
-            db:
-              image: postgres:16
-          YAML
-          docker run --rm -v /tmp/test.yml:/src/docker-compose.yml composelint/compose-lint:pr-smoke --format sarif --fail-on critical \
+          docker run --rm \
+            -v "${PWD}/tests/smoke/sarif-shape.yml:/src/docker-compose.yml:ro" \
+            composelint/compose-lint:pr-smoke --format sarif --fail-on critical \
             | python3 -c "import sys, json; json.load(sys.stdin); print('Valid SARIF JSON')"
 
   action-smoke:
@@ -798,9 +788,11 @@ jobs:
           persist-credentials: false
 
       # Smoke fixtures live in tests/smoke/ and are shared with every
-      # other workflow that runs compose-lint end-to-end (publish.yml
-      # testpypi-smoke, publish.yml docker-smoke, marketplace-smoke.yml).
-      # One source of truth prevents per-workflow drift.
+      # other job that runs compose-lint end-to-end (docker-smoke above,
+      # precommit-smoke and fix-smoke below, publish.yml's testpypi-smoke
+      # and docker-smoke, marketplace-smoke.yml). One source of truth
+      # prevents per-workflow drift; tests/test_release_layer.py enforces
+      # it, because this list was wrong for as long as it existed.
 
       # `version: latest` is deliberate. The action now *pins* by default so a
       # consumer's SHA-pinned `uses:` gets a reproducible check, but what this

--- a/.github/workflows/publish-channel.yml
+++ b/.github/workflows/publish-channel.yml
@@ -83,30 +83,9 @@ jobs:
         run: |
           python -m venv /tmp/smoke-venv
           /tmp/smoke-venv/bin/pip install dist/*.whl
-          cat > /tmp/clean.yml <<'YAML'
-          services:
-            web:
-              image: nginx:1.27-alpine
-              ports:
-                - "127.0.0.1:8080:80"
-              security_opt:
-                - no-new-privileges:true
-              cap_drop:
-                - ALL
-              read_only: true
-              tmpfs:
-                - /tmp
-                - /run
-          YAML
-          cat > /tmp/insecure.yml <<'YAML'
-          services:
-            app:
-              image: myapp:1.0
-              privileged: true
-          YAML
-          /tmp/smoke-venv/bin/compose-lint /tmp/clean.yml
+          /tmp/smoke-venv/bin/compose-lint tests/smoke/clean.yml
           exit_code=0
-          /tmp/smoke-venv/bin/compose-lint /tmp/insecure.yml || exit_code=$?
+          /tmp/smoke-venv/bin/compose-lint tests/smoke/insecure.yml || exit_code=$?
           if [ "${exit_code}" -ne 1 ]; then
             echo "::error::Expected exit 1 on insecure fixture, got ${exit_code}"
             exit 1
@@ -180,21 +159,6 @@ jobs:
           fi
       - name: Test — clean fixture exits 0 (hardened)
         run: |
-          cat > /tmp/clean.yml <<'YAML'
-          services:
-            web:
-              image: nginx:1.27-alpine
-              ports:
-                - "127.0.0.1:8080:80"
-              security_opt:
-                - no-new-privileges:true
-              cap_drop:
-                - ALL
-              read_only: true
-              tmpfs:
-                - /tmp
-                - /run
-          YAML
           docker run --rm \
             --read-only \
             --cap-drop ALL \
@@ -202,16 +166,10 @@ jobs:
             --network none \
             --user 65532:65532 \
             --pids-limit 256 \
-            -v /tmp/clean.yml:/src/docker-compose.yml:ro \
+            -v "${PWD}/tests/smoke/clean.yml:/src/docker-compose.yml:ro" \
             composelint/compose-lint:channel-smoke
       - name: Test — insecure fixture exits 1 (hardened)
         run: |
-          cat > /tmp/insecure.yml <<'YAML'
-          services:
-            app:
-              image: myapp:1.0
-              privileged: true
-          YAML
           exit_code=0
           docker run --rm \
             --read-only \
@@ -220,7 +178,7 @@ jobs:
             --network none \
             --user 65532:65532 \
             --pids-limit 256 \
-            -v /tmp/insecure.yml:/src/docker-compose.yml:ro \
+            -v "${PWD}/tests/smoke/insecure.yml:/src/docker-compose.yml:ro" \
             composelint/compose-lint:channel-smoke || exit_code=$?
           if [ "${exit_code}" -ne 1 ]; then
             echo "::error::Expected exit 1 on insecure fixture, got ${exit_code}"

--- a/tests/test_release_layer.py
+++ b/tests/test_release_layer.py
@@ -283,3 +283,53 @@ def test_a_called_workflow_is_granted_what_its_jobs_request(
 def test_the_reusable_call_scan_finds_something() -> None:
     """Guard the guard: an empty scan would make the check above vacuous."""
     assert _reusable_calls(), "no reusable-workflow calls detected"
+
+
+# --- Smoke fixtures: one copy, or they drift (#624) -----------------------
+
+
+def _run_scripts() -> list[tuple[str, str]]:
+    """Every ``run:`` script in every workflow, as (workflow, script)."""
+    scripts: list[tuple[str, str]] = []
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for job in (workflow.get("jobs") or {}).values():
+            for step in job.get("steps") or []:
+                run = step.get("run")
+                if isinstance(run, str):
+                    scripts.append((path.name, run))
+    return scripts
+
+
+def test_no_workflow_inlines_a_compose_document() -> None:
+    """Smoke fixtures live in tests/smoke/, and nowhere else.
+
+    ``tests/smoke/clean.yml`` exists because the fixture once lived in five
+    heredocs and only some of them included ``tmpfs:``. That consolidation
+    missed all five: ci.yml's docker-smoke was still grading the pre-0.3.x
+    document, and publish-channel.yml carried four more copies (#624). A
+    comment naming the participating workflows had been wrong for as long
+    as it existed, because nothing checked it.
+
+    A duplicated fixture is not a style problem. It is a surface being
+    graded against a definition of "insecure" that no longer matches the
+    one every other surface uses, reporting success either way.
+    """
+    offenders = [
+        name
+        for name, script in _run_scripts()
+        if re.search(r"^\s*services:\s*$", script, re.MULTILINE)
+    ]
+    assert not offenders, (
+        "workflow run: blocks contain an inline Compose document "
+        f"({sorted(set(offenders))}). Mount tests/smoke/*.yml instead — see #624."
+    )
+
+
+def test_the_shared_fixtures_are_actually_consumed() -> None:
+    """Guard the guard: the check above passes trivially if nothing uses them."""
+    consumers = {name for name, script in _run_scripts() if "tests/smoke/" in script}
+    assert len(consumers) >= 3, (
+        f"only {sorted(consumers)} reference tests/smoke/ — the no-inline-fixture "
+        "check above would pass vacuously if the fixtures fell out of use"
+    )


### PR DESCRIPTION
Closes #624.

`tests/smoke/clean.yml`'s header explains why it exists:

> Keeping one copy prevents the drift we had through 0.3.x where the fixture
> existed in five heredocs and only some included `tmpfs:`.

**That consolidation missed all five.**

- `ci.yml`'s `docker-smoke` was still writing its own copy — and it was the
  drifted one, without `tmpfs:`. The PR-time Docker check has been grading a
  pre-0.3.x document that nobody maintains.
- `publish-channel.yml` carried four more, across its wheel smoke and its two
  hardened-image smokes.

The four in `publish-channel.yml` happen to match the shared fixture today,
which is precisely the argument for removing them: nothing keeps them matching.
A rule added to `tests/smoke/insecure.yml` reaches five surfaces and silently
skips these.

All of them now mount `tests/smoke/*` read-only, the way `publish.yml`'s
docker-smoke already did. The wheel smoke lints the checkout's copies directly.
`:ro` throughout — a linter should not be able to write to the file it is
linting, least of all one in the checkout.

## The comment was wrong too

`ci.yml:800` enumerated the workflows sharing the fixtures and named
`publish.yml`'s docker-smoke but not the job fifty lines above it. It had been
wrong for as long as it existed, because nothing checked it. Updated, and
demoted to a pointer at the test that now enforces it.

## The guard

`tests/test_release_layer.py` gains two checks:

- **No workflow `run:` block contains a `services:` document.** This is what
  would have caught the consolidation missing one.
- **The shared fixtures are still consumed by ≥3 workflows** — otherwise the
  first check passes vacuously the day the fixtures fall out of use.

Verified the guard discriminates rather than trivially passing: reintroducing a
heredoc into `ci.yml` fails it with `assert not ['ci.yml']`, and removing it
passes. Confirmed zero `services:` documents remain in any workflow.

## Verification

`ruff`, `mypy --strict`, `pytest` (1838 passed, 6 skipped), `actionlint` all green.

**Not verified locally:** the Docker mounts themselves — no Docker in this
container. `ci.yml`'s `docker-smoke` is path-gated on build inputs and this PR
doesn't touch them, so it will skip here; it runs unconditionally on the
push-to-`main` build after merge, which is where the mounts get their first
real exercise. `publish-channel.yml` is manual-dispatch only and is not
exercised by this PR at all.

Prerequisite for #621 — the cross-surface golden finding-set comparison can now
include the Docker surface, because it finally lints the same document as
everything else.
