### PR TITLE
Hold the surfaces to a golden finding set, not just an exit code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -767,6 +767,23 @@ jobs:
             echo "::error::Expected exit code 1, got ${exit_code}"
             exit 1
           fi
+      # Exit codes are a one-bit assertion: the insecure fixture trips six
+      # rules and only CL-0002 is at or above the default threshold, so this
+      # surface could stop reporting the other five and the step above would
+      # still be green (#621). Compare the whole set instead.
+      - name: Findings match the golden set
+        run: |
+          # `|| true` is safe because the assertion is the comparison below,
+          # not this exit code: the fixture's CL-0002 is critical so the run
+          # exits 1 at every threshold, and an image that crashed writes no
+          # parseable report and fails the comparison anyway.
+          docker run --rm \
+            -v "${PWD}/tests/smoke/insecure.yml:/src/docker-compose.yml:ro" \
+            composelint/compose-lint:pr-smoke --format json --fail-on critical \
+            > "${RUNNER_TEMP}/docker.json" || true
+          python3 scripts/assert_golden_findings.py \
+            --surface "docker/${{ matrix.arch }}" "${RUNNER_TEMP}/docker.json"
+
       # The mount shape decides whether the user's policy exists at all.
       # `.compose-lint.yml` is discovered in the working directory, which is
       # /src in the image — so mounting the *directory* is what puts a config
@@ -1119,6 +1136,30 @@ jobs:
   # insecure state is the Docker default, or the flagged config produces the
   # insecure behavior). Catches the CL-0022/CL-0023 failure mode — a rule that
   # flags a Docker default — before it ships. Runners have Docker preinstalled.
+      # Same one-bit problem as everywhere else: the steps above prove the
+      # hook runs and fails, not that it found the right things. `try-repo`
+      # builds the hook from the working tree, so the tree's golden applies
+      # here — unlike action-smoke, which installs `version: latest` on
+      # purpose and is therefore testing published-against-source drift, a
+      # different contract a tree-derived golden would wrongly fail.
+      - name: Findings match the golden set
+        env:
+          SMOKE: ${{ runner.temp }}/golden
+        run: |
+          set -euo pipefail
+          mkdir -p "$SMOKE"
+          cp tests/smoke/insecure.yml "$SMOKE/docker-compose.yml"
+          cd "$SMOKE"
+          git init -q
+          git add -A
+          # The hook exits 1 on the insecure fixture by design; the assertion
+          # is the comparison below, not this exit code.
+          pre-commit try-repo "$GITHUB_WORKSPACE" compose-lint --all-files \
+            > out.txt 2>&1 || true
+          cat out.txt
+          python3 "$GITHUB_WORKSPACE/scripts/assert_golden_findings.py" \
+            --in-text --surface pre-commit out.txt
+
   rule-premises:
     name: Validate rule premises (live container)
     needs: changes

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -65,6 +65,7 @@ cancels in-progress runs when you push new commits to the same PR.
 | `dockerfile-digests`      | Fails if any `FROM @sha256:` in the Dockerfile is a per-arch manifest instead of an index |
 | `docker-smoke`            | Builds `linux/amd64` **and `linux/arm64`** from the Dockerfile on native runners and runs each against fixtures (only when build inputs change) |
 | `action-smoke`            | Runs `./action.yml` against clean and insecure fixtures; asserts exit codes               |
+| `docker-smoke` / `precommit-smoke` | Also compare the reported findings against `tests/smoke/insecure.golden.json` — exit codes alone hid five of the fixture's six rules |
 | `fix-smoke`               | `fix --apply` round trip on LF and CRLF copies of the insecure fixture — result parses, `docker compose config` accepts it, endings stay uniform, no new finding, idempotent |
 | `rule-premises`           | Runs `scripts/validate_rule_premises.py` in a live container to prove each rule's premise  |
 | `version-consistency`     | Fails if `pyproject.toml` and `src/compose_lint/__init__.py` disagree on the version      |

