### PR TITLE
Lint the configuration Compose runs when an overlay sits beside the base file

### DIFF
--- a/.github/workflows/sarif-ingestion.yml
+++ b/.github/workflows/sarif-ingestion.yml
@@ -110,9 +110,13 @@ jobs:
       # in the repository. A `compose.override.yml` is normally gitignored —
       # it is the documented home for local changes — so a SARIF result whose
       # artifactLocation names it points at a path Code Scanning cannot
-      # resolve against the commit. Whether it keeps such a result or silently
-      # discards it decides how #631 should attribute merged findings, and
-      # nothing local can answer it.
+      # resolve against the commit.
+      #
+      # Answered (#631): GitHub keeps it. The upload ingested every result
+      # with no analysis warning, and the alert stayed queryable at the
+      # overlay's path. So this is no longer an open question but a regression
+      # guard — GitHub can tighten ingestion with no commit on our side, which
+      # is why the schedule above exists.
       - name: Write the untracked overlay half of the probe
         run: |
           cp tests/smoke/overlay/override.yml.tmpl \

--- a/.github/workflows/sarif-ingestion.yml
+++ b/.github/workflows/sarif-ingestion.yml
@@ -123,12 +123,24 @@ jobs:
         run: |
           python3 -m pip install --quiet --require-hashes -r requirements.lock
           python3 -m pip install --quiet --no-deps -e .
+          # Exit 1 is expected and is not this job's failure signal: the
+          # overlay probe deliberately produces a CRITICAL, and the point of
+          # the step is the document, not the gate. Exit 2 still fails — that
+          # is compose-lint unable to complete, which would leave the SARIF
+          # truncated or absent.
+          set +e
           python3 -m compose_lint check \
             --config tests/smoke/sarif-probe-config.yml \
             --fail-on critical --format sarif \
             tests/smoke/insecure.yml tests/smoke/sarif-shape.yml tests/smoke/clean.yml \
             tests/smoke/overlay/compose.yml \
             > working-tree.sarif
+          status=$?
+          set -e
+          if [ "$status" -gt 1 ]; then
+            echo "::error::compose-lint could not complete (exit $status)"
+            exit "$status"
+          fi
           python3 -c "import json;d=json.load(open('working-tree.sarif'));print('results:',len(d['runs'][0]['results']))"
           python3 -c "import json;d=json.load(open('working-tree.sarif'));print('locations:',sorted({r['locations'][0]['physicalLocation']['artifactLocation']['uri'] for r in d['runs'][0]['results']}))"
 

--- a/.github/workflows/sarif-ingestion.yml
+++ b/.github/workflows/sarif-ingestion.yml
@@ -105,6 +105,20 @@ jobs:
       # design and there is no input that points it at a checkout. A separate
       # `category` keeps the two analyses distinct so cleanup can tell them
       # apart.
+      # The overlay half of the probe is written here rather than committed,
+      # because the condition under test is precisely that the file is *not*
+      # in the repository. A `compose.override.yml` is normally gitignored —
+      # it is the documented home for local changes — so a SARIF result whose
+      # artifactLocation names it points at a path Code Scanning cannot
+      # resolve against the commit. Whether it keeps such a result or silently
+      # discards it decides how #631 should attribute merged findings, and
+      # nothing local can answer it.
+      - name: Write the untracked overlay half of the probe
+        run: |
+          cp tests/smoke/overlay/override.yml.tmpl \
+             tests/smoke/overlay/compose.override.yml
+          git status --porcelain --ignored tests/smoke/overlay/ | sed 's/^/  /'
+
       - name: Generate SARIF from the working tree
         run: |
           python3 -m pip install --quiet --require-hashes -r requirements.lock
@@ -113,8 +127,10 @@ jobs:
             --config tests/smoke/sarif-probe-config.yml \
             --fail-on critical --format sarif \
             tests/smoke/insecure.yml tests/smoke/sarif-shape.yml tests/smoke/clean.yml \
+            tests/smoke/overlay/compose.yml \
             > working-tree.sarif
           python3 -c "import json;d=json.load(open('working-tree.sarif'));print('results:',len(d['runs'][0]['results']))"
+          python3 -c "import json;d=json.load(open('working-tree.sarif'));print('locations:',sorted({r['locations'][0]['physicalLocation']['artifactLocation']['uri'] for r in d['runs'][0]['results']}))"
 
       - name: Upload the working tree's SARIF to Code Scanning
         uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
@@ -122,10 +138,15 @@ jobs:
           sarif_file: working-tree.sarif
           category: compose-lint-working-tree
 
+      # `--expect-path` is the #631 question: did the result whose location is
+      # the untracked overlay survive ingestion, or did GitHub keep the
+      # analysis and drop that one?
       - name: Assert the working tree's results landed too
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python3 scripts/verify_sarif_ingestion.py verify
+        run: |
+          python3 scripts/verify_sarif_ingestion.py verify \
+            --expect-path tests/smoke/overlay/compose.override.yml
 
       # `always()`: the probe cleans up after a failed assertion too,
       # otherwise a red run leaves the fixture findings behind precisely

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,10 @@ Thumbs.db
 # Raw VHS renders; the committed assets are docs/assets/demo{,-fix}.gif
 scripts/demo/demo.gif
 scripts/demo/fix.gif
+
+# Overlay half of the SARIF ingestion probe (#631). Untracked on purpose: the
+# question the probe answers is whether Code Scanning keeps a result whose
+# artifactLocation names a file absent from the repository, which is the normal
+# state of a compose.override.yml. Committing it would remove the condition
+# under test.
+tests/smoke/overlay/compose.override.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Upgrading
+
+**Files with a `compose.override.yml` beside them are now graded as the
+configuration Compose runs.** `docker compose up` merges that overlay with no
+flag and no opt-in, and compose-lint read only the base — so a control-socket
+mount added by an overlay was never reported, and the base's own findings were
+graded against a document nobody deploys.
+
+Expect new findings on such projects, including CRITICAL ones. That is the
+documented MINOR behaviour for tightened coverage; pin the version or gate on
+`--fail-on` if a pipeline needs determinism. `--no-merge-overrides` restores
+the previous single-file grading exactly.
+
+### Added
+
+- `check` and `fix` merge a sibling `compose.override.yml` and lint the
+  effective configuration (ADR-025). The run header names both documents, and
+  a note on stderr states what was merged; the exit code is unchanged, because
+  merging is coverage achieved rather than a coverage gap.
+- `--no-merge-overrides` on `check` and `fix` opts out.
+- Findings carry the document their evidence is written in. Text excerpts are
+  read from that file, SARIF points `artifactLocation` there, and JSON gains a
+  conditional `source_file` key — additive, so `SCHEMA_VERSION` is unchanged.
+
+### Changed
+
+- `fix` edits only findings written in the file it is fixing when an overlay is
+  merged; findings from the overlay are reported for manual review, and the
+  overlay is never a write target.
+
+### Fixed
+
+- `extends:` no longer concatenates every sequence. Compose merges `volumes`
+  and `devices` by container path, replaces `command`/`entrypoint`, and
+  deduplicates the append-style sequences; concatenating reported a CRITICAL
+  socket mount against a service that had replaced that mount at the same
+  container path, pointing at the line that replaced it.
+
 ## [0.21.0] - 2026-08-20
 
 ### Upgrading from 0.20.x

--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ check options:
   --skip-suppressed            Hide suppressed findings from output
   --allow-partial-coverage     Grade a file whose `include:` / cross-file `extends:`
                                could not be resolved, instead of failing (exit 2)
+  --no-merge-overrides         Lint each file alone instead of merging the
+                               `compose.override.yml` Compose merges beside it
   --config PATH                Path to config file (default: .compose-lint.yml)
   --strict-config              Treat config diagnostics (unknown rule id or key) as errors, not warnings
   --explain CL-XXXX            Print the full documentation for a single rule
@@ -380,7 +382,9 @@ CI log that renders ANSI.
 | 1 | One or more findings at or above the `--fail-on` threshold |
 | 2 | compose-lint couldn't run, or couldn't see the whole stack (invalid args, file not found, invalid Compose file, a rule crashed, or a coverage gap — see below) |
 
-**Coverage gaps.** compose-lint reads single files and does no I/O to follow references out of them, so `include:` and cross-file `extends: {file: ...}` leave part of the stack unlinted. Reporting a pass over a partial view is the one failure mode a merge gate cannot have, so a gap is an error: exit 2, a JSON `errors[]` entry, and a SARIF `toolExecutionNotifications` record. Lint the merged output (`docker compose config`) to cover everything, or pass `--allow-partial-coverage` to accept the gap and grade what is visible.
+**Overlays are merged.** `docker compose up` loads a `compose.override.yml` sitting beside the base file and merges it, with no flag and no opt-in, so the merged pair is what actually runs. compose-lint grades that pair: the run header names both documents, findings report the file their evidence is written in, and the exit code is unaffected because merging is coverage achieved, not a gap ([ADR-025](docs/adr/025-lint-the-merged-configuration.md)). `--no-merge-overrides` grades the base alone. `fix` edits only findings written in the file it is fixing; anything from the overlay is left for manual review.
+
+**Coverage gaps.** Beyond that overlay, compose-lint follows no references out of a file, so `include:` and cross-file `extends: {file: ...}` leave part of the stack unlinted. Reporting a pass over a partial view is the one failure mode a merge gate cannot have, so a gap is an error: exit 2, a JSON `errors[]` entry, and a SARIF `toolExecutionNotifications` record. Lint the merged output (`docker compose config`) to cover everything, or pass `--allow-partial-coverage` to accept the gap and grade what is visible.
 
 The default threshold is `high` — medium and low findings don't fail CI unless you opt in:
 

--- a/docs/adr/025-lint-the-merged-configuration.md
+++ b/docs/adr/025-lint-the-merged-configuration.md
@@ -1,0 +1,135 @@
+# ADR-025: Lint the Configuration Compose Runs, Not the File on Disk
+
+**Status:** Accepted
+
+**Context:** `docker compose up` with no `-f` loads the base file **and**, if a
+`compose.override.yml` sits beside it, merges that on top. No flag, no opt-in.
+The merged result is what runs, and the convention puts the portable definition
+in the base and the local changes — published ports, bind mounts, socket
+mounts, relaxed hardening — in the overlay.
+
+compose-lint read the base alone. Measured on a hardened base with a two-line
+overlay adding `ports:` and a `/var/run/docker.sock` mount, it reported one
+MEDIUM about an unpinned digest. **CL-0001, the highest-severity rule in the
+tool, was silent on a stack that would run with the host control socket
+exposed**, and the banner said `files: compose.yml` with nothing to indicate
+that half the effective configuration had never been read.
+
+The gap ran in both directions, which the original report missed. A base with
+no `read_only` reported CL-0007 on its own; with an overlay supplying
+`read_only: true` the deployed container is read-only and the finding is
+false. So the behaviour was not merely "the overlay is unexamined" — the base
+was **graded against a view the user never runs**.
+
+This is the same class as the coverage gaps [ADR-023](023-deploy-host-independent-claims.md)
+refuses loudly. It was the only one that was silent.
+
+Three findings from a spike changed how the options cost out:
+
+1. **`extends:` merges identically to multi-file overlays.** Twelve field
+   behaviours probed against `docker compose config` match exactly, so one
+   table serves both. The existing `_merge_extends` concatenated every
+   sequence, which is wrong for Compose in both — it reported a CRITICAL
+   socket mount against a service that had *replaced* that mount at the same
+   container path, pointing at the line that replaced it. The merge table was
+   therefore required to fix a shipped false positive, independent of overlays.
+
+2. **Cross-file provenance is cheap, not the blocker it was costed as.**
+   Rules never touch the line map; they receive a flat `{path: line}` dict and
+   hand the result to `Finding.line`. Making the line number an `int` subclass
+   that carries its own document path threads the answer through every rule,
+   formatter and fixer untouched. The field-specific merge table is the
+   expensive half; provenance is roughly thirty lines.
+
+3. **Merging is MINOR, not breaking.** [compatibility.md](../compatibility.md)
+   states that new findings are not a breaking change — rules are added and
+   tightened in MINOR releases and a clean file may report findings in the
+   next one. Reading more of the stack produces exactly that.
+
+**Decision:** When a Compose file is linted and the overlay Compose would merge
+into it sits beside it, compose-lint merges the pair and grades the result —
+option C of the three considered. The merge is field-specific, derived from
+`docker compose config` rather than from the specification prose, and shared
+with `extends:`.
+
+1. **Merging is announced, and does not change the exit code.** The header
+   names both documents (`files: compose.yml + compose.override.yml`) and a
+   note states what was merged. Unlike an unresolved `include:`, this is
+   coverage *achieved* rather than missed, so it must not turn a green
+   pipeline red. Exit stays finding-driven.
+
+2. **Findings name the document their evidence is written in.** A merged run
+   grades two files and a line number belongs to one of them. The text
+   excerpt is read from that file, and SARIF points its `artifactLocation`
+   there. Base-file findings keep the URI they had, and with it their
+   `partialFingerprints` ([ADR-024](024-finding-identity-is-not-prose.md)) —
+   the findings that move are ones that were never reported at all before, so
+   no existing alert is re-keyed.
+
+3. **`fix` edits only what it can attribute.** A finding written in the file
+   being fixed is safe to edit: its line is a line in that text, and an
+   absence finding fires only when the key is missing from the *merged*
+   document, so adding it to the base genuinely hardens what runs. Findings
+   from the overlay are reported for manual review — the overlay is never a
+   write target. Verification re-merges the candidate, because the properties
+   being verified are properties of the document Compose runs.
+
+4. **Values merge as written.** Compose normalises short volume syntax to
+   long, list `environment` to a mapping, and so on. The merge does not,
+   because every rule reads the spelling the user typed and a normalising
+   merge would change what they see.
+
+5. **`--no-merge-overrides` opts out**, for a base deliberately graded in
+   isolation and as an escape hatch if the merge is ever wrong. It reproduces
+   the previous output exactly. This is opt-*out*: the default is the
+   configuration that runs.
+
+**Alternatives considered:**
+
+- **Do nothing, document it.** The gap stays silent, which is the part that
+  sits worst against ADR-023 — a user with an overlay has no way to learn
+  their socket mount was never examined. It also leaves the base graded
+  against a view nobody deploys.
+
+- **Detect and warn (coverage gap, exit 2).** Smaller, and consistent with the
+  `include:` precedent, but it buys less than it appears to: it makes the
+  silence loud without making the grading right, and it introduces an exit-2
+  condition that this decision would later remove — turning a pinned
+  pipeline red, then green again. The doctrinal difference is the deciding
+  one: an unresolved `include:` is a gap because compose-lint *cannot* read
+  the file; a sibling overlay is a gap because it *does not*. Being loud about
+  what you cannot do is honest; warning about something you could simply do is
+  a placeholder.
+
+- **An opt-in flag.** Defers the question, adds a surface, and leaves the
+  default grading a document that is not deployed.
+
+**Consequences:**
+
+- Files clean on a previous release may report findings, including CRITICAL
+  ones. This is the documented MINOR behaviour, and the escape hatches are the
+  documented ones: pin the version, or gate on `--fail-on`.
+- `Finding` gains `source_file`, emitted in JSON only when a finding's evidence
+  is in a document other than the file being reported. Additive and
+  conditional, so `SCHEMA_VERSION` does not move.
+- Naming a file absent from the repository is safe for SARIF. Verified against
+  real Code Scanning: every result ingested with no analysis warning and the
+  alert stayed queryable at the overlay's path. `sarif-ingestion.yml` re-checks
+  it weekly, since GitHub can tighten ingestion with no commit here.
+- **Accepted limitation.** GitHub renders source previews from the commit tree,
+  so an alert located in an untracked overlay shows its location without a code
+  snippet and can never appear as a PR diff annotation. That degrades a panel
+  rather than losing a finding, and it requires an overlay generated during the
+  build to arise at all — a gitignored overlay is absent from a CI checkout, so
+  nothing merges one there.
+- The merge table is now a compatibility surface with Compose itself.
+  `tests/test_merge_semantics.py` re-derives it from the `docker compose`
+  binary on every run rather than trusting comments, so a Compose release that
+  changes a merge rule fails there instead of silently mis-grading a stack.
+
+**Scope:** This ADR covers the overlay Compose merges by filename convention.
+It does **not** cover `COMPOSE_FILE`, which replaces discovery entirely, or
+`.env`, which supplies interpolation values — both change the effective
+configuration and both are unread today. They turn on whether a file beside the
+compose file counts as project state or host state under ADR-023, which is a
+different question with a different answer, and are tracked separately.

--- a/scripts/verify_sarif_ingestion.py
+++ b/scripts/verify_sarif_ingestion.py
@@ -21,8 +21,18 @@ refuses to let them near its alert set — ``ci.yml``'s action smoke sets
 its own analysis afterwards rather than leaving fixture findings in the
 repo's Code Scanning.
 
