### PR TITLE
Stop a transient Scout CLI download from failing the scan

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -402,8 +402,15 @@ jobs:
           # safe because the document is also cosign-attested to the
           # image manifest. See ADR-012.
           vex-author: .*
+      # `always()` is gated on the SARIF existing so a Scout CLI download
+      # failure surfaces as one error instead of cascading into a second
+      # ("Path does not exist") plus a CodeQL CONFIGURATION_ERROR. The
+      # scan step still writes the file when it exits non-zero on a real
+      # critical, so that upload is unaffected. Deliberately no retry
+      # here, unlike the scheduled scans: this is a release gate and
+      # should fail closed for a human to re-run.
       - name: Upload Scout results to GitHub Security
-        if: always()
+        if: always() && hashFiles('scout-results.sarif') != ''
         uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: scout-results.sarif

--- a/.github/workflows/scout-scan.yml
+++ b/.github/workflows/scout-scan.yml
@@ -31,35 +31,18 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # Gate the run on criticals so a fresh critical CVE fails the job
-      # and the `Report scheduled failure as issue` step downstream fires
-      # on schedule. High-severity stays warning-only — still uploaded to
-      # the Security tab by the second scan, just doesn't page.
-      - name: Scan for critical CVEs (fails the run)
-        uses: docker/scout-action@7c6b6c3f7844478ace1ffd4e7aef649053d1f87d # v1.24.0
-        with:
-          command: cves
-          image: composelint/compose-lint:latest
-          only-severities: critical
-          exit-code: true
-          # Apply the same OpenVEX document the release asset and image
-          # attestation carry, so any critical-rated CVE already marked
-          # not_affected doesn't spuriously fail the schedule.
-          vex-location: .vex/compose-lint.openvex.json
-          # Scout's default vex-author allowlist is `<.*@docker.com>`,
-          # which silently drops our maintainer-authored statements.
-          # The first override attempt (`<.*@gmail\.com>`) was also
-          # silently dropped — Scout appears to require a full-string
-          # regex match on the author field, not substring. `.*`
-          # accepts any author and is safe because the document is
-          # also cosign-attested to the image manifest. See ADR-012.
-          vex-author: .*
-
-      # Full-severity sweep for SARIF upload. Runs even when the
-      # critical scan fails, so the Security tab always reflects the
-      # complete picture rather than a partial snapshot.
+      # Full-severity sweep, ordered first so it also warms the Scout
+      # CLI. `docker/scout-action` downloads its ~180 MB binary from the
+      # docker/scout-action release on first use in a job and reuses it
+      # for every later step (observed in runs 142/143), and the
+      # `@actions/tool-cache` download it uses does not retry 4xx. A
+      # transient 403 on that download killed run 142 before either scan
+      # ran. Putting the `exit-code: false` scan first means only this
+      # step can hit the download path, and it fails on infra errors
+      # only — never on findings — so the retry below is unambiguous.
       - name: Scan all severities for SARIF upload
-        if: always()
+        id: sweep
+        continue-on-error: true
         uses: docker/scout-action@7c6b6c3f7844478ace1ffd4e7aef649053d1f87d # v1.24.0
         with:
           command: cves
@@ -71,13 +54,59 @@ jobs:
           # vulnerable_code_not_present against the published image.
           # See .vex/compose-lint.openvex.json.
           vex-location: .vex/compose-lint.openvex.json
-          # See note on the gate step above re: the default vex-author
-          # allowlist. Same override required here.
+          # Scout's default vex-author allowlist is `<.*@docker.com>`,
+          # which silently drops our maintainer-authored statements.
+          # The first override attempt (`<.*@gmail\.com>`) was also
+          # silently dropped — Scout appears to require a full-string
+          # regex match on the author field, not substring. `.*`
+          # accepts any author and is safe because the document is
+          # also cosign-attested to the image manifest. See ADR-012.
           vex-author: .*
 
+      # One retry, for the transient-download case described above.
+      # Deliberately no `continue-on-error`: if the download fails twice
+      # the run should fail loudly rather than scan nothing quietly.
+      - name: Retry sweep after a failed Scout CLI download
+        if: steps.sweep.outcome == 'failure'
+        uses: docker/scout-action@7c6b6c3f7844478ace1ffd4e7aef649053d1f87d # v1.24.0
+        with:
+          command: cves
+          image: composelint/compose-lint:latest
+          exit-code: false
+          sarif-file: scout-results.sarif
+          vex-location: .vex/compose-lint.openvex.json
+          vex-author: .*
+
+      # Gate the run on criticals so a fresh critical CVE fails the job
+      # and the `Report scheduled failure as issue` step downstream fires
+      # on schedule. High-severity stays warning-only — still uploaded to
+      # the Security tab by the sweep above, just doesn't page. The CLI
+      # is already warm by this point, so this step cannot fail on the
+      # binary download; a failure here means a real critical finding.
+      - name: Scan for critical CVEs (fails the run)
+        uses: docker/scout-action@7c6b6c3f7844478ace1ffd4e7aef649053d1f87d # v1.24.0
+        with:
+          command: cves
+          image: composelint/compose-lint:latest
+          only-severities: critical
+          exit-code: true
+          # Apply the same OpenVEX document the release asset and image
+          # attestation carry, so any critical-rated CVE already marked
+          # not_affected doesn't spuriously fail the schedule.
+          vex-location: .vex/compose-lint.openvex.json
+          # See the note on the sweep step above re: the default
+          # vex-author allowlist. Same override required here.
+          vex-author: .*
+
+      # Upload only when a SARIF actually exists. Bare `always()` turned
+      # run 142's failed download into two further errors — this step's
+      # "Path does not exist" plus a CodeQL CONFIGURATION_ERROR — which
+      # buried the real cause. `hashFiles` still uploads when the gate
+      # step fails on a genuine critical (the sweep wrote the file
+      # already) and skips only when no scan produced one.
       - name: Upload Scout results to GitHub Security
         uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