--- a/scripts/assert_golden_findings.py
+++ b/scripts/assert_golden_findings.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Compare a surface's report against the golden finding set (#621).
+
+Every cross-surface smoke used to assert one bit: exit 0 versus exit 1.
+``tests/smoke/insecure.yml`` trips six rules and only one of them is at or
+above the default threshold, so a surface could stop reporting five of the
+six and every smoke stayed green. The failure is invisible in exactly the
+direction that matters for a security linter — fewer findings, same
+verdict.
+
+This is the shared comparator. It reads a compose-lint report in **json or
+sarif** and holds it to ``tests/smoke/insecure.golden.json``. Both are
+accepted because not every surface can emit both: the GitHub Action writes
+SARIF and never JSON, and ``tests/test_format_equivalence.py`` is what
+makes reading the SARIF equivalent to reading the JSON (#623).
+
+Two properties make one golden file work everywhere:
+
+* **The reported set does not depend on ``--fail-on``.** The threshold
+  moves the exit code, not the findings — verified across low/high/critical.
+  So a surface may use whatever threshold it likes.
+* **The path is not part of the key.** Docker sees the fixture mounted at
+  ``/src/docker-compose.yml``, the Action sees ``tests/smoke/insecure.yml``.
+  Each smoke lints exactly one file, which the comparator asserts, so
+  ``(rule, line)`` identifies a finding unambiguously.
+
+Usage:
+    compose-lint --format json ... | python3 scripts/assert_golden_findings.py
+    python3 scripts/assert_golden_findings.py --surface docker report.json
+    python3 scripts/assert_golden_findings.py --update < report.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+from typing import Any
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+GOLDEN = REPO / "tests" / "smoke" / "insecure.golden.json"
+
+# The documented severity -> SARIF level correspondence
+# (src/compose_lint/formatters/sarif.py, `_SARIF_LEVEL`).
+SARIF_LEVEL = {
+    "critical": "error",
+    "high": "error",
+    "medium": "warning",
+    "low": "note",
+}
+
+
+def _load_report(raw: str) -> tuple[str, list[dict[str, Any]], set[str]]:
+    """Normalise json or sarif to ``(kind, findings, files)``."""
+    document = json.loads(raw)
+    if "runs" in document:
+        results = document["runs"][0]["results"]
+        findings = []
+        files = set()
+        for r in results:
+            physical = r["locations"][0]["physicalLocation"]
+            files.add(physical["artifactLocation"]["uri"])
+            findings.append(
+                {
+                    "rule": r["ruleId"],
+                    "line": physical["region"]["startLine"],
+                    "level": r["level"],
+                    "suppressed": bool(r.get("suppressions")),
+                }
+            )
+        return "sarif", findings, files
+    findings = [
+        {
+            "rule": f["rule_id"],
+            "line": f["line"],
+            "severity": f["severity"],
+            "service": f["service"],
+            "suppressed": bool(f["suppressed"]),
+        }
+        for f in document["findings"]
+    ]
+    return "json", findings, {f["file"] for f in document["findings"]}
+
+
+def _key(findings: list[dict[str, Any]]) -> set[tuple[str, int]]:
+    return {(f["rule"], f["line"]) for f in findings}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("report", nargs="?", help="report file (default: stdin)")
+    parser.add_argument("--surface", default="report", help="name used in messages")
+    parser.add_argument(
+        "--in-text",
+        action="store_true",
+        help=(
+            "input is human-readable output, not json/sarif: assert every "
+            "golden rule id appears in it (the pre-commit hook's only view)"
+        ),
+    )
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="rewrite the golden from this report (json only)",
+    )
+    args = parser.parse_args()
+
+    raw = pathlib.Path(args.report).read_text() if args.report else sys.stdin.read()
+
+    if args.in_text:
+        # The pre-commit hook runs the CLI in text mode and there is no way to
+        # ask it for json — `args:` in the manifest is what a consumer
+        # overrides, not something a smoke can inject. So this surface gets the
+        # assertion it can support: every rule the golden says fires must be
+        # named in what the hook actually printed. Weaker than a set
+        # comparison, and still far past "it exited 1".
+        golden_text = json.loads(GOLDEN.read_text())["findings"]
+        missing = [g["rule"] for g in golden_text if g["rule"] not in raw]
+        if missing:
+            print(
+                f"::error::[{args.surface}] output does not mention "
+                f"{sorted(missing)} — the golden set says they fire on this fixture"
+            )
+            return 1
+        print(
+            f"[{args.surface}] all {len(golden_text)} golden rule(s) appear in the output"
+        )
+        return 0
+
+    kind, findings, files = _load_report(raw)
+
+    if args.update:
+        if kind != "json":
+            print("::error::--update needs a json report (sarif has no severity)")
+            return 2
+        GOLDEN.write_text(
+            json.dumps(
+                {
+                    "_comment": (
+                        "Golden finding set for tests/smoke/insecure.yml, shared by "
+                        "every surface smoke (#621). Regenerate with: compose-lint "
+                        "check --format json --fail-on low tests/smoke/insecure.yml "
+                        "| python3 scripts/assert_golden_findings.py --update"
+                    ),
+                    "fixture": "tests/smoke/insecure.yml",
+                    "findings": sorted(
+                        findings, key=lambda f: (f["rule"], f["line"])
+                    ),
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        print(f"golden updated: {len(findings)} finding(s)")
+        return 0
+
+    golden = json.loads(GOLDEN.read_text())["findings"]
+
+    if len(files) != 1:
+        print(
+            f"::error::[{args.surface}] expected exactly one linted file, saw "
+            f"{sorted(files)} — (rule, line) is only unambiguous for a single file"
+        )
+        return 1
+
+    want, got = _key(golden), _key(findings)
+    if want != got:
+        missing = sorted(want - got)
+        extra = sorted(got - want)
+        print(f"::error::[{args.surface}] finding set does not match the golden")
+        if missing:
+            print(f"  missing (golden has, {args.surface} did not report): {missing}")
+        if extra:
+            print(f"  unexpected ({args.surface} reported, golden does not): {extra}")
+        return 1
+
+    by_key = {(f["rule"], f["line"]): f for f in findings}
+    for g in golden:
+        actual = by_key[(g["rule"], g["line"])]
+
+        # Severity, in whichever vocabulary this format speaks.
+        if kind == "json":
+            if actual["severity"] != g["severity"]:
+                print(
+                    f"::error::[{args.surface}] {g['rule']} severity is "
+                    f"{actual['severity']!r}, golden says {g['severity']!r}"
+                )
+                return 1
+            if actual["service"] != g["service"]:
+                print(
+                    f"::error::[{args.surface}] {g['rule']} service is "
+                    f"{actual['service']!r}, golden says {g['service']!r}"
+                )
+                return 1
+        elif actual["level"] != SARIF_LEVEL[g["severity"]]:
+            print(
+                f"::error::[{args.surface}] {g['rule']} SARIF level is "
+                f"{actual['level']!r}, expected {SARIF_LEVEL[g['severity']]!r} "
+                f"for {g['severity']}"
+            )
+            return 1
+
+        # Suppression, in both formats. These smokes run with no config, so a
+        # suppressed finding means the surface picked one up from somewhere —
+        # the Docker mount question (#625) surfacing as a quietly smaller
+        # result set rather than as an error.
+        if actual["suppressed"] != g["suppressed"]:
+            print(
+                f"::error::[{args.surface}] {g['rule']} suppressed="
+                f"{actual['suppressed']}, golden says {g['suppressed']} — a "
+                "surface applying a config the others do not is a divergence"
+            )
+            return 1
+
+    print(
+        f"[{args.surface}] {len(got)} finding(s) match the golden set "
+        f"({', '.join(sorted(r for r, _ in got))})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/assert_golden_findings.py
+++ b/scripts/assert_golden_findings.py
@@ -106,7 +106,15 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    raw = pathlib.Path(args.report).read_text() if args.report else sys.stdin.read()
+    # UTF-8 explicitly, both ways. Text reports carry the verdict marks and
+    # excerpt gutters (⚠ · │ ─), and Windows defaults these to the locale
+    # encoding — cp1252 — which mangles or refuses them. The workflows pass a
+    # path; stdin stays supported for ad-hoc use.
+    if args.report:
+        raw = pathlib.Path(args.report).read_text(encoding="utf-8")
+    else:
+        sys.stdin.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
+        raw = sys.stdin.read()
 
     if args.in_text:
         # The pre-commit hook runs the CLI in text mode and there is no way to
@@ -115,7 +123,7 @@ def main() -> int:
         # assertion it can support: every rule the golden says fires must be
         # named in what the hook actually printed. Weaker than a set
         # comparison, and still far past "it exited 1".
-        golden_text = json.loads(GOLDEN.read_text())["findings"]
+        golden_text = json.loads(GOLDEN.read_text(encoding="utf-8"))["findings"]
         missing = [g["rule"] for g in golden_text if g["rule"] not in raw]
         if missing:
             print(
@@ -150,12 +158,13 @@ def main() -> int:
                 },
                 indent=2,
             )
-            + "\n"
+            + "\n",
+            encoding="utf-8",
         )
         print(f"golden updated: {len(findings)} finding(s)")
         return 0
 
-    golden = json.loads(GOLDEN.read_text())["findings"]
+    golden = json.loads(GOLDEN.read_text(encoding="utf-8"))["findings"]
 
     if len(files) != 1:
         print(

--- a/scripts/assert_golden_findings.py
+++ b/scripts/assert_golden_findings.py
@@ -106,6 +106,16 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    # Every diagnostic this script prints contains an em dash, and its own
+    # error prefix is read by a human. On Windows a piped stdout defaults to
+    # cp1252, so `print()` raises UnicodeEncodeError — an *unhandled* one,
+    # which exits 1. That is indistinguishable from "the comparison failed",
+    # except the reason never reaches anyone: the process reports the right
+    # code for the wrong cause and prints nothing. Pin both streams to UTF-8
+    # before writing anything.
+    for stream in (sys.stdout, sys.stderr):
+        stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
+
     # UTF-8 explicitly, both ways. Text reports carry the verdict marks and
     # excerpt gutters (⚠ · │ ─), and Windows defaults these to the locale
     # encoding — cp1252 — which mangles or refuses them. The workflows pass a
@@ -152,9 +162,7 @@ def main() -> int:
                         "| python3 scripts/assert_golden_findings.py --update"
                     ),
                     "fixture": "tests/smoke/insecure.yml",
-                    "findings": sorted(
-                        findings, key=lambda f: (f["rule"], f["line"])
-                    ),
+                    "findings": sorted(findings, key=lambda f: (f["rule"], f["line"])),
                 },
                 indent=2,
             )

