### PR TITLE
Share one Docker smoke between both publish paths

### DIFF
--- a/.github/workflows/publish-channel.yml
+++ b/.github/workflows/publish-channel.yml
@@ -110,80 +110,24 @@ jobs:
           TAG: ${{ inputs.tag }}
         run: gh release upload "${TAG}" sbom.spdx.json --clobber
 
-  # Pre-publish smoke for the docker channel. publish.yml runs docker-smoke
-  # multi-arch before the release-gate; this emergency path has no shared
-  # gate, so a broken Dockerfile or runtime dep could push straight to Docker
-  # Hub on a single approval. Single-arch (amd64) keeps the smoke cheap —
-  # multi-arch is still covered by the real build-docker matrix below.
+  # Pre-publish smoke for the docker channel. publish.yml runs the same
+  # battery before its release-gate; this emergency path has no shared gate,
+  # so a broken Dockerfile or runtime dep could push straight to Docker Hub
+  # on a single approval.
+  #
+  # One definition, called by both paths, so the steps this break-glass
+  # workflow runs under pressure are the ones every normal release has
+  # already run (#633). Single-arch (amd64) keeps the smoke cheap; multi-arch
+  # is still covered by the build-docker matrix below.
   docker-smoke:
     needs: verify-tag
     if: inputs.channel == 'docker'
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
     permissions:
       contents: read
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          ref: ${{ inputs.tag }}
-          persist-credentials: false
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-      - name: Build image for testing
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          platforms: linux/amd64
-          load: true
-          tags: composelint/compose-lint:channel-smoke
-      # Every docker-smoke step uses the fully-hardened flag set documented
-      # in README.md ("Running with full hardening"). If a user copy-pastes
-      # that recipe and it breaks, this matrix fails the release gate. Keep
-      # these flags in sync with README.md — both should change together.
-      - name: Test — version output matches tag (hardened)
-        env:
-          TAG: ${{ inputs.tag }}
-        run: |
-          expected="compose-lint ${TAG#v}"
-          actual="$(docker run --rm \
-            --read-only \
-            --cap-drop ALL \
-            --security-opt no-new-privileges:true \
-            --network none \
-            --user 65532:65532 \
-            --pids-limit 256 \
-            composelint/compose-lint:channel-smoke --version)"
-          if [ "${actual}" != "${expected}" ]; then
-            echo "::error::Version mismatch: '${actual}' vs expected '${expected}'"
-            exit 1
-          fi
-      - name: Test — clean fixture exits 0 (hardened)
-        run: |
-          docker run --rm \
-            --read-only \
-            --cap-drop ALL \
-            --security-opt no-new-privileges:true \
-            --network none \
-            --user 65532:65532 \
-            --pids-limit 256 \
-            -v "${PWD}/tests/smoke/clean.yml:/src/docker-compose.yml:ro" \
-            composelint/compose-lint:channel-smoke
-      - name: Test — insecure fixture exits 1 (hardened)
-        run: |
-          exit_code=0
-          docker run --rm \
-            --read-only \
-            --cap-drop ALL \
-            --security-opt no-new-privileges:true \
-            --network none \
-            --user 65532:65532 \
-            --pids-limit 256 \
-            -v "${PWD}/tests/smoke/insecure.yml:/src/docker-compose.yml:ro" \
-            composelint/compose-lint:channel-smoke || exit_code=$?
-          if [ "${exit_code}" -ne 1 ]; then
-            echo "::error::Expected exit 1 on insecure fixture, got ${exit_code}"
-            exit 1
-          fi
+    uses: ./.github/workflows/release-docker-smoke.yml
+    with:
+      tag: ${{ inputs.tag }}
+      matrix: '{"include":[{"platform":"linux/amd64","runner":"ubuntu-24.04"}]}'
 
   # Build one image per arch on a native runner (no QEMU) and push by
   # digest only. See the matching block in publish.yml for the full

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -331,23 +331,35 @@ jobs:
   # Build the image natively on each target arch and run the fixture battery.
   # Emulated arm64 via QEMU crashes on Debian apt-get, and a single-arch smoke
   # can't catch per-arch digest pins or native-wheel mismatches before the
