### PR TITLE
Bump marketplace-smoke pin to v0.21.0

### DIFF
--- a/.github/workflows/marketplace-smoke.yml
+++ b/.github/workflows/marketplace-smoke.yml
@@ -53,7 +53,7 @@ permissions: {}
 # bump-marketplace-smoke-pin seds this literal line, which does not care
 # where in the file it lives.
 env:
-  CL_RELEASE_TAG: v0.20.0
+  CL_RELEASE_TAG: v0.21.0
 
 jobs:
   # This workflow's whole point is to run moments after a publish — the
@@ -109,7 +109,7 @@ jobs:
           persist-credentials: false
 
       - name: Clean fixture should pass
-        uses: tmatens/compose-lint@86aa003f03ac82a3c2544cc35eac56aff8be769e # v0.20.0
+        uses: tmatens/compose-lint@50d147004984f929e0b5fd74eaa776d832601cea # v0.21.0
         with:
           files: tests/smoke/clean.yml
           fail-on: high
@@ -117,7 +117,7 @@ jobs:
       - name: Insecure fixture should fail
         id: insecure
         continue-on-error: true
-        uses: tmatens/compose-lint@86aa003f03ac82a3c2544cc35eac56aff8be769e # v0.20.0
+        uses: tmatens/compose-lint@50d147004984f929e0b5fd74eaa776d832601cea # v0.21.0
         with:
           files: tests/smoke/insecure.yml
           fail-on: high

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ jobs:
       security-events: write  # upload the SARIF to Code Scanning
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: tmatens/compose-lint@86aa003f03ac82a3c2544cc35eac56aff8be769e # v0.20.0
+      - uses: tmatens/compose-lint@50d147004984f929e0b5fd74eaa776d832601cea # v0.21.0
         with:
           sarif-file: results.sarif
 ```


### PR DESCRIPTION
**Post-tag follow-up.** This PR was opened automatically by `publish.yml` *after*:

- Tag `v0.21.0` was pushed and triggered the Publish workflow
- TestPyPI + Docker smoke tests passed
- The `release-gate` environment was approved
- `publish` (PyPI) and `docker-publish` (Docker Hub) both succeeded
- `create-release` created the GitHub Release `v0.21.0`

So the pinned SHA `50d147004984f929e0b5fd74eaa776d832601cea` is guaranteed to correspond to a release that actually shipped through every channel.

Bumps the pin in `.github/workflows/marketplace-smoke.yml` **and** the copy-paste GitHub Action snippet in `README.md` — both use the `@<sha> # vX.Y.Z` form that CI cannot check pre-tag.

**After merging this PR**, trigger **Actions → Marketplace smoke test → Run workflow** to verify the published Action end-to-end against the new tag.