--- a/tests/smoke/insecure.golden.json
+++ b/tests/smoke/insecure.golden.json
@@ -1,0 +1,48 @@
+{
+  "_comment": "Golden finding set for tests/smoke/insecure.yml, shared by every surface smoke (#621). Regenerate with: compose-lint check --format json --fail-on low tests/smoke/insecure.yml | python3 scripts/assert_golden_findings.py --update",
+  "fixture": "tests/smoke/insecure.yml",
+  "findings": [
+    {
+      "rule": "CL-0002",
+      "line": 8,
+      "severity": "critical",
+      "service": "app",
+      "suppressed": false
+    },
+    {
+      "rule": "CL-0003",
+      "line": 6,
+      "severity": "medium",
+      "service": "app",
+      "suppressed": false
+    },
+    {
+      "rule": "CL-0006",
+      "line": 6,
+      "severity": "medium",
+      "service": "app",
+      "suppressed": false
+    },
+    {
+      "rule": "CL-0007",
+      "line": 6,
+      "severity": "low",
+      "service": "app",
+      "suppressed": false
+    },
+    {
+      "rule": "CL-0019",
+      "line": 7,
+      "severity": "medium",
+      "service": "app",
+      "suppressed": false
+    },
+    {
+      "rule": "CL-0026",
+      "line": 6,
+      "severity": "medium",
+      "service": "app",
+      "suppressed": false
+    }
+  ]
+}