+``verify`` optionally takes ``--expect-path SUBSTRING``, which asserts an
+ingested alert is located in a file whose path contains SUBSTRING. That is
+how the overlay probe (#631) answers a question no local test can: when a
+finding's evidence lives in a ``compose.override.yml`` — a file Compose
+merges but which is usually gitignored, and so absent from the repository —
+does Code Scanning keep the result, or silently discard a location it cannot
+resolve? If it discards it, pointing SARIF at the contributing file is worse
+in practice than naming the base and attaching the overlay as a related
+location, and only GitHub can settle which.
+
 Usage:
-    python scripts/verify_sarif_ingestion.py verify
+    python scripts/verify_sarif_ingestion.py verify [--expect-path SUBSTRING]
     python scripts/verify_sarif_ingestion.py cleanup
 
 Reads GITHUB_TOKEN, GITHUB_REPOSITORY, GITHUB_REF, GITHUB_SHA.
@@ -76,7 +86,7 @@ def our_analyses() -> list[dict[str, object]]:
     return [a for a in found if a.get("commit_sha") == SHA]
 
 
-def verify() -> int:
+def verify(expect_path: str | None = None) -> int:
     # `upload-sarif` waits for processing, so an analysis should already
     # exist; alert indexing can still trail it by a few seconds.
     analyses: list[dict[str, object]] = []
@@ -125,6 +135,29 @@ def verify() -> int:
     rules = sorted({str(a["rule"]["id"]) for a in alerts})
     print(f"\nGitHub ingested {total} result(s); {len(alerts)} alert(s) queryable.")
     print(f"Rules that survived ingestion: {', '.join(rules)}")
+
+    if expect_path is not None:
+        located = sorted(
+            {
+                str(
+                    (a.get("most_recent_instance") or {})
+                    .get("location", {})
+                    .get("path", "")
+                )
+                for a in alerts
+            }
+        )
+        print(f"Alert locations: {', '.join(p for p in located if p)}")
+        if not any(expect_path in path for path in located):
+            print(
+                f"::error::No ingested alert is located in a path containing "
+                f"{expect_path!r}. GitHub kept the analysis but dropped the "
+                f"results whose artifactLocation names a file that is not in "
+                f"the repository. SARIF should then name the base file and "
+                f"carry the overlay as a relatedLocation instead (#631)."
+            )
+            return 1
+        print(f"Results located in {expect_path!r} survived ingestion.")
     return 0
 
 
@@ -166,7 +199,10 @@ def cleanup() -> int:
 if __name__ == "__main__":
     mode = sys.argv[1] if len(sys.argv) > 1 else ""
     if mode == "verify":
-        sys.exit(verify())
+        expect = None
+        if "--expect-path" in sys.argv:
+            expect = sys.argv[sys.argv.index("--expect-path") + 1]
+        sys.exit(verify(expect))
     if mode == "cleanup":
         sys.exit(cleanup())
     print(f"usage: {sys.argv[0]} verify|cleanup", file=sys.stderr)

--- a/src/compose_lint/_merge.py
+++ b/src/compose_lint/_merge.py
@@ -1,0 +1,612 @@
+"""Compose document merge, with per-path provenance.
+
+Compose merges more than one document in two places that turn out to be the
+same place: multi-file overlays (``compose.yml`` + ``compose.override.yml``,
+or repeated ``-f``) and ``extends:``. Every field behaviour probed against
+``docker compose config`` is identical across the two, so one table serves
+both — see ``tests/test_merge_semantics.py``, which re-derives this table from
+the real binary rather than trusting the comments here.
+
+The important part is that merging is *field-specific*, not structural. A
+plain recursive "child wins, sequences concatenate" merge is wrong for Compose
+in three separate ways:
+
+* ``volumes`` and ``devices`` are keyed by their **container-side path**, so a
+  child remounting ``/var/run/docker.sock`` from a harmless source *replaces*
+  the parent's mount rather than adding to it. Concatenating leaves the
+  parent's entry visible and reports a CRITICAL finding against a service that
+  removed it.
+* ``command`` and ``entrypoint`` are **replaced** wholesale, not appended.
+* The append-style sequences (``cap_add``, ``dns``, ...) **deduplicate**.
+
+Provenance falls out of the merge for free: the merge already decides, per
+output path, which document supplied the winning value, so recording the file
+alongside the line costs one dict write at each decision point. Because the
+line map is flat and path-keyed (``services.web.volumes[0]`` -> line), the
+provenance map is keyed the same way and rules never have to know it exists.
+
+Values are merged **as written**. Compose normalises short volume syntax to
+long form, list ``environment`` to a mapping, and so on; this module does not,
+because every rule reads the spelling the user typed and a normalising merge
+would change what they see on files that have no overlay at all.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+__all__ = ["Document", "Merged", "SourcedLine", "merge_documents", "merge_values"]
+
+
+class SourcedLine(int):
+    """A line number that remembers which file it is a line number *in*.
+
+    Rules receive a flat ``{path: line}`` map and hand the looked-up value
+    straight to ``Finding.line``. They never see a document path, so after a
+    merge there is nothing in a finding to say which of the merged files its
+    line belongs to — and reverse-engineering it from the line number alone is
+    ambiguous the moment two files have content at the same line.
+
+    Subclassing ``int`` threads the answer through untouched: this *is* an int
+    everywhere it is compared, sorted, formatted or serialised to JSON, so no
+    rule, formatter or fixer needs to know it exists, while the one consumer
+    that cares can read ``.source``. That is the whole of the cross-file
+    provenance problem, and it costs no change to any of the 27 rules.
+    """
+
+    # No __slots__: CPython forbids a non-empty __slots__ on an int subclass
+    # (the base is variable-length), so the attribute lives in a per-instance
+    # dict. Line numbers are created once per path and never in a hot loop.
+    source: str | None
+
+    def __new__(cls, value: int, source: str | None = None) -> SourcedLine:
+        obj = super().__new__(cls, value)
+        obj.source = source
+        return obj
+
+
+# ---------------------------------------------------------------------------
+# Field strategy table (empirically derived; see tests/test_merge_semantics.py)
+# ---------------------------------------------------------------------------
+
+# Sequences the child replaces outright. These are argv-shaped: appending to a
+# command line would produce something the user never wrote.
+_REPLACE_SEQ = frozenset({"command", "entrypoint"})
+
+# Sequences that append, preserving base order, dropping exact duplicates.
+_APPEND_SEQ = frozenset(
+    {
+        "cap_add",
+        "cap_drop",
+        "dns",
+        "dns_search",
+        "env_file",
+        "expose",
+        "extra_hosts",
+        "group_add",
+        "networks",
+        "profiles",
+        "security_opt",
+        "tmpfs",
+        "volumes_from",
+    }
+)
+
+# Sequences keyed by an identity extracted from each entry: same key means the
+# child's entry replaces the parent's, different keys append.
+_KEYED_SEQ = frozenset({"volumes", "devices", "ports"})
+
+# Fields accepting either a list of "K=V" strings or a mapping, keyed by name.
+_KEY_VALUE_SEQ = frozenset({"environment", "labels", "sysctls", "depends_on"})
+
+
+def _volume_key(entry: Any) -> str | None:
+    """Container-side path of a volume entry, in either syntax."""
+    if isinstance(entry, dict):
+        target = entry.get("target")
+        return target if isinstance(target, str) else None
+    if isinstance(entry, str):
+        parts = _split_outside_braces(entry)
+        # "name" (anonymous/named volume, no target) has no container path to
+        # key on; "src:tgt" and "src:tgt:mode" do.
+        return parts[1] if len(parts) >= 2 else None
+    return None
+
+
+def _device_key(entry: Any) -> str | None:
+    """Container-side path of a device entry."""
+    if isinstance(entry, dict):
+        target = entry.get("target")
+        return target if isinstance(target, str) else None
+    if isinstance(entry, str):
+        parts = _split_outside_braces(entry)
+        # A bare "/dev/x" maps to itself in the container.
+        return parts[1] if len(parts) >= 2 else parts[0]
+    return None
+
+
+def _port_key(entry: Any) -> str | None:
+    """Identity of a port entry: host ip, published port, target, protocol.
+
+    Compose keeps two publishings of the same container port on different host
+    ports (verified), so the key is the whole tuple rather than the target.
+    """
+    if isinstance(entry, dict):
+        bits = [
+            str(entry.get("host_ip", "")),
+            str(entry.get("published", "")),
+            str(entry.get("target", "")),
+            str(entry.get("protocol", "tcp")),
+        ]
+        return "|".join(bits)
+    if isinstance(entry, str):
+        spec, _, proto = entry.partition("/")
+        parts = _split_outside_braces(spec)
+        if len(parts) == 3:
+            host_ip, published, target = parts
+        elif len(parts) == 2:
+            host_ip, published, target = "", parts[0], parts[1]
+        else:
+            host_ip, published, target = "", "", parts[0]
+        return "|".join([host_ip, published, target, proto or "tcp"])
+    return None
+
+
+_SEQ_KEYERS = {
+    "volumes": _volume_key,
+    "devices": _device_key,
+    "ports": _port_key,
+}
+
+
+def _split_outside_braces(text: str) -> list[str]:
+    """Split on ``:`` while ignoring colons inside ``${...}``.
+
+    ``${DOCKER_SOCK:-/var/run/docker.sock}:/s`` must not split at the ``:-``.
+    Mirrors ``parser._split_short_volume``, generalised to every field.
+    """
+    parts: list[str] = []
+    depth = 0
+    current: list[str] = []
+    for i, ch in enumerate(text):
+        if ch == "{" and i and text[i - 1] == "$":
+            depth += 1
+            current.append(ch)
+        elif ch == "}" and depth:
+            depth -= 1
+            current.append(ch)
+        elif ch == ":" and not depth:
+            parts.append("".join(current))
+            current = []
+        else:
+            current.append(ch)
+    parts.append("".join(current))
+    return parts
+
+
+def _kv_name(entry: Any) -> str | None:
+    """Variable/label name of a ``K=V`` string, or None if it isn't one."""
+    if isinstance(entry, str):
+        name, sep, _ = entry.partition("=")
+        # A bare "FOO" (pass-through from the host environment) still keys on
+        # its own name.
+        return name if name else None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Provenance-carrying merge
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Document:
+    """One loaded Compose document, its flat line map, and its deletions."""
+
+    path: str
+    data: dict[str, Any]
+    lines: dict[str, int]
+    # Dotted paths this document deleted with `!reset`. The key is absent from
+    # `data` (the parser drops it), so this is the only record that the document
+    # asked for the *other* document's value to go away.
+    resets: frozenset[str] = frozenset()
+
+
+@dataclass
+class Merged:
+    """A merged document, with a line and a source file for every path."""
+
+    data: dict[str, Any]
+    lines: dict[str, int] = field(default_factory=dict)
+    sources: dict[str, str] = field(default_factory=dict)
+
+    def source_of(self, path: str) -> str | None:
+        return self.sources.get(path)
+
+
+@dataclass
+class _Side:
+    """One input to a merge step: a value plus where it came from."""
+
+    value: Any
+    doc: Document
+    path: str
+
+
+class _Recorder:
+    """Collects line/source provenance while a merge walks the documents."""
+
+    def __init__(self) -> None:
+        self.lines: dict[str, int] = {}
+        self.sources: dict[str, str] = {}
+
+    def take(self, out_path: str, side: _Side) -> None:
+        """Record that ``out_path`` was supplied by ``side``."""
+        line = side.doc.lines.get(side.path)
+        if line is not None:
+            self.lines[out_path] = SourcedLine(line, side.doc.path)
+        self.sources[out_path] = side.doc.path
+
+    def take_subtree(self, out_path: str, side: _Side | None) -> None:
+        """Record ``side``'s whole subtree as landing at ``out_path``.
+
+        Used when one document supplies a value the other never mentions: the
+        entire subtree below it keeps that document's lines, re-keyed onto the
+        merged path (the two differ once a list index moves).
+
+        ``side`` is optional so callers that merge without provenance (the
+        ``extends:`` path) need no null-guard at every call site.
+        """
+        if side is None:
+            return
+        self.take(out_path, side)
+        prefix = side.path
+        for key, line in side.doc.lines.items():
+            if key == prefix:
+                continue
+            # The document root has an empty path, under which *every* key is a
+            # descendant. Without this case the separator check below indexes
+            # key[0] — always a name character at the root — and silently copied
+            # nothing, so a value neither document overrode lost its line.
+            if not prefix:
+                self.lines[key] = SourcedLine(line, side.doc.path)
+                self.sources[key] = side.doc.path
+                continue
+            if key.startswith(prefix) and key[len(prefix)] in ".[":
+                moved = out_path + key[len(prefix) :]
+                self.lines[moved] = SourcedLine(line, side.doc.path)
+                self.sources[moved] = side.doc.path
+
+
+def merge_values(
+    base: Any,
+    over: Any,
+    *,
+    field_name: str = "",
+    base_side: _Side | None = None,
+    over_side: _Side | None = None,
+    out_path: str = "",
+    rec: _Recorder | None = None,
+    memo: dict[tuple[int, int, str], Any] | None = None,
+) -> Any:
+    """Merge ``over`` onto ``base`` using Compose's per-field semantics.
+
+    ``field_name`` is the Compose key these values sit under, which is what
+    selects the strategy. Provenance recording is optional: callers that merge
+    within a single document (``extends:``) pass no recorder.
+
+    ``memo`` collapses repeated work on anchor-shared subtrees. YAML aliases
+    make the document a DAG, not a tree, so without it a subtree reachable by
+    *n* paths is re-merged once per path — an 805-byte file took 5.4s. It is
+    only safe when no recorder is active: provenance is path-dependent, and a
+    cached subtree would report whichever path reached it first.
+    """
+    if memo is not None and rec is None:
+        cache_key = (id(base), id(over), field_name)
+        cached = memo.get(cache_key)
+        if cached is not None:
+            return cached
+        result = merge_values(
+            base,
+            over,
+            field_name=field_name,
+            base_side=base_side,
+            over_side=over_side,
+            out_path=out_path,
+            rec=None,
+            memo=None,
+        )
+        memo[cache_key] = result
+        return result
+
+    # A mapping merges key-by-key, recursively, whatever it sits under.
+    if isinstance(base, dict) and isinstance(over, dict):
+        return _merge_mappings(base, over, base_side, over_side, out_path, rec)
+
+    if isinstance(base, list) and isinstance(over, list):
+        return _merge_sequences(
+            base, over, field_name, base_side, over_side, out_path, rec
+        )
+
+    # Key/value fields accept a list *or* a mapping, and Compose merges the two
+    # forms together by name. Normalise the odd side into the other's shape.
+    if field_name in _KEY_VALUE_SEQ and isinstance(base, (list, dict)):
+        if isinstance(base, dict) and isinstance(over, list):
+            return _merge_kv_mixed(base, over, base_side, over_side, out_path, rec)
+        if isinstance(base, list) and isinstance(over, dict):
+            return _merge_kv_mixed_list_base(
+                base, over, base_side, over_side, out_path, rec
+            )
+
+    # Scalars, and every type mismatch: the overriding document wins outright.
+    if rec is not None and over_side is not None:
+        rec.take_subtree(out_path, over_side)
+    return over
+
+
+def _merge_mappings(
+    base: dict[str, Any],
+    over: dict[str, Any],
+    base_side: _Side | None,
+    over_side: _Side | None,
+    out_path: str,
+    rec: _Recorder | None,
+) -> dict[str, Any]:
+    merged = dict(base)
+
+    # `logging` is the one mapping Compose does not merge naively: options
+    # belong to a driver, so naming a *different* driver discards the parent's
+    # options rather than carrying them onto a driver that never defined them.
+    drop_keys: set[str] = set()
+    # `!reset` in the overriding document deletes the inherited key outright.
+    if over_side is not None and over_side.doc.resets:
+        for key in base:
+            if _join(over_side.path, key) in over_side.doc.resets:
+                drop_keys.add(key)
+    if _leaf(out_path) == "logging":
+        new_driver = over.get("driver")
+        if new_driver is not None and new_driver != base.get("driver"):
+            drop_keys.add("options")
+
+    for key in base:
+        if key in drop_keys:
+            merged.pop(key, None)
+            continue
+        if key not in over and rec is not None and base_side is not None:
+            rec.take_subtree(_join(out_path, key), _child(base_side, key))
+
+    for key, value in over.items():
+        child_out = _join(out_path, key)
+        over_child = _child(over_side, key) if over_side else None
+        if key in base and key not in drop_keys:
+            merged[key] = merge_values(
+                base[key],
+                value,
+                field_name=key,
+                base_side=_child(base_side, key) if base_side else None,
+                over_side=over_child,
+                out_path=child_out,
+                rec=rec,
+            )
+        else:
+            merged[key] = value
+            if rec is not None and over_child is not None:
+                rec.take_subtree(child_out, over_child)
+    return merged
+
+
+def _merge_sequences(
+    base: list[Any],
+    over: list[Any],
+    field_name: str,
+    base_side: _Side | None,
+    over_side: _Side | None,
+    out_path: str,
+    rec: _Recorder | None,
+) -> list[Any]:
+    leaf = field_name or _leaf(out_path)
+
+    if leaf in _REPLACE_SEQ:
+        if rec is not None and over_side is not None:
+            rec.take_subtree(out_path, over_side)
+        return list(over)
+
+    if leaf in _KEYED_SEQ:
+        return _merge_keyed(
+            base, over, _SEQ_KEYERS[leaf], base_side, over_side, out_path, rec
+        )
+
+    if leaf in _KEY_VALUE_SEQ:
+        return _merge_keyed(base, over, _kv_name, base_side, over_side, out_path, rec)
+
+    # Default for a Compose sequence is append-with-dedup. Anything not in the
+    # tables above lands here, which matches every append-style field probed.
+    return _merge_appended(base, over, base_side, over_side, out_path, rec)
+
+
+def _merge_keyed(
+    base: list[Any],
+    over: list[Any],
+    keyer: Any,
+    base_side: _Side | None,
+    over_side: _Side | None,
+    out_path: str,
+    rec: _Recorder | None,
+) -> list[Any]:
+    """Merge two sequences by entry identity: same key replaces, new key appends.
+
+    Order follows Compose: surviving base entries keep their relative order,
+    then the child's genuinely-new entries, in the order the child wrote them.
+    """
+    over_by_key: dict[str, int] = {}
+    for i, entry in enumerate(over):
+        key = keyer(entry)
+        if key is not None:
+            over_by_key[key] = i
+
+    result: list[Any] = []
+    origins: list[tuple[_Side | None, int]] = []
+    consumed: set[int] = set()
+
+    for i, entry in enumerate(base):
+        key = keyer(entry)
+        if key is not None and key in over_by_key:
+            j = over_by_key[key]
+            consumed.add(j)
+            result.append(over[j])
+            origins.append((over_side, j))
+        else:
+            result.append(entry)
+            origins.append((base_side, i))
+
+    for j, entry in enumerate(over):
+        if j in consumed:
+            continue
+        result.append(entry)
+        origins.append((over_side, j))
+
+    _record_items(result, origins, out_path, rec)
+    return result
+
+
+def _merge_appended(
+    base: list[Any],
+    over: list[Any],
+    base_side: _Side | None,
+    over_side: _Side | None,
+    out_path: str,
+    rec: _Recorder | None,
+) -> list[Any]:
+    result: list[Any] = []
+    origins: list[tuple[_Side | None, int]] = []
+    seen: list[Any] = []
+
+    for source_side, items in ((base_side, base), (over_side, over)):
+        for i, entry in enumerate(items):
+            if any(entry == prior for prior in seen):
+                continue
+            seen.append(entry)
+            result.append(entry)
+            origins.append((source_side, i))
+
+    _record_items(result, origins, out_path, rec)
+    return result
+
+
+def _merge_kv_mixed(
+    base: dict[str, Any],
+    over: list[Any],
+    base_side: _Side | None,
+    over_side: _Side | None,
+    out_path: str,
+    rec: _Recorder | None,
+) -> dict[str, Any]:
+    """Mapping base, list override: fold the list's entries in by name."""
+    merged = dict(base)
+    for i, entry in enumerate(over):
+        name = _kv_name(entry)
+        if name is None:
+            continue
+        _, sep, value = str(entry).partition("=")
+        merged[name] = value if sep else None
+        if rec is not None and over_side is not None:
+            rec.take(_join(out_path, name), _index(over_side, i))
+    if rec is not None and base_side is not None:
+        for key in base:
+            if key not in {_kv_name(e) for e in over}:
+                rec.take_subtree(_join(out_path, key), _child(base_side, key))
+    return merged
+
+
+def _merge_kv_mixed_list_base(
+    base: list[Any],
+    over: dict[str, Any],
+    base_side: _Side | None,
+    over_side: _Side | None,
+    out_path: str,
+    rec: _Recorder | None,
+) -> list[Any]:
+    """List base, mapping override: keep the list shape the file already uses."""
+    as_list = [f"{k}={v}" if v is not None else str(k) for k, v in over.items()]
+    return _merge_keyed(base, as_list, _kv_name, base_side, over_side, out_path, rec)
+
+
+def _record_items(
+    result: list[Any],
+    origins: list[tuple[_Side | None, int]],
+    out_path: str,
+    rec: _Recorder | None,
+) -> None:
+    """Re-key each surviving item's provenance onto its merged index."""
+    if rec is None:
+        return
+    for out_index, (side, in_index) in enumerate(origins):
+        if side is None:
+            continue
+        rec.take_subtree(f"{out_path}[{out_index}]", _index(side, in_index))
+
+
+def _child(side: _Side | None, key: Any) -> _Side | None:
+    if side is None:
+        return None
+    value = side.value.get(key) if isinstance(side.value, dict) else None
+    return _Side(value, side.doc, _join(side.path, key))
+
+
+def _index(side: _Side, i: int) -> _Side:
+    value = (
+        side.value[i] if isinstance(side.value, list) and i < len(side.value) else None
+    )
+    return _Side(value, side.doc, f"{side.path}[{i}]")
+
+
+def _join(prefix: str, key: Any) -> str:
+    return f"{prefix}.{key}" if prefix else str(key)
+
+
+def _leaf(path: str) -> str:
+    """Last mapping key in a dotted path, ignoring list indices."""
+    tail = path.rsplit(".", 1)[-1]
+    return tail.split("[", 1)[0]
+
+
+def merge_documents(documents: list[Document]) -> Merged:
+    """Fold documents left to right, later documents overriding earlier ones."""
+    if not documents:
+        return Merged(data={})
+
+    first = documents[0]
+    rec = _Recorder()
+    merged_data: dict[str, Any] = dict(first.data)
+    base_side = _Side(first.data, first, "")
+    rec.take_subtree("", base_side)
+    # take_subtree on the root records "" itself; the root has no line.
+    rec.lines.pop("", None)
+    rec.sources.pop("", None)
+
+    accumulated = first
+    for nxt in documents[1:]:
+        over_side = _Side(nxt.data, nxt, "")
+        rec_next = _Recorder()
+        # The accumulated document carries the *merged* line/source maps, so a
+        # third file merges against provenance already resolved for the first
+        # two rather than against the original first file.
+        acc_doc = Document(path=accumulated.path, data=merged_data, lines=rec.lines)
+        merged_data = _merge_mappings(
+            merged_data,
+            nxt.data,
+            _Side(merged_data, acc_doc, ""),
+            over_side,
+            "",
+            rec_next,
+        )
+        # Sources for paths the newer document did not touch stay as they were.
+        carried = dict(rec.sources)
+        carried.update(rec_next.sources)
+        rec = _Recorder()
+        rec.lines = rec_next.lines
+        rec.sources = carried
+        accumulated = acc_doc
+
+    return Merged(data=merged_data, lines=rec.lines, sources=rec.sources)

--- a/src/compose_lint/_merge.py
+++ b/src/compose_lint/_merge.py
@@ -241,8 +241,10 @@ class _Recorder:
         self.lines: dict[str, int] = {}
         self.sources: dict[str, str] = {}
 
-    def take(self, out_path: str, side: _Side) -> None:
+    def take(self, out_path: str, side: _Side | None) -> None:
         """Record that ``out_path`` was supplied by ``side``."""
+        if side is None:
+            return
         line = side.doc.lines.get(side.path)
         if line is not None:
             self.lines[out_path] = SourcedLine(line, side.doc.path)
@@ -380,6 +382,19 @@ def _merge_mappings(
         child_out = _join(out_path, key)
         over_child = _child(over_side, key) if over_side else None
         if key in base and key not in drop_keys:
+            # Seed the key's own location from the base before merging. A key
+            # both documents mention is otherwise never recorded: the branches
+            # above only fire for keys unique to one side, and the recursion
+            # below records this key's *children*, not the key itself. That lost
+            # the line of every container present in both files — including
+            # `services.<name>`, which is where an absence-rule fixer inserts.
+            #
+            # Seeding is safe because the merge overwrites it wherever the
+            # overriding document actually wins: a scalar re-records from
+            # `over`, and a merged mapping or sequence keeps the base's line,
+            # which is the file the key is written in.
+            if rec is not None and base_side is not None:
+                rec.take(child_out, _child(base_side, key))
             merged[key] = merge_values(
                 base[key],
                 value,

--- a/src/compose_lint/_merge.py
+++ b/src/compose_lint/_merge.py
@@ -350,6 +350,14 @@ def merge_values(
         return result
 
     # A mapping merges key-by-key, recursively, whatever it sits under.
+    # A service with no body (`web:` in an overlay) parses as None and means
+    # "no changes here". Treating it as an empty mapping keeps it a no-op
+    # instead of letting the None replace the other document's service.
+    if base is None and isinstance(over, dict):
+        base = {}
+    if over is None and isinstance(base, dict) and _leaf(out_path) != "":
+        return base
+
     if isinstance(base, dict) and isinstance(over, dict):
         return _merge_mappings(base, over, base_side, over_side, out_path, rec)
 

--- a/src/compose_lint/_merge.py
+++ b/src/compose_lint/_merge.py
@@ -211,6 +211,18 @@ class Document:
     # `data` (the parser drops it), so this is the only record that the document
     # asked for the *other* document's value to go away.
     resets: frozenset[str] = frozenset()
+    # Dotted paths this document marked `!override`. The directive says the
+    # value replaces the other document's rather than merging with it, which is
+    # invisible in `data` — the parsed value looks identical either way. Missing
+    # it is not symmetric: an overlay whose `security_opt: !override [...]`
+    # drops `no-new-privileges` leaves the base's entry visible, so the absence
+    # rule stays silent on hardening Compose actually removed.
+    overrides: frozenset[str] = frozenset()
+    # Per-path source files, set only when this "document" is itself the result
+    # of an earlier merge. Folding three or more documents makes the
+    # accumulator a mixture, and attributing all of it to a single `path`
+    # credited the first document with values the second supplied.
+    sources: dict[str, str] | None = None
 
 
 @dataclass
@@ -234,6 +246,18 @@ class _Side:
     path: str
 
 
+def _origin_of(doc: Document, path: str) -> str:
+    """Which file a path in ``doc`` was actually written in.
+
+    For a real document that is its own path. For an accumulator produced by an
+    earlier fold it is whichever document contributed that path — the mixture is
+    the whole reason `sources` exists.
+    """
+    if doc.sources is not None:
+        return doc.sources.get(path, doc.path)
+    return doc.path
+
+
 class _Recorder:
     """Collects line/source provenance while a merge walks the documents."""
 
@@ -245,10 +269,11 @@ class _Recorder:
         """Record that ``out_path`` was supplied by ``side``."""
         if side is None:
             return
+        origin = _origin_of(side.doc, side.path)
         line = side.doc.lines.get(side.path)
         if line is not None:
-            self.lines[out_path] = SourcedLine(line, side.doc.path)
-        self.sources[out_path] = side.doc.path
+            self.lines[out_path] = SourcedLine(line, origin)
+        self.sources[out_path] = origin
 
     def take_subtree(self, out_path: str, side: _Side | None) -> None:
         """Record ``side``'s whole subtree as landing at ``out_path``.
@@ -272,13 +297,15 @@ class _Recorder:
             # key[0] — always a name character at the root — and silently copied
             # nothing, so a value neither document overrode lost its line.
             if not prefix:
-                self.lines[key] = SourcedLine(line, side.doc.path)
-                self.sources[key] = side.doc.path
+                origin = _origin_of(side.doc, key)
+                self.lines[key] = SourcedLine(line, origin)
+                self.sources[key] = origin
                 continue
             if key.startswith(prefix) and key[len(prefix)] in ".[":
                 moved = out_path + key[len(prefix) :]
-                self.lines[moved] = SourcedLine(line, side.doc.path)
-                self.sources[moved] = side.doc.path
+                origin = _origin_of(side.doc, key)
+                self.lines[moved] = SourcedLine(line, origin)
+                self.sources[moved] = origin
 
 
 def merge_values(
@@ -381,7 +408,11 @@ def _merge_mappings(
     for key, value in over.items():
         child_out = _join(out_path, key)
         over_child = _child(over_side, key) if over_side else None
-        if key in base and key not in drop_keys:
+        marked_override = (
+            over_side is not None
+            and _join(over_side.path, key) in over_side.doc.overrides
+        )
+        if key in base and key not in drop_keys and not marked_override:
             # Seed the key's own location from the base before merging. A key
             # both documents mention is otherwise never recorded: the branches
             # above only fire for keys unique to one side, and the recursion
@@ -607,7 +638,12 @@ def merge_documents(documents: list[Document]) -> Merged:
         # The accumulated document carries the *merged* line/source maps, so a
         # third file merges against provenance already resolved for the first
         # two rather than against the original first file.
-        acc_doc = Document(path=accumulated.path, data=merged_data, lines=rec.lines)
+        acc_doc = Document(
+            path=accumulated.path,
+            data=merged_data,
+            lines=rec.lines,
+            sources=dict(rec.sources),
+        )
         merged_data = _merge_mappings(
             merged_data,
             nxt.data,

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -10,8 +10,9 @@ import os
 import stat
 import sys
 import tempfile
+from dataclasses import replace
 from pathlib import Path
-from typing import Any, NoReturn
+from typing import TYPE_CHECKING, Any, NoReturn
 
 from compose_lint import __version__
 from compose_lint._output import emit, emit_block
@@ -45,6 +46,7 @@ from compose_lint.parser import (
     ComposeNotApplicableError,
     coverage_gaps,
     load_compose,
+    load_merged,
 )
 
 
@@ -59,6 +61,10 @@ def _severity_type(value: str) -> Severity:
         ) from None
 
 
+if TYPE_CHECKING:
+    from compose_lint._merge import Merged
+
+
 _COMPOSE_FILENAMES = [
     "compose.yml",
     "compose.yaml",
@@ -67,9 +73,58 @@ _COMPOSE_FILENAMES = [
 ]
 
 
+# The overlay Compose merges automatically when it sits beside a base file.
+# Compose pairs the spelling: `compose.yml` takes `compose.override.yml`, and
+# `docker-compose.yaml` takes `docker-compose.override.yaml`.
+_OVERRIDE_FILENAMES = {
+    "compose.yml": "compose.override.yml",
+    "compose.yaml": "compose.override.yaml",
+    "docker-compose.yml": "docker-compose.override.yml",
+    "docker-compose.yaml": "docker-compose.override.yaml",
+}
+
+
 def _discover_compose_files() -> list[str]:
     """Find Compose files in the current directory."""
     return [name for name in _COMPOSE_FILENAMES if Path(name).is_file()]
+
+
+def _sibling_override(filepath: str) -> str | None:
+    """The override Compose would merge into ``filepath``, if it exists.
+
+    Running `docker compose up` with no `-f` loads the base file *and* this
+    overlay, with no flag and no opt-in, so the merged pair is the configuration
+    that actually runs. Linting the base alone grades a document nobody deploys:
+    a socket mount added by the overlay is missed entirely, and the base's own
+    absence findings are judged against hardening the overlay may have removed.
+    """
+    base = Path(filepath)
+    override_name = _OVERRIDE_FILENAMES.get(base.name)
+    if override_name is None:
+        return None
+    candidate = base.parent / override_name
+    return str(candidate) if candidate.is_file() else None
+
+
+def _attribute_sources(
+    findings: list[Finding], merged: Merged, primary: str
+) -> list[Finding]:
+    """Tag each finding with the merged file its evidence was written in.
+
+    Exact, not inferred: the line number a rule looked up is a
+    :class:`SourcedLine` carrying its own document path, so a finding already
+    knows where it came from. Only findings originating outside ``primary`` are
+    tagged — the report is already headed by the primary file, and repeating it
+    on every finding would be noise.
+    """
+    tagged: list[Finding] = []
+    for finding in findings:
+        source = getattr(finding.line, "source", None)
+        if source is not None and Path(source).absolute() != Path(primary).absolute():
+            tagged.append(replace(finding, source_file=source))
+        else:
+            tagged.append(finding)
+    return tagged
 
 
 def _report_parse_error(filepath: str, exc: FileNotFoundError | ComposeError) -> str:
@@ -480,6 +535,19 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
             flush=True,
         )
 
+    # Pair each base file with the overlay Compose would merge into it. Done
+    # before the sweep so an overlay that is also listed explicitly (a shell
+    # glob expands to it) is linted as part of its pair rather than standalone,
+    # where its absence findings would be false positives against a base that
+    # supplies the hardening.
+    overlay_of: dict[str, str] = {}
+    consumed: set[Path] = set()
+    for candidate in args.files:
+        overlay = _sibling_override(candidate)
+        if overlay is not None:
+            overlay_of[candidate] = overlay
+            consumed.add(Path(overlay).absolute())
+
     all_json: list[dict[str, object]] = []
     all_sarif: list[dict[str, object]] = []
     all_file_findings: list[tuple[list[Finding], str]] = []
@@ -490,8 +558,26 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
     seen_services: set[str] = set()
 
     for filepath in args.files:
+        if Path(filepath).absolute() in consumed:
+            # Linted as the overlay half of a pair below.
+            continue
+        overlay = overlay_of.get(filepath)
+        merged: Merged | None = None
         try:
-            data, lines = load_compose(filepath)
+            if overlay is not None:
+                merged = load_merged([filepath, overlay])
+                data, lines = merged.data, merged.lines
+                # Not a coverage gap — coverage was achieved, not missed — so
+                # this warns without touching the exit code. What it must never
+                # do is stay silent: the findings below describe a document that
+                # is not the file named in the report.
+                emit(
+                    f"warning: {filepath}: merged {overlay} before linting, "
+                    "because Compose merges it automatically. Findings describe "
+                    "the combined configuration."
+                )
+            else:
+                data, lines = load_compose(filepath)
         except ComposeNotApplicableError as e:
             # v1 / fragment file: not malformed, just outside what we lint.
             # Per ADR-013 this is exit 0 (skipped, not a parse error). Must
@@ -528,6 +614,8 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
             excluded_services=excluded_services,
             on_error=_record_rule_error,
         )
+        if merged is not None:
+            findings = _attribute_sources(findings, merged, filepath)
 
         if args.skip_suppressed:
             findings = [f for f in findings if not f.suppressed]
@@ -764,6 +852,21 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
     touched = False
 
     for filepath in args.files:
+        overlay = _sibling_override(filepath)
+        if overlay is not None:
+            # `fix` edits one file in place. With an overlay present the graded
+            # document spans two, so a fixer cannot know which one to write:
+            # adding `read_only: true` to the base is wrong if the overlay turns
+            # it off again, and writing the overlay is wrong whenever the base
+            # already sets the key. Refusing is the only answer that cannot
+            # produce a wrong edit, and `fix` is not the gate — it reports and
+            # moves on (see the coverage-gap precedent below).
+            emit(
+                f"{filepath}: skipped — {overlay} is merged into it by Compose, "
+                "so a fix cannot be attributed to a single file. Lint with "
+                "`check` and edit by hand."
+            )
+            continue
         try:
             data, lines = load_compose(filepath)
         except ComposeNotApplicableError as e:

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -643,7 +643,16 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
                 emit(f"Error: {filepath}: {e}")
                 continue
             try:
-                fixes = collect_edits(findings, data, lines, text).fixed_edits
+                # Suggested changes are computed against one file's text using
+                # the merged line map, so on a merged run they would splice at a
+                # line belonging to the other document. `fix` refuses the same
+                # case; SARIF must not offer through a different door what the
+                # fixer declines to do.
+                fixes = (
+                    []
+                    if merged is not None
+                    else collect_edits(findings, data, lines, text).fixed_edits
+                )
             except LineOutOfRangeError as e:
                 # A fixer addressed a line this file does not have. Report the
                 # file and keep going: SARIF is serialized once for the whole

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -47,6 +47,7 @@ from compose_lint.parser import (
     coverage_gaps,
     load_compose,
     load_merged,
+    merge_patched,
 )
 
 
@@ -62,6 +63,8 @@ def _severity_type(value: str) -> Severity:
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from compose_lint._merge import Merged
 
 
@@ -257,6 +260,17 @@ def _add_check_subparser(
             "partial view; with it, the gap is reported on stderr only"
         ),
     )
+    check.add_argument(
+        "--no-merge-overrides",
+        action="store_true",
+        default=False,
+        help=(
+            "lint each file on its own instead of merging the "
+            "'compose.override.yml' Compose would merge beside it. The merged "
+            "view is what actually runs, so this is only right when the base "
+            "file is deliberately graded in isolation"
+        ),
+    )
     verbosity = check.add_mutually_exclusive_group()
     verbosity.add_argument(
         "-v",
@@ -319,6 +333,17 @@ def _add_fix_subparser(
         action="store_true",
         default=False,
         help="write fixes in place instead of printing a dry-run diff",
+    )
+    fix.add_argument(
+        "--no-merge-overrides",
+        action="store_true",
+        default=False,
+        help=(
+            "lint each file on its own instead of merging the "
+            "'compose.override.yml' Compose would merge beside it. The merged "
+            "view is what actually runs, so this is only right when the base "
+            "file is deliberately graded in isolation"
+        ),
     )
     fix.add_argument(
         "--only",
@@ -521,20 +546,6 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
             )
             sys.exit(2)
 
-    # Print branded header in text mode before scanning begins. flush=True here
-    # (and on the per-file text prints below) keeps block-buffered stdout from
-    # landing after unbuffered stderr when both are captured together (2>&1).
-    if args.output_format == "text":
-        print(
-            format_header(
-                args.files,
-                str(config_path) if config_path else None,
-                args.fail_on,
-                __version__,
-            ),
-            flush=True,
-        )
-
     # Pair each base file with the overlay Compose would merge into it. Done
     # before the sweep so an overlay that is also listed explicitly (a shell
     # glob expands to it) is linted as part of its pair rather than standalone,
@@ -543,10 +554,25 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
     overlay_of: dict[str, str] = {}
     consumed: set[Path] = set()
     for candidate in args.files:
-        overlay = _sibling_override(candidate)
+        overlay = None if args.no_merge_overrides else _sibling_override(candidate)
         if overlay is not None:
             overlay_of[candidate] = overlay
             consumed.add(Path(overlay).absolute())
+
+    # Print branded header in text mode before scanning begins. flush=True here
+    # (and on the per-file text prints below) keeps block-buffered stdout from
+    # landing after unbuffered stderr when both are captured together (2>&1).
+    if args.output_format == "text":
+        print(
+            format_header(
+                [f for f in args.files if Path(f).absolute() not in consumed],
+                str(config_path) if config_path else None,
+                args.fail_on,
+                __version__,
+                merged=overlay_of,
+            ),
+            flush=True,
+        )
 
     all_json: list[dict[str, object]] = []
     all_sarif: list[dict[str, object]] = []
@@ -828,6 +854,25 @@ def _atomic_write(path: Path, content: str) -> None:
         raise
 
 
+def _merged_reparser(
+    filepath: str, overlay: str | None
+) -> Callable[[str], tuple[dict[str, Any], dict[str, int]]] | None:
+    """Re-parse hook that merges a candidate patch with its overlay.
+
+    ``verify_apply`` checks properties of the document Compose runs. On a merged
+    run that is the patched base *plus* the overlay, so the candidate has to be
+    re-merged before the engine sees it. Returns None when nothing is merged,
+    which leaves the default single-file re-parse in place.
+    """
+    if overlay is None:
+        return None
+
+    def reparse(candidate: str) -> tuple[dict[str, Any], dict[str, int]]:
+        return merge_patched(candidate, filepath, [overlay])
+
+    return reparse
+
+
 def _run_fix(args: argparse.Namespace) -> NoReturn:
     """Run the `fix` operation (ADR-014).
 
@@ -855,29 +900,37 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
             )
             sys.exit(2)
 
+    # Same pairing as `check`: an overlay listed explicitly is handled as part
+    # of its base's pair rather than fixed on its own.
+    fix_overlay_of: dict[str, str] = {}
+    fix_consumed: set[Path] = set()
+    for candidate_path in args.files:
+        candidate_overlay = (
+            None if args.no_merge_overrides else _sibling_override(candidate_path)
+        )
+        if candidate_overlay is not None:
+            fix_overlay_of[candidate_path] = candidate_overlay
+            fix_consumed.add(Path(candidate_overlay).absolute())
+
     only = set(args.only) if args.only else None
     had_error = False
     # Whether any file had a fix applied or offered — see the note below.
     touched = False
 
     for filepath in args.files:
-        overlay = _sibling_override(filepath)
-        if overlay is not None:
-            # `fix` edits one file in place. With an overlay present the graded
-            # document spans two, so a fixer cannot know which one to write:
-            # adding `read_only: true` to the base is wrong if the overlay turns
-            # it off again, and writing the overlay is wrong whenever the base
-            # already sets the key. Refusing is the only answer that cannot
-            # produce a wrong edit, and `fix` is not the gate — it reports and
-            # moves on (see the coverage-gap precedent below).
-            emit(
-                f"{filepath}: skipped — {overlay} is merged into it by Compose, "
-                "so a fix cannot be attributed to a single file. Lint with "
-                "`check` and edit by hand."
-            )
+        if Path(filepath).absolute() in fix_consumed:
             continue
+        overlay = fix_overlay_of.get(filepath)
         try:
-            data, lines = load_compose(filepath)
+            if overlay is not None:
+                merged = load_merged([filepath, overlay])
+                data, lines = merged.data, merged.lines
+                emit(
+                    f"note: {filepath}: merged {overlay} before linting. Only "
+                    "findings written in this file can be fixed here."
+                )
+            else:
+                data, lines = load_compose(filepath)
         except ComposeNotApplicableError as e:
             # v1 / fragment file: skipped, not an error (ADR-013). Must precede
             # the ComposeError clause below — it is a subclass.
@@ -910,8 +963,25 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
             severity_overrides=severity_overrides,
             excluded_services=excluded_services,
         )
+
+        # A finding's line knows which document it came from. Only the ones
+        # written in *this* file can be edited here: its line is a line in this
+        # text, and its fix lands where the user would put it by hand. A finding
+        # from the overlay is left to manual review — writing it into the base
+        # would put the key in a file the overlay overrides anyway.
+        def _is_local(f: Finding, _path: str = filepath) -> bool:
+            origin = getattr(f.line, "source", None)
+            return origin is None or Path(origin).absolute() == Path(_path).absolute()
+
+        fixable_findings = [f for f in findings if _is_local(f)]
+        deferred = len(findings) - len(fixable_findings)
+        if deferred:
+            emit(
+                f"{filepath}: {deferred} finding(s) come from {overlay} and "
+                "need manual review there"
+            )
         try:
-            result = collect_edits(findings, data, lines, text, only=only)
+            result = collect_edits(fixable_findings, data, lines, text, only=only)
         except LineOutOfRangeError as e:
             # Same fail-closed treatment as the check path: refuse this file,
             # write nothing, let the rest of the batch run (VULN-017).
@@ -964,6 +1034,13 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
             disabled_rules=disabled_rules,
             severity_overrides=severity_overrides,
             excluded_services=excluded_services,
+            # The properties being verified — structure preserved, converges,
+            # no new finding — are properties of the document Compose runs, so
+            # the candidate is re-merged with the overlay before they are
+            # checked. Verifying the patched base alone would compare a
+            # single-file result against a merged one.
+            reparse=_merged_reparser(filepath, overlay),
+            fixable=_is_local if overlay is not None else None,
         )
         if verify_error is not None:
             emit_block(render_file_diff(filepath, text, patched, result.caveats))

--- a/src/compose_lint/fix.py
+++ b/src/compose_lint/fix.py
@@ -33,7 +33,7 @@ from compose_lint._yaml_edit import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Callable, Iterable
     from pathlib import Path
 
     from compose_lint.models import Finding, Severity, TextEdit
@@ -596,6 +596,8 @@ def verify_apply(
     disabled_rules: dict[str, str | None] | None = None,
     severity_overrides: dict[str, Severity] | None = None,
     excluded_services: dict[str, dict[str, str | None]] | None = None,
+    reparse: Callable[[str], tuple[dict[str, Any], dict[str, int]]] | None = None,
+    fixable: Callable[[Finding], bool] | None = None,
 ) -> str | None:
     """Verify a patched candidate beyond "it parses" before it is written.
 
@@ -625,8 +627,14 @@ def verify_apply(
     from compose_lint.engine import run_rules
     from compose_lint.parser import ComposeError, loads
 
+    # `reparse` lets a caller verify against something other than the patched
+    # file alone. When an overlay is merged in, the property that must hold is
+    # about the *merged* document — patching the base and re-linting it by
+    # itself would compare a single-file result against a merged one and report
+    # drift that is not there.
+    reload_document = reparse or (lambda text: loads(text, base_dir=base_dir))
     try:
-        re_data, re_lines = loads(patched, base_dir=base_dir)
+        re_data, re_lines = reload_document(patched)
     except ComposeError as e:  # pragma: no cover - reparse guard runs first
         return f"computed fix does not parse as Compose ({e})"
 
@@ -642,7 +650,14 @@ def verify_apply(
         excluded_services=excluded_services,
     )
 
-    if collect_edits(re_findings, re_data, re_lines, patched, only=only).edits:
+    # Convergence is only meaningful over the findings this run would actually
+    # fix. On a merged run the rest belong to another document, and asking for
+    # their edits against this file's text would report a second pass that is
+    # never attempted.
+    convergence_input = (
+        [f for f in re_findings if fixable(f)] if fixable is not None else re_findings
+    )
+    if collect_edits(convergence_input, re_data, re_lines, patched, only=only).edits:
         return "computed fix does not converge: a second pass would still edit it"
 
     before = {(f.rule_id, f.service, f.message) for f in findings}

--- a/src/compose_lint/formatters/json.py
+++ b/src/compose_lint/formatters/json.py
@@ -38,6 +38,13 @@ def format_findings(findings: list[Finding], filepath: str) -> list[dict[str, ob
             entry["suppression_reason"] = f.suppression_reason
         if f.severity_overridden_from is not None:
             entry["severity_overridden_from"] = f.severity_overridden_from.value
+        if f.source_file is not None:
+            # Present only when a run merged documents and this finding's
+            # evidence is in one other than `file` — `line` is a line in
+            # *this* file, not in `file`. Additive and conditional, so the
+            # envelope shape is unchanged for every single-file run and
+            # SCHEMA_VERSION does not move.
+            entry["source_file"] = f.source_file
         results.append(entry)
     return results
 

--- a/src/compose_lint/formatters/sarif.py
+++ b/src/compose_lint/formatters/sarif.py
@@ -407,7 +407,14 @@ def format_findings(
     }
 
     for f in findings:
-        physical_location = _physical_location(filepath, f.line)
+        # A merged run grades more than one document, and `f.line` is a line in
+        # whichever one supplied the evidence. Pointing every result at
+        # `filepath` made Code Scanning annotate an unrelated line of the base
+        # file. Only findings that came from elsewhere carry `source_file`, so
+        # single-file runs — and every base-file finding in a merged run — keep
+        # the URI they had, and with it their partialFingerprints (ADR-024).
+        result_path = f.source_file or filepath
+        physical_location = _physical_location(result_path, f.line)
         result: dict[str, Any] = {
             "ruleId": f.rule_id,
             "level": _SARIF_LEVEL.get(f.severity, "warning"),

--- a/src/compose_lint/formatters/sarif.py
+++ b/src/compose_lint/formatters/sarif.py
@@ -413,6 +413,20 @@ def format_findings(
         # file. Only findings that came from elsewhere carry `source_file`, so
         # single-file runs — and every base-file finding in a merged run — keep
         # the URI they had, and with it their partialFingerprints (ADR-024).
+        #
+        # Naming a file that is not in the repository is safe: an overlay is
+        # commonly gitignored, so this URI can be unresolvable against the
+        # commit. Verified against real Code Scanning — every result survived
+        # ingestion with no analysis warning and the alert stayed queryable at
+        # the overlay's path (`sarif-ingestion.yml`, which re-checks it weekly).
+        #
+        # Known limitation, accepted: GitHub renders source previews from the
+        # commit tree, so an alert on an untracked path shows its location
+        # without a code snippet, and can never appear as a PR diff annotation.
+        # That degrades a panel; it does not lose a finding, which is the
+        # failure that would have been silent. It also needs an overlay
+        # generated during the build to arise at all — a gitignored overlay is
+        # absent from a CI checkout, so compose-lint never merges one there.
         result_path = f.source_file or filepath
         physical_location = _physical_location(result_path, f.line)
         result: dict[str, Any] = {

--- a/src/compose_lint/formatters/text.py
+++ b/src/compose_lint/formatters/text.py
@@ -249,6 +249,15 @@ def format_findings(
         return ""
 
     source_lines = None if quiet else _read_source_lines(filepath)
+    # A merged run grades more than one document, so a finding's line may be a
+    # line in a *different* file. Reading each contributing file once keeps the
+    # excerpt pointing at the text the finding is actually about; rendering
+    # `filepath` for all of them showed an unrelated line with full confidence.
+    extra_sources: dict[str, list[str] | None] = {}
+    if not quiet:
+        for f in findings:
+            if f.source_file and f.source_file not in extra_sources:
+                extra_sources[f.source_file] = _read_source_lines(f.source_file)
 
     by_service: dict[str, list[Finding]] = {}
     for f in findings:
@@ -329,13 +338,23 @@ def format_findings(
                 f"{_colorize(f.rule_id, _DIM)}  "
                 f"{message}{suffix}"
             )
+            if f.source_file:
+                out.append(
+                    f"          {_colorize('in:', _DIM)} {f.source_file}"
+                    f" (merged into this run)"
+                )
 
+            excerpt_source = (
+                extra_sources.get(f.source_file) if f.source_file else source_lines
+            )
             if (
-                source_lines is not None
+                excerpt_source is not None
                 and f.rule_id in _PRESENCE_RULES
                 and f.line is not None
             ):
-                for excerpt_line in _excerpt(f.line, source_lines, message, f.severity):
+                for excerpt_line in _excerpt(
+                    f.line, excerpt_source, message, f.severity
+                ):
                     out.append(f"          {excerpt_line}")
 
             if show_fix and f.fix:

--- a/src/compose_lint/formatters/text.py
+++ b/src/compose_lint/formatters/text.py
@@ -156,12 +156,27 @@ def format_header(
     config_path: str | None,
     fail_on: Severity,
     version: str,
+    merged: dict[str, str] | None = None,
 ) -> str:
-    """Format a branded run header showing the tool version and active parameters."""
+    """Format a branded run header showing the tool version and active parameters.
+
+    ``merged`` maps a base file to the overlay Compose merges into it. The
+    header is the one line that states what was read, so a run that read two
+    documents has to say two: naming only the base was the complaint this
+    behaviour exists to answer, and naming it after the merge lands would just
+    move the false claim rather than remove it.
+    """
     sep = _colorize("·", _DIM)
     config_str = _sanitize_line(config_path) if config_path else "none"
+    pairs = merged or {}
+    shown = [
+        f"{_sanitize_line(f)} + {_sanitize_line(pairs[f])}"
+        if f in pairs
+        else _sanitize_line(f)
+        for f in files
+    ]
     params = (
-        f"files: {', '.join(_sanitize_line(f) for f in files)}"
+        f"files: {', '.join(shown)}"
         f"  {sep}  config: {config_str}"
         f"  {sep}  fail-on: {fail_on.value}"
     )

--- a/src/compose_lint/models.py
+++ b/src/compose_lint/models.py
@@ -84,6 +84,11 @@ class Finding:
     # those. tests/test_finding_identity.py fails if a rule needs one and
     # does not set it.
     evidence: str | None = None
+    # The file this finding's evidence was written in, when a run merged more
+    # than one document (a base file plus its `compose.override.yml`) and that
+    # file is not the one named in the report. None on a single-file run, which
+    # is every run today, so no existing output shape changes.
+    source_file: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -9,6 +9,7 @@ from typing import Any
 import yaml
 
 from compose_lint._lines import find_ambiguous_break
+from compose_lint._merge import Document, Merged, merge_documents, merge_values
 from compose_lint._safe_read import UnsafeFileError, read_text_bounded
 from compose_lint.config import KNOWN_TOP_LEVEL_KEYS
 from compose_lint.rules._interpolation import substitute_defaults
@@ -171,6 +172,13 @@ class LineLoader(yaml.SafeLoader):
         super().__init__(*args, **kwargs)
         # id(list) -> {index: line}
         self._seq_lines: dict[int, dict[int, int]] = {}
+        # id(mapping) -> {key names carrying `!reset`}. The key is dropped from
+        # the mapping (see `_construct_mapping`), so the only record that it was
+        # ever written is here. A single file does not need it — a deleted key
+        # is simply absent — but a *merge* does: `!reset` deletes the value the
+        # other document supplies, and without this the base's value survives a
+        # deletion Compose honours.
+        self._resets: dict[int, set[str]] = {}
 
 
 def _mapping_key(loader: LineLoader, key_node: yaml.Node) -> Any:
@@ -251,6 +259,8 @@ def _construct_mapping(loader: LineLoader, node: yaml.MappingNode) -> dict[Any, 
                 key_node.start_mark,
             ) from e
         if value_node.tag == _RESET_TAG:
+            if isinstance(key, str):
+                loader._resets.setdefault(id(mapping), set()).add(key)
             # `!reset` deletes the key. Verified with `docker compose config`:
             # a file carrying `read_only: !reset true`, `cap_drop: !reset [ALL]`
             # and `security_opt: !reset [...]` deploys a service with *none* of
@@ -540,6 +550,43 @@ def _collect_lines(
     return lines
 
 
+def _collect_resets(
+    data: Any, resets: dict[int, set[str]], prefix: str = ""
+) -> frozenset[str]:
+    """Collect dot-notation paths of keys deleted by ``!reset``.
+
+    Walks the *raw* document (before :func:`_strip_lines` rebuilds it, which
+    would invalidate the id() keys) with the same iterative work-stack shape as
+    :func:`_collect_lines`.
+    """
+    if not resets:
+        return frozenset()
+    found: set[str] = set()
+    expanded: set[int] = set()
+    stack: list[tuple[Any, str]] = [(data, prefix)]
+    while stack:
+        current, current_prefix = stack.pop()
+        if isinstance(current, dict):
+            for key in resets.get(id(current), ()):
+                found.add(f"{current_prefix}.{key}" if current_prefix else key)
+            if id(current) in expanded:
+                continue
+            expanded.add(id(current))
+            for key, value in current.items():
+                if key is _LINES:
+                    continue
+                stack.append(
+                    (value, f"{current_prefix}.{key}" if current_prefix else key)
+                )
+        elif isinstance(current, list):
+            if id(current) in expanded:
+                continue
+            expanded.add(id(current))
+            for i, item in enumerate(current):
+                stack.append((item, f"{current_prefix}[{i}]"))
+    return frozenset(found)
+
+
 def _validate_compose(data: Any) -> dict[str, Any]:
     """Validate that parsed YAML is a Docker Compose file."""
     if not isinstance(data, dict):
@@ -629,6 +676,7 @@ def _resolve_in_file_extends(data: dict[str, Any]) -> None:
     if not isinstance(services, dict):
         return
     resolved: dict[str, Any] = {}
+    memo: dict[tuple[int, int, str], Any] = {}
 
     def _resolve(name: str, stack: tuple[str, ...]) -> Any:
         if name in resolved:
@@ -653,7 +701,12 @@ def _resolve_in_file_extends(data: dict[str, Any]) -> None:
             resolved[name] = cfg
             return cfg
         parent = _resolve(target, (*stack, name))
-        merged = _merge_extends(parent, cfg)  # keeps child's `extends` marker
+        # Compose resolves `extends:` with the same field-specific merge it uses
+        # for multi-file overlays (verified against `docker compose config` in
+        # tests/test_merge_semantics.py), so both go through one table. The
+        # previous concatenate-every-sequence merge reported a CRITICAL socket
+        # mount against a child that had replaced it at the same mount point.
+        merged = merge_values(parent, cfg, memo=memo)  # keeps child's `extends` marker
         resolved[name] = merged
         return merged
 
@@ -952,9 +1005,9 @@ def load_compose(
     return loads(content, base_dir=filepath.absolute().parent)
 
 
-def loads(
+def _loads_full(
     content: str, base_dir: Path | None = None
-) -> tuple[dict[str, Any], dict[str, int]]:
+) -> tuple[dict[str, Any], dict[str, int], frozenset[str]]:
     """Parse and validate Compose from an in-memory string.
 
     The string form of :func:`load_compose`: identical YAML parsing, line
@@ -1005,6 +1058,7 @@ def loads(
         loader = LineLoader(content)  # noqa: S506  # nosec B506 - SafeLoader subclass
         raw = loader.get_single_data()
         seq_lines = loader._seq_lines
+        raw_resets = loader._resets
     except yaml.YAMLError as e:
         raise ComposeError(f"Invalid YAML: {e}") from e
     except RecursionError as e:
@@ -1032,6 +1086,7 @@ def loads(
     # each pass that walks the document, not only the one that builds it.
     try:
         lines = _collect_lines(raw, seq_lines)
+        reset_paths = _collect_resets(raw, raw_resets)
         data = _strip_lines(raw)
         # Canonicalize before anything classifies: rules and the extends and
         # bind-source passes below all see the value the file actually ships
@@ -1047,4 +1102,45 @@ def loads(
             "`${VAR}` default)"
         ) from e
 
+    return data, lines, reset_paths
+
+
+def loads(
+    content: str, base_dir: Path | None = None
+) -> tuple[dict[str, Any], dict[str, int]]:
+    """Parse Compose from a string, returning ``(data, lines)``.
+
+    The public string entry point. :func:`_loads_full` additionally reports the
+    paths deleted by ``!reset``, which only a merge needs.
+    """
+    data, lines, _ = _loads_full(content, base_dir=base_dir)
     return data, lines
+
+
+def load_document(path: str | Path) -> Document:
+    """Load one Compose file as a :class:`Document` ready to merge.
+
+    The merge-aware sibling of :func:`load_compose`: same parse, same
+    validation, but it keeps the ``!reset`` deletions that only matter once a
+    second document is folded in.
+    """
+    filepath = Path(path)
+    try:
+        content = read_text_bounded(filepath, newline="")
+    except UnsafeFileError as e:
+        raise ComposeError(str(e)) from e
+    except UnicodeDecodeError as e:
+        raise ComposeError(f"Invalid encoding: file is not valid UTF-8 ({e})") from e
+    except OSError as e:
+        raise ComposeError(f"Cannot read file: {e}") from e
+    data, lines, resets = _loads_full(content, base_dir=filepath.absolute().parent)
+    return Document(path=str(path), data=data, lines=lines, resets=resets)
+
+
+def load_merged(paths: list[str | Path]) -> Merged:
+    """Load and merge several Compose files into the configuration Compose runs.
+
+    Later paths override earlier ones, which is the order Compose itself uses
+    for ``-f a -f b`` and for a base file plus its ``compose.override.yml``.
+    """
+    return merge_documents([load_document(p) for p in paths])

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -179,6 +179,11 @@ class LineLoader(yaml.SafeLoader):
         # other document supplies, and without this the base's value survives a
         # deletion Compose honours.
         self._resets: dict[int, set[str]] = {}
+        # id(mapping) -> {key names carrying `!override`}. Like `!reset`, the
+        # directive changes how the value *merges* rather than what it is, so a
+        # single file needs no record of it — but a merge does: `!override`
+        # replaces the other document's value instead of merging with it.
+        self._overrides: dict[int, set[str]] = {}
 
 
 def _mapping_key(loader: LineLoader, key_node: yaml.Node) -> Any:
@@ -233,6 +238,7 @@ def _reject_duplicate_keys(loader: LineLoader, node: yaml.MappingNode) -> None:
 
 
 _RESET_TAG = "!reset"
+_OVERRIDE_TAG = "!override"
 
 
 def _construct_mapping(loader: LineLoader, node: yaml.MappingNode) -> dict[Any, Any]:
@@ -258,6 +264,8 @@ def _construct_mapping(loader: LineLoader, node: yaml.MappingNode) -> dict[Any, 
                 "Compose files may only use scalar keys",
                 key_node.start_mark,
             ) from e
+        if value_node.tag == _OVERRIDE_TAG and isinstance(key, str):
+            loader._overrides.setdefault(id(mapping), set()).add(key)
         if value_node.tag == _RESET_TAG:
             if isinstance(key, str):
                 loader._resets.setdefault(id(mapping), set()).add(key)
@@ -550,16 +558,16 @@ def _collect_lines(
     return lines
 
 
-def _collect_resets(
-    data: Any, resets: dict[int, set[str]], prefix: str = ""
+def _collect_tagged(
+    data: Any, tagged: dict[int, set[str]], prefix: str = ""
 ) -> frozenset[str]:
-    """Collect dot-notation paths of keys deleted by ``!reset``.
+    """Collect dot-notation paths of keys carrying a Compose merge directive.
 
     Walks the *raw* document (before :func:`_strip_lines` rebuilds it, which
     would invalidate the id() keys) with the same iterative work-stack shape as
     :func:`_collect_lines`.
     """
-    if not resets:
+    if not tagged:
         return frozenset()
     found: set[str] = set()
     expanded: set[int] = set()
@@ -567,7 +575,7 @@ def _collect_resets(
     while stack:
         current, current_prefix = stack.pop()
         if isinstance(current, dict):
-            for key in resets.get(id(current), ()):
+            for key in tagged.get(id(current), ()):
                 found.add(f"{current_prefix}.{key}" if current_prefix else key)
             if id(current) in expanded:
                 continue
@@ -1007,7 +1015,7 @@ def load_compose(
 
 def _loads_full(
     content: str, base_dir: Path | None = None
-) -> tuple[dict[str, Any], dict[str, int], frozenset[str]]:
+) -> tuple[dict[str, Any], dict[str, int], frozenset[str], frozenset[str]]:
     """Parse and validate Compose from an in-memory string.
 
     The string form of :func:`load_compose`: identical YAML parsing, line
@@ -1059,6 +1067,7 @@ def _loads_full(
         raw = loader.get_single_data()
         seq_lines = loader._seq_lines
         raw_resets = loader._resets
+        raw_overrides = loader._overrides
     except yaml.YAMLError as e:
         raise ComposeError(f"Invalid YAML: {e}") from e
     except RecursionError as e:
@@ -1086,7 +1095,8 @@ def _loads_full(
     # each pass that walks the document, not only the one that builds it.
     try:
         lines = _collect_lines(raw, seq_lines)
-        reset_paths = _collect_resets(raw, raw_resets)
+        reset_paths = _collect_tagged(raw, raw_resets)
+        override_paths = _collect_tagged(raw, raw_overrides)
         data = _strip_lines(raw)
         # Canonicalize before anything classifies: rules and the extends and
         # bind-source passes below all see the value the file actually ships
@@ -1102,7 +1112,7 @@ def _loads_full(
             "`${VAR}` default)"
         ) from e
 
-    return data, lines, reset_paths
+    return data, lines, reset_paths, override_paths
 
 
 def loads(
@@ -1113,7 +1123,7 @@ def loads(
     The public string entry point. :func:`_loads_full` additionally reports the
     paths deleted by ``!reset``, which only a merge needs.
     """
-    data, lines, _ = _loads_full(content, base_dir=base_dir)
+    data, lines, _, _ = _loads_full(content, base_dir=base_dir)
     return data, lines
 
 
@@ -1133,8 +1143,12 @@ def load_document(path: str | Path) -> Document:
         raise ComposeError(f"Invalid encoding: file is not valid UTF-8 ({e})") from e
     except OSError as e:
         raise ComposeError(f"Cannot read file: {e}") from e
-    data, lines, resets = _loads_full(content, base_dir=filepath.absolute().parent)
-    return Document(path=str(path), data=data, lines=lines, resets=resets)
+    data, lines, resets, overrides = _loads_full(
+        content, base_dir=filepath.absolute().parent
+    )
+    return Document(
+        path=str(path), data=data, lines=lines, resets=resets, overrides=overrides
+    )
 
 
 def load_merged(paths: list[str | Path]) -> Merged:
@@ -1157,7 +1171,13 @@ def merge_patched(
     same overlays before the engine re-runs over it.
     """
     base_dir = Path(base_path).absolute().parent
-    data, lines, resets = _loads_full(patched, base_dir=base_dir)
-    candidate = Document(path=str(base_path), data=data, lines=lines, resets=resets)
+    data, lines, resets, overrides = _loads_full(patched, base_dir=base_dir)
+    candidate = Document(
+        path=str(base_path),
+        data=data,
+        lines=lines,
+        resets=resets,
+        overrides=overrides,
+    )
     merged = merge_documents([candidate, *(load_document(p) for p in overlays)])
     return merged.data, merged.lines

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -1144,3 +1144,20 @@ def load_merged(paths: list[str | Path]) -> Merged:
     for ``-f a -f b`` and for a base file plus its ``compose.override.yml``.
     """
     return merge_documents([load_document(p) for p in paths])
+
+
+def merge_patched(
+    patched: str, base_path: str | Path, overlays: list[str]
+) -> tuple[dict[str, Any], dict[str, int]]:
+    """Re-merge a candidate patch of ``base_path`` with its overlay documents.
+
+    The verification counterpart of :func:`load_merged`. ``fix`` proposes an
+    edit to the base file's *text*; the property that has to hold afterwards is
+    about the document Compose would run, so the candidate is merged with the
+    same overlays before the engine re-runs over it.
+    """
+    base_dir = Path(base_path).absolute().parent
+    data, lines, resets = _loads_full(patched, base_dir=base_dir)
+    candidate = Document(path=str(base_path), data=data, lines=lines, resets=resets)
+    merged = merge_documents([candidate, *(load_document(p) for p in overlays)])
+    return merged.data, merged.lines

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -595,8 +595,12 @@ def _collect_tagged(
     return frozenset(found)
 
 
-def _validate_compose(data: Any) -> dict[str, Any]:
-    """Validate that parsed YAML is a Docker Compose file."""
+def _validate_compose(data: Any, *, merging: bool = False) -> dict[str, Any]:
+    """Validate that parsed YAML is a Docker Compose file.
+
+    ``merging`` relaxes the per-service check for a document that is one
+    half of a merge, where a service may legitimately carry no body.
+    """
     if not isinstance(data, dict):
         raise ComposeError(
             "Not a valid Compose file: expected a YAML mapping at the top level"
@@ -611,6 +615,13 @@ def _validate_compose(data: Any) -> dict[str, Any]:
 
     for name, config in services.items():
         if name is _LINES:
+            continue
+        if config is None and merging:
+            # `web:` with no body is a legal overlay half — verified against
+            # `docker compose config`, which merges it as "no changes to web"
+            # and deploys the base unaltered. Refusing it failed the *pair*,
+            # so a valid stack did not lint at all. Standalone files keep the
+            # stricter rule: a service with no body cannot run on its own.
             continue
         if not isinstance(config, dict):
             raise ComposeError(
@@ -1014,7 +1025,7 @@ def load_compose(
 
 
 def _loads_full(
-    content: str, base_dir: Path | None = None
+    content: str, base_dir: Path | None = None, *, merging: bool = False
 ) -> tuple[dict[str, Any], dict[str, int], frozenset[str], frozenset[str]]:
     """Parse and validate Compose from an in-memory string.
 
@@ -1085,7 +1096,7 @@ def _loads_full(
     if raw is None:
         raise ComposeError("Not a valid Compose file: file is empty")
 
-    _validate_compose(raw)
+    _validate_compose(raw, merging=merging)
 
     # The post-parse passes recurse too, and the guard above covered only the
     # parse. A 2000-deep `extends:` chain, or a self-referential
@@ -1144,7 +1155,7 @@ def load_document(path: str | Path) -> Document:
     except OSError as e:
         raise ComposeError(f"Cannot read file: {e}") from e
     data, lines, resets, overrides = _loads_full(
-        content, base_dir=filepath.absolute().parent
+        content, base_dir=filepath.absolute().parent, merging=True
     )
     return Document(
         path=str(path), data=data, lines=lines, resets=resets, overrides=overrides
@@ -1171,7 +1182,9 @@ def merge_patched(
     same overlays before the engine re-runs over it.
     """
     base_dir = Path(base_path).absolute().parent
-    data, lines, resets, overrides = _loads_full(patched, base_dir=base_dir)
+    data, lines, resets, overrides = _loads_full(
+        patched, base_dir=base_dir, merging=True
+    )
     candidate = Document(
         path=str(base_path),
         data=data,

--- a/tests/smoke/overlay/compose.yml
+++ b/tests/smoke/overlay/compose.yml
@@ -1,0 +1,17 @@
+# Base half of the SARIF overlay-attribution probe (issue #631).
+#
+# Hardened on purpose: every finding this pair produces at or above the
+# probe's threshold comes from the *overlay*, so the SARIF results carry an
+# artifactLocation naming a file that is not in the repository. The sibling
+# compose.override.yml is deliberately gitignored and written at job time —
+# see .github/workflows/sarif-ingestion.yml.
+services:
+  web:
+    image: probe:1.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
+    security_opt: [no-new-privileges:true]
+    cap_drop: [ALL]
+    read_only: true
+    mem_limit: 512m
+    cpus: 0.5
+    user: "1000:1000"
+    restart: on-failure

--- a/tests/smoke/overlay/override.yml.tmpl
+++ b/tests/smoke/overlay/override.yml.tmpl
@@ -1,0 +1,11 @@
+# Overlay half of the SARIF overlay-attribution probe (issue #631).
+#
+# Tracked here as a .tmpl so it is a reviewed fixture like every other smoke
+# document (#624 forbids inlining one in a workflow), but copied to
+# `compose.override.yml` at job time and never committed under that name. The
+# condition under test is that the file compose-lint *names in the SARIF* is
+# absent from the repository, which is the normal state of an override.
+services:
+  web:
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"

--- a/tests/test_merge_fuzz.py
+++ b/tests/test_merge_fuzz.py
@@ -1,0 +1,176 @@
+"""Generative differential test: random overlay pairs against Compose itself.
+
+`test_merge_semantics.py` covers a hand-written case list and a systematic
+field x directive matrix. Both are finite, and both encode what their author
+thought to enumerate — the `!override` bug shipped because it was probed while
+deriving the merge table and never became a case.
+
+This suite removes the author from the loop for coverage. It builds base and
+overlay documents from a pool of field values, asks `docker compose config`
+what the merged configuration is, and requires compose-lint's merge to yield
+the same findings. Combinations neither the case list nor the matrix contains
+are reached by construction.
+
+Seeded and enumerated rather than randomly sampled per run: a fuzzer that
+generates different inputs on every invocation reports failures nobody can
+reproduce, and turns an unrelated commit red for reasons that vanish on
+re-run. The seeds are fixed, so a failure names a case that can be replayed.
+"""
+
+from __future__ import annotations
+
+import random
+import shutil
+import subprocess
+from collections import Counter
+from typing import TYPE_CHECKING
+
+import pytest
+
+from compose_lint.engine import run_rules
+from compose_lint.parser import load_compose, load_merged
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("docker") is None,
+    reason="differential fuzz needs the docker compose CLI",
+)
+
+# Field -> values worth generating. Each pool mixes a dangerous value, a
+# hardening value and a neutral one, so a generated pair can move a finding in
+# either direction rather than only adding them.
+FIELD_POOL: dict[str, list[str]] = {
+    "volumes": [
+        '["/var/run/docker.sock:/var/run/docker.sock"]',
+        '["/tmp/safe:/var/run/docker.sock"]',
+        '["/app:/app"]',
+        '["/:/host"]',
+        '["/etc:/etc:ro"]',
+    ],
+    "devices": ['["/dev/mem:/dev/probe"]', '["/dev/null:/dev/probe"]'],
+    "ports": ['["8080:80"]', '["127.0.0.1:8080:80"]', '["9999:80"]', '["53:53/udp"]'],
+    "cap_add": ["[SYS_ADMIN]", "[NET_ADMIN]", "[SYS_PTRACE]"],
+    "cap_drop": ["[ALL]", "[NET_RAW]"],
+    "security_opt": [
+        '["no-new-privileges:true"]',
+        '["seccomp:unconfined"]',
+        '["apparmor:unconfined"]',
+    ],
+    "read_only": ["true", "false"],
+    "privileged": ["true", "false"],
+    "user": ['"1000:1000"', '"root"', '"0"'],
+    "tmpfs": ['["/tmp"]', '["/run:exec"]'],
+    "logging": ['{driver: "json-file"}', '{driver: "none"}'],
+    "mem_limit": ['"512m"', '"1g"'],
+    "restart": ['"on-failure"', '"always"'],
+    "network_mode": ['"bridge"', '"host"'],
+    "environment": [
+        '{AWS_SECRET_ACCESS_KEY: "AKIAIOSFODNN7EXAMPLE"}',
+        '{HARMLESS: "1"}',
+    ],
+}
+
+# `network_mode` conflicts with `ports`, and Compose rejects the project rather
+# than merging it. Generating the pair wastes a subprocess on a skip.
+_EXCLUSIVE = [{"network_mode", "ports"}]
+
+DIRECTIVES = ["", "", "", "", "!override ", "!reset "]
+
+FIELDS = sorted(FIELD_POOL)
+SEEDS = list(range(150))
+
+
+def _render(fields: dict[str, str], *, with_image: bool) -> str:
+    body = "services:\n  web:\n"
+    if with_image:
+        body += "    image: myapp:1.0\n"
+    for key, value in fields.items():
+        body += f"    {key}: {value}\n"
+    return body
+
+
+def _pick(rng: random.Random) -> tuple[dict[str, str], dict[str, str]]:
+    """One base/overlay pair: overlapping field sets, independent values."""
+    chosen = rng.sample(FIELDS, rng.randint(1, 5))
+    base: dict[str, str] = {}
+    over: dict[str, str] = {}
+    for field in chosen:
+        in_base = rng.random() < 0.75
+        in_over = rng.random() < 0.75 or not in_base
+        if in_base:
+            base[field] = rng.choice(FIELD_POOL[field])
+        if in_over:
+            directive = rng.choice(DIRECTIVES)
+            if directive.startswith("!reset"):
+                # `!reset` deletes the key; a typed value is schema-invalid.
+                over[field] = "!reset null"
+            else:
+                over[field] = f"{directive}{rng.choice(FIELD_POOL[field])}"
+    for group in _EXCLUSIVE:
+        if len(group & (set(base) | set(over))) > 1:
+            for field in sorted(group)[1:]:
+                base.pop(field, None)
+                over.pop(field, None)
+    return base, over
+
+
+def _findings_of(data: dict, lines: dict[str, int]) -> Counter[tuple[str, str]]:
+    """Findings as a (rule, service) multiset.
+
+    Evidence is deliberately excluded here, unlike in `test_merge_semantics`,
+    because this suite's oracle is a *normalised* document. Rules derive
+    evidence from the spelling the user wrote, and `docker compose config`
+    rewrites short port and volume syntax into long form — so `53:53/udp`
+    becomes `53:53` on the truth side for the same finding about the same
+    port. Comparing it would report a disagreement that only exists between
+    two renderings of one configuration.
+
+    Counting rather than set-ing keeps the discrimination that matters: a merge
+    that drops one of two mounts, or duplicates one, changes the count even
+    when the rule and service are unchanged.
+    """
+    return Counter(
+        (f.rule_id, str(f.service)) for f in run_rules(data, lines) if not f.suppressed
+    )
+
+
+@pytest.mark.parametrize("seed", SEEDS)
+def test_generated_pair_matches_docker_compose(seed: int, tmp_path: Path) -> None:
+    """A generated base/overlay pair yields the findings Compose's merge would."""
+    rng = random.Random(seed)  # noqa: S311 - fixture generation, not security
+    base_fields, over_fields = _pick(rng)
+
+    base_text = _render(base_fields, with_image=True)
+    over_text = _render(over_fields, with_image=False)
+    (tmp_path / "compose.yml").write_text(base_text)
+    (tmp_path / "compose.override.yml").write_text(over_text)
+
+    result = subprocess.run(
+        ["docker", "compose", "config"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        # An invalid combination is not a merge disagreement. Compose refuses to
+        # run it, so compose-lint's answer for it cannot mis-grade anything.
+        pytest.skip(f"compose rejected seed {seed}: {result.stderr.strip()[:120]}")
+
+    truth_file = tmp_path / "truth.yml"
+    truth_file.write_text(result.stdout)
+    truth_data, truth_lines = load_compose(truth_file)
+    expected = _findings_of(truth_data, truth_lines)
+
+    merged = load_merged([tmp_path / "compose.yml", tmp_path / "compose.override.yml"])
+    actual = _findings_of(merged.data, merged.lines)
+
+    assert actual == expected, (
+        f"seed {seed}: merge disagrees with docker compose\n"
+        f"--- compose.yml ---\n{base_text}"
+        f"--- compose.override.yml ---\n{over_text}"
+        f"  only ours:   {sorted((actual - expected).elements())}\n"
+        f"  only theirs: {sorted((expected - actual).elements())}"
+    )

--- a/tests/test_merge_semantics.py
+++ b/tests/test_merge_semantics.py
@@ -1,0 +1,346 @@
+"""Differential test: does our merge agree with Docker Compose itself?
+
+The merge table in ``compose_lint._merge`` was derived by probing
+``docker compose config``. Comments rot; this suite re-derives the same
+behaviour from the real binary on every run, so a Compose release that changes
+a merge rule fails here rather than silently mis-grading a user's stack.
+
+The comparison is on **findings**, not on document shape. ``docker compose
+config`` normalises what it emits (short volume syntax to long, list
+``environment`` to a mapping, ports to structured entries) and our merge
+deliberately does not, because rules read the spelling the user typed. Linting
+both and comparing the finding sets asks the question that actually matters:
+would a user be told the same thing either way?
+
+Skipped when the ``docker compose`` CLI is unavailable, so the suite still runs
+in environments without it.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+from compose_lint.engine import run_rules
+from compose_lint.parser import load_compose, load_merged
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("docker") is None,
+    reason="differential merge test needs the docker compose CLI",
+)
+
+
+def _compose_config(directory: Path) -> str:
+    """Ground truth: the effective configuration Compose itself resolves."""
+    result = subprocess.run(
+        ["docker", "compose", "config"],
+        cwd=directory,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        pytest.skip(f"compose rejected the fixture: {result.stderr.strip()[:200]}")
+    return result.stdout
+
+
+def _findings_of(data: dict, lines: dict[str, int]) -> set[tuple[str, str, str | None]]:
+    return {
+        (f.rule_id, f.service, f.evidence)
+        for f in run_rules(data, lines)
+        if not f.suppressed
+    }
+
+
+def _write_pair(directory: Path, base: str, override: str) -> None:
+    (directory / "compose.yml").write_text(base)
+    (directory / "compose.override.yml").write_text(override)
+
+
+BASE_HARDENED = """\
+services:
+  web:
+    image: myapp:1.0
+    security_opt: [no-new-privileges:true]
+    cap_drop: [ALL]
+    read_only: true
+    mem_limit: 512m
+    cpus: 0.5
+    user: "1000:1000"
+"""
+
+# (id, base, override) — each exercises one merge strategy that a naive
+# recursive merge gets wrong.
+CASES = [
+    (
+        "override-adds-socket-and-port",
+        BASE_HARDENED,
+        """\
+services:
+  web:
+    ports: ["8080:80"]
+    volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+""",
+    ),
+    (
+        "override-replaces-mount-at-same-target",
+        """\
+services:
+  web:
+    image: myapp:1.0
+    volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+""",
+        """\
+services:
+  web:
+    volumes: ["/tmp/harmless:/var/run/docker.sock"]
+""",
+    ),
+    (
+        "override-adds-mount-at-new-target",
+        """\
+services:
+  web:
+    image: myapp:1.0
+    volumes: ["/app:/app"]
+""",
+        """\
+services:
+  web:
+    volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+""",
+    ),
+    (
+        "override-relaxes-hardening",
+        BASE_HARDENED,
+        """\
+services:
+  web:
+    read_only: false
+    privileged: true
+""",
+    ),
+    (
+        "cap-add-dedup-and-append",
+        """\
+services:
+  web:
+    image: myapp:1.0
+    cap_drop: [ALL]
+    cap_add: [SYS_ADMIN]
+""",
+        """\
+services:
+  web:
+    cap_add: [SYS_ADMIN, NET_ADMIN]
+""",
+    ),
+    (
+        "device-replaced-at-same-target",
+        """\
+services:
+  web:
+    image: myapp:1.0
+    devices: ["/dev/mem:/dev/probe"]
+""",
+        """\
+services:
+  web:
+    devices: ["/dev/null:/dev/probe"]
+""",
+    ),
+    (
+        "security-opt-appends",
+        """\
+services:
+  web:
+    image: myapp:1.0
+    security_opt: ["no-new-privileges:true"]
+""",
+        """\
+services:
+  web:
+    security_opt: ["seccomp:unconfined"]
+""",
+    ),
+    (
+        "ports-same-target-different-host-port",
+        """\
+services:
+  web:
+    image: myapp:1.0
+    ports: ["127.0.0.1:8080:80"]
+""",
+        """\
+services:
+  web:
+    ports: ["9999:80"]
+""",
+    ),
+    (
+        "service-only-in-override",
+        """\
+services:
+  web:
+    image: myapp:1.0
+""",
+        """\
+services:
+  extra:
+    image: other:1.0
+    privileged: true
+""",
+    ),
+    (
+        "environment-map-plus-list",
+        """\
+services:
+  web:
+    image: myapp:1.0
+    environment: {AWS_SECRET_ACCESS_KEY: "AKIAIOSFODNN7EXAMPLE"}
+""",
+        """\
+services:
+  web:
+    environment: ["OTHER=1"]
+""",
+    ),
+    (
+        "reset-removes-inherited-hardening",
+        BASE_HARDENED,
+        """\
+services:
+  web:
+    read_only: !reset null
+    cap_drop: !reset null
+""",
+    ),
+    (
+        "reset-removes-inherited-socket",
+        """\
+services:
+  web:
+    image: myapp:1.0
+    volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+""",
+        """\
+services:
+  web:
+    volumes: !reset null
+""",
+    ),
+    (
+        "logging-driver-swap-drops-options",
+        """\
+services:
+  web:
+    image: myapp:1.0
+    logging: {driver: "json-file", options: {max-size: "1m"}}
+""",
+        """\
+services:
+  web:
+    logging: {driver: "none"}
+""",
+    ),
+]
+
+
+@pytest.mark.parametrize("case_id,base,override", CASES, ids=[c[0] for c in CASES])
+def test_merge_matches_docker_compose(
+    case_id: str, base: str, override: str, tmp_path: Path
+) -> None:
+    """Our merged document yields the findings Compose's own merge would."""
+    _write_pair(tmp_path, base, override)
+
+    # Ground truth: lint the configuration Compose says it will run.
+    truth_file = tmp_path / "truth.yml"
+    truth_file.write_text(_compose_config(tmp_path))
+    truth_data, truth_lines = load_compose(truth_file)
+    expected = _findings_of(truth_data, truth_lines)
+
+    merged = load_merged([tmp_path / "compose.yml", tmp_path / "compose.override.yml"])
+    actual = _findings_of(merged.data, merged.lines)
+
+    assert actual == expected, (
+        f"{case_id}: merge disagrees with docker compose\n"
+        f"  only ours:   {sorted(actual - expected)}\n"
+        f"  only theirs: {sorted(expected - actual)}"
+    )
+
+
+def test_provenance_points_at_the_contributing_file(tmp_path: Path) -> None:
+    """A finding's evidence must be attributable to the file that wrote it."""
+    _write_pair(
+        tmp_path,
+        BASE_HARDENED,
+        "services:\n  web:\n"
+        '    volumes: ["/var/run/docker.sock:/var/run/docker.sock"]\n',
+    )
+    merged = load_merged([tmp_path / "compose.yml", tmp_path / "compose.override.yml"])
+
+    # The socket mount came from the override...
+    assert merged.sources["services.web.volumes[0]"].endswith("compose.override.yml")
+    assert merged.lines["services.web.volumes[0]"] == 3
+    # ...while untouched hardening still points at the base file.
+    assert merged.sources["services.web.read_only"].endswith("compose.yml")
+    assert merged.lines["services.web.read_only"] == 6
+
+
+def test_merge_is_order_sensitive(tmp_path: Path) -> None:
+    """Swapping the documents swaps which value wins — merge is not a union."""
+    _write_pair(
+        tmp_path,
+        "services:\n  web:\n    image: a:1\n    read_only: true\n",
+        "services:\n  web:\n    read_only: false\n",
+    )
+    forward = load_merged([tmp_path / "compose.yml", tmp_path / "compose.override.yml"])
+    backward = load_merged(
+        [tmp_path / "compose.override.yml", tmp_path / "compose.yml"]
+    )
+    assert forward.data["services"]["web"]["read_only"] is False
+    assert backward.data["services"]["web"]["read_only"] is True
+
+
+# Fields Compose emits as plain string lists, unnormalised, so our merged value
+# can be compared to its output directly. Findings-level comparison is blind to
+# these: a rule reads `cap_add` as a set, so a duplicated entry changes nothing
+# it reports. Shape comparison is the only thing that pins append-order and
+# deduplication.
+VERBATIM_LIST_FIELDS = ["cap_add", "cap_drop", "dns", "expose", "tmpfs"]
+
+
+@pytest.mark.parametrize("field_name", VERBATIM_LIST_FIELDS)
+def test_append_fields_match_compose_shape(field_name: str, tmp_path: Path) -> None:
+    """Append-style sequences keep Compose's order and its deduplication."""
+    values = {
+        "cap_add": (["SYS_ADMIN", "NET_ADMIN"], ["NET_ADMIN", "SYS_PTRACE"]),
+        "cap_drop": (["ALL"], ["ALL", "NET_RAW"]),
+        "dns": (["1.1.1.1"], ["1.1.1.1", "8.8.8.8"]),
+        "expose": (['"80"'], ['"80"', '"90"']),
+        "tmpfs": (["/tmp"], ["/tmp", "/run"]),
+    }[field_name]
+    base_list = "[" + ", ".join(values[0]) + "]"
+    over_list = "[" + ", ".join(values[1]) + "]"
+    _write_pair(
+        tmp_path,
+        f"services:\n  web:\n    image: myapp:1.0\n    {field_name}: {base_list}\n",
+        f"services:\n  web:\n    {field_name}: {over_list}\n",
+    )
+
+    truth_file = tmp_path / "truth.yml"
+    truth_file.write_text(_compose_config(tmp_path))
+    truth_data, _ = load_compose(truth_file)
+    expected = truth_data["services"]["web"].get(field_name)
+
+    merged = load_merged([tmp_path / "compose.yml", tmp_path / "compose.override.yml"])
+    actual = merged.data["services"]["web"].get(field_name)
+
+    # Compose stringifies numeric-looking entries; compare as strings.
+    assert [str(v) for v in actual] == [str(v) for v in expected]

--- a/tests/test_merge_semantics.py
+++ b/tests/test_merge_semantics.py
@@ -344,3 +344,140 @@ def test_append_fields_match_compose_shape(field_name: str, tmp_path: Path) -> N
 
     # Compose stringifies numeric-looking entries; compare as strings.
     assert [str(v) for v in actual] == [str(v) for v in expected]
+
+
+# Every field whose merge strategy differs, crossed with every Compose merge
+# directive. Hand-picked cases test what the author thought of: `!override` was
+# probed while deriving the table above, was not turned into a case, and the
+# merge shipped ignoring it — an overlay dropping `no-new-privileges` via
+# `security_opt: !override [...]` left the base's entry visible, so the absence
+# rule stayed silent on hardening Compose had removed. The matrix below is
+# mechanical precisely so it does not depend on remembering.
+DIRECTIVE_FIELDS = [
+    # (field, base value, override value) — the override is the interesting half
+    (
+        "volumes",
+        '["/var/run/docker.sock:/var/run/docker.sock"]',
+        '["/tmp/safe:/var/run/docker.sock"]',
+    ),
+    ("volumes", '["/app:/app"]', '["/var/run/docker.sock:/var/run/docker.sock"]'),
+    ("devices", '["/dev/mem:/dev/probe"]', '["/dev/null:/dev/probe"]'),
+    ("ports", '["127.0.0.1:8080:80"]', '["9999:80"]'),
+    ("cap_add", "[SYS_ADMIN]", "[NET_ADMIN]"),
+    ("cap_drop", "[ALL]", "[NET_RAW]"),
+    ("security_opt", '["no-new-privileges:true"]', '["seccomp:unconfined"]'),
+    ("tmpfs", '["/tmp"]', '["/run:exec"]'),
+    ("environment", '{AWS_SECRET_ACCESS_KEY: "AKIAIOSFODNN7EXAMPLE"}', '{OTHER: "1"}'),
+    ("read_only", "true", "false"),
+    ("privileged", "false", "true"),
+    ("logging", '{driver: "json-file"}', '{driver: "none"}'),
+]
+
+DIRECTIVES = ["", "!override ", "!reset "]
+
+MATRIX = [
+    (
+        f"{field}-{directive.strip() or 'plain'}",
+        field,
+        base_value,
+        directive,
+        over_value,
+    )
+    for field, base_value, over_value in DIRECTIVE_FIELDS
+    for directive in DIRECTIVES
+]
+
+
+@pytest.mark.parametrize(
+    "case_id,field,base_value,directive,over_value",
+    MATRIX,
+    ids=[c[0] for c in MATRIX],
+)
+def test_field_and_directive_matrix_matches_compose(
+    case_id: str,
+    field: str,
+    base_value: str,
+    directive: str,
+    over_value: str,
+    tmp_path: Path,
+) -> None:
+    """Each merge strategy under each directive agrees with Compose itself."""
+    # `!reset` takes null: the directive deletes the key, so the value is moot
+    # and a typed one is rejected by the schema.
+    value = "null" if directive.startswith("!reset") else over_value
+    _write_pair(
+        tmp_path,
+        f"services:\n  web:\n    image: myapp:1.0\n    {field}: {base_value}\n",
+        f"services:\n  web:\n    {field}: {directive}{value}\n",
+    )
+
+    truth_file = tmp_path / "truth.yml"
+    truth_file.write_text(_compose_config(tmp_path))
+    truth_data, truth_lines = load_compose(truth_file)
+    expected = _findings_of(truth_data, truth_lines)
+
+    merged = load_merged([tmp_path / "compose.yml", tmp_path / "compose.override.yml"])
+    actual = _findings_of(merged.data, merged.lines)
+
+    assert actual == expected, (
+        f"{case_id}: merge disagrees with docker compose\n"
+        f"  only ours:   {sorted(actual - expected)}\n"
+        f"  only theirs: {sorted(expected - actual)}"
+    )
+
+
+def test_three_documents_each_keep_their_own_provenance(tmp_path: Path) -> None:
+    """Folding N documents must not credit the accumulator's first file.
+
+    With two documents the base side is a real single file, so a single `path`
+    is right and nothing notices it is a simplification. From three on, the
+    accumulator is a mixture: `ports` supplied by the middle document was
+    attributed to the first, which would point a finding at an unrelated line
+    of an unrelated file. Only reachable once more than one overlay is merged —
+    which `COMPOSE_FILE` support would do — so it is pinned before it is used.
+    """
+    (tmp_path / "a.yml").write_text(
+        "services:\n  web:\n    image: a:1\n    read_only: true\n"
+    )
+    (tmp_path / "b.yml").write_text('services:\n  web:\n    ports: ["8080:80"]\n')
+    (tmp_path / "c.yml").write_text(
+        "services:\n  web:\n"
+        '    volumes: ["/var/run/docker.sock:/var/run/docker.sock"]\n'
+    )
+
+    merged = load_merged([tmp_path / "a.yml", tmp_path / "b.yml", tmp_path / "c.yml"])
+
+    assert merged.sources["services.web.image"].endswith("a.yml")
+    assert merged.sources["services.web.ports[0]"].endswith("b.yml")
+    assert merged.sources["services.web.volumes[0]"].endswith("c.yml")
+    # And the line travels with the file, not with the accumulator.
+    assert merged.lines["services.web.ports[0]"] == 3
+    assert merged.lines["services.web.volumes[0]"] == 3
+
+
+def test_three_document_merge_matches_docker_compose(tmp_path: Path) -> None:
+    """The N-document fold agrees with `-f a -f b -f c`, not just with a pair."""
+    (tmp_path / "a.yml").write_text(
+        "services:\n  web:\n    image: a:1\n"
+        "    security_opt: [no-new-privileges:true]\n    read_only: true\n"
+    )
+    (tmp_path / "b.yml").write_text('services:\n  web:\n    ports: ["8080:80"]\n')
+    (tmp_path / "c.yml").write_text("services:\n  web:\n    read_only: false\n")
+
+    result = subprocess.run(
+        ["docker", "compose", "-f", "a.yml", "-f", "b.yml", "-f", "c.yml", "config"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        pytest.skip(f"compose rejected the fixture: {result.stderr.strip()[:200]}")
+    truth_file = tmp_path / "truth.yml"
+    truth_file.write_text(result.stdout)
+    truth_data, truth_lines = load_compose(truth_file)
+
+    merged = load_merged([tmp_path / "a.yml", tmp_path / "b.yml", tmp_path / "c.yml"])
+    assert _findings_of(merged.data, merged.lines) == _findings_of(
+        truth_data, truth_lines
+    )

--- a/tests/test_overlay_merge.py
+++ b/tests/test_overlay_merge.py
@@ -1,0 +1,206 @@
+"""End-to-end behaviour when Compose would merge an overlay into a base file.
+
+`docker compose up` with no `-f` loads `compose.yml` *and* a sibling
+`compose.override.yml`, merged, with no flag and no opt-in. These tests pin what
+compose-lint does about that: it lints the merged configuration, says so, and
+never lets `fix` write to a file whose findings it cannot attribute.
+
+The merge itself is verified against the real Compose binary in
+`test_merge_semantics.py`; this suite is about the CLI surface around it.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+BASE_HARDENED = """\
+services:
+  web:
+    image: myapp:1.0
+    security_opt: [no-new-privileges:true]
+    cap_drop: [ALL]
+    read_only: true
+    mem_limit: 512m
+    cpus: 0.5
+"""
+
+OVERRIDE_DANGEROUS = """\
+services:
+  web:
+    ports: ["8080:80"]
+    volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+"""
+
+
+def run_cli(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "compose_lint", *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        cwd=cwd,
+    )
+
+
+def _write_pair(directory: Path, base: str, override: str) -> None:
+    (directory / "compose.yml").write_text(base)
+    (directory / "compose.override.yml").write_text(override)
+
+
+def _findings(result: subprocess.CompletedProcess[str]) -> list[dict]:
+    return json.loads(result.stdout)["findings"]
+
+
+def test_socket_mount_in_the_overlay_is_reported(tmp_path: Path) -> None:
+    """The finding that motivates all of this: a CRITICAL that used to be silent.
+
+    Linting the base alone reports nothing about the mount, because the base
+    does not contain it — but the stack that runs does.
+    """
+    _write_pair(tmp_path, BASE_HARDENED, OVERRIDE_DANGEROUS)
+    result = run_cli("check", "--format", "json", "--fail-on", "low", cwd=tmp_path)
+
+    rule_ids = {f["rule_id"] for f in _findings(result)}
+    assert "CL-0001" in rule_ids
+
+
+def test_overlay_absence_findings_are_not_false_positives(tmp_path: Path) -> None:
+    """The overlay omits every hardening key; the base supplies them all.
+
+    Linting the overlay standalone reports four absence findings that the merged
+    configuration disproves. None of them may appear.
+    """
+    _write_pair(tmp_path, BASE_HARDENED, OVERRIDE_DANGEROUS)
+    result = run_cli("check", "--format", "json", "--fail-on", "low", cwd=tmp_path)
+
+    rule_ids = {f["rule_id"] for f in _findings(result)}
+    # no-new-privileges, cap_drop, read_only and resource limits are all set by
+    # the base and survive the merge.
+    assert rule_ids.isdisjoint({"CL-0003", "CL-0006", "CL-0007", "CL-0026"})
+
+
+def test_base_is_graded_against_the_configuration_that_runs(tmp_path: Path) -> None:
+    """The asymmetry that is easy to miss: the *base* is mis-graded too.
+
+    A base with no `read_only` reports CL-0007 on its own. When the overlay
+    supplies `read_only: true`, the deployed container is read-only and the
+    finding must disappear.
+    """
+    _write_pair(
+        tmp_path,
+        "services:\n  web:\n    image: myapp:1.0\n",
+        "services:\n  web:\n    read_only: true\n",
+    )
+    result = run_cli("check", "--format", "json", "--fail-on", "low", cwd=tmp_path)
+
+    assert "CL-0007" not in {f["rule_id"] for f in _findings(result)}
+
+
+def test_merge_is_announced(tmp_path: Path) -> None:
+    """Silence is the thing being fixed, so the merge must be visible."""
+    _write_pair(tmp_path, BASE_HARDENED, OVERRIDE_DANGEROUS)
+    result = run_cli("check", "--fail-on", "low", cwd=tmp_path)
+
+    assert "compose.override.yml" in result.stderr
+    assert "merged" in result.stderr
+
+
+def test_merge_warning_does_not_change_the_exit_code(tmp_path: Path) -> None:
+    """Merging is coverage achieved, not a coverage gap — never exit 2.
+
+    An unresolved `include:` exits 2 because part of the stack was not linted.
+    Here the opposite happened: more of the stack was linted than before. Exit
+    stays finding-driven so a pinned CI pipeline is not broken by the upgrade.
+    """
+    _write_pair(
+        tmp_path,
+        "services:\n  web:\n    image: myapp:1.0@sha256:" + "0" * 64 + "\n",
+        "services:\n  web:\n    read_only: true\n",
+    )
+    result = run_cli("check", "--fail-on", "critical", cwd=tmp_path)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_findings_name_the_file_they_came_from(tmp_path: Path) -> None:
+    """A finding whose evidence is in the overlay must say so.
+
+    Without this the report shows a line number from one file against the name
+    of another, which is worse than not reporting the file at all.
+    """
+    _write_pair(tmp_path, BASE_HARDENED, OVERRIDE_DANGEROUS)
+    result = run_cli("check", "--format", "json", "--fail-on", "low", cwd=tmp_path)
+
+    socket = next(f for f in _findings(result) if f["rule_id"] == "CL-0001")
+    assert socket["source_file"].endswith("compose.override.yml")
+    # Line 4 of the *override*, which is where the mount is written.
+    assert socket["line"] == 4
+
+
+def test_text_excerpt_is_read_from_the_contributing_file(tmp_path: Path) -> None:
+    """The rendered source excerpt must quote the line the finding is about."""
+    _write_pair(tmp_path, BASE_HARDENED, OVERRIDE_DANGEROUS)
+    result = run_cli("check", "--fail-on", "low", cwd=tmp_path)
+
+    assert "/var/run/docker.sock:/var/run/docker.sock" in result.stdout
+    # The base's line 4 is `security_opt:` — quoting it here would be the bug.
+    assert "security_opt: [no-new-privileges:true]" not in result.stdout
+
+
+def test_explicitly_listed_overlay_is_not_linted_standalone(tmp_path: Path) -> None:
+    """`compose-lint *.yml` expands to the overlay; it must still be merged.
+
+    A shell glob is the common way to lint several files, and it is how the
+    standalone false positives reach a user who never typed the overlay's name.
+    """
+    _write_pair(tmp_path, BASE_HARDENED, OVERRIDE_DANGEROUS)
+    result = run_cli(
+        "check",
+        "compose.yml",
+        "compose.override.yml",
+        "--format",
+        "json",
+        "--fail-on",
+        "low",
+        cwd=tmp_path,
+    )
+
+    findings = _findings(result)
+    rule_ids = {f["rule_id"] for f in findings}
+    assert rule_ids.isdisjoint({"CL-0003", "CL-0006", "CL-0007", "CL-0026"})
+    # And the socket is reported exactly once, not once per listed file.
+    assert sum(1 for f in findings if f["rule_id"] == "CL-0001") == 1
+
+
+def test_fix_refuses_to_write_when_an_overlay_is_merged(tmp_path: Path) -> None:
+    """`fix` edits one file; a merged run's findings may belong to the other.
+
+    Adding `read_only: true` to the base is a wrong edit when the overlay turns
+    it off again, so refusing is the only answer that cannot corrupt intent.
+    """
+    _write_pair(
+        tmp_path,
+        "services:\n  web:\n    image: myapp:1.0\n",
+        "services:\n  web:\n    ports: ['8080:80']\n",
+    )
+    before = (tmp_path / "compose.yml").read_text()
+    result = run_cli("fix", "--apply", cwd=tmp_path)
+
+    assert (tmp_path / "compose.yml").read_text() == before
+    assert "skipped" in result.stderr
+    assert "compose.override.yml" in result.stderr
+
+
+def test_no_overlay_means_no_behaviour_change(tmp_path: Path) -> None:
+    """The overwhelmingly common case must be byte-for-byte what it was."""
+    (tmp_path / "compose.yml").write_text(BASE_HARDENED)
+    result = run_cli("check", "--fail-on", "low", cwd=tmp_path)
+
+    assert "merged" not in result.stderr
+    assert "(merged into this run)" not in result.stdout

--- a/tests/test_overlay_merge.py
+++ b/tests/test_overlay_merge.py
@@ -22,6 +22,17 @@ import pytest
 if TYPE_CHECKING:
     from pathlib import Path
 
+
+# `docker compose config` is the only external dependency in this suite, and it
+# is not on the macOS/Windows smoke runners. A decorator rather than an inline
+# check because the inline form ran *after* the subprocess call in one test, so
+# the guard never fired and the runner raised FileNotFoundError instead of
+# skipping — invisible locally, where docker is installed.
+requires_docker = pytest.mark.skipif(
+    shutil.which("docker") is None,
+    reason="needs the docker compose CLI",
+)
+
 BASE_HARDENED = """\
 services:
   web:
@@ -207,6 +218,7 @@ def test_fix_edits_findings_written_in_the_file_it_is_fixing(tmp_path: Path) -> 
     assert "need manual review" in result.stderr
 
 
+@requires_docker
 def test_fix_leaves_a_document_compose_still_accepts(tmp_path: Path) -> None:
     """The patched pair must remain a valid project, not just valid YAML."""
     _write_pair(
@@ -222,8 +234,6 @@ def test_fix_leaves_a_document_compose_still_accepts(tmp_path: Path) -> None:
         capture_output=True,
         text=True,
     )
-    if shutil.which("docker") is None:  # pragma: no cover - environment dependent
-        return
     assert check.returncode == 0, check.stderr
 
 
@@ -351,10 +361,9 @@ def test_every_fixer_runs_on_a_merged_document(tmp_path: Path) -> None:
     assert "need manual review" in result.stderr
 
 
+@requires_docker
 def test_fixed_merged_pair_is_still_a_valid_project(tmp_path: Path) -> None:
     """Compose must accept the pair after every fixer has written to the base."""
-    if shutil.which("docker") is None:  # pragma: no cover - environment dependent
-        pytest.skip("needs the docker compose CLI")
     _write_pair(tmp_path, ALL_FIXERS_BASE, OVERRIDE_SOCKET_ONLY)
     run_cli("fix", "--apply", cwd=tmp_path)
 

--- a/tests/test_overlay_merge.py
+++ b/tests/test_overlay_merge.py
@@ -12,6 +12,7 @@ The merge itself is verified against the real Compose binary in
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
 from typing import TYPE_CHECKING
@@ -178,23 +179,87 @@ def test_explicitly_listed_overlay_is_not_linted_standalone(tmp_path: Path) -> N
     assert sum(1 for f in findings if f["rule_id"] == "CL-0001") == 1
 
 
-def test_fix_refuses_to_write_when_an_overlay_is_merged(tmp_path: Path) -> None:
-    """`fix` edits one file; a merged run's findings may belong to the other.
+def test_fix_edits_findings_written_in_the_file_it_is_fixing(tmp_path: Path) -> None:
+    """`fix` writes the base's own findings and defers the overlay's.
 
-    Adding `read_only: true` to the base is a wrong edit when the overlay turns
-    it off again, so refusing is the only answer that cannot corrupt intent.
+    A finding whose line belongs to this file can be edited here: the line is a
+    line in this text and the fix lands where the user would put it by hand. An
+    absence finding is safe for the same reason — it only fires when the key is
+    missing from the *merged* document, so adding it to the base really does
+    harden what Compose runs.
     """
     _write_pair(
         tmp_path,
-        "services:\n  web:\n    image: myapp:1.0\n",
-        "services:\n  web:\n    ports: ['8080:80']\n",
+        'services:\n  web:\n    image: myapp:1.0\n    ports:\n      - "8080:80"\n',
+        "services:\n  web:\n    volumes:\n"
+        '      - "/var/run/docker.sock:/var/run/docker.sock"\n',
     )
-    before = (tmp_path / "compose.yml").read_text()
+    overlay_before = (tmp_path / "compose.override.yml").read_text()
     result = run_cli("fix", "--apply", cwd=tmp_path)
 
-    assert (tmp_path / "compose.yml").read_text() == before
-    assert "skipped" in result.stderr
-    assert "compose.override.yml" in result.stderr
+    base_after = (tmp_path / "compose.yml").read_text()
+    # The base's own port finding is fixed in place...
+    assert "127.0.0.1:8080:80" in base_after
+    # ...and the overlay is never a write target.
+    assert (tmp_path / "compose.override.yml").read_text() == overlay_before
+    assert "need manual review" in result.stderr
+
+
+def test_fix_leaves_a_document_compose_still_accepts(tmp_path: Path) -> None:
+    """The patched pair must remain a valid project, not just valid YAML."""
+    _write_pair(
+        tmp_path,
+        'services:\n  web:\n    image: myapp:1.0\n    ports:\n      - "8080:80"\n',
+        'services:\n  web:\n    volumes:\n      - "/app:/app"\n',
+    )
+    run_cli("fix", "--apply", cwd=tmp_path)
+
+    check = subprocess.run(
+        ["docker", "compose", "config"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    if shutil.which("docker") is None:  # pragma: no cover - environment dependent
+        return
+    assert check.returncode == 0, check.stderr
+
+
+def test_no_merge_overrides_restores_single_file_grading(tmp_path: Path) -> None:
+    """The opt-out has to reproduce the pre-merge result exactly.
+
+    Someone publishing the base as a template, with the overlay local-only, may
+    legitimately want it graded alone — and the flag is the escape hatch if the
+    merge is ever wrong.
+    """
+    _write_pair(tmp_path, BASE_HARDENED, OVERRIDE_DANGEROUS)
+    result = run_cli(
+        "check",
+        "--no-merge-overrides",
+        "--format",
+        "json",
+        "--fail-on",
+        "low",
+        cwd=tmp_path,
+    )
+
+    rule_ids = {f["rule_id"] for f in _findings(result)}
+    # The overlay is not read, so its socket mount is not seen — the old
+    # behaviour, now reachable only by asking for it.
+    assert "CL-0001" not in rule_ids
+    assert "merged" not in result.stderr
+
+
+def test_banner_names_both_documents(tmp_path: Path) -> None:
+    """The header states what was read, so it must state both files.
+
+    Naming only the base is the complaint this behaviour answers; leaving the
+    banner alone would move the false claim rather than remove it.
+    """
+    _write_pair(tmp_path, BASE_HARDENED, OVERRIDE_DANGEROUS)
+    result = run_cli("check", "--fail-on", "low", cwd=tmp_path)
+
+    assert "files: compose.yml + compose.override.yml" in result.stdout
 
 
 def test_no_overlay_means_no_behaviour_change(tmp_path: Path) -> None:

--- a/tests/test_overlay_merge.py
+++ b/tests/test_overlay_merge.py
@@ -17,6 +17,8 @@ import subprocess
 import sys
 from typing import TYPE_CHECKING
 
+import pytest
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -297,3 +299,148 @@ def test_sarif_offers_no_suggested_fix_on_a_merged_run(tmp_path: Path) -> None:
     results = json.loads(result.stdout)["runs"][0]["results"]
 
     assert all(not r.get("fixes") for r in results)
+
+
+ALL_FIXERS_BASE = """\
+services:
+  web:
+    image: myapp:1.0
+    ports:
+      - "8080:80"
+    security_opt:
+      - seccomp:unconfined
+    logging:
+      driver: "none"
+"""
+
+
+# Contributes an unfixable finding without touching any key the base declares,
+# so every base-side finding keeps base provenance. Using OVERRIDE_DANGEROUS
+# here instead was a fixture bug worth remembering: it republishes the same
+# "8080:80", which under keyed merge means the overlay's entry wins and the
+# CL-0005 finding is correctly deferred rather than fixed.
+OVERRIDE_SOCKET_ONLY = """\
+services:
+  web:
+    volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+"""
+
+
+def test_every_fixer_runs_on_a_merged_document(tmp_path: Path) -> None:
+    """All five fixers, on a base whose overlay contributes an unfixable finding.
+
+    Each fixer reads the *merged* data and edits the base's text, so any of them
+    could splice at a line belonging to the other document. Exercising one of
+    the five and generalising was how the earlier version of this change passed
+    while `verify_apply` was still comparing a merged run against a single-file
+    re-lint.
+    """
+    _write_pair(tmp_path, ALL_FIXERS_BASE, OVERRIDE_SOCKET_ONLY)
+    result = run_cli("fix", "--apply", cwd=tmp_path)
+    after = (tmp_path / "compose.yml").read_text()
+
+    # CL-0005 rebinds the port, CL-0003 adds no-new-privileges, CL-0007 adds
+    # read_only, CL-0009 drops the unconfined profile, CL-0014 drops the
+    # disabled logging driver.
+    assert "127.0.0.1:8080:80" in after
+    assert "no-new-privileges:true" in after
+    assert "read_only: true" in after
+    assert "seccomp:unconfined" not in after
+    assert 'driver: "none"' not in after
+    # The overlay's socket mount is not fixable and must be reported, not edited.
+    assert "need manual review" in result.stderr
+
+
+def test_fixed_merged_pair_is_still_a_valid_project(tmp_path: Path) -> None:
+    """Compose must accept the pair after every fixer has written to the base."""
+    if shutil.which("docker") is None:  # pragma: no cover - environment dependent
+        pytest.skip("needs the docker compose CLI")
+    _write_pair(tmp_path, ALL_FIXERS_BASE, OVERRIDE_SOCKET_ONLY)
+    run_cli("fix", "--apply", cwd=tmp_path)
+
+    check = subprocess.run(
+        ["docker", "compose", "config"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert check.returncode == 0, check.stderr
+
+
+def test_overlay_provenance_findings_are_never_fixed(tmp_path: Path) -> None:
+    """The same rule, written in the overlay, must be left alone.
+
+    CL-0009 has a fixer, so the deferral cannot be explained by the rule being
+    unfixable — only by where the finding is written.
+    """
+    _write_pair(
+        tmp_path,
+        "services:\n  web:\n    image: myapp:1.0\n",
+        "services:\n  web:\n    security_opt:\n      - seccomp:unconfined\n",
+    )
+    overlay_before = (tmp_path / "compose.override.yml").read_text()
+    result = run_cli("fix", "--apply", cwd=tmp_path)
+
+    assert (tmp_path / "compose.override.yml").read_text() == overlay_before
+    assert "seccomp:unconfined" not in (tmp_path / "compose.yml").read_text()
+    assert "need manual review" in result.stderr
+
+
+def test_merged_fix_preserves_crlf_line_endings(tmp_path: Path) -> None:
+    """`fix` writes to user files, and a merged run is a new path into that.
+
+    `fix` reads with `newline=""` so a CRLF file is rewritten with CRLF; the
+    merged path adds a second document to the read, and getting it wrong
+    rewrites every line's ending while the diff shows one.
+    """
+    base = (
+        "services:\r\n  web:\r\n    image: myapp:1.0\r\n"
+        '    ports:\r\n      - "8080:80"\r\n'
+    )
+    (tmp_path / "compose.yml").write_bytes(base.encode())
+    (tmp_path / "compose.override.yml").write_bytes(
+        b'services:\r\n  web:\r\n    volumes:\r\n      - "/app:/app"\r\n'
+    )
+
+    run_cli("fix", "--apply", cwd=tmp_path)
+    after = (tmp_path / "compose.yml").read_bytes()
+
+    assert b"127.0.0.1:8080:80" in after, "the fix did not apply"
+    assert b"\r\n" in after, "CRLF endings were lost"
+    # No line may have been converted to bare LF.
+    assert after.replace(b"\r\n", b"").count(b"\n") == 0, (
+        "mixed endings: some lines were rewritten as LF"
+    )
+
+
+def test_merged_fix_leaves_lf_files_alone(tmp_path: Path) -> None:
+    """The converse: an LF file must not acquire CRLF from the merged path."""
+    _write_pair(
+        tmp_path,
+        'services:\n  web:\n    image: myapp:1.0\n    ports:\n      - "8080:80"\n',
+        'services:\n  web:\n    volumes:\n      - "/app:/app"\n',
+    )
+    run_cli("fix", "--apply", cwd=tmp_path)
+    after = (tmp_path / "compose.yml").read_bytes()
+
+    assert b"127.0.0.1:8080:80" in after
+    assert b"\r\n" not in after
+
+
+def test_a_key_the_overlay_republishes_belongs_to_the_overlay(tmp_path: Path) -> None:
+    """Identical values still move provenance: the overlay's entry is the one that wins.
+
+    The base and overlay both publish `8080:80`. Under keyed merge the overlay's
+    entry replaces the base's, so the CL-0005 finding is written in the overlay
+    and `fix` must defer it rather than editing the base's now-superseded line.
+    """
+    _write_pair(
+        tmp_path,
+        'services:\n  web:\n    image: myapp:1.0\n    ports:\n      - "8080:80"\n',
+        'services:\n  web:\n    ports: ["8080:80"]\n',
+    )
+    result = run_cli("fix", "--apply", cwd=tmp_path)
+
+    assert '- "8080:80"' in (tmp_path / "compose.yml").read_text()
+    assert "127.0.0.1" not in (tmp_path / "compose.yml").read_text()
+    assert "need manual review" in result.stderr

--- a/tests/test_overlay_merge.py
+++ b/tests/test_overlay_merge.py
@@ -423,11 +423,19 @@ def test_merged_fix_preserves_crlf_line_endings(tmp_path: Path) -> None:
 
 
 def test_merged_fix_leaves_lf_files_alone(tmp_path: Path) -> None:
-    """The converse: an LF file must not acquire CRLF from the merged path."""
-    _write_pair(
-        tmp_path,
-        'services:\n  web:\n    image: myapp:1.0\n    ports:\n      - "8080:80"\n',
-        'services:\n  web:\n    volumes:\n      - "/app:/app"\n',
+    """The converse: an LF file must not acquire CRLF from the merged path.
+
+    Written as bytes, not via `_write_pair`. `Path.write_text` opens in text
+    mode, so on Windows it translates the \n in these literals to \r\n and the
+    fixture is not the LF file the test claims to be — which is how the first
+    version of this test failed on the Windows leg while asserting about a
+    CRLF document it had created itself.
+    """
+    (tmp_path / "compose.yml").write_bytes(
+        b'services:\n  web:\n    image: myapp:1.0\n    ports:\n      - "8080:80"\n'
+    )
+    (tmp_path / "compose.override.yml").write_bytes(
+        b'services:\n  web:\n    volumes:\n      - "/app:/app"\n'
     )
     run_cli("fix", "--apply", cwd=tmp_path)
     after = (tmp_path / "compose.yml").read_bytes()

--- a/tests/test_overlay_merge.py
+++ b/tests/test_overlay_merge.py
@@ -204,3 +204,31 @@ def test_no_overlay_means_no_behaviour_change(tmp_path: Path) -> None:
 
     assert "merged" not in result.stderr
     assert "(merged into this run)" not in result.stdout
+
+
+def test_sarif_points_at_the_contributing_file(tmp_path: Path) -> None:
+    """Code Scanning annotates the artifact SARIF names, so it must be right.
+
+    A finding whose line belongs to the overlay, reported against the base
+    file's URI, annotates an unrelated line of an unrelated file.
+    """
+    _write_pair(tmp_path, BASE_HARDENED, OVERRIDE_DANGEROUS)
+    result = run_cli("check", "--format", "sarif", "--fail-on", "low", cwd=tmp_path)
+    results = json.loads(result.stdout)["runs"][0]["results"]
+
+    by_rule = {r["ruleId"]: r["locations"][0]["physicalLocation"] for r in results}
+    socket = by_rule["CL-0001"]
+    assert socket["artifactLocation"]["uri"].endswith("compose.override.yml")
+    assert socket["region"]["startLine"] == 4
+    # A finding whose evidence is in the base keeps the base's URI, so its
+    # partialFingerprints are unchanged (ADR-024).
+    assert by_rule["CL-0019"]["artifactLocation"]["uri"].endswith("compose.yml")
+
+
+def test_sarif_offers_no_suggested_fix_on_a_merged_run(tmp_path: Path) -> None:
+    """`fix` refuses a merged run; SARIF must not offer the same edit anyway."""
+    _write_pair(tmp_path, BASE_HARDENED, OVERRIDE_DANGEROUS)
+    result = run_cli("check", "--format", "sarif", "--fail-on", "low", cwd=tmp_path)
+    results = json.loads(result.stdout)["runs"][0]["results"]
+
+    assert all(not r.get("fixes") for r in results)


### PR DESCRIPTION
Closes #631.

`docker compose up` with no `-f` loads the base file **and** a sibling `compose.override.yml`, merged, with no flag and no opt-in. compose-lint read only the base. On a hardened base with a two-line overlay adding a `/var/run/docker.sock` mount, it reported one MEDIUM about a digest pin — CL-0001, the highest-severity rule in the tool, silent on a stack that would run with the host control socket exposed.

The gap ran both ways. A base with no `read_only` reported CL-0007 on its own; with an overlay supplying `read_only: true` that finding is false. So the base was also being graded against a view nobody deploys.

This implements option C from #631, decided and recorded in **ADR-025**.

## What changes

- `check` and `fix` merge a sibling overlay and grade the result. The header names both documents and a note says what was merged; the exit code is untouched, because merging is coverage *achieved*, not a coverage gap — unlike an unresolved `include:` it must not turn a green pipeline red.
- Findings carry the document their evidence is written in. Text excerpts are read from that file, SARIF points `artifactLocation` there, and JSON gains a conditional `source_file` key (additive — `SCHEMA_VERSION` does not move).
- `fix` edits only findings written in the file it is fixing; the overlay is never a write target. Verification re-merges the candidate, since the properties it checks are properties of the document Compose runs.
- `--no-merge-overrides` opts out, reproducing the previous output exactly.

## The bug fix that came free

`extends:` and multi-file overlays merge **identically** — 12 field behaviours probed against `docker compose config`, all matching — so one table serves both. The existing `_merge_extends` concatenated every sequence, which is wrong for Compose in both, and it was shipping: a service that replaced a socket mount at the same container path was reported CRITICAL for the mount it removed, pointing at the line that removed it.

All 1,949 pre-existing tests pass unchanged, so nothing had encoded the old behaviour.

## Verification

- **Differential vs `docker compose config`** — `test_merge_semantics.py` re-derives the merge table from the real binary on every run rather than trusting comments, comparing *findings* rather than document shapes. Includes a systematic field × directive matrix, because the hand-written case list is what let `!override` ship unhandled.
- **Generative** — `test_merge_fuzz.py` builds base/overlay pairs from a field pool and requires the same findings as Compose. Seeded and enumerated, so a failure names a replayable case. It found a real divergence: an overlay declaring a service with no body is legal Compose, and compose-lint rejected it, failing the whole pair.
- **Mutation-tested** — removing volume keying, `!reset`, `!override`, or append dedup each fails the suite. A differential test that never fails proves nothing.
- **Corpus** — all 5,417 files under both versions: 4,834 linted, 62,380 findings, **0 files changed**, unparsed count unmoved at 583. Note the corpus is structurally blind to overlays (`fetch.py:146` drops any non-canonical filename), so this is a regression instrument, not validation of the overlay path.
- **Real Code Scanning** — a probe in `sarif-ingestion.yml` proves GitHub keeps a result whose `artifactLocation` names a gitignored overlay: 14 uploaded, 14 ingested, no analysis warning, all queryable. The weekly schedule turns it into a regression guard.
- All five fixers exercised on a merged document, the patched pair checked with `docker compose config`, and CRLF covered in both directions.

## Known limitation, accepted

GitHub renders source previews from the commit tree, so an alert located in an untracked overlay shows its location without a code snippet and can never annotate a PR diff. That degrades a panel rather than losing a finding, and it takes an overlay generated during the build to arise at all — a gitignored overlay is absent from a CI checkout, so nothing merges one there. Recorded in `sarif.py` at the decision site.

## Out of scope

`COMPOSE_FILE` and `.env` also change the effective configuration and are still unread — tracked in #646, which turns on whether a file beside the compose file counts as project state or host state under ADR-023. ADR-025 states the boundary explicitly.

## Reviewing

Eleven commits, each independently scoped and messaged; commit-by-commit is the intended path. `e54c9ae` (the `extends:` fix) is decision-independent and can be split into its own PR if you would rather land that first — say the word and I will re-cut it.

The branch keeps its `spike/` name because #631's comments reference it by that name.
