### PR TITLE
Assert text, json and sarif describe the same run

### DIFF
--- a/tests/test_format_equivalence.py
+++ b/tests/test_format_equivalence.py
@@ -1,0 +1,286 @@
+"""text, json and sarif must describe the same run (#623).
+
+Each formatter had its own tests, asserting its own expectations. Nothing
+asserted the three agree, so a formatter could drop a finding, re-grade a
+severity, or lose a suppression and only its own test would notice — and
+that test would be asserting the new behaviour.
+
+Format selection is a user-experience choice, not a semantic one: json is
+for a machine, sarif is for Code Scanning, text is for a human at a
+terminal. All three are views of one result set, and the failure this
+guards is the quiet one — a human's terminal and their Code Scanning
+dashboard disagreeing about what is wrong with their stack.
+
+The fixture is deliberately wide: several rules, three severities, more
+than one file, and a suppression carrying a reason.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, NamedTuple
+
+import pytest
+
+from tests._cli_env import cli_env
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# The documented correspondence (formatters/sarif.py `_SARIF_LEVEL`). Stated
+# here independently so a change to the mapping has to be made twice, on
+# purpose, rather than propagating silently into "the formats still agree".
+SEVERITY_TO_SARIF_LEVEL = {
+    "critical": "error",
+    "high": "error",
+    "medium": "warning",
+    "low": "note",
+}
+
+SUPPRESSED_RULE = "CL-0003"
+SUPPRESSION_REASON = "accepted risk, tracked in TICKET-42"
+CONFIG = (
+    f"rules:\n  {SUPPRESSED_RULE}:\n    enabled: false\n"
+    f'    reason: "{SUPPRESSION_REASON}"\n'
+)
+TARGETS = ["tests/smoke/insecure.yml", "tests/smoke/sarif-shape.yml"]
+
+
+class Finding(NamedTuple):
+    """The identity all three views can express.
+
+    File and line are in every format; the service name is not (see
+    ``test_sarif_still_cannot_name_the_service``). Two files in one run can
+    carry the same rule at the same line — the shared fixtures do exactly
+    that — so the file is part of the key, not decoration.
+    """
+
+    file: str
+    rule_id: str
+    line: int
+
+
+class Detail(NamedTuple):
+    severity: str  # "" when suppressed: the views spell that differently
+    suppressed: bool
+    service: str | None  # None where the format cannot say
+
+
+def _run(*args: str, cwd: Path) -> str:
+    proc = subprocess.run(
+        [sys.executable, "-m", "compose_lint", "check", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        env=cli_env(PYTHONPATH=str(REPO_ROOT / "src"), NO_COLOR="1"),
+        timeout=120,
+    )
+    assert proc.returncode in (0, 1), proc.stderr
+    return proc.stdout
+
+
+@pytest.fixture(scope="module")
+def workspace(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """A checkout-relative run, so paths in every format are comparable."""
+    ws = tmp_path_factory.mktemp("fmt")
+    (ws / "tests" / "smoke").mkdir(parents=True)
+    for target in TARGETS:
+        (ws / target).write_bytes((REPO_ROOT / target).read_bytes())
+    (ws / "policy.yml").write_text(CONFIG, encoding="utf-8")
+    return ws
+
+
+@pytest.fixture(scope="module")
+def outputs(workspace: Path) -> dict[str, str]:
+    common = ["--fail-on", "low", "--config", "policy.yml", *TARGETS]
+    return {
+        "text": _run(*common, cwd=workspace),
+        "quiet": _run("--quiet", *common, cwd=workspace),
+        "json": _run("--format", "json", *common, cwd=workspace),
+        "sarif": _run("--format", "sarif", *common, cwd=workspace),
+    }
+
+
+# --- parsing each view into the same shape -------------------------------
+
+_FILE_HEADER = re.compile(r"^(\S+\.ya?ml)$")
+_SERVICE_HEADER = re.compile(r"^\s+service: (\S+)\s+\(line \d+\)")
+_ROW = re.compile(r"^\s*(\d+)\s+(SUPPRESSED|CRITICAL|HIGH|MEDIUM|LOW)\s+(CL-\d{4})\b")
+
+
+def _from_text(out: str) -> dict[Finding, Detail]:
+    """Read the rendered table back, tracking which file and service we are in."""
+    parsed: dict[Finding, Detail] = {}
+    current_file = ""
+    current_service: str | None = None
+    for raw in out.splitlines():
+        header = _FILE_HEADER.match(raw)
+        if header:
+            current_file, current_service = header.group(1), None
+            continue
+        service = _SERVICE_HEADER.match(raw)
+        if service:
+            current_service = service.group(1)
+            continue
+        row = _ROW.match(raw)
+        if row:
+            line, severity, rule = row.groups()
+            suppressed = severity == "SUPPRESSED"
+            parsed[Finding(current_file, rule, int(line))] = Detail(
+                "" if suppressed else severity.lower(), suppressed, current_service
+            )
+    return parsed
+
+
+def _from_json(out: str) -> dict[Finding, Detail]:
+    payload: dict[str, Any] = json.loads(out)
+    return {
+        Finding(f["file"], f["rule_id"], f["line"]): Detail(
+            "" if f["suppressed"] else f["severity"],
+            bool(f["suppressed"]),
+            f["service"],
+        )
+        for f in payload["findings"]
+    }
+
+
+def _from_sarif(out: str) -> dict[Finding, Detail]:
+    parsed: dict[Finding, Detail] = {}
+    for r in json.loads(out)["runs"][0]["results"]:
+        physical = r["locations"][0]["physicalLocation"]
+        suppressed = bool(r.get("suppressions"))
+        finding = Finding(
+            physical["artifactLocation"]["uri"],
+            r["ruleId"],
+            physical["region"]["startLine"],
+        )
+        parsed[finding] = Detail("" if suppressed else r["level"], suppressed, None)
+    return parsed
+
+
+# --- the comparisons ------------------------------------------------------
+
+
+def test_the_fixture_is_wide_enough_to_be_worth_comparing(
+    outputs: dict[str, str],
+) -> None:
+    """Guard the guard: a thin document makes every assertion below vacuous."""
+    findings = _from_json(outputs["json"])
+    assert len(findings) >= 5
+    severities = {d.severity for d in findings.values() if not d.suppressed}
+    assert len(severities) >= 3, f"only {severities} exercised"
+    assert any(d.suppressed for d in findings.values()), "no suppression exercised"
+
+
+def test_all_three_report_the_same_findings(outputs: dict[str, str]) -> None:
+    """Set equality, not counts — a substituted rule id keeps the count."""
+    text = set(_from_text(outputs["quiet"]))
+    js = set(_from_json(outputs["json"]))
+    sarif = set(_from_sarif(outputs["sarif"]))
+    assert text == js, f"text vs json: only-text={text - js} only-json={js - text}"
+    assert js == sarif, f"json vs sarif: only-json={js - sarif} only-sarif={sarif - js}"
+
+
+def test_severity_agrees_through_the_documented_mapping(
+    outputs: dict[str, str],
+) -> None:
+    js = _from_json(outputs["json"])
+    text = _from_text(outputs["quiet"])
+    sarif = _from_sarif(outputs["sarif"])
+    for finding, (severity, suppressed, _svc) in js.items():
+        if suppressed:
+            continue
+        assert text[finding].severity == severity, f"{finding}: text disagrees"
+        assert sarif[finding].severity == SEVERITY_TO_SARIF_LEVEL[severity], (
+            f"{finding}: sarif level {sarif[finding].severity!r} is not the documented "
+            f"rendering of {severity!r}"
+        )
+
+
+def test_suppression_state_agrees(outputs: dict[str, str]) -> None:
+    js = _from_json(outputs["json"])
+    text = _from_text(outputs["quiet"])
+    sarif = _from_sarif(outputs["sarif"])
+    for finding, (_severity, suppressed, _svc) in js.items():
+        assert text[finding].suppressed == suppressed, (
+            f"{finding}: text suppression differs"
+        )
+        assert sarif[finding].suppressed == suppressed, (
+            f"{finding}: sarif suppression differs"
+        )
+    assert any(d.suppressed for d in js.values())
+
+
+def test_text_and_json_agree_on_the_service(outputs: dict[str, str]) -> None:
+    """The two views that can name a service must name the same one.
+
+    This is what a user acts on — "which of my services is wrong" — and it
+    is reconstructed differently in each view: json carries it per finding,
+    the terminal groups findings under a ``service:`` heading. A grouping
+    bug puts a finding under the wrong heading while the json stays right.
+    """
+    text = _from_text(outputs["quiet"])
+    js = _from_json(outputs["json"])
+    for finding, detail in js.items():
+        assert text[finding].service == detail.service, (
+            f"{finding}: text groups it under {text[finding].service!r}, "
+            f"json says {detail.service!r}"
+        )
+
+
+def test_the_suppression_reason_survives_into_every_view(
+    outputs: dict[str, str],
+) -> None:
+    """One value wearing three names (AGENTS.md).
+
+    A suppression whose reason is lost is a suppression nobody can audit.
+    """
+    entry = next(
+        f
+        for f in json.loads(outputs["json"])["findings"]
+        if f["rule_id"] == SUPPRESSED_RULE
+    )
+    assert entry["suppression_reason"] == SUPPRESSION_REASON
+
+    result = next(
+        r
+        for r in json.loads(outputs["sarif"])["runs"][0]["results"]
+        if r["ruleId"] == SUPPRESSED_RULE and r.get("suppressions")
+    )
+    assert result["suppressions"][0]["justification"] == SUPPRESSION_REASON
+
+    # Text carries it on a continuation line under the row; `--quiet` is
+    # documented as one line per finding, so it is not expected there.
+    assert SUPPRESSION_REASON in outputs["text"]
+    assert SUPPRESSION_REASON not in outputs["quiet"]
+
+
+def test_sarif_still_cannot_name_the_service(outputs: dict[str, str]) -> None:
+    """A known asymmetry, pinned so it cannot change unnoticed.
+
+    text and json both name the service a finding belongs to; SARIF results
+    carry only ``ruleId``, ``artifactLocation`` and ``startLine``. In a
+    multi-service file the line number is a Code Scanning user's only
+    disambiguator, while a terminal user is told "service: web" outright.
+
+    This is why the comparisons above key on (rule, line) rather than the
+    (rule, service) the three views cannot all express. Asserting it here
+    keeps that a deliberate limitation rather than an oversight — and if
+    SARIF ever does carry the service, this test is where the equivalence
+    key gets widened.
+    """
+    findings = json.loads(outputs["json"])["findings"]
+    assert all(f.get("service") for f in findings), "json lost the service name"
+
+    results = json.loads(outputs["sarif"])["runs"][0]["results"]
+    services = {f["service"] for f in findings}
+    for r in results:
+        blob = json.dumps(r)
+        assert not any(
+            f'"{s}"' == r.get("properties", {}).get("service") for s in services
+        ), "SARIF now carries a service property — widen the equivalence key"
+        assert "service" not in r.get("properties", {}), blob[:200]


### PR DESCRIPTION
Closes #623.

`text`, `json` and `sarif` each had their own tests asserting their own expectations. Nothing asserted the three describe the same run — so a formatter could drop a finding, re-grade a severity or lose a suppression, and only its own test would notice, while asserting the *new* behaviour.

One run over both smoke fixtures with a rule suppressed, three renderings, compared on:

- **the finding set** — set equality, not counts (a substituted rule id keeps the count)
- **severity** — through the documented `_SARIF_LEVEL` correspondence, restated in the test so changing the mapping has to be done twice, on purpose
- **suppression state**
- **the suppression reason** in each of its three spellings — `suppression_reason` / `justification` / the text continuation line
- **the service name**, for the two views that can express it

## Two things the fixtures forced

**The key had to include the file.** Both fixtures carry CL-0003 at line 6, so my first `(rule, line)` key silently collided across files and three comparisons passed for the wrong reason. Caught because the suppressed finding went missing from one side; the key is now `(file, rule, line)`.

**The key could not be `(rule, service)`** — which is what the issue proposed. SARIF results carry only `ruleId`, `artifactLocation` and `startLine`. **There is no service name in our SARIF at all.** In a multi-service file, a Code Scanning user's only disambiguator is the line number, while a terminal user is told `service: web` outright.

That's a genuine asymmetry, so it gets its own test pinning it rather than being worked around silently — and that test is where the equivalence key gets widened if SARIF ever does carry the service. I have **not** changed the SARIF output here: adding a service would alter user-facing results and interacts with alert fingerprinting, which deserves its own decision. Happy to file it as a follow-up.

## Verification

Proved the comparison discriminates rather than passing trivially: flipping `_SARIF_LEVEL[MEDIUM]` from `warning` to `note` fails `test_severity_agrees_through_the_documented_mapping`; restoring it passes. There's also a guard-the-guard test asserting the fixture still exercises ≥5 findings, ≥3 severities and at least one suppression, so the comparisons can't go vacuous.

`ruff`, `mypy --strict`, `pytest` (1845 passed, 6 skipped) green. Tests only — no source changes.