--- a/tests/test_golden_findings.py
+++ b/tests/test_golden_findings.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -45,13 +46,25 @@ def _lint(*args: str) -> str:
     return proc.stdout
 
 
-def _compare(report: str, *extra: str) -> subprocess.CompletedProcess[str]:
+def _compare(
+    report: str, *extra: str, tmp_path: Path | None = None
+) -> subprocess.CompletedProcess[str]:
+    """Hand the comparator a file, the way the workflows do.
+
+    Not stdin: a text report carries the verdict marks and excerpt gutters
+    (⚠ · │ ─), and piping those to a subprocess on Windows deadlocked the
+    parent — the test timed out at 60s rather than failing (#621). Writing
+    UTF-8 to a file and passing the path is both what CI actually does and
+    the one shape that behaves the same on every platform.
+    """
+    target = (tmp_path or Path(tempfile.mkdtemp())) / "report.txt"
+    target.write_text(report, encoding="utf-8")
     return subprocess.run(
-        [sys.executable, str(COMPARATOR), "--surface", "test", *extra],
-        input=report,
+        [sys.executable, str(COMPARATOR), "--surface", "test", *extra, str(target)],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
+        encoding="utf-8",
         timeout=60,
     )
 

--- a/tests/test_golden_findings.py
+++ b/tests/test_golden_findings.py
@@ -1,0 +1,181 @@
+"""The golden finding set, and the surfaces that must match it (#621).
+
+Every cross-surface smoke asserted one bit — exit 0 versus exit 1.
+``tests/smoke/insecure.yml`` trips six rules and only CL-0002 is at or
+above the default threshold, so a surface could stop reporting the other
+five and every smoke in the repo stayed green. Fewer findings, same
+verdict: invisible in exactly the direction that matters for a security
+linter.
+
+``tests/smoke/insecure.golden.json`` is the shared answer, and
+``scripts/assert_golden_findings.py`` is the comparator the workflows call
+for the Docker and pre-commit surfaces. These tests cover the CLI surface
+and, more importantly, keep the golden honest — a golden nobody
+regenerates becomes a golden everybody forces past.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests._cli_env import cli_env
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+COMPARATOR = REPO_ROOT / "scripts" / "assert_golden_findings.py"
+GOLDEN = REPO_ROOT / "tests" / "smoke" / "insecure.golden.json"
+FIXTURE = "tests/smoke/insecure.yml"
+
+
+def _lint(*args: str) -> str:
+    proc = subprocess.run(
+        [sys.executable, "-m", "compose_lint", "check", *args, FIXTURE],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        env=cli_env(PYTHONPATH=str(REPO_ROOT / "src"), NO_COLOR="1"),
+        timeout=120,
+    )
+    assert proc.returncode in (0, 1), proc.stderr
+    return proc.stdout
+
+
+def _compare(report: str, *extra: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(COMPARATOR), "--surface", "test", *extra],
+        input=report,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def test_the_golden_still_describes_the_fixture() -> None:
+    """The golden must never be allowed to drift from the working tree.
+
+    If this fails, a rule started or stopped firing on the shared fixture.
+    That is a real change and may well be correct — regenerate with the
+    command in the golden's own ``_comment`` and read the diff. What must
+    not happen is the surfaces being held to an answer the tool no longer
+    gives.
+    """
+    result = _compare(_lint("--format", "json", "--fail-on", "low"))
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_the_golden_is_not_empty() -> None:
+    """Guard the guard: an empty golden would match a broken surface."""
+    findings = json.loads(GOLDEN.read_text(encoding="utf-8"))["findings"]
+    assert len(findings) >= 5
+    assert {f["severity"] for f in findings} >= {"critical", "medium", "low"}
+    assert not any(f["suppressed"] for f in findings), (
+        "the golden is generated without a config; a suppressed entry means it "
+        "was captured from a configured run and the surfaces would inherit that"
+    )
+
+
+@pytest.mark.parametrize("fail_on", ["low", "medium", "high", "critical"])
+def test_the_golden_holds_at_every_threshold(fail_on: str) -> None:
+    """--fail-on moves the exit code, not the result set.
+
+    This is the property that lets one golden serve every surface: each
+    smoke picks the threshold that keeps its own step green, and the
+    comparison is unaffected.
+    """
+    result = _compare(_lint("--format", "json", "--fail-on", fail_on))
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_sarif_matches_the_same_golden() -> None:
+    """The Action writes SARIF and never JSON, so the comparator reads both."""
+    result = _compare(_lint("--format", "sarif", "--fail-on", "critical"))
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_a_dropped_finding_is_caught() -> None:
+    """The whole point: a surface reporting less must fail, not pass quietly."""
+    report = json.loads(_lint("--format", "json", "--fail-on", "low"))
+    report["findings"] = [f for f in report["findings"] if f["rule_id"] != "CL-0006"]
+    result = _compare(json.dumps(report))
+    assert result.returncode == 1
+    assert "CL-0006" in result.stdout
+    assert "missing" in result.stdout
+
+
+def test_an_unexpected_finding_is_caught() -> None:
+    """Extra is as wrong as missing — this is set equality, not a subset."""
+    report = json.loads(_lint("--format", "json", "--fail-on", "low"))
+    invented = dict(report["findings"][0])
+    invented["rule_id"] = "CL-9999"
+    report["findings"].append(invented)
+    result = _compare(json.dumps(report))
+    assert result.returncode == 1
+    assert "unexpected" in result.stdout
+
+
+def test_a_silently_applied_config_is_caught() -> None:
+    """A surface that picked up a config the others did not is a divergence.
+
+    It is also how the Docker mount question (#625) would surface here: a
+    quietly smaller effective result set rather than an error.
+    """
+    report = json.loads(_lint("--format", "json", "--fail-on", "low"))
+    report["findings"][0]["suppressed"] = True
+    result = _compare(json.dumps(report))
+    assert result.returncode == 1
+    assert "suppressed" in result.stdout
+
+
+def test_a_regraded_severity_is_caught() -> None:
+    report = json.loads(_lint("--format", "json", "--fail-on", "low"))
+    report["findings"][0]["severity"] = "low"
+    result = _compare(json.dumps(report))
+    assert result.returncode == 1
+    assert "severity" in result.stdout
+
+
+def test_text_mode_catches_a_missing_rule() -> None:
+    """The pre-commit surface's only available view."""
+    text = _lint("--fail-on", "low")
+    assert _compare(text, "--in-text").returncode == 0
+    thinned = "\n".join(line for line in text.splitlines() if "CL-0019" not in line)
+    result = _compare(thinned, "--in-text")
+    assert result.returncode == 1
+    assert "CL-0019" in result.stdout
+
+
+def test_more_than_one_linted_file_is_refused() -> None:
+    """(rule, line) is only unambiguous for a single file.
+
+    Both shared fixtures carry CL-0003 at line 6, so a multi-file report
+    would collide silently. The comparator refuses rather than compare.
+    """
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "compose_lint",
+            "check",
+            "--format",
+            "json",
+            "--fail-on",
+            "low",
+            FIXTURE,
+            "tests/smoke/sarif-shape.yml",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        env=cli_env(PYTHONPATH=str(REPO_ROOT / "src"), NO_COLOR="1"),
+        timeout=120,
+    )
+    result = _compare(proc.stdout)
+    assert result.returncode == 1
+    assert "exactly one linted file" in result.stdout

