### PR TITLE
Say when no config is in effect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -767,6 +767,37 @@ jobs:
             echo "::error::Expected exit code 1, got ${exit_code}"
             exit 1
           fi
+      # The mount shape decides whether the user's policy exists at all.
+      # `.compose-lint.yml` is discovered in the working directory, which is
+      # /src in the image — so mounting the *directory* is what puts a config
+      # in scope, and mounting just the file leaves every suppression outside
+      # the container (#625). Only the directory form is supported, so the
+      # directory form is what gets asserted: CL-0002 is the insecure
+      # fixture's one critical finding, and suppressing it must flip the
+      # verdict. If it does not, the config was not read.
+      - name: Config in a mounted directory is honoured
+        run: |
+          set -euo pipefail
+          workdir="${RUNNER_TEMP}/config-mount"
+          mkdir -p "$workdir"
+          cp tests/smoke/insecure.yml "$workdir/docker-compose.yml"
+          printf 'rules:\n  CL-0002:\n    enabled: false\n    reason: "smoke: prove a mounted config is read"\n' \
+            > "$workdir/.compose-lint.yml"
+
+          # Without the config the same stack must still fail, or the check
+          # below would pass for reasons that have nothing to do with it.
+          exit_code=0
+          docker run --rm \
+            -v "${PWD}/tests/smoke/insecure.yml:/src/docker-compose.yml:ro" \
+            composelint/compose-lint:pr-smoke || exit_code=$?
+          if [ "${exit_code}" -ne 1 ]; then
+            echo "::error::Expected exit 1 without a config, got ${exit_code}"
+            exit 1
+          fi
+
+          docker run --rm -v "${workdir}:/src:ro" \
+            composelint/compose-lint:pr-smoke
+
       - name: SARIF output is valid JSON
         run: |
           docker run --rm \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`check` and `fix` now say when no config was in effect.** A run that
+  reports findings — or a `fix` that has changes to make — with no
+  `.compose-lint.yml` found and none passed via `--config` prints a one-line
+  note on stderr naming the directory it looked in. This is aimed at the
+  Docker case: the image's working directory is `/src`, so a run that mounts
+  only the compose file leaves the config outside the container and silently
+  drops every suppression. Passing runs, and runs that found a config, stay
+  quiet.
+
 ### Fixed
 
 - **CL-0005 now flags `::ffff:0.0.0.0` on every supported interpreter.** The

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,16 @@
 
 compose-lint reads `.compose-lint.yml` from the current working directory by default. Use `--config PATH` to point at a different file.
 
+> **Running in Docker: mount the directory, not the file.** The image's working directory is `/src`, so the config has to be *inside* it:
+>
+> ```bash
+> docker run --rm -v "$(pwd):/src" composelint/compose-lint            # config found
+> docker run --rm -v "$(pwd)/docker-compose.yml:/src/docker-compose.yml" \
+>   composelint/compose-lint                                            # config NOT found
+> ```
+>
+> The second form leaves `.compose-lint.yml` outside the container, so every suppression is silently absent and findings you disabled come back. compose-lint cannot tell that apart from having no config at all, so it does not fail — but when a run reports findings with no config in effect it says so on stderr, naming the directory it looked in.
+
 ## Which files get linted
 
 Given explicit paths or a `--pattern`, compose-lint lints exactly those. With no arguments it looks in the **current directory only**, for exactly four names:

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -96,6 +96,30 @@ def _effective_config_path(explicit: str | None) -> Path | None:
     return p if p.exists() else None
 
 
+def _note_no_config_in_effect() -> None:
+    """Say that nothing was suppressed, naming the directory we looked in.
+
+    A config that was never found is indistinguishable from one that was
+    never written, so this cannot be an error — most runs legitimately have
+    no config. What it can do is name the directory, which is the whole
+    diagnosis for the case it exists for: the image's working directory is
+    ``/src``, so a ``docker run -v "$(pwd)/docker-compose.yml:/src/docker-
+    compose.yml"`` mounts the file and not the config beside it, and every
+    suppression the user wrote is silently absent (#625). Seeing ``/src``
+    in the message is what makes that click.
+
+    Deliberately not printed on every run. It is emitted only where the
+    missing config would have changed the outcome — a failing ``check``, or
+    a ``fix`` that is about to touch a file — because a line on every green
+    run is noise, and noise on green runs is how a diagnostic stops being
+    read at all.
+    """
+    emit(
+        f"Note: no .compose-lint.yml found in '{Path.cwd()}' — all rules are "
+        "enabled and no suppressions are in effect."
+    )
+
+
 # Flags handled by the top-level parser, not `check`. A flag-only invocation
 # carrying one of these (e.g. `compose-lint --version`) is left untouched so the
 # top-level parser sees it; any other flag-only invocation routes to `check`.
