### PR TITLE
Log the SARIF fingerprint change under Changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Upgrading
+### Upgrading from 0.20.x
 
 **SARIF consumers: your Code Scanning alerts will be re-keyed once.** The
 `partialFingerprints` key moves from `composeLintFinding/v1` to `/v2`, and
@@ -41,6 +41,17 @@ re-dismiss after the first post-upgrade scan.
   only the compose file leaves the config outside the container and silently
   drops every suppression. Passing runs, and runs that found a config, stay
   quiet.
+
+### Changed
+
+- **SARIF alert identity no longer includes the finding's message.** The
+  `partialFingerprints` key moves from `composeLintFinding/v1` to `/v2`, and
+  the digest is now `[uri, rule_id, service, evidence]` rather than
+  `[uri, rule_id, service, message]`. `evidence` is a new internal field
+  holding the specific offending value in normalized form, so a rule that
+  fires more than once for one service still distinguishes its hits without
+  making prose part of the alert's identity (ADR-024). See Upgrading above
+  for the one-time re-key.
 
 ### Fixed
 


### PR DESCRIPTION
`[Unreleased]` describes the SARIF fingerprint re-key under **Upgrading** but never says what changed.

All the SARIF surface in this release comes from one commit, 193dd71 (#634) — confirmed by tracing both symbols with `git log -S`:

| Change | Logged? |
|---|---|
| `logicalLocations` naming the service | ✅ under `### Added` |
| `partialFingerprints` `composeLintFinding/v1` → `/v2`, digest recomposed | ❌ Upgrading narrative only |

The Upgrading preamble is a *migration warning* — "your alerts re-key once, dismissals are lost" — not a statement of what changed. The two coexist by precedent: `[0.20.0]` carries both `### Upgrading from 0.19.x` and `### Changed`.

Nothing would have caught this. `scripts/check_changelog_unreleased.py` validates section order and uniqueness only, so an absent section passes.

Also matches `[0.20.0]`'s versioned spelling of the Upgrading heading (`### Upgrading` → `### Upgrading from 0.20.x`). `_key()` normalises `Upgrading(\s+from\s+.+)?` to one key, so both spellings validate — this is style, not a fix.

Timed before `release-prep`, which renames `[Unreleased]` verbatim into `[0.21.0]`: dispatching first would ship the gap.

## Verification

- `scripts/check_changelog_unreleased.py --require-content` → `[Unreleased] OK`
- `pytest tests/test_changelog_shape.py` → 10 passed