--- a/tests/test_golden_findings.py
+++ b/tests/test_golden_findings.py
@@ -65,8 +65,20 @@ def _compare(
         capture_output=True,
         text=True,
         encoding="utf-8",
+        errors="replace",
         timeout=60,
     )
+
+
+def _said(result: subprocess.CompletedProcess[str]) -> str:
+    """Everything the comparator emitted, whichever stream it chose.
+
+    Asserting against ``result.stdout`` alone made a Windows failure read as
+    ``TypeError: argument of type 'NoneType' is not iterable`` — the real
+    cause (an unhandled UnicodeEncodeError in the child, which exits 1 and
+    prints nothing) was invisible behind it.
+    """
+    return (result.stdout or "") + (result.stderr or "")
 
 
 def test_the_golden_still_describes_the_fixture() -> None:
@@ -79,7 +91,7 @@ def test_the_golden_still_describes_the_fixture() -> None:
     gives.
     """
     result = _compare(_lint("--format", "json", "--fail-on", "low"))
-    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.returncode == 0, _said(result)
 
 
 def test_the_golden_is_not_empty() -> None:
@@ -102,13 +114,13 @@ def test_the_golden_holds_at_every_threshold(fail_on: str) -> None:
     comparison is unaffected.
     """
     result = _compare(_lint("--format", "json", "--fail-on", fail_on))