@@ -604,6 +628,12 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
         )
         print(json.dumps(sarif_log, indent=2, allow_nan=False))
 
+    # A failing run with no config loaded is the shape of a config that was
+    # never found. This is the moment the user asks "why is this failing?",
+    # so it is the moment naming the working directory is worth a line.
+    if has_errors and config_path is None:
+        _note_no_config_in_effect()
+
     if run_errors or rule_errors:
         sys.exit(2)
     sys.exit(1 if has_errors else 0)
@@ -730,6 +760,8 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
 
     only = set(args.only) if args.only else None
     had_error = False
+    # Whether any file had a fix applied or offered — see the note below.
+    touched = False
 
     for filepath in args.files:
         try:
@@ -853,6 +885,7 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
                 f"{filepath}: applied {len(result.edits)} fix(es) across "
                 f"{len(result.fixed)} finding(s)"
             )
+            touched = True
         else:
             print(
                 render_file_diff(filepath, text, patched, result.caveats),
@@ -863,6 +896,14 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
                 f"{filepath}: {len(result.edits)} fix(es) available; "
                 f"{len(result.manual)} finding(s) need manual review"
             )
+            touched = touched or bool(result.edits)
+
+    # `fix` honours suppressions — a suppressed finding is never touched — so a
+    # config that went missing here does not just change a report, it changes
+    # which of the user's files get written. Say so whenever there was
+    # something to fix, applied or merely offered.
+    if touched and _effective_config_path(args.config) is None:
+        _note_no_config_in_effect()
 
     sys.exit(2 if had_error else 0)
 

--- a/tests/test_no_config_notice.py
+++ b/tests/test_no_config_notice.py
@@ -1,0 +1,117 @@
+"""Saying when no config is in effect — and staying quiet otherwise (#625).
+
+``.compose-lint.yml`` is discovered in the current working directory. Inside
+the image that is ``/src``, so a ``docker run`` that mounts only the compose
+file leaves the config outside the container and every suppression the user
+wrote silently absent. It fails toward *more* findings, which reads as the
+tool being noisy rather than as a mount mistake.
+
+It cannot be an error: a config that was never mounted is indistinguishable
+from one that was never written, and most runs legitimately have no config.
+So the contract is narrow, and both halves of it are load-bearing — a notice
+that fires on every green run stops being read, and one that never fires
+explains nothing.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests._cli_env import cli_env
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+NOTICE = "no .compose-lint.yml found"
+
+_INSECURE = "services:\n  app:\n    image: myapp:1.0\n    privileged: true\n"
+_CLEAN = (
+    "services:\n  web:\n    image: nginx:1.27-alpine@sha256:"
+    + "0" * 64
+    + '\n    ports:\n      - "127.0.0.1:8080:80"\n'
+    "    security_opt:\n      - no-new-privileges:true\n"
+    "    cap_drop:\n      - ALL\n    read_only: true\n"
+    "    mem_limit: 512m\n    cpus: 0.5\n    tmpfs:\n      - /tmp\n"
+)
+
+
+def _run(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "compose_lint", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        env=cli_env(PYTHONPATH=str(REPO_ROOT / "src"), NO_COLOR="1"),
+        timeout=120,
+    )
+
+
+@pytest.fixture
+def stack(tmp_path: Path) -> Path:
+    (tmp_path / "docker-compose.yml").write_text(_INSECURE, encoding="utf-8")
+    return tmp_path
+
+
+def test_a_failing_check_says_no_config_was_in_effect(stack: Path) -> None:
+    """The moment the user asks "why is this failing?"."""
+    proc = _run("check", "docker-compose.yml", cwd=stack)
+    assert proc.returncode == 1
+    assert NOTICE in proc.stderr
+    # Naming the directory is the whole diagnosis for the Docker case — a
+    # user seeing /src knows immediately what they failed to mount.
+    assert str(stack) in proc.stderr
+
+
+def test_the_notice_is_on_stderr_only(stack: Path) -> None:
+    """It must never reach a machine consumer's data stream."""
+    for fmt in ("json", "sarif"):
+        proc = _run("check", "--format", fmt, "docker-compose.yml", cwd=stack)
+        assert NOTICE not in proc.stdout, f"{fmt} stdout carries the notice"
+        assert NOTICE in proc.stderr, f"{fmt} run lost the notice entirely"
+
+
+def test_a_passing_check_stays_quiet(tmp_path: Path) -> None:
+    """Noise on green runs is how a diagnostic stops being read."""
+    (tmp_path / "docker-compose.yml").write_text(_CLEAN, encoding="utf-8")
+    proc = _run("check", "docker-compose.yml", cwd=tmp_path)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert NOTICE not in proc.stderr
+
+
+def test_a_config_that_was_found_stays_quiet(stack: Path) -> None:
+    (stack / ".compose-lint.yml").write_text(
+        'rules:\n  CL-0002:\n    enabled: false\n    reason: "test"\n',
+        encoding="utf-8",
+    )
+    proc = _run("check", "docker-compose.yml", cwd=stack)
+    assert NOTICE not in proc.stderr
+
+
+def test_an_explicit_config_stays_quiet(stack: Path) -> None:
+    """--config elsewhere is not a missing config."""
+    cfg = stack / "policy.yml"
+    cfg.write_text(
+        'rules:\n  CL-0003:\n    enabled: false\n    reason: "test"\n',
+        encoding="utf-8",
+    )
+    proc = _run("check", "--config", str(cfg), "docker-compose.yml", cwd=stack)
+    assert NOTICE not in proc.stderr
+
+
+def test_fix_says_it_too(stack: Path) -> None:
+    """`fix` honours suppressions, so a missing config changes what is written.
+
+    That makes this the more consequential of the two: `check` reports a
+    state, `fix` mutates the user's file.
+    """
+    proc = _run("fix", "docker-compose.yml", cwd=stack)
+    assert NOTICE in proc.stderr
+
+
+def test_fix_with_nothing_to_do_stays_quiet(tmp_path: Path) -> None:
+    (tmp_path / "docker-compose.yml").write_text(_CLEAN, encoding="utf-8")
+    proc = _run("fix", "docker-compose.yml", cwd=tmp_path)
+    assert NOTICE not in proc.stderr


