### PR TITLE
Record the 0.21.0 base image bump in its changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,13 @@ re-dismiss after the first post-upgrade scan.
   making prose part of the alert's identity (ADR-024). See Upgrading above
   for the one-time re-key.
 
+- **The published image moves to a newer distroless base.**
+  `gcr.io/distroless/python3-debian13:nonroot` is repinned from
+  `sha256:eff0a605…` to `sha256:4376456c…`, picking up the base image's own
+  updates. This landed after `release-prep` snapshotted the changelog but
+  before the tag, so it shipped in the 0.21.0 image without being recorded
+  here at the time.
+
 ### Fixed
 
 - **CL-0005 now flags `::ffff:0.0.0.0` on every supported interpreter.** The


### PR DESCRIPTION
The distroless base digest bump (#635) merged **after** `release-prep` snapshotted `[Unreleased]` into `[0.21.0]`, but **before** the tag was cut at `50d1470` — so it shipped inside the 0.21.0 image while leaving no trace in that release's entry.

## Why this one, when digest bumps normally aren't logged

Checked the precedent first: in ~2,400 lines of CHANGELOG, the only base-image mention is the original switch *to* distroless. Routine Renovate digest bumps have never been logged, and that stays correct — they change nothing a user observes.

This one differs on one point: it landed **inside a release window** and changed the artifact that release published. A reader comparing the shipped `composelint/compose-lint:0.21.0` image against its notes would find a base image the notes never mention.

## Scope check

Audited every commit in `v0.20.0..v0.21.0` against the `[0.21.0]` section. `#635` is the only unlogged user-facing change. The SARIF surface is fully covered — `git show --stat` confirms **#634 is the only commit touching `src/`**; #618, #629, #630 and #627 are tests/CI only, and #634's two user-facing effects are already recorded (`logicalLocations` under Added, fingerprint v1→v2 under Changed via #639).

## Verification

- `scripts/check_changelog_unreleased.py` → `[Unreleased] OK`
- `pytest tests/test_changelog_shape.py` → 10 passed

## Note

The GitHub Release body for v0.21.0 was generated from the section as it stood at `create-release` time and is **not** rewritten by this commit.