-    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.returncode == 0, _said(result)
 
 
 def test_sarif_matches_the_same_golden() -> None:
     """The Action writes SARIF and never JSON, so the comparator reads both."""
     result = _compare(_lint("--format", "sarif", "--fail-on", "critical"))
-    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.returncode == 0, _said(result)
 
 
 def test_a_dropped_finding_is_caught() -> None:
@@ -117,8 +129,8 @@ def test_a_dropped_finding_is_caught() -> None:
     report["findings"] = [f for f in report["findings"] if f["rule_id"] != "CL-0006"]
     result = _compare(json.dumps(report))
     assert result.returncode == 1
-    assert "CL-0006" in result.stdout
-    assert "missing" in result.stdout
+    assert "CL-0006" in _said(result), _said(result)
+    assert "missing" in _said(result), _said(result)
 
 
 def test_an_unexpected_finding_is_caught() -> None:
@@ -129,7 +141,7 @@ def test_an_unexpected_finding_is_caught() -> None:
     report["findings"].append(invented)
     result = _compare(json.dumps(report))
     assert result.returncode == 1
-    assert "unexpected" in result.stdout
+    assert "unexpected" in _said(result), _said(result)
 
 
 def test_a_silently_applied_config_is_caught() -> None:
@@ -142,7 +154,7 @@ def test_a_silently_applied_config_is_caught() -> None:
     report["findings"][0]["suppressed"] = True
     result = _compare(json.dumps(report))
     assert result.returncode == 1