-  # release-gate — so both legs are exercised here, on their own runners, no
-  # QEMU. Scout CVE scanning stays single-arch (amd64): CVE findings come from
-  # base-image layers that are identical across arch in practice, and running
-  # Scout twice would double-upload SARIF under the same category.
+  # release-gate — so both legs are exercised, on their own runners, no QEMU.
+  #
+  # The battery itself lives in release-docker-smoke.yml because
+  # publish-channel.yml runs the same one. See that file for why it is shared
+  # rather than copied (#633).
   docker-smoke:
     needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-24.04
-            scout: true
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-            scout: false
-    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/release-docker-smoke.yml
+    with:
+      tag: ${{ github.ref_name }}
+      matrix: >-
+        {"include":[
+        {"platform":"linux/amd64","runner":"ubuntu-24.04"},
+        {"platform":"linux/arm64","runner":"ubuntu-24.04-arm"}]}
+
+  # Scout is a separate job from the smoke above because it answers a
+  # different question and needs a stronger token. Keeping it here rather
+  # than in the shared workflow means publish-channel.yml — which does not
+  # CVE-scan — is not made to grant `security-events: write` to a job whose
+  # steps it never runs. It costs one extra amd64 build on the release path.
+  #
+  # Single-arch (amd64) is deliberate: CVE findings come from base-image
+  # layers that are identical across arch in practice, and scanning twice
+  # would double-upload SARIF under the same category.
+  docker-scout:
+    needs: build
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
       contents: read
@@ -357,84 +369,22 @@ jobs:
         with:
           persist-credentials: false
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-      - name: Build image for testing
+      - name: Build image for scanning
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64
           load: true
-          tags: composelint/compose-lint:test
-      # Every docker-smoke step uses the fully-hardened flag set documented
-      # in README.md ("Running with full hardening"). If a user copy-pastes
-      # that recipe and it breaks, this matrix fails the release gate. Keep
-      # these flags in sync with README.md — both should change together.
-      - name: Test — version output matches tag (hardened)
-        run: |
-          expected="compose-lint ${GITHUB_REF_NAME#v}"
-          actual="$(docker run --rm \
-            --read-only \
-            --cap-drop ALL \
-            --security-opt no-new-privileges:true \
-            --network none \
-            --user 65532:65532 \
-            --pids-limit 256 \
-            composelint/compose-lint:test --version)"
-          echo "Expected: ${expected}"
-          echo "Actual:   ${actual}"
-          if [ "${actual}" != "${expected}" ]; then
-            echo "::error::Version mismatch: image reports '${actual}', expected '${expected}'"
-            exit 1
-          fi
-      - name: Test — clean fixture exits 0 (hardened)
-        run: |
-          docker run --rm \
-            --read-only \
-            --cap-drop ALL \
-            --security-opt no-new-privileges:true \
-            --network none \
-            --user 65532:65532 \
-            --pids-limit 256 \
-            -v "${PWD}/tests/smoke/clean.yml:/src/docker-compose.yml:ro" \
-            composelint/compose-lint:test
-      - name: Test — insecure fixture exits 1 (hardened)
-        run: |
-          exit_code=0
-          docker run --rm \
-            --read-only \
-            --cap-drop ALL \
-            --security-opt no-new-privileges:true \
-            --network none \
-            --user 65532:65532 \
-            --pids-limit 256 \
-            -v "${PWD}/tests/smoke/insecure.yml:/src/docker-compose.yml:ro" \
-            composelint/compose-lint:test || exit_code=$?
-          if [ "${exit_code}" -ne 1 ]; then
-            echo "::error::Expected exit code 1, got ${exit_code}"
-            exit 1
-          fi
-      - name: Test — SARIF output is valid JSON (hardened)
-        run: |
-          docker run --rm \
-            --read-only \
-            --cap-drop ALL \
-            --security-opt no-new-privileges:true \
-            --network none \
-            --user 65532:65532 \
-            --pids-limit 256 \
-            -v "${PWD}/tests/smoke/sarif-shape.yml:/src/docker-compose.yml:ro" \
-            composelint/compose-lint:test --format sarif --fail-on critical \
-            | python3 -c "import sys, json; json.load(sys.stdin); print('Valid SARIF JSON')"
+          tags: composelint/compose-lint:scout
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        if: matrix.scout
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Scan for vulnerabilities (Docker Scout)
-        if: matrix.scout
         uses: docker/scout-action@7c6b6c3f7844478ace1ffd4e7aef649053d1f87d # v1.24.0
         with:
           command: cves
