### PR TITLE
Pin the three definitions of "a Compose file" to each other

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,31 @@
 
 compose-lint reads `.compose-lint.yml` from the current working directory by default. Use `--config PATH` to point at a different file.
 
+## Which files get linted
+
+Given explicit paths or a `--pattern`, compose-lint lints exactly those. With no arguments it looks in the **current directory only**, for exactly four names:
+
+```
+compose.yml   compose.yaml   docker-compose.yml   docker-compose.yaml
+```
+
+Finding none is an error (exit 2), not a pass — a gate reporting success over an unlinted repository is the one outcome this tool must never produce.
+
+**The pre-commit hook is deliberately broader.** It selects any path matching `(^|/)(docker-)?compose[^/]*\.ya?ml$` — so `compose.prod.yml`, `docker-compose.override.yml` and `stack/compose.yml` are linted by the hook and *not* by a bare `compose-lint` run:
+
+| path | `compose-lint` / GitHub Action | pre-commit hook |
+| --- | --- | --- |
+| `compose.yml` | linted | linted |
+| `compose.prod.yml` | not found | linted |
+| `docker-compose.override.yml` | not found | linted |
+| `stack/compose.yml` | not found | linted |
+
+The asymmetry is intentional. pre-commit hands the hook a filename-filtered list of files you actually changed, so matching broadly is useful and safe. A bare `compose-lint` has no such list and must not guess which of a repository's YAML files are Compose files.
+
+**What this means for you:** if your Compose files are not among the four default names, pass them explicitly (`compose-lint compose.prod.yml`) or use `--pattern`, and configure the GitHub Action's `files:` or `pattern:` input the same way. Otherwise a repository that passes pre-commit can report "no Compose files found" in CI.
+
+`tests/test_discovery_parity.py` holds all three surfaces to this table, so the hook can never become *narrower* than the CLI and the Action's list cannot drift from it.
+
 ## Generating a starter config
 
 Rather than hand-author the file from this page, run `compose-lint init` to turn a file's current findings into a `.compose-lint.yml` you then triage:

--- a/tests/test_discovery_parity.py
+++ b/tests/test_discovery_parity.py
@@ -1,0 +1,126 @@
+"""What counts as "a Compose file" is defined in three places (#622).
+
+``_COMPOSE_FILENAMES`` in the CLI, a hand-copied bash list in ``action.yml``,
+and a regex in ``.pre-commit-hooks.yaml``. A user who moves between surfaces
+expects the same repository to lint the same way, and nothing held the three
+together.
+
+The two relationships are deliberately different, so they are asserted
+differently:
+
+* **The action must match the CLI exactly.** Its list is a duplicate of a
+  list that lives in Python — it exists only because ``steps[].uses`` cannot
+  call into the package. A duplicate that is allowed to differ is just a bug
+  with a delay on it, and the action is the surface most users meet first.
+
+* **The hook may be broader, and is.** pre-commit hands it a filename-filtered
+  changeset, so matching ``compose.prod.yml`` is the useful behavior there,
+  whereas bare ``compose-lint`` must not guess which of a repository's files
+  are Compose files. What must not happen is the hook *missing* something the
+  CLI would lint — that direction is a user losing coverage on the surface
+  they trust most, and it is what these tests pin.
+
+Whether the CLI's default set should itself grow (``compose.override.yml`` is
+the obvious candidate, since Compose merges it automatically) is a product
+question, not a consistency one. It is deliberately not decided here.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from compose_lint.cli import _COMPOSE_FILENAMES
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ACTION = REPO_ROOT / "action.yml"
+HOOKS = REPO_ROOT / ".pre-commit-hooks.yaml"
+
+# Names the hook selects and the CLI/action deliberately do not. Each is a
+# real spelling a user would write, and each is currently linted by the hook
+# and invisible to `compose-lint` with no arguments.
+BROADER_THAN_CLI = [
+    "compose.prod.yml",
+    "docker-compose.override.yml",
+    "compose.dev.yaml",
+    "nested/compose.yml",
+]
+
+
+def _action_default_filenames() -> set[str]:
+    """The filename list in action.yml's discovery step."""
+    action = yaml.safe_load(ACTION.read_text(encoding="utf-8"))
+    step = next(s for s in action["runs"]["steps"] if s.get("id") == "find-files")
+    # The step has two `for f in …` loops: one over $CL_FILES (the explicit
+    # `files:` input) and one over the literal default names. Select on the
+    # absence of a variable rather than on position, and require the choice
+    # to be unambiguous — matching the wrong loop would compare this list
+    # against something that is not a filename list at all.
+    loops = [
+        operand
+        for operand in re.findall(r"for f in ([^;]+); do", step["run"])
+        if "$" not in operand
+    ]
+    assert len(loops) == 1, (
+        f"expected exactly one literal filename loop in action.yml, found {loops}"
+    )
+    return set(loops[0].split())
+
+
+def _hook() -> dict[str, Any]:
+    hooks = yaml.safe_load(HOOKS.read_text(encoding="utf-8"))
+    return next(h for h in hooks if h["id"] == "compose-lint")
+
+
+def _hook_selects(path: str) -> bool:
+    hook = _hook()
+    files = re.compile(hook.get("files", ""))
+    exclude = re.compile(hook.get("exclude", "^$"))
+    return bool(files.search(path)) and not exclude.search(path)
+
+
+def test_the_action_list_is_recognisable() -> None:
+    """Guard the guard: a silent extraction failure would pass everything."""
+    assert _action_default_filenames(), "extracted no filenames from action.yml"
+
+
+def test_the_action_default_matches_the_cli_exactly() -> None:
+    """A hand-copied duplicate is a bug with a delay on it.
+
+    If ``_COMPOSE_FILENAMES`` gains an entry, the action keeps the old list
+    silently — and reports "no Compose files found" on a repository the CLI
+    lints happily.
+    """
+    assert _action_default_filenames() == set(_COMPOSE_FILENAMES), (
+        "action.yml's default discovery list has drifted from "
+        "cli.py's _COMPOSE_FILENAMES; they are the same contract"
+    )
+
+
+@pytest.mark.parametrize("name", _COMPOSE_FILENAMES)
+def test_the_hook_selects_everything_the_cli_would_lint(name: str) -> None:
+    """The hook must never be narrower than the CLI.
+
+    Broader is a documented choice; narrower means a user's pre-commit run
+    passes over a file their CI run fails on.
+    """
+    assert _hook_selects(name), f"the pre-commit hook would skip {name}"
+    assert _hook_selects(f"nested/{name}"), f"the hook would skip nested/{name}"
+
+
+@pytest.mark.parametrize("name", BROADER_THAN_CLI)
+def test_the_documented_divergence_is_still_exactly_this(name: str) -> None:
+    """The hook is broader than the CLI, on purpose — pin how much.
+
+    Listing the divergence beats asserting it away: if one of these ever
+    starts being linted by bare ``compose-lint`` too, that is a deliberate
+    change to the CLI's default set and this test is where it gets noticed
+    (and where docs/configuration.md gets updated).
+    """
+    assert _hook_selects(name), f"the hook no longer selects {name}"
+    assert name not in _COMPOSE_FILENAMES
+    assert name not in _action_default_filenames()