-    assert "suppressed" in result.stdout
+    assert "suppressed" in _said(result), _said(result)
 
 
 def test_a_regraded_severity_is_caught() -> None:
@@ -150,7 +162,7 @@ def test_a_regraded_severity_is_caught() -> None:
     report["findings"][0]["severity"] = "low"
     result = _compare(json.dumps(report))
     assert result.returncode == 1
-    assert "severity" in result.stdout
+    assert "severity" in _said(result), _said(result)
 
 
 def test_text_mode_catches_a_missing_rule() -> None:
@@ -160,7 +172,7 @@ def test_text_mode_catches_a_missing_rule() -> None:
     thinned = "\n".join(line for line in text.splitlines() if "CL-0019" not in line)
     result = _compare(thinned, "--in-text")
     assert result.returncode == 1
-    assert "CL-0019" in result.stdout
+    assert "CL-0019" in _said(result), _said(result)
 
 
 def test_more_than_one_linted_file_is_refused() -> None:
@@ -191,4 +203,4 @@ def test_more_than_one_linted_file_is_refused() -> None:
     )
     result = _compare(proc.stdout)
     assert result.returncode == 1
-    assert "exactly one linted file" in result.stdout
+    assert "exactly one linted file" in _said(result), _said(result)


### PR DESCRIPTION
Closes #621.