-          image: local://composelint/compose-lint:test
+          image: local://composelint/compose-lint:scout
           only-severities: critical
           exit-code: true
           sarif-file: scout-results.sarif
@@ -453,7 +403,7 @@ jobs:
           # image manifest. See ADR-012.
           vex-author: .*
       - name: Upload Scout results to GitHub Security
-        if: matrix.scout && always()
+        if: always()
         uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: scout-results.sarif
@@ -462,7 +412,7 @@ jobs:
   # Single approval gate — all smoke tests (PyPI + Docker) must pass first.
   # Configure the 'release' GitHub Environment with required reviewers.
   release-gate:
-    needs: [testpypi-smoke, docker-smoke]
+    needs: [testpypi-smoke, docker-smoke, docker-scout]
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     environment:

--- a/.github/workflows/release-docker-smoke.yml
+++ b/.github/workflows/release-docker-smoke.yml
@@ -1,0 +1,131 @@
+name: Release Docker smoke
+
+# The functional smoke every publish path runs against the image before it
+# ships, called by publish.yml and publish-channel.yml.
+#
+# It used to be inlined in both, which made the emergency path the weaker
+# copy: publish.yml asserted the container emits valid SARIF and
+# publish-channel.yml did not, so the escape hatch shipped an image against
+# a smaller definition of "works" than the normal path — the same shape of
+# drift verify-tag.yml was extracted to stop, and the same one #624 found in
+# the fixtures.
+#
+# Sharing the definition also makes it *exercised*. publish-channel.yml is
+# dispatch-only and last ran in April; any edit to its copy was checked by
+# reading and by actionlint, never by running (#633). One definition means
+# every normal release runs the same steps the break-glass path will run.
+#
+# Vulnerability scanning is deliberately not here. Scout answers a different
+# question (does the image carry a critical CVE), needs `security-events:
+# write` to upload its SARIF, and is not part of the emergency path — so it
+# stays a publish.yml job rather than forcing every caller to grant a
+# permission its own path never uses.
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: "Release tag under test (e.g. v1.2.3)"
+        required: true
+        type: string
+      matrix:
+        description: >-
+          JSON strategy matrix, e.g.
+          {"include":[{"platform":"linux/amd64","runner":"ubuntu-24.04"}]}.
+          The normal path smokes both shipped arches; the emergency path
+          smokes amd64 only, because its multi-arch coverage comes from the
+          build matrix that follows it.
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  docker-smoke:
+    name: Smoke ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(inputs.matrix) }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The tag, not the dispatched branch: workflow_dispatch sets
+          # GITHUB_REF to the branch the run was started from, so the
+          # emergency path would otherwise smoke main while publishing a tag.
+          ref: ${{ inputs.tag }}
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - name: Build image for testing
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          load: true
+          tags: composelint/compose-lint:release-smoke
+
+      # Every step below uses the fully-hardened flag set documented in
+      # README.md ("Running with full hardening"). If a user copy-pastes that
+      # recipe and it breaks, this smoke fails the release. Keep these flags
+      # in sync with README.md — both should change together.
+      - name: Test — version output matches tag (hardened)
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          expected="compose-lint ${TAG#v}"
+          actual="$(docker run --rm \
+            --read-only \
+            --cap-drop ALL \
+            --security-opt no-new-privileges:true \
+            --network none \
+            --user 65532:65532 \
+            --pids-limit 256 \
+            composelint/compose-lint:release-smoke --version)"
+          echo "Expected: ${expected}"
+          echo "Actual:   ${actual}"
+          if [ "${actual}" != "${expected}" ]; then
+            echo "::error::Version mismatch: image reports '${actual}', expected '${expected}'"
+            exit 1
+          fi
+      - name: Test — clean fixture exits 0 (hardened)
+        run: |
+          docker run --rm \
+            --read-only \
+            --cap-drop ALL \
+            --security-opt no-new-privileges:true \
+            --network none \
+            --user 65532:65532 \
+            --pids-limit 256 \
+            -v "${PWD}/tests/smoke/clean.yml:/src/docker-compose.yml:ro" \
+            composelint/compose-lint:release-smoke
+      - name: Test — insecure fixture exits 1 (hardened)
+        run: |
+          exit_code=0
+          docker run --rm \
+            --read-only \
+            --cap-drop ALL \
+            --security-opt no-new-privileges:true \
+            --network none \
+            --user 65532:65532 \
+            --pids-limit 256 \
+            -v "${PWD}/tests/smoke/insecure.yml:/src/docker-compose.yml:ro" \
+            composelint/compose-lint:release-smoke || exit_code=$?
+          if [ "${exit_code}" -ne 1 ]; then
+            echo "::error::Expected exit code 1, got ${exit_code}"
+            exit 1
+          fi
+      - name: Test — SARIF output is valid JSON (hardened)
+        run: |
+          docker run --rm \
+            --read-only \
+            --cap-drop ALL \
+            --security-opt no-new-privileges:true \
+            --network none \
+            --user 65532:65532 \
+            --pids-limit 256 \
+            -v "${PWD}/tests/smoke/sarif-shape.yml:/src/docker-compose.yml:ro" \
+            composelint/compose-lint:release-smoke --format sarif --fail-on critical \
+            | python3 -c "import sys, json; json.load(sys.stdin); print('Valid SARIF JSON')"

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -232,8 +232,23 @@ Tag-triggered. Full detail in [`RELEASING.md`](RELEASING.md) and the
 per-channel contract in [`DISTRIBUTION.md`](DISTRIBUTION.md). Summary:
 
 `verify-tag` → `build` → `testpypi` → `testpypi-smoke` + `docker-smoke`
