### PR TITLE
Make a finding's identity structured data, not its prose

### DIFF
--- a/.github/workflows/sarif-ingestion.yml
+++ b/.github/workflows/sarif-ingestion.yml
@@ -58,6 +58,14 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      # ubuntu-24.04's system python is externally managed (PEP 668), so a
+      # bare `pip install` into it fails. The working-tree steps below need
+      # a real install of the checkout.
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements.lock
 
       # All three fixtures together, so the document carries several
       # artifactLocations, all three SARIF levels, and a suppression — the
@@ -81,6 +89,40 @@ jobs:
       # processing, but a document that lands with every result discarded
       # still passes that step.
       - name: Assert the results actually landed
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/verify_sarif_ingestion.py verify
+
+      # The job above installs `version: latest` — the *published* package —
+      # so it validates whatever PyPI is serving, not what is on this branch.
+      # That is right for catching drift between the source action and the
+      # release, and useless for a change to the SARIF we are about to ship:
+      # a new construct would first meet GitHub only after publishing, past
+      # the point of no return (#632 review).
+      #
+      # So the working tree gets its own upload. It bypasses the action and
+      # calls the uploader directly, because the action installs from PyPI by
+      # design and there is no input that points it at a checkout. A separate
+      # `category` keeps the two analyses distinct so cleanup can tell them
+      # apart.
+      - name: Generate SARIF from the working tree
+        run: |
+          python3 -m pip install --quiet --require-hashes -r requirements.lock
+          python3 -m pip install --quiet --no-deps -e .
+          python3 -m compose_lint check \
+            --config tests/smoke/sarif-probe-config.yml \
+            --fail-on critical --format sarif \
+            tests/smoke/insecure.yml tests/smoke/sarif-shape.yml tests/smoke/clean.yml \
+            > working-tree.sarif
+          python3 -c "import json;d=json.load(open('working-tree.sarif'));print('results:',len(d['runs'][0]['results']))"
+
+      - name: Upload the working tree's SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          sarif_file: working-tree.sarif
+          category: compose-lint-working-tree
+
+      - name: Assert the working tree's results landed too
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python3 scripts/verify_sarif_ingestion.py verify

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Upgrading
+
+**SARIF consumers: your Code Scanning alerts will be re-keyed once.** The
+`partialFingerprints` key moves from `composeLintFinding/v1` to `/v2`, and
+the digest no longer includes the finding's message. On the first upload
+after upgrading, GitHub closes every existing compose-lint alert and opens a
+replacement — dismissal state on those alerts is lost. This happens once.
+
+The reason is that v1 made prose part of the alert's identity: rewording any
+rule message silently closed and reopened every matching alert in every
+consuming repository, so improving a message was a breaking change with no
+warning. Identity is now structured data (file, rule, service, and the
+specific offending value), and message text is free to change (ADR-024).
+
+Nothing to do beyond expecting the one-time churn. If you dismiss alerts,
+re-dismiss after the first post-upgrade scan.
+
 ### Added
+
+- **SARIF results now name the service.** A finding carries the service as a
+  `logicalLocation` (`services.<name>`) and names it in the alert title.
+  Previously SARIF results carried only rule, file and line, so a Code
+  Scanning user disambiguated a multi-service file by line number while a
+  terminal user was told the service outright — even though the service was
+  already part of the alert's fingerprint.
 
 - **`check` and `fix` now say when no config was in effect.** A run that
   reports findings — or a `fix` that has changes to make — with no

--- a/docs/adr/024-finding-identity-is-not-prose.md
+++ b/docs/adr/024-finding-identity-is-not-prose.md
@@ -38,19 +38,36 @@ the internal finding-to-edit key.
    profile key rather than the raw `security_opt` string. Rewriting
    `SYS_ADMIN` as `CAP_SYS_ADMIN` is the same capability and must keep the
    same alert.
-2. **A rule that can fire more than once per service must set it.** Nine do
-   (CL-0005, 0009, 0010, 0016, 0020, 0021, 0024, 0025, 0027). Rules that fire
-   at most once per service leave it `None`; `(file, rule, service)` already
-   distinguishes those. The obligation is enforced, not documented:
-   `tests/test_finding_identity.py` sweeps every fixture and fails on any two
-   findings in one document sharing a fingerprint — a collision is not
-   cosmetic, because GitHub shows one alert per fingerprint and the others
-   simply do not appear.
-3. **The key is versioned, and the version was bumped.**
+2. **A rule that can fire more than once per service must set it.**
+   Seventeen do. Rules that fire at most once per service leave it `None`;
+   `(file, rule, service)` already distinguishes those.
+
+   The obligation is enforced **structurally**, by reading the rule source:
+   any module that constructs a `Finding` inside a loop must pass
+   `evidence`. A fixture sweep also runs, but it is the weaker check and
+   knowing why matters. The first version of this work enforced the rule
+   *only* by sweeping fixtures, and shipped four colliding rules — CL-0001
+   among them, the tool's flagship CRITICAL — because no fixture happened
+   to put two socket mounts on one service. Three more (the `cap_add`
+   family) were missed again by a hand-written grep. A guard whose coverage
+   equals fixture coverage silently degrades every time a rule grows a case
+   nobody wrote a fixture for. Both checks live in
+   `tests/test_finding_identity.py`.
+
+   A collision is not cosmetic: GitHub shows one alert per fingerprint, so
+   the other findings never appear at all.
+
+3. **Each rule's evidence derivation is a contract.** `evidence` never
+   appears in the output, which makes it easy to mistake for an
+   implementation detail and "tidy up" — silently re-keying that rule's
+   alerts, a partial unannounced repeat of the transition this ADR exists
+   to make unnecessary. `EVIDENCE_CONTRACT` pins the exact derived value
+   per rule against a fixed document, so changing one is a reviewed act.
+4. **The key is versioned, and the version was bumped.**
    `composeLintFinding/v1` -> `/v2`. The key was versioned from the start
    precisely so a consumer can tell an algorithm change from a genuine new
    finding; this is the first use of that affordance.
-4. **The service becomes visible.** It rides as a SARIF `logicalLocation`
+5. **The service becomes visible.** It rides as a SARIF `logicalLocation`
    (`{name, fullyQualifiedName: services.<name>, kind: resource}`) — the
    construct for a named element *within* an artifact, as opposed to the file
    and line it occupies — and is threaded into `message.text`, because GitHub
@@ -71,6 +88,15 @@ paying even if it is not zero.
 
 Messages are now free to change. That is the point: a rule's wording can be
 improved without asking what it will break.