Every cross-surface smoke asserted one bit. `tests/smoke/insecure.yml` trips six rules and only CL-0002 is at or above the default threshold — so a surface could stop reporting **five of the six** and every smoke in the repo stayed green. Fewer findings, same verdict: invisible in exactly the direction that matters for a security linter, and the shape #619 already took once at the unit level.

`tests/smoke/insecure.golden.json` is the shared answer; `scripts/assert_golden_findings.py` is the comparator.

## Three input modes, because the surfaces differ

- **json** — full comparison: finding set, severity, service, suppression.
- **sarif** — the Action writes SARIF and never JSON. Reading it is equivalent because #623 holds the two formats to the same finding set; severity is checked through the documented `_SARIF_LEVEL` map.
- **text** (`--in-text`) — the pre-commit hook runs the CLI in text mode, and `args:` is a *consumer's* override, not something a smoke can inject. So that surface gets what it can support: every golden rule id must appear in what the hook printed. Weaker than set equality, still far past "it exited 1".

## Two properties that let one golden serve everything

Both asserted rather than assumed:

- **The reported set doesn't depend on `--fail-on`** — verified across low/medium/high/critical. The threshold moves the exit code, not the findings, so each smoke picks whatever keeps its own step green.
- **The path isn't part of the key** — Docker sees `/src/docker-compose.yml`, the others see the checkout path. Each smoke lints exactly one file, which the comparator *requires*: both shared fixtures carry CL-0003 at line 6, so a multi-file report would collide silently. It refuses rather than compare.

## Where it is — and deliberately isn't — wired

Wired into the surfaces built from the **working tree**: `docker-smoke` (both arches) and `precommit-smoke` (via `try-repo`), plus the CLI in pytest.

**Not** `action-smoke` or `marketplace-smoke.yml`. Those install `version: latest` on purpose — they exist to catch published-against-source drift, which is a *different* contract. A tree-derived golden there would fail every PR that legitimately changes a finding, which is how a check gets disabled. Called out because it's the obvious next thing someone would add.

## Suppression is compared too

These smokes run with no config, so a suppressed finding means a surface picked one up from somewhere. That's the #625 Docker mount question surfacing here as a quietly smaller effective result set rather than as an error.

## Verified to discriminate

Nine tests drive the comparator against deliberately broken reports — each must fail, and does:

| mutation | caught |
|---|---|
| finding dropped | `missing (golden has, … did not report): [('CL-0006', 6)]` |
| finding invented | `unexpected (… reported, golden does not)` |
| severity re-graded | severity mismatch |
| suppression appearing | suppressed mismatch |
| rule missing from text output | named in the error |
| two files linted | `expected exactly one linted file` |

Plus guards on the golden itself: it must be non-empty, span ≥3 severities, and contain no suppressed entry (which would mean it was captured from a configured run and every surface would inherit that).

`ruff`, `mypy --strict`, `pytest` (1861 passed, 6 skipped), `actionlint` green.

## Not verified locally

The Docker and pre-commit workflow steps — no Docker here, and `docker-smoke` is path-gated off on this PR. `precommit-smoke` **will** run here since this touches `ci.yml`. Both get their first full exercise on the push-to-`main` build; I'll confirm there.