-→ **`release-gate` (manual approval)** → `publish` + `docker-publish`
-in parallel → `create-release` → `bump-marketplace-smoke-pin`.
++ `docker-scout` → **`release-gate` (manual approval)** → `publish` +
+`docker-publish` in parallel → `create-release` →
+`bump-marketplace-smoke-pin`.
+
+`docker-smoke` calls [`release-docker-smoke.yml`](../.github/workflows/release-docker-smoke.yml),
+the shared pre-publish battery — build the image, then assert the version
+matches the tag, the clean fixture exits 0, the insecure fixture exits 1,
+and SARIF output parses, each under the fully-hardened flag set README
+documents. `publish-channel.yml` calls the same workflow, so the
+emergency path's smoke is exercised by every normal release rather than
+only when someone reaches for the escape hatch (#633).
+
+`docker-scout` is separate from the smoke because it needs
+`security-events: write` to upload its SARIF, and the emergency path does
+not CVE-scan; keeping it here means that path is not made to grant a
+permission it never uses. It gates `release-gate` alongside the smoke, so
+a critical CVE still blocks the release.
 
 `verify-tag` is the first gate: it asserts the tag is annotated (not
 lightweight), that the tag commit is reachable from `origin/main`, and
@@ -327,6 +342,14 @@ Both paths re-apply the `verify-tag` check (annotated + reachable from
 gates. The pypi path also generates an SBOM and attaches it to the
 existing GitHub Release with `gh release upload --clobber`, matching
 what `publish.yml`'s normal path produces.
+
+The docker path's pre-publish smoke is the shared
+[`release-docker-smoke.yml`](../.github/workflows/release-docker-smoke.yml),
+not a copy of it. This workflow is `workflow_dispatch`-only, so nothing
+routinely runs it and an edit to a private copy would first execute
+mid-emergency — which is how its copy came to omit the SARIF check the
+normal path ran. Calling the shared definition means every normal release
+exercises the steps this path will take under pressure.
 
 Document why you used it in the GitHub Release notes — every invocation
 should leave a paper trail.

--- a/tests/test_release_layer.py
+++ b/tests/test_release_layer.py
@@ -333,3 +333,74 @@ def test_the_shared_fixtures_are_actually_consumed() -> None:
         f"only {sorted(consumers)} reference tests/smoke/ — the no-inline-fixture "
         "check above would pass vacuously if the fixtures fell out of use"
     )
+
+
+# --- The pre-publish smoke is one definition, not two (#633) --------------
+
+_SHARED_DOCKER_SMOKE = "release-docker-smoke.yml"
+
+
+@pytest.mark.parametrize("workflow", ["publish.yml", "publish-channel.yml"])
+def test_publish_paths_call_the_shared_docker_smoke(workflow: str) -> None:
+    """Both publish paths smoke the image with the same steps, or one drifts.
+
+    publish-channel.yml is dispatch-only and last ran in April, so its copy of
+    the battery was never executed — edits to it were checked by reading and by
+    actionlint, and nothing else. It had already lost a check the normal path
+    ran: publish.yml asserted the container emits valid SARIF and the emergency
+    path did not, so the escape hatch graded the image against a smaller
+    definition of "works" than every normal release used.
+
+    A `uses:` job cannot carry `steps:`, so this also makes the drift
+    impossible to reintroduce by hand rather than merely detectable.
+    """
+    job = _load(workflow)["jobs"]["docker-smoke"]
+    assert job.get("uses", "").endswith(_SHARED_DOCKER_SMOKE), (
+        f"{workflow}: docker-smoke defines its own battery instead of calling "
+        f"{_SHARED_DOCKER_SMOKE} — the emergency path is the one nothing runs"
+    )
+    assert "steps" not in job, (
+        f"{workflow}: docker-smoke calls the shared smoke but also carries its "
+        "own steps"
+    )
+
+
+def test_the_shared_docker_smoke_keeps_its_whole_battery() -> None:
+    """Sharing stops the paths diverging; it does not stop both losing a check.
+
+    With one definition a dropped assertion is invisible in review — every
+    caller still "runs the smoke". Pin what the battery asserts, the same way
+    tests/smoke/insecure.golden.json pins what a surface must report.
+    """
+    doc = _load(_SHARED_DOCKER_SMOKE)
+    steps = doc["jobs"]["docker-smoke"]["steps"]
+    names = [str(step.get("name", "")) for step in steps]
+    for expected in ("version output", "clean fixture", "insecure fixture", "SARIF"):
+        assert any(expected in name for name in names), (
+            f"{_SHARED_DOCKER_SMOKE} no longer asserts '{expected}'; every "
+            f"publish path lost that check at once. Steps: {names}"
+        )
+
+
+def test_the_shared_docker_smoke_runs_the_documented_hardened_flags() -> None:
+    """The smoke runs README.md's copy-paste recipe, so a broken one fails CI.
+
+    These flags exist to prove the hardening users are told to apply still
+    works against the shipped image. A smoke that quietly dropped, say,
+    ``--read-only`` would keep passing while the documented recipe broke.
+    """
+    raw = (WORKFLOWS / _SHARED_DOCKER_SMOKE).read_text(encoding="utf-8")
+    docker_runs = raw.count("docker run --rm")
+    for flag in (
+        "--read-only",
+        "--cap-drop ALL",
+        "--security-opt no-new-privileges:true",
+        "--network none",
+        "--user 65532:65532",
+        "--pids-limit 256",
+    ):
+        assert raw.count(flag) == docker_runs, (
+            f"{_SHARED_DOCKER_SMOKE}: '{flag}' appears {raw.count(flag)} times "
+            f"across {docker_runs} `docker run` invocations — every smoke step "
+            "runs the fully-hardened flag set documented in README.md"
+        )


### PR DESCRIPTION
Closes #633.

`publish-channel.yml` is the break-glass single-channel publish path. It is `workflow_dispatch`-only and last ran in April, so nothing exercises it — its copy of the pre-publish smoke was checked by reading and by `actionlint`, never by running. The only way to execute it is to be mid-emergency-publish, which is the worst possible moment to discover a path bug, and its smokes are what gate that publish.

Taking option **C** from the issue, with no interim step.

## The copy had already drifted

In the direction the release layer must never drift: `publish.yml` asserted the container emits valid SARIF and `publish-channel.yml` did not. The escape hatch was grading the image against a smaller definition of "works" than every normal release used — the same shape as the `verify-tag` copy that performed two of three checks, and the same as the fixtures in #624.

Nobody would have noticed, because the only surface that would have reported it never runs.

## What changed

The battery moves to `release-docker-smoke.yml`, called by both paths. One definition cannot diverge, and since `publish.yml` runs it on every tag push, the steps the emergency path will take under pressure are the ones a normal release has already taken. `publish-channel.yml` picks up the SARIF assertion it was missing as a consequence of sharing, not as a separate fix.

Callers differ only in what is genuinely path-specific — the tag source (`github.ref_name` vs `inputs.tag`) and the arch matrix, passed as an input. The emergency path stays single-arch because its multi-arch coverage comes from the `build-docker` matrix that follows it.

**Scout does not move with it.** It answers a different question (does the image carry a critical CVE) and needs `security-events: write` to upload its SARIF. Sharing it would force `publish-channel.yml` — which does not CVE-scan — to grant that scope to a job whose steps it never runs. It becomes its own job in `publish.yml` and still gates `release-gate`, so a critical CVE blocks the release exactly as before. The cost is one extra amd64 build on the release path.

## Tests

The issue asked for a check that the two paths' smokes have not diverged, "since that is what nobody will notice". Three, in `tests/test_release_layer.py`:

- both paths must call the shared workflow and carry no `steps:` of their own — a `uses:` job cannot hold steps, so the drift becomes impossible to reintroduce by hand rather than merely detectable;
- the shared battery must keep all four assertions, since sharing stops the paths diverging but not both losing a check at once;
- every smoke step must run the fully-hardened flag set README documents — a comment asked for that sync and nothing enforced it.

Each was verified to **fail** against a deliberately mutated tree (SARIF step renamed; one `--read-only` dropped; `publish.yml` re-inlining its own steps), so none of them passes vacuously.

## Verification

`actionlint` (same pinned 1.7.12 CI uses, SHA-verified) clean; `ruff check`, `ruff format --check`, `mypy src/` clean; full suite 1929 passed, 6 skipped.

What that does **not** cover: `publish-channel.yml` still cannot be executed outside an emergency, so this change is verified statically like every other edit to that file. The difference is that its smoke is now the same code `publish.yml` runs on every release, so the next release exercises it. That is the property the issue was asking for, and it is why the issue's option B (a dry-run input) was skipped — it would have made the copy testable rather than removing the copy.

`docs/CI.md` gains the new job in the release DAG and the reasoning in both workflow sections. No CHANGELOG entry: no version bump and no user-facing change.

## Note on the April failures

The three `workflow_dispatch` runs from 2026-04-18 all failed, and I could not determine why — GitHub returns HTTP 410 for their logs, so the retention window has closed. Worth recording that the last three exercises of the break-glass path failed for reasons nobody wrote down.