### PR DESCRIPTION
Closes #622.

Three definitions of the same contract — `cli.py:62`'s `_COMPOSE_FILENAMES`, a
hand-copied bash list at `action.yml:166`, and the regex at
`.pre-commit-hooks.yaml:19` — with nothing holding them together.

## The decision I made

The issue offered two paths. I took **(b): pin the divergence, don't erase it** —
and deliberately did not change what any surface lints.

Making the CLI broader would be a user-facing behaviour change: more files
linted, more findings, potentially a red gate on somebody's next run. That
belongs to you, not to a test-consistency PR. So this PR changes zero
behaviour and only makes drift impossible.

The two relationships get asserted differently, because they *are* different:

- **The action must match the CLI exactly.** Its list exists only because
  `steps[].uses` cannot call into the package. A duplicate that's allowed to
  differ is a bug with a delay on it, and it's the surface most users meet
  first. The test extracts the list from `action.yml` and compares it.
- **The hook may be broader, and is.** pre-commit hands it a filename-filtered
  changeset, so matching `compose.prod.yml` is useful there; a bare
  `compose-lint` has no such list and must not guess. What must *not* happen is
  the hook becoming **narrower** — a user losing coverage on the surface they
  trust most — so that direction is pinned, and the current divergence is
  listed explicitly rather than asserted away.

## Docs

`docs/configuration.md` gains a "Which files get linted" section with the
comparison table. Discovery was documented nowhere before, which is a fair part
of why the divergence went unnoticed — and the practical advice a user needs
("pass them explicitly, or your pre-commit-green repo says *no Compose files
found* in CI") had no home.

## Verification

Both new checks proved to discriminate rather than pass trivially:

- Dropping `compose.yaml` from `action.yml`'s list → `test_the_action_default_matches_the_cli_exactly` fails; restoring → passes.
- The extractor asserts it found **exactly one** literal filename loop. Worth
  noting: my first version silently matched `for f in $CL_FILES` — the
  explicit-`files:` branch — and compared `{'$CL_FILES'}` against the CLI list.
  It failed loudly, but only by luck, so the extraction now selects on absence
  of a variable and requires the choice to be unambiguous.

`ruff`, `mypy --strict`, `pytest` (1846 passed, 6 skipped) green.

## Left open, on purpose

Whether `_COMPOSE_FILENAMES` should cover `compose.override.yml` /
`docker-compose.override.yml`. Compose merges an override file automatically, so
a user with both is currently linting half their effective configuration — a
real gap, but a product decision with its own blast radius. Noted in the test's
module docstring so it isn't lost.