### PR DESCRIPTION
Closes #625.

`.compose-lint.yml` is discovered in the current working directory (`config.py:154`). The image's working directory is `/src`, so:

```bash
docker run --rm -v "$(pwd):/src" composelint/compose-lint            # config found
docker run --rm -v "$(pwd)/docker-compose.yml:/src/docker-compose.yml" \
  composelint/compose-lint                                            # config NOT found
```

The second form drops every suppression silently. It fails toward *more* findings, so it reads as the tool being noisy rather than as a mount mistake.

## Where I narrowed the issue's proposal

The issue proposed a stderr line "when config discovery comes up empty". Taken literally that prints on **every run by any user who has no config** — which is most of them. A diagnostic that fires on every green run stops being read, and then it isn't a diagnostic.

So it is emitted only where a missing config would have **changed the outcome**:

- a `check` that reports findings at/above the threshold — the moment the user is asking "why is this failing?"
- a `fix` that has changes to make, applied or merely offered

Passing runs stay silent. Runs that found a config stay silent. `--config` pointing elsewhere stays silent.

`fix` is the more consequential of the two and worth calling out: it honours suppressions ("suppressed findings are never touched"), so a config that went missing there changes **which of the user's files get written**, not just what gets reported.

On stderr only — a JSON/SARIF consumer's data stream is untouched, while a CI job whose suppressions vanished still gets told. Verified both directions.

## Verified behaviour

| scenario | notice |
|---|---|
| failing `check`, no config | **shown**, naming the cwd |
| passing `check`, no config | silent |
| failing `check`, config present | silent |
| failing `check`, `--config elsewhere.yml` | silent |
| `fix` with fixes available, no config | **shown** |
| `fix` with nothing to do | silent |
| `--format json` / `--format sarif` | stderr only, never stdout |

## The Docker smoke

`ci.yml`'s docker-smoke now asserts the supported shape end to end: a directory mount carrying a config that disables CL-0002 (the insecure fixture's only critical finding) must flip the verdict to a pass. The **unconfigured** run is asserted to still fail in the same step, so the check cannot go green for reasons unrelated to the config being read.

That is a real assertion about the surface rather than about the CLI — it is what would catch a future `WORKDIR` change or an entrypoint that resets the working directory.

## Also

`docs/configuration.md` gains the mount guidance up front, since the failure is only obvious once you know `/src` is the working directory. CHANGELOG entry under Added.

## Verification

`ruff`, `mypy --strict`, `pytest` (1845 passed, 6 skipped), `actionlint` green. Seven new tests in `tests/test_no_config_notice.py` covering the table above.

**Not verified locally:** the Docker step — no Docker in this container. It is path-gated on build inputs, which this PR does not touch, so `docker-smoke` will skip on this PR and run on the push-to-`main` build after merge. I'll confirm it there.