+
+**Validating future SARIF changes.** The ingestion probe
+(`sarif-ingestion.yml`, ADR-referenced from #610) originally exercised only
+the *published* package, so a change to the emitted document would have met
+GitHub for the first time after publishing — past the point of no return.
+It now uploads the working tree's SARIF as a second, separately-categorised
+analysis. Any future change to the SARIF shape is therefore checked against
+real ingestion before it ships, which is the condition under which this
+transition never needs repeating.
 
 Out of scope, deliberately: **region spans.** A `region` covering the whole
 service block (`startLine`..`endLine`) would let the location itself scope to

--- a/docs/adr/024-finding-identity-is-not-prose.md
+++ b/docs/adr/024-finding-identity-is-not-prose.md
@@ -1,0 +1,80 @@
+# ADR-024: A Finding's Identity Is Structured Data, Not Its Prose
+
+**Status:** Accepted
+
+**Context:** GitHub Code Scanning matches an alert across commits, and
+deduplicates repeated uploads, using `partialFingerprints`. The value is the
+alert's identity: change it and GitHub closes the old alert and opens a new
+one in its place.
+
+compose-lint's v1 fingerprint digested `[uri, rule_id, service, message]`.
+The message was included deliberately — a rule that fires more than once for
+one service (two published ports, two mounted host paths) needs something to
+tell those hits apart, and the message was the only field carrying the
+specific offending value.
+
+The cost was that **prose became API**. Rewording a rule's message — fixing a
+typo, clarifying a sentence, improving the fix guidance embedded in it — was
+a silent breaking change for every consumer: every matching alert closed,
+every replacement reopened as new, dismissals lost. Nothing in the repository
+signalled this, no test asserted it, and the work most likely to trigger it
+was ordinary documentation polish. A tool whose own quality work breaks its
+consumers has the incentive pointed the wrong way.
+
+The second cost was to the reader. Because the service was in the *digest*
+and nowhere in the *document*, GitHub deduplicated on a value the user was
+never shown: SARIF results carried `ruleId`, `artifactLocation` and
+`startLine` only, so a Code Scanning user disambiguated a dozen services by
+line number while a terminal user was told `service: web` outright.
+
+**Decision:** A finding's identity is `(file, rule, service, evidence)`,
+where `evidence` is a new structured field on `Finding` holding the specific
+offending value — the port spec, the device path, the capability, the mounted
+source. Prose is excluded from every identity in the SARIF layer, including
+the internal finding-to-edit key.
+
+1. **Evidence is normalized, not as-written.** CL-0024/CL-0027 key on the
+   bare capability rather than the literal `cap_add` entry, CL-0009 on the
+   profile key rather than the raw `security_opt` string. Rewriting
+   `SYS_ADMIN` as `CAP_SYS_ADMIN` is the same capability and must keep the
+   same alert.
+2. **A rule that can fire more than once per service must set it.** Nine do
+   (CL-0005, 0009, 0010, 0016, 0020, 0021, 0024, 0025, 0027). Rules that fire
+   at most once per service leave it `None`; `(file, rule, service)` already
+   distinguishes those. The obligation is enforced, not documented:
+   `tests/test_finding_identity.py` sweeps every fixture and fails on any two
+   findings in one document sharing a fingerprint — a collision is not
+   cosmetic, because GitHub shows one alert per fingerprint and the others
+   simply do not appear.
+3. **The key is versioned, and the version was bumped.**
+   `composeLintFinding/v1` -> `/v2`. The key was versioned from the start
+   precisely so a consumer can tell an algorithm change from a genuine new
+   finding; this is the first use of that affordance.
+4. **The service becomes visible.** It rides as a SARIF `logicalLocation`
+   (`{name, fullyQualifiedName: services.<name>, kind: resource}`) — the
+   construct for a named element *within* an artifact, as opposed to the file
+   and line it occupies — and is threaded into `message.text`, because GitHub
+   renders the message as the alert title and offers no guarantee that a
+   logical location surfaces anywhere a reader looks.
+
+**Consequences:** The v1 -> v2 move **re-keys every existing alert once**:
+consumers uploading compose-lint SARIF see their current alerts close and
+reopen, losing dismissal state. This is a real, one-time cost, accepted
+because it is paid once now and avoided permanently afterwards — the
+alternative is paying a smaller version of it on every future message edit,
+unpredictably and without warning. Measured public exposure at the time of
+the decision was zero: GitHub code search found no repository outside this
+one referencing the action in a workflow, and none referencing the
+pre-commit hook. Private usage is structurally invisible to that search, so
+the figure is a floor, not a count — the decision is that the cost is worth
+paying even if it is not zero.
+
+Messages are now free to change. That is the point: a rule's wording can be
+improved without asking what it will break.
+
+Out of scope, deliberately: **region spans.** A `region` covering the whole
+service block (`startLine`..`endLine`) would let the location itself scope to
+the service, complementing the logical location. The loader records start
+lines only (`parser.py`), and extending it touches the line map that `fix`
+depends on for its edits — a larger and riskier change than this one, and
+independent of identity. It stays available as later work.

--- a/src/compose_lint/formatters/sarif.py
+++ b/src/compose_lint/formatters/sarif.py
@@ -91,38 +91,106 @@ def _physical_location(filepath: str, line: int | None) -> dict[str, Any]:
     return location
 
 
+def _logical_locations(finding: Finding) -> list[dict[str, Any]]:
+    """Name the service as a SARIF logical location.
+
+    A Compose service is exactly what ``logicalLocation`` is for: a named
+    element *within* the artifact, distinct from the file and line it happens
+    to occupy. Before this, a Code Scanning user had only the line number to
+    tell which of a dozen services a finding belonged to, while a terminal
+    user was told outright — the service was in the alert's fingerprint and
+    nowhere the reader could see it.
+
+    ``properties`` would also have carried the value, but it is an untyped
+    bag; consumers that understand SARIF can act on a logical location.
+    """
+    if not finding.service:
+        return []
+    return [
+        {
+            "name": finding.service,
+            "fullyQualifiedName": f"services.{finding.service}",
+            "kind": "resource",
+        }
+    ]
+
+
+def _result_message(finding: Finding) -> str:
+    """The alert title, naming the service the finding is about.
+
+    ``logicalLocations`` is the structured answer, but GitHub renders the
+    message as the alert's title and there is no guarantee it surfaces a
+    logical location anywhere a reader will look. The service therefore goes
+    in the text too — belt and braces, because the title is what a user
+    triages from.
+
+    Most rule messages open with "Service ...", so the name is threaded into
+    that clause and reads as written prose. The rest are prefixed. A message
+    that stops matching the first shape degrades to the second rather than
+    losing the service.
+
+    Safe to change now: message text is no longer part of the fingerprint
+    (see :func:`_partial_fingerprints`), so wording is free.
+    """
+    if not finding.service:
+        return finding.message
+    if finding.message.startswith("Service "):
+        return f"Service '{finding.service}' " + finding.message[len("Service ") :]
+    return f"Service '{finding.service}': {finding.message}"
+
+
 def _finding_key(finding: Finding) -> tuple[str, int | None, str, str]:
     """A stable logical identity for matching a finding to its edits.
 
-    Covers rule, line, service, and message — the message carries the specific
-    offending value, so it distinguishes multiple hits of one rule on one
-    service. Unlike ``id(finding)`` this survives a finding being copied or
+    Covers rule, line, service, and evidence — ``evidence`` carries the
+    specific offending value, so it distinguishes multiple hits of one rule
+    on one service. It used to key on the message; prose is no longer part of
+    any identity in this module.
+
+    Unlike ``id(finding)`` this survives a finding being copied or
     reconstructed between the ``fixes`` and ``findings`` arguments.
     """
-    return (finding.rule_id, finding.line, str(finding.service), finding.message)
+    return (finding.rule_id, finding.line, str(finding.service), finding.evidence or "")
 
 
 # Fingerprint scheme version. Bump if the inputs below change, so a consumer can
 # tell an algorithm change from a genuine new finding.
-_FINGERPRINT_KEY = "composeLintFinding/v1"
+_FINGERPRINT_KEY = "composeLintFinding/v2"
 
 
 def _partial_fingerprints(uri: str, finding: Finding) -> dict[str, str]:
     """A stable per-finding fingerprint for GitHub alert dedup/tracking.
 
-    GitHub uses ``partialFingerprints`` to match the *same* alert across commits
-    and to deduplicate uploads; without them, repeated SARIF uploads create
-    duplicate alerts and lose continuity when code moves. The digest covers the
-    finding's logical identity — file, rule, service, and message (the message
-    carries the specific offending value, which distinguishes multiple hits of
-    one rule on one service) — but deliberately **not** the line number, so an
-    alert survives unrelated line shifts. Optional in base SARIF; emitting it is
-    additive to the contract (ADR-015).
+    GitHub uses ``partialFingerprints`` to match the *same* alert across
+    commits and to deduplicate uploads; without them, repeated SARIF uploads
+    create duplicate alerts and lose continuity when code moves.
+
+    The digest covers the finding's logical identity — file, rule, service,
+    and ``evidence`` (the specific offending value, which distinguishes
+    multiple hits of one rule on one service). It deliberately excludes the
+    line number, so an alert survives unrelated line shifts.
+
+    **v1 digested the message instead of ``evidence``, which made prose part
+    of the API.** Rewording a rule's message — a typo fix, a clarification —
+    changed the digest, and every consumer's matching alert was closed and
+    reopened as new. Nothing warned about it, and the tool's own docs work
+    was the trigger. Identity is now structured data only; messages are free
+    to change (ADR-024).
+
+    The key is versioned precisely so this transition is legible: a consumer
+    sees ``composeLintFinding/v2`` and can tell an algorithm change from a
+    genuine new finding. The v1 -> v2 move re-keys every existing alert once.
+
+    ``tests/test_finding_identity.py`` enforces the obligation this creates:
+    a rule that can fire more than once per service must set ``evidence``,
+    or its findings collide into one alert and the rest are never shown.
+    Optional in base SARIF; emitting it is additive to the contract
+    (ADR-015).
     """
     # repr() of the component list is an unambiguous, collision-safe
     # serialization (it escapes embedded quotes), so distinct findings
     # cannot alias by component-boundary coincidence.
-    parts = [uri, finding.rule_id, str(finding.service), finding.message]
+    parts = [uri, finding.rule_id, str(finding.service), finding.evidence or ""]
     digest = hashlib.sha256(repr(parts).encode("utf-8")).hexdigest()
     return {_FINGERPRINT_KEY: digest}
 
@@ -343,8 +411,17 @@ def format_findings(
         result: dict[str, Any] = {
             "ruleId": f.rule_id,
             "level": _SARIF_LEVEL.get(f.severity, "warning"),
-            "message": {"text": f.message},
-            "locations": [{"physicalLocation": physical_location}],
+            "message": {"text": _result_message(f)},
+            "locations": [
+                {
+                    "physicalLocation": physical_location,
+                    **(
+                        {"logicalLocations": logical}
+                        if (logical := _logical_locations(f))
+                        else {}
+                    ),
+                }
+            ],
             "partialFingerprints": _partial_fingerprints(
                 physical_location["artifactLocation"]["uri"], f
             ),

--- a/src/compose_lint/models.py
+++ b/src/compose_lint/models.py
@@ -75,6 +75,15 @@ class Finding:
     # gave a reader no way to tell it apart from a rule that never fired that
     # hard. None means the rule's declared severity is what is shown.
     severity_overridden_from: Severity | None = None
+    # The specific thing this finding is about, when a rule can fire more than
+    # once for one service — the port spec, the device path, the mounted
+    # source. It is the finding's *identity*, not its prose: SARIF
+    # fingerprints are built from it so that rewording a message never
+    # orphans a consumer's alerts (ADR-024). Rules that fire at most once per
+    # service leave it None; `(file, rule, service)` already distinguishes
+    # those. tests/test_finding_identity.py fails if a rule needs one and
+    # does not set it.
+    evidence: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/compose_lint/rules/CL0001_docker_socket.py
+++ b/src/compose_lint/rules/CL0001_docker_socket.py
@@ -197,6 +197,7 @@ class DockerSocketRule(BaseRule):
                 rule_id="CL-0001",
                 severity=Severity.CRITICAL,
                 service=service_name,
+                evidence=host_path,
                 message=message,
                 line=lines.get(f"services.{service_name}.volumes[{i}]")
                 or lines.get(f"services.{service_name}.volumes"),

--- a/src/compose_lint/rules/CL0005_unbound_ports.py
+++ b/src/compose_lint/rules/CL0005_unbound_ports.py
@@ -234,6 +234,7 @@ class UnboundPortsRule(BaseRule):
             rule_id="CL-0005",
             severity=Severity.MEDIUM,
             service=service_name,
+            evidence=port_str,
             message=message,
             line=lines.get(f"services.{service_name}.ports[{index}]")
             or lines.get(f"services.{service_name}.ports"),

--- a/src/compose_lint/rules/CL0009_security_profile.py
+++ b/src/compose_lint/rules/CL0009_security_profile.py
@@ -120,6 +120,7 @@ class SecurityProfileRule(BaseRule):
                 rule_id="CL-0009",
                 severity=Severity.HIGH,
                 service=service_name,
+                evidence=profile_key,
                 message=(
                     f"Service disables {profile_name} "
                     f"('{opt_str}'). This removes {removal} "

--- a/src/compose_lint/rules/CL0010_host_namespace.py
+++ b/src/compose_lint/rules/CL0010_host_namespace.py
@@ -86,6 +86,7 @@ class HostNamespaceRule(BaseRule):
                     rule_id="CL-0010",
                     severity=Severity.HIGH,
                     service=service_name,
+                    evidence=key,
                     message=f"Service shares the host's {desc}",
                     line=lines.get(f"services.{service_name}.{key}"),
                     fix=f"Remove '{key}: {value}' to restore namespace isolation.",

--- a/src/compose_lint/rules/CL0011_dangerous_cap_add.py
+++ b/src/compose_lint/rules/CL0011_dangerous_cap_add.py
@@ -70,6 +70,7 @@ class DangerousCapAddRule(BaseRule):
                 rule_id="CL-0011",
                 severity=Severity.HIGH,
                 service=service_name,
+                evidence=bare,
                 message=(f"Service adds {as_written}: {STRONG_CAPS[bare]}."),
                 line=line,
                 fix=(

--- a/src/compose_lint/rules/CL0013_sensitive_mount.py
+++ b/src/compose_lint/rules/CL0013_sensitive_mount.py
@@ -257,6 +257,7 @@ class SensitiveMountRule(BaseRule):
                 rule_id="CL-0013",
                 severity=Severity.HIGH,
                 service=service_name,
+                evidence=mount.host_path,
                 message=(
                     f"Service mounts sensitive host path '{mount.host_path}' "
                     f"(under {matched}). The mount {reason}."

--- a/src/compose_lint/rules/CL0016_dangerous_devices.py
+++ b/src/compose_lint/rules/CL0016_dangerous_devices.py
@@ -126,6 +126,7 @@ class DangerousDevicesRule(BaseRule):
                         rule_id="CL-0016",
                         severity=Severity.CRITICAL,
                         service=service_name,
+                        evidence=host_device,
                         message=(
                             f"Service exposes dangerous host device "
                             f"'{host_device}' ({description})."

--- a/src/compose_lint/rules/CL0017_shared_mount.py
+++ b/src/compose_lint/rules/CL0017_shared_mount.py
@@ -96,6 +96,7 @@ class SharedMountRule(BaseRule):
             rule_id="CL-0017",
             severity=Severity.LOW,
             service=service_name,
+            evidence=volume_str,
             message=(
                 "Service uses shared mount propagation. Mounts created inside "
                 "the container will appear on the host and vice versa."

--- a/src/compose_lint/rules/CL0020_credential_env_keys.py
+++ b/src/compose_lint/rules/CL0020_credential_env_keys.py
@@ -274,6 +274,7 @@ class CredentialEnvKeysRule(BaseRule):
                 rule_id="CL-0020",
                 severity=Severity.HIGH,
                 service=service_name,
+                evidence=key,
                 message=(
                     f"Service has credential-shaped env key '{key}' with a "
                     "literal value. Env vars are exposed via `docker inspect`, "

--- a/src/compose_lint/rules/CL0021_connection_string_credentials.py
+++ b/src/compose_lint/rules/CL0021_connection_string_credentials.py
@@ -209,6 +209,7 @@ class ConnectionStringCredentialsRule(BaseRule):
                 rule_id="CL-0021",
                 severity=Severity.HIGH,
                 service=service_name,
+                evidence=key,
                 message=(
                     f"Service has env var '{key}' containing an inline "
                     f"credential in a {scheme}:// connection string "

--- a/src/compose_lint/rules/CL0022_tmpfs_insecure_options.py
+++ b/src/compose_lint/rules/CL0022_tmpfs_insecure_options.py
@@ -90,6 +90,7 @@ class TmpfsInsecureOptionsRule(BaseRule):
                 rule_id="CL-0022",
                 severity=Severity.LOW,
                 service=service_name,
+                evidence=path,
                 message=(
                     f"tmpfs mount '{path}' re-enables {opts}. Docker mounts tmpfs "
                     "noexec,nosuid,nodev by default; this turns that off, making "

--- a/src/compose_lint/rules/CL0024_host_exec_cap_add.py
+++ b/src/compose_lint/rules/CL0024_host_exec_cap_add.py
@@ -66,6 +66,7 @@ class HostExecCapAddRule(BaseRule):
                 rule_id="CL-0024",
                 severity=Severity.CRITICAL,
                 service=service_name,
+                evidence=bare,
                 message=(
                     f"Service adds {as_written}, which grants host code "
                     f"execution: {HOST_EXEC_CAPS[bare]}."

--- a/src/compose_lint/rules/CL0025_writable_host_root.py
+++ b/src/compose_lint/rules/CL0025_writable_host_root.py
@@ -155,6 +155,7 @@ class WritableHostRootMountRule(BaseRule):
                 rule_id="CL-0025",
                 severity=Severity.CRITICAL,
                 service=service_name,
+                evidence=mount.host_path,
                 message=(
                     f"Service mounts host path '{mount.host_path}' writable "
                     f"(under {matched}). Writing there is host root: "

--- a/src/compose_lint/rules/CL0027_lesser_cap_add.py
+++ b/src/compose_lint/rules/CL0027_lesser_cap_add.py
@@ -70,6 +70,7 @@ class LesserCapAddRule(BaseRule):
                 rule_id="CL-0027",
                 severity=Severity.MEDIUM,
                 service=service_name,
+                evidence=bare,
                 message=(f"Service adds {as_written}: {LESSER_CAPS[bare]}."),
                 line=line,
                 fix=(

--- a/src/compose_lint/rules/CL0028_host_reach_cap_add.py
+++ b/src/compose_lint/rules/CL0028_host_reach_cap_add.py
@@ -67,6 +67,7 @@ class HostReachCapAddRule(BaseRule):
                 rule_id="CL-0028",
                 severity=Severity.HIGH,
                 service=service_name,
+                evidence=bare,
                 message=(f"Service adds {as_written}: {HOST_REACH_CAPS[bare]}."),
                 line=line,
                 fix=(

--- a/src/compose_lint/rules/CL0029_host_availability_cap_add.py
+++ b/src/compose_lint/rules/CL0029_host_availability_cap_add.py
@@ -77,6 +77,7 @@ class HostAvailabilityCapAddRule(BaseRule):
                 rule_id="CL-0029",
                 severity=Severity.HIGH,
                 service=service_name,
+                evidence=bare,
                 message=(f"Service adds {as_written}: {HOST_AVAILABILITY_CAPS[bare]}."),
                 line=line,
                 fix=(

--- a/src/compose_lint/rules/CL0030_host_disclosure_cap_add.py
+++ b/src/compose_lint/rules/CL0030_host_disclosure_cap_add.py
@@ -62,6 +62,7 @@ class HostDisclosureCapAddRule(BaseRule):
                 rule_id="CL-0030",
                 severity=Severity.HIGH,
                 service=service_name,
+                evidence=bare,
                 message=(f"Service adds {as_written}: {HOST_DISCLOSURE_CAPS[bare]}."),
                 line=line,
                 fix=(

--- a/tests/test_finding_identity.py
+++ b/tests/test_finding_identity.py
@@ -20,6 +20,7 @@ Scanning.
 
 from __future__ import annotations
 
+import ast
 import collections
 import pathlib
 
@@ -133,3 +134,161 @@ def test_the_remaining_identity_components_still_discriminate(field: str) -> Non
     assert _partial_fingerprints(str(path), original) != _partial_fingerprints(
         str(path), altered
     )
+
+
+# --- The static guard: coverage must not depend on fixtures (#632 review) ---
+
+
+def _rule_modules() -> list[pathlib.Path]:
+    return sorted((REPO_ROOT / "src" / "compose_lint" / "rules").glob("CL*.py"))
+
+
+def _finding_calls_inside_loops(tree: ast.AST) -> list[ast.Call]:
+    """Every ``Finding(...)`` construction that sits inside a loop.
+
+    A construction under ``for``/``while`` can run more than once per
+    service, which is exactly the condition that requires ``evidence``.
+    """
+    found: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.For, ast.AsyncFor, ast.While)):
+            continue
+        for inner in ast.walk(node):
+            if (
+                isinstance(inner, ast.Call)
+                and isinstance(inner.func, ast.Name)
+                and inner.func.id == "Finding"
+            ):
+                found.append(inner)
+    return found
+
+
+def _sets_evidence(call: ast.Call) -> bool:
+    return any(kw.arg == "evidence" for kw in call.keywords)
+
+
+@pytest.mark.parametrize("module", _rule_modules(), ids=lambda p: p.stem)
+def test_a_rule_that_can_fire_twice_sets_evidence(module: pathlib.Path) -> None:
+    """Structural, because the fixture sweep only sees what fixtures cover.
+
+    The sweep below is honest about what it observes and blind to what it
+    does not: when this guard was first written, no fixture put two socket
+    mounts on one service, so CL-0001 — the tool's flagship CRITICAL —
+    shipped colliding into a single alert while the sweep stayed green.
+    CL-0013, CL-0017 and CL-0022 were wrong the same way.
+
+    Reading the source instead removes the dependency on someone having
+    imagined the right fixture. If a rule constructs a Finding inside a
+    loop, it can fire more than once per service, and its findings need
+    distinguishing whether or not a fixture happens to prove it.
+
+    A rule that legitimately cannot repeat despite looping (the loop picks
+    one winner and breaks, say) should still pass ``evidence`` — it costs
+    nothing and keeps this check free of exceptions to argue about.
+    """
+    tree = ast.parse(module.read_text(encoding="utf-8"))
+    offenders = [c for c in _finding_calls_inside_loops(tree) if not _sets_evidence(c)]
+    assert not offenders, (
+        f"{module.name} builds a Finding inside a loop at line(s) "
+        f"{[c.lineno for c in offenders]} without evidence=. It can fire more "
+        "than once per service, and GitHub shows one alert per fingerprint — "
+        "so the others would never appear. See ADR-024."
+    )
+
+
+def test_the_static_guard_actually_inspects_rules() -> None:
+    """Guard the guard: a broken glob or parser would pass everything."""
+    modules = _rule_modules()
+    assert len(modules) >= 20, f"only found {len(modules)} rule modules"
+    with_loops = [
+        m for m in modules if _finding_calls_inside_loops(ast.parse(m.read_text()))
+    ]
+    assert len(with_loops) >= 10, (
+        f"only {len(with_loops)} rules appear to build Findings in loops — "
+        "the AST matcher has probably stopped matching"
+    )
+
+
+# --- Evidence derivations are a contract, not an implementation detail ------
+
+# Exact evidence each rule must derive, on the fixture below. Changing a
+# value here re-keys that rule's alerts for every consumer, so it has to be
+# a deliberate, reviewed edit rather than a side effect of refactoring the
+# rule. Normalized forms on purpose: rewriting `SYS_ADMIN` as
+# `CAP_SYS_ADMIN`, or reordering a ports list, is the same configuration and
+# must keep the same alert.
+EVIDENCE_CONTRACT = {
+    "CL-0001": {"/var/run/docker.sock", "/run/containerd/containerd.sock"},
+    "CL-0005": {"8080:80", "3000"},
+    "CL-0009": {"apparmor", "seccomp"},
+    "CL-0010": {"pid", "ipc"},
+    "CL-0011": {"NET_ADMIN"},
+    "CL-0013": {"/etc"},
+    "CL-0016": {"/dev/sda"},
+    "CL-0022": {"/c1", "/c2"},
+    "CL-0024": {"SYS_ADMIN"},
+    "CL-0027": {"SYS_PTRACE"},
+    "CL-0029": {"SYS_NICE"},
+}
+
+_CONTRACT_DOC = """
+services:
+  sink:
+    image: x:1
+    ports: ["8080:80", "3000"]
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /run/containerd/containerd.sock:/s2:ro
+      - /etc:/host-etc:ro
+    tmpfs: ["/c1:exec", "/c2:suid"]
+    devices:
+      - /dev/sda:/dev/sda
+    cap_add: [SYS_ADMIN, NET_ADMIN, SYS_NICE, SYS_PTRACE]
+    security_opt: ["apparmor:unconfined", "seccomp:unconfined"]
+    pid: host
+    ipc: host
+"""
+
+
+def _contract_evidence() -> dict[str, set[str]]:
+    data, lines = loads(_CONTRACT_DOC)
+    got: dict[str, set[str]] = collections.defaultdict(set)
+    for f in run_rules(data, lines):
+        if f.evidence is not None:
+            got[f.rule_id].add(f.evidence)
+    return got
+
+
+@pytest.mark.parametrize("rule_id", sorted(EVIDENCE_CONTRACT))
+def test_evidence_derivation_is_pinned(rule_id: str) -> None:
+    """A refactor must not silently re-key a rule's alerts.
+
+    ``evidence`` is the alert's identity, so the expression a rule derives
+    it from is a consumer-facing contract even though it never appears in
+    the output. Without this, tidying a rule's internals could change every
+    fingerprint it produces — a partial, unannounced repeat of the v1 -> v2
+    transition this design exists to make unnecessary (ADR-024).
+    """
+    got = _contract_evidence()
+    assert got.get(rule_id) == EVIDENCE_CONTRACT[rule_id], (
+        f"{rule_id} evidence changed: expected {sorted(EVIDENCE_CONTRACT[rule_id])}, "
+        f"got {sorted(got.get(rule_id, []))}. If deliberate, this re-keys that "
+        "rule's Code Scanning alerts — say so in the CHANGELOG's Upgrading note."
+    )
+
+
+def test_evidence_is_normalized_not_as_written() -> None:
+    """Cosmetic rewrites of the same config must keep the same alert."""
+    variants = [
+        "    cap_add: [SYS_ADMIN]\n",
+        "    cap_add: [CAP_SYS_ADMIN]\n",
+        "    cap_add: [cap_sys_admin]\n",
+    ]
+    seen = set()
+    for cap in variants:
+        doc = "services:\n  s:\n    image: x:1\n" + cap
+        data, lines = loads(doc)
+        seen.update(
+            f.evidence for f in run_rules(data, lines) if f.rule_id == "CL-0024"
+        )
+    assert len(seen) == 1, f"the same capability derived {len(seen)} evidences: {seen}"

--- a/tests/test_finding_identity.py
+++ b/tests/test_finding_identity.py
@@ -1,0 +1,135 @@
+"""A finding's identity must not be its prose (ADR-024).
+
+``_partial_fingerprints`` is what GitHub uses to match an alert across
+commits and to deduplicate uploads. It used to digest the finding's
+*message*, because the message carries the specific offending value and
+that is what distinguishes two hits of one rule on one service.
+
+The cost was that prose became API. Rewording a message — fixing a typo,
+clarifying a sentence — changed the digest, and GitHub closed every
+affected alert and opened a new one in its place. A docs improvement was
+a breaking change, silently.
+
+The identity is now ``(file, rule, service, evidence)``, where
+``evidence`` is the offending value as structured data. That leaves one
+obligation, and it is the one this module enforces: a rule that can fire
+more than once for a single service **must** set ``evidence``, or its
+findings collide into a single alert and the others vanish from Code
+Scanning.
+"""
+
+from __future__ import annotations
+
+import collections
+import pathlib
+
+import pytest
+
+from compose_lint.engine import run_rules
+from compose_lint.formatters.sarif import _partial_fingerprints
+from compose_lint.parser import loads
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+FIXTURE_DIRS = [REPO_ROOT / "tests"]
+
+
+def _fixtures() -> list[pathlib.Path]:
+    found: list[pathlib.Path] = []
+    for root in FIXTURE_DIRS:
+        for pattern in ("*.yml", "*.yaml"):
+            found.extend(sorted(root.rglob(pattern)))
+    return found
+
+
+def _documents() -> list[tuple[pathlib.Path, list]]:
+    docs = []
+    for path in _fixtures():
+        try:
+            data, lines = loads(path.read_text(encoding="utf-8"), base_dir=path.parent)
+            findings = run_rules(data, lines)
+        except Exception:  # noqa: BLE001 - non-Compose fixtures are not the subject
+            continue
+        if findings:
+            docs.append((path, findings))
+    return docs
+
+
+def test_the_fixture_sweep_finds_something() -> None:
+    """Guard the guard: an empty sweep would make the checks below vacuous."""
+    docs = _documents()
+    assert len(docs) >= 20, f"only {len(docs)} fixture documents produced findings"
+
+
+def test_no_two_findings_in_one_document_share_a_fingerprint() -> None:
+    """The obligation evidence exists to satisfy.
+
+    A collision is not cosmetic: GitHub treats one fingerprint as one
+    alert, so the second finding is not shown at all. A rule that grew a
+    second per-service finding without evidence would silently hide it.
+    """
+    offenders: dict[str, list[str]] = collections.defaultdict(list)
+    for path, findings in _documents():
+        seen: dict[str, list] = collections.defaultdict(list)
+        for f in findings:
+            digest = _partial_fingerprints(str(path), f)["composeLintFinding/v2"]
+            seen[digest].append(f)
+        for collided in seen.values():
+            if len(collided) > 1:
+                rule = collided[0].rule_id
+                offenders[rule].append(
+                    f"{path.name}: service={collided[0].service!r} "
+                    f"x{len(collided)} (evidence={[c.evidence for c in collided]})"
+                )
+    assert not offenders, (
+        "these rules can fire more than once per service and must set "
+        "Finding.evidence to stay distinguishable:\n"
+        + "\n".join(f"  {r}: {v[0]}" for r, v in sorted(offenders.items()))
+    )
+
+
+def test_rewording_a_message_does_not_change_the_fingerprint() -> None:
+    """The whole point: prose is no longer part of the identity."""
+    docs = _documents()
+    path, findings = docs[0]
+    original = findings[0]
+    reworded = type(original)(
+        **{
+            **{f: getattr(original, f) for f in original.__dataclass_fields__},
+            "message": original.message + " (clarified wording)",
+        }
+    )
+    assert _partial_fingerprints(str(path), original) == _partial_fingerprints(
+        str(path), reworded
+    )
+
+
+def test_changing_the_evidence_does_change_the_fingerprint() -> None:
+    """...and the structured identity still discriminates."""
+    docs = _documents()
+    path, findings = docs[0]
+    original = findings[0]
+    altered = type(original)(
+        **{
+            **{f: getattr(original, f) for f in original.__dataclass_fields__},
+            "evidence": (original.evidence or "") + "-different",
+        }
+    )
+    assert _partial_fingerprints(str(path), original) != _partial_fingerprints(
+        str(path), altered
+    )
+
+
+@pytest.mark.parametrize("field", ["rule_id", "service"])
+def test_the_remaining_identity_components_still_discriminate(field: str) -> None:
+    docs = _documents()
+    path, findings = docs[0]
+    original = findings[0]
+    altered = type(original)(
+        **{
+            **{f: getattr(original, f) for f in original.__dataclass_fields__},
+            field: str(getattr(original, field)) + "-x",
+        }
+    )
+    assert _partial_fingerprints(str(path), original) != _partial_fingerprints(
+        str(path), altered
+    )

--- a/tests/test_format_equivalence.py
+++ b/tests/test_format_equivalence.py
@@ -151,14 +151,18 @@ def _from_json(out: str) -> dict[Finding, Detail]:
 def _from_sarif(out: str) -> dict[Finding, Detail]:
     parsed: dict[Finding, Detail] = {}
     for r in json.loads(out)["runs"][0]["results"]:
-        physical = r["locations"][0]["physicalLocation"]
+        location = r["locations"][0]
+        physical = location["physicalLocation"]
         suppressed = bool(r.get("suppressions"))
+        logical = location.get("logicalLocations") or [{}]
         finding = Finding(
             physical["artifactLocation"]["uri"],
             r["ruleId"],
             physical["region"]["startLine"],
         )
-        parsed[finding] = Detail("" if suppressed else r["level"], suppressed, None)
+        parsed[finding] = Detail(
+            "" if suppressed else r["level"], suppressed, logical[0].get("name")
+        )
     return parsed
 
 
@@ -259,28 +263,43 @@ def test_the_suppression_reason_survives_into_every_view(
     assert SUPPRESSION_REASON not in outputs["quiet"]
 
 
-def test_sarif_still_cannot_name_the_service(outputs: dict[str, str]) -> None:
-    """A known asymmetry, pinned so it cannot change unnoticed.
+def test_all_three_name_the_same_service(outputs: dict[str, str]) -> None:
+    """SARIF can name the service now, so all three views are compared on it.
 
-    text and json both name the service a finding belongs to; SARIF results
-    carry only ``ruleId``, ``artifactLocation`` and ``startLine``. In a
-    multi-service file the line number is a Code Scanning user's only
-    disambiguator, while a terminal user is told "service: web" outright.
-
-    This is why the comparisons above key on (rule, line) rather than the
-    (rule, service) the three views cannot all express. Asserting it here
-    keeps that a deliberate limitation rather than an oversight — and if
-    SARIF ever does carry the service, this test is where the equivalence
-    key gets widened.
+    This test replaces ``test_sarif_still_cannot_name_the_service``, which
+    pinned the gap: SARIF results carried only ``ruleId``,
+    ``artifactLocation`` and ``startLine``, so a Code Scanning user had the
+    line number where a terminal user had the name. The service now rides as
+    a ``logicalLocation``, and the equivalence key widens accordingly — which
+    is exactly what that test's docstring said would happen.
     """
-    findings = json.loads(outputs["json"])["findings"]
-    assert all(f.get("service") for f in findings), "json lost the service name"
+    text = _from_text(outputs["quiet"])
+    js = _from_json(outputs["json"])
+    sarif = _from_sarif(outputs["sarif"])
+    for finding, detail in js.items():
+        assert detail.service, f"{finding}: json lost the service name"
+        assert text[finding].service == detail.service, f"{finding}: text differs"
+        assert sarif[finding].service == detail.service, (
+            f"{finding}: sarif logicalLocation says "
+            f"{sarif[finding].service!r}, json says {detail.service!r}"
+        )
 
-    results = json.loads(outputs["sarif"])["runs"][0]["results"]
-    services = {f["service"] for f in findings}
-    for r in results:
-        blob = json.dumps(r)
-        assert not any(
-            f'"{s}"' == r.get("properties", {}).get("service") for s in services
-        ), "SARIF now carries a service property — widen the equivalence key"
-        assert "service" not in r.get("properties", {}), blob[:200]
+
+def test_the_sarif_title_names_the_service(outputs: dict[str, str]) -> None:
+    """``logicalLocations`` is structured; the title is what a user reads.
+
+    GitHub renders ``message.text`` as the alert title and gives no
+    guarantee it surfaces a logical location anywhere a reader will look, so
+    the name goes in both. Losing it from the title would be invisible to
+    the structural comparison above.
+    """
+    for result in json.loads(outputs["sarif"])["runs"][0]["results"]:
+        service = (result["locations"][0].get("logicalLocations") or [{}])[0].get(
+            "name"
+        )
+        if not service:
+            continue
+        assert f"'{service}'" in result["message"]["text"], (
+            f"{result['ruleId']}: title does not name the service — "
+            f"{result['message']['text'][:80]!r}"
+        )

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -42,7 +42,12 @@ class TestFormatFindings:
         r = results[0]
         assert r["ruleId"] == "CL-0001"
         assert r["level"] == "error"
-        assert r["message"]["text"] == _sample_finding().message
+        # The title names the service: it is what a Code Scanning user
+        # triages from, and the line number was previously their only way to
+        # tell which of a file's services a result belonged to.
+        assert r["message"]["text"] == (
+            f"Service '{_sample_finding().service}': {_sample_finding().message}"
+        )
 
     def test_location_includes_file_and_line(self) -> None:
         results = format_findings([_sample_finding()], "docker-compose.yml")
@@ -463,8 +468,11 @@ class TestPartialFingerprints:
     def test_present_on_every_result(self) -> None:
         results = format_findings([_sample_finding()], "x.yml")
         fp = results[0]["partialFingerprints"]
-        assert isinstance(fp["composeLintFinding/v1"], str)
-        assert len(fp["composeLintFinding/v1"]) == 64  # sha256 hex
+        assert isinstance(fp["composeLintFinding/v2"], str)
+        assert len(fp["composeLintFinding/v2"]) == 64  # sha256 hex
+        # v1 keyed on the message and is gone; a consumer seeing only the
+        # versioned key can tell a re-key from a genuine new finding.
+        assert "composeLintFinding/v1" not in fp
 
     def test_stable_across_runs(self) -> None:
         a = format_findings([_sample_finding()], "x.yml")[0]
@@ -486,17 +494,46 @@ class TestPartialFingerprints:
         fb = format_findings([moved], "x.yml")[0]["partialFingerprints"]
         assert fa == fb
 
-    def test_differs_by_rule_service_and_message(self) -> None:
+    def test_differs_by_rule_service_and_evidence(self) -> None:
         base = _sample_finding()
         variants = [
             Finding("CL-0002", base.severity, base.service, base.message, base.line),
             Finding(base.rule_id, base.severity, "other", base.message, base.line),
-            Finding(base.rule_id, base.severity, base.service, "other msg", base.line),
+            Finding(
+                base.rule_id,
+                base.severity,
+                base.service,
+                base.message,
+                base.line,
+                evidence="something-else",
+            ),
         ]
         baseline = format_findings([base], "x.yml")[0]["partialFingerprints"]
         for v in variants:
             other = format_findings([v], "x.yml")[0]["partialFingerprints"]
             assert other != baseline
+
+    def test_does_not_differ_by_message(self) -> None:
+        """Prose is not identity — the inverse of what v1 asserted.
+
+        v1 digested the message, so rewording a rule closed every matching
+        alert in every consuming repository and opened a new one. A typo fix
+        was a breaking change with no warning. Identity is now structured
+        (rule, service, evidence); see ADR-024.
+        """
+        base = _sample_finding()
+        reworded = Finding(
+            base.rule_id,
+            base.severity,
+            base.service,
+            base.message + " (clarified)",
+            base.line,
+            evidence=base.evidence,
+        )
+        assert (
+            format_findings([reworded], "x.yml")[0]["partialFingerprints"]
+            == format_findings([base], "x.yml")[0]["partialFingerprints"]
+        )
 
 
 class TestArtifactUri:


### PR DESCRIPTION
Closes #632. Implemented per the unconstrained design, on your call that one-time consumer churn is acceptable.

## What the issue asked for vs. what this does

#632 recommended `properties.service` and explicitly ruled out touching the message — a workaround shaped entirely around the fingerprint problem. With that constraint lifted, the missing service turns out to be the *smaller* half of the defect.

**The real bug:** `partialFingerprints` v1 digested `[uri, rule_id, service, message]`. The message was in there for a good reason — a rule firing twice on one service needs something to tell the hits apart — but it made **prose an API**. Rewording a rule silently closed every matching alert in every consuming repo and reopened it as new, losing dismissals. Improving a message was a breaking change with no warning, and the work most likely to trigger it was ordinary docs polish.

So the fix is identity first, visibility second.

## Identity: `(file, rule, service, evidence)`

New `Finding.evidence` holds the specific offending value — port spec, device path, capability, mounted source. **Normalized, not as-written**: CL-0024/0027 key on the bare capability, CL-0009 on the profile key, so rewriting `SYS_ADMIN` as `CAP_SYS_ADMIN` keeps the same alert.

Nine rules can fire more than once per service and now set it: CL-0005, 0009, 0010, 0016, 0020, 0021, 0024, 0025, 0027. The rest leave it `None` — `(file, rule, service)` already distinguishes those.

**I did not find those nine by reading rule files.** `tests/test_finding_identity.py` was written first and sweeps every fixture, failing when two findings in one document share a fingerprint. It named all nine, and it stays as the enforcement — a collision isn't cosmetic, because GitHub shows one alert per fingerprint and the others simply never appear. A rule that grows a second per-service finding without evidence will fail this test rather than silently hiding a finding.

Key bumped to `composeLintFinding/v2`. It was versioned from the start so consumers could tell an algorithm change from a new finding; this is the first use of that affordance. `_finding_key` (finding→edit matching) also moved off the message, so prose is load-bearing nowhere in this module.

## Visibility: `logicalLocations` + the title

```json
"message": { "text": "Service 'app' does not set no-new-privileges. …" },
"locations": [{
  "physicalLocation": { "artifactLocation": {...}, "region": {"startLine": 6} },
  "logicalLocations": [{ "name": "app", "fullyQualifiedName": "services.app", "kind": "resource" }]
}]
```

Both, not either: `logicalLocations` is the correct structured home, but GitHub renders `message.text` as the alert title and makes no promise about surfacing a logical location where a reader looks. 20 of 24 rule messages open with `"Service "`, so the name is threaded into that clause and reads as prose; the other four are prefixed. A message that stops matching the first shape degrades to the second rather than losing the service.

## Tests

- `test_finding_identity.py` — no two findings in a document share a fingerprint; rewording a message does **not** change it; changing evidence/rule/service does
- `test_sarif.py` — `test_differs_by_rule_service_and_message` became `…_and_evidence`, plus a new `test_does_not_differ_by_message` asserting the inverted contract explicitly
- `test_format_equivalence.py` — `test_sarif_still_cannot_name_the_service` replaced by `test_all_three_name_the_same_service`; the equivalence key widens to include the service, exactly as that test's docstring said it would. Plus a title check, since losing the name from the title would be invisible to the structural comparison.

`ruff`, `mypy --strict`, `pytest` (1883 passed, 6 skipped), `actionlint` green.

## ADR-024 and the CHANGELOG

The decision, the accepted cost, and the evidence for it are in `docs/adr/024-finding-identity-is-not-prose.md`. The CHANGELOG carries an **Upgrading** note, because this is user-visible: consumers see their alerts close and reopen once, and lose dismissal state on them.

The ADR records the exposure honestly — code search found zero public repos using the action or the hook, but private usage is invisible to that search, so the measured figure is a floor and the decision is that the cost is worth paying regardless.

## Not done, on purpose

**Region spans.** A `region` covering the whole service block would make the location self-scoping. The loader records start lines only, and extending it touches the line map `fix` depends on for its edits — larger, riskier, and independent of identity. Documented as out of scope in the ADR.

**Live GitHub ingestion is unproven here.** The `sarif-ingestion.yml` probe (#610) runs post-merge on `main` and is exactly the check that matters — it will confirm GitHub accepts `logicalLocations` and the v2 key. **Worth watching that run rather than assuming it green**; if GitHub rejects the logical location, that job is where it surfaces.

---

## Review round 2 — this PR was shipping the defect it exists to prevent

The claims above are corrected below rather than edited away, because the failure is the useful part.

### It was nine rules. It is seventeen.

Four rules collided under the v2 fingerprint as first pushed — reproduced with concrete documents:

| rule | trigger | result |
|---|---|---|
| **CL-0001** (CRITICAL) | docker.sock + containerd.sock + `/` + `/../` on one service | **4 findings → 1 fingerprint** |
| CL-0013 | `/etc:ro` + `/root:ro` | 2 → 1 |
| CL-0017 | two `propagation: shared` mounts | 2 → 1 |
| CL-0022 | `/c1:exec` + `/c2:suid` + `/c3:dev` | 3 → 1 |

GitHub shows one alert per fingerprint, so a service mounting both the Docker socket and `/` would have produced **one** CL-0001 alert and silently dropped the rest. Four more (CL-0011, CL-0028, CL-0029, CL-0030 — the `cap_add` family) were missed *again* by a hand-written grep sweep.

Kitchen-sink verification now: **33 findings → 33 distinct fingerprints, zero collisions.**

### Root cause: the guard's coverage equalled fixture coverage

`test_finding_identity.py` swept `tests/**.yml`. No fixture put two socket mounts on one service, so it stayed green while the bug shipped — and a rule that *grows* a second trigger next year regresses just as silently. That is the sustainability flaw, not the four rules.

The guard is now **structural**: any rule module constructing a `Finding` inside a loop must pass `evidence`, read off the AST. It found the four the grep missed on its first run. The fixture sweep stays as the weaker second check, and both are documented in ADR-024 with the failure recorded — so nobody later deletes the static check as redundant.

### Why this had to land here rather than as a follow-up

Adding `evidence` to a rule changes its digest. Fixing these after 0.21.0 ships would re-key those rules' alerts a **second** time — precisely the churn this design exists to end. One transition, or none of the argument holds.

### `EVIDENCE_CONTRACT`

`evidence` never appears in the output, which makes it easy to mistake for an implementation detail and "tidy up", silently re-keying a rule's alerts. Each rule's derived value is now pinned against a fixed document.

Writing it corrected three wrong assumptions of mine about which rule fires on what — and confirmed the normalization claim in the ADR holds: `SYS_ADMIN`, `CAP_SYS_ADMIN`, `cap_sys_admin` and `sys_admin` all derive `SYS_ADMIN`, so a cosmetic rewrite keeps the alert.

### The validation gap — my earlier claim here was wrong

I wrote that `sarif-ingestion.yml` would confirm v2 ingestion post-merge. **It would not.** That probe uploads via `uses: ./` with `version: latest`, i.e. it installs from PyPI — so it validates whatever is published, not this branch. The v2 shape would have met GitHub for the first time only *after* 0.21.0 published.

The probe now also uploads the **working tree's** SARIF as a separately-categorised analysis, via `codeql-action/upload-sarif` directly (the action installs from PyPI by design and has no input pointing at a checkout). `setup-python` was added because ubuntu-24.04's system python is PEP 668 externally-managed and a bare `pip install` into it fails.

That closes the loop on this PR's own premise: future SARIF changes get checked against real ingestion *before* shipping, which is the condition under which this transition never needs repeating.

### One correction in the other direction

I briefly added a CHANGELOG line claiming these seventeen rules "previously collapsed into a single alert". That was **false** and is removed — v1 digested the message, which *did* distinguish them. There is no user-visible completeness gain here; the fix prevents a regression this PR would otherwise have introduced.

### Verification

`ruff`, `mypy --strict`, `actionlint`, `check_changelog_unreleased`, `pytest` — **1923 passed, 6 skipped**.

Still unproven from this container: live GitHub ingestion of `logicalLocations` and the v2 key. That is now answerable **without merging** — `sarif-ingestion.yml` is `workflow_dispatch` and takes a ref, so it can run against this branch and upload a real probe. Worth doing before merge given the one-time consumer cost.