-        if: always()
+        if: always() && hashFiles('scout-results.sarif') != ''
         with:
           sarif_file: scout-results.sarif
           category: docker-scout-scheduled

--- a/.github/workflows/vuln-report.yml
+++ b/.github/workflows/vuln-report.yml
@@ -63,7 +63,15 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # `continue-on-error` + the retry below absorb a transient 403 on
+      # the Scout CLI download, which is not retried by the action (see
+      # scout-scan.yml for the full note). This scan is `exit-code:
+      # false`, so a failure here is always an infra error, never a
+      # finding — and `Build report body` hard-fails on a missing SARIF,
+      # so letting one through would surface as a confusing parse error.
       - name: Scan published image for fixable CVEs (all severities)
+        id: scan
+        continue-on-error: true
         uses: docker/scout-action@7c6b6c3f7844478ace1ffd4e7aef649053d1f87d # v1.24.0
         with:
           command: cves
@@ -75,6 +83,18 @@ jobs:
           # Same OpenVEX document the image attestation carries, so CVEs
           # already marked not_affected don't page. See scout-scan.yml
           # for why vex-author must be `.*`.
+          vex-location: .vex/compose-lint.openvex.json
+          vex-author: .*
+
+      - name: Retry scan after a failed Scout CLI download
+        if: steps.scan.outcome == 'failure'
+        uses: docker/scout-action@7c6b6c3f7844478ace1ffd4e7aef649053d1f87d # v1.24.0
+        with:
+          command: cves
+          image: composelint/compose-lint:latest
+          only-fixed: true
+          exit-code: false
+          sarif-file: scout-fixable.sarif
           vex-location: .vex/compose-lint.openvex.json
           vex-author: .*
 


### PR DESCRIPTION
## What broke

`scout-scan.yml` run [142](https://github.com/tmatens/compose-lint/actions/runs/32341516697) failed on 2026-08-20. It was **not** a CVE — `docker/scout-action` got a **403 downloading its own CLI binary**:

```
Logging into docker.io...
Login Succeeded!
...
Downloading asset: docker-scout-action_linux_amd64 (179.2 MB)
##[error]Unexpected HTTP response: 403
```

Both scan steps died in **under 0.1s**; no scan ever ran.

Confirmed transient, not a config or credential problem:
- `vuln-report.yml` ran the *same* pinned action (v1.24.0) successfully 20 minutes later ([run 24](https://github.com/tmatens/compose-lint/actions/runs/32343055225), green).
- A re-dispatch, [run 143](https://github.com/tmatens/compose-lint/actions/runs/32363321510), is fully green with no critical CVEs.
- First failure in 15+ consecutive scheduled runs. Filed [#637](https://github.com/tmatens/compose-lint/issues/637) as a false alarm; closed as not planned.

## Why one 403 caused three errors

The action downloads its binary through `@actions/tool-cache`, which **does not retry 4xx**. When it failed:

1. Both scans failed instantly — including the `exit-code: false` sweep, which by design can't fail on findings.
2. No `scout-results.sarif` was written → `upload-sarif` (`if: always()`) failed with `Path does not exist`.
3. CodeQL recorded `JOB_STATUS_CONFIGURATION_ERROR`.
4. `Report scheduled failure as issue` filed a generic "Scheduled run failed" issue that reads like a critical CVE.

## The fix

Grounded in the action's actual behaviour ([`src/index.js`](https://github.com/docker/scout-action/blob/v1.24.0/src/index.js)): it downloads to `__dirname/dist` and **reuses an existing binary** on later steps. Verified in run 143's log — step 4 logs `Downloading asset`, step 5 logs `Using bundled binary`. So only the **first** `scout-action` step in a job can hit the download path.

In `scout-scan.yml` that first step was the critical-CVE gate, which can't be retried blindly because it *also* exits non-zero on a genuine finding. **Reordering the full-severity sweep first** solves that: the sweep is `exit-code: false`, so a failure there is unambiguously infra, one retry covers it, and the gate that follows is warm and can no longer fail on the download.

| Workflow | Change |
|---|---|
| `scout-scan.yml` | Sweep moved ahead of the gate, `continue-on-error` + one retry; upload gated on the SARIF existing |
| `vuln-report.yml` | Same retry on its `exit-code: false` scan — `Build report body` hard-fails on a missing SARIF, which would surface as a confusing parse error |
| `publish.yml` | Upload gate only — **deliberately no retry**, since it's a release gate and should fail closed for a human to re-run |

`hashFiles('scout-results.sarif') != ''` replaces bare `always()` on both uploads. This still uploads when a scan exits non-zero on a **real** critical (the file is written in that case) and skips only when no scan produced one.

### Behaviour matrix

| Scenario | Result |
|---|---|
| Sweep OK | Retry skipped, gate runs, SARIF uploads |
| Sweep 403 → retry OK | Gate runs, SARIF uploads, no issue filed |
| Sweep 403 → retry 403 | Job fails loudly, issue filed (genuinely needs a human) |
| Real critical CVE | Gate fails, SARIF still uploads, issue filed — unchanged |

## Verification

- `actionlint` clean (required check).
- `pytest tests/test_release_layer.py tests/test_vuln_report.py tests/test_sarif_ingestion_probe.py` — 35 passed.
- Not verifiable here: the retry path itself only exercises under a real transient 403. The happy path is what CI on this PR covers.
