### PR TITLE
Warn when running on Python 3.10, before the floor moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,21 @@ the previous single-file grading exactly.
   merged; findings from the overlay are reported for manual review, and the
   overlay is never a write target.
 
+### Deprecated
+
+- **Python 3.10 is deprecated.** It reaches upstream end-of-life in October
+  2026, and compose-lint will require 3.11 or newer before its 1.0 release.
+  Running on 3.10 now prints a one-line warning to stderr naming the version
+  you are on and the version to pin if you need to stay there. Nothing else
+  changes yet: 3.10 remains in the test matrix and fully supported until the
+  drop lands.
+
+  The warning exists because the drop itself is silent. `requires-python` does
+  not fail an install on an unsupported interpreter — pip resolves to the last
+  release that allowed it, so after the floor moves `pip install -U
+  compose-lint` leaves a 3.10 user on a frozen version with nothing printed in
+  either direction. This is the last chance to say so.
+
 ### Fixed
 
 - CL-0005 includes a non-default protocol in a long-syntax port's evidence.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -132,7 +132,7 @@ Track current CPython: add new minor versions to the CI matrix within ~3 months 
 | 3.13    | 2024-10   | 2029-10   | 0.2.0           |
 | 3.14    | 2025-10   | 2030-10   | 0.3.8           |
 
-Python 3.10 is scheduled to age out of the matrix when it reaches upstream EOL in October 2026 (release bump to 0.4.x or later).
+Python 3.10 ages out of the matrix at its upstream EOL in October 2026. Because dropping a version is a MINOR pre-1.0 and a MAJOR after, the drop lands **before 1.0** rather than being forced into a 2.0 by a routine EOL. Deliberately stated as a milestone rather than a release number: the version that ships it is not chosen yet, and a number written here goes stale (this line promised "0.4.x or later" until 0.21.0). Running on 3.10 warns on stderr from the release that announced the deprecation onward, per [compatibility.md](compatibility.md#deprecation-lifecycle).
 
 ---
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -52,13 +52,14 @@ CI) is a MAJOR.
 ## Deprecation lifecycle
 
 Nothing stable is removed without warning. When a flag, config key, output
-field, or rule is slated for removal:
+field, rule, or supported Python version is slated for removal:
 
 1. **Announce** — mark it deprecated under `Deprecated` in `CHANGELOG.md` and in
    the relevant doc, in the release that introduces the deprecation.
 2. **Warn at runtime** — where the deprecated surface is user-invoked (a flag, a
-   config key), emit a one-line `warning:` to **stderr** when it is used, naming
-   the replacement. Warnings never change exit codes or stdout.
+   config key, the interpreter the tool is running on), emit a one-line
+   `warning:` to **stderr** when it is used, naming the replacement. Warnings
+   never change exit codes or stdout.
 3. **Grace period** — the deprecated surface keeps working for **at least one
    MINOR release** after the announcement.
 4. **Remove** — removal happens only in a **MAJOR** release, listed under
@@ -93,3 +94,12 @@ within ~3 months of its October release (additive), and dropped at upstream
 end-of-life. Dropping a version is a MAJOR change post-1.0. The authoritative
 list is `requires-python` in `pyproject.toml`; see the
 [roadmap](ROADMAP.md#python-version-support) for the schedule.
+
+A drop follows the [deprecation lifecycle](#deprecation-lifecycle) above: the
+release that announces it warns on stderr when run on that interpreter, and the
+drop lands no earlier than the next MINOR. The warning matters more here than
+for a flag, because the removal itself is silent — `requires-python` does not
+fail an install on an unsupported interpreter, it makes pip resolve to the last
+release that allowed it. Without the warning, `pip install -U compose-lint`
+leaves that user on a frozen version indefinitely, with nothing printed in
+either direction.

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -465,9 +465,64 @@ def _utf8_stdio() -> None:
             stream.reconfigure(encoding="utf-8")
 
 
+# The Python version the floor moves to when the current one ages out. Kept as
+# a constant so retiring an interpreter is a one-line edit here plus deleting
+# the warning, rather than a search for version literals in prose.
+_NEXT_PYTHON_FLOOR = (3, 11)
+
+# When the interpreter below the floor reaches upstream end-of-life. Stated as a
+# date rather than a compose-lint release, because that date is fixed by CPython
+# and the release that drops support is not chosen yet — and a version number
+# written into a user-facing string goes stale the moment the schedule moves
+# (docs/ROADMAP.md promised "0.4.x or later" and was still saying it at 0.21.0).
+_PYTHON_EOL = "October 2026"
+
+
+def _dotted(version: tuple[int, ...]) -> str:
+    """Render a version tuple as ``3.10.14``, at whatever length it is."""
+    return ".".join(str(part) for part in version)
+
+
+def _warn_deprecated_python(version: tuple[int, ...] | None = None) -> None:
+    """Warn once when running on an interpreter that is about to be dropped.
+
+    This has to be said by the *last* release that supports the interpreter,
+    because the release after it cannot say anything at all. ``requires-python``
+    does not fail an install on an unsupported version — pip backtracks and
+    resolves to the last release that allowed it. So a 3.10 user who runs
+    ``pip install -U compose-lint`` after the floor moves keeps a frozen linter
+    and a green pipeline, with nothing printed in either direction, and no
+    channel is left through which to tell them. A stderr line here is the only
+    one aimed at exactly the population that is losing support.
+
+    Per ``docs/compatibility.md``'s deprecation lifecycle the warning goes to
+    stderr, names the replacement, and touches neither stdout nor the exit code,
+    so a JSON or SARIF consumer parsing stdout is unaffected.
+
+    ``version`` is injectable so the message can be tested from any interpreter;
+    it defaults to the running one. It is kept as a tuple and sliced rather than
+    unpacked into names, because the arity of ``sys.version_info[:3]`` is not
+    provable to a static analyser — CodeQL's ``py/mismatched-multiple-assignment``
+    reads the slice as a possible 2-tuple and calls the three-name unpacking an
+    error. Indexing is equally readable and true for any length.
+    """
+    running = tuple(sys.version_info[:3]) if version is None else version
+    if running[:2] >= _NEXT_PYTHON_FLOOR:
+        return
+    floor = _dotted(_NEXT_PYTHON_FLOOR)
+    emit(
+        f"warning: Python {_dotted(running[:2])} reaches end-of-life in "
+        f"{_PYTHON_EOL}, and compose-lint will require {floor}+ before its "
+        f"1.0 release. You are on Python {_dotted(running)}.\n"
+        f"Upgrade to {floor}+, or pin compose-lint=={__version__} to stay on "
+        "this line."
+    )
+
+
 def main(argv: list[str] | None = None) -> NoReturn:
     """Main entry point for the CLI."""
     _utf8_stdio()
+    _warn_deprecated_python()
     parser = _build_parser()
     raw = sys.argv[1:] if argv is None else argv
     args = parser.parse_args(_normalize_argv(raw))

--- a/tests/test_python_deprecation.py
+++ b/tests/test_python_deprecation.py
@@ -1,0 +1,83 @@
+"""Tests for the end-of-life warning on the interpreter about to be dropped.
+
+Deleted wholesale when the floor moves — the warning it covers is meant to be
+temporary, and a test that outlives its subject becomes an argument for keeping
+the code.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from compose_lint import __version__
+from compose_lint.cli import _NEXT_PYTHON_FLOOR, _warn_deprecated_python
+
+if TYPE_CHECKING:
+    import pytest
+
+BELOW_FLOOR = (3, 10, 14)
+AT_FLOOR = (*_NEXT_PYTHON_FLOOR, 0)
+
+
+class TestDeprecatedPythonWarning:
+    """The last release supporting an interpreter has to say so."""
+
+    def test_warns_below_the_floor(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _warn_deprecated_python(BELOW_FLOOR)
+        assert "warning:" in capsys.readouterr().err
+
+    def test_silent_at_and_above_the_floor(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _warn_deprecated_python(AT_FLOOR)
+        _warn_deprecated_python((99, 0, 0))
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        assert captured.out == ""
+
+    def test_never_writes_to_stdout(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """A JSON or SARIF consumer parses stdout; the warning must not reach it."""
+        _warn_deprecated_python(BELOW_FLOOR)
+        assert capsys.readouterr().out == ""
+
+    def test_names_the_running_interpreter_exactly(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Down to the patch level, so the user need not go looking for it."""
+        _warn_deprecated_python(BELOW_FLOOR)
+        assert "Python 3.10.14" in capsys.readouterr().err
+
+    def test_pin_advice_is_the_installed_version(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Whatever the user is holding is what they are told to pin.
+
+        A literal here would send everyone to one release regardless of what
+        they had, which is worse advice than none: it is the version *they* are
+        on that still supports their interpreter.
+        """
+        _warn_deprecated_python(BELOW_FLOOR)
+        assert f"compose-lint=={__version__}" in capsys.readouterr().err
+
+    def test_names_no_release_as_the_one_that_drops_support(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The dropping release is not chosen yet, so the message anchors
+        on upstream EOL and the 1.0 milestone instead.
+
+        Guards the acceptance criterion directly: the only ``0.x``-shaped token
+        allowed in the message is the installed version in the pin advice.
+        """
+        _warn_deprecated_python(BELOW_FLOOR)
+        message = capsys.readouterr().err.replace(f"compose-lint=={__version__}", "")
+        assert re.search(r"\b0\.\d+", message) is None
+        assert "end-of-life in October 2026" in message
+        assert "before its 1.0 release" in message
+
+    def test_points_at_the_replacement(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _warn_deprecated_python(BELOW_FLOOR)
+        floor = f"{_NEXT_PYTHON_FLOOR[0]}.{_NEXT_PYTHON_FLOOR[1]}"
+        assert f"Upgrade to {floor}+" in capsys.readouterr().err


### PR DESCRIPTION
Closes #650.

The last release that supports Python 3.10 has to say so, because the release after it cannot. `requires-python` does not fail an install on an unsupported interpreter — pip backtracks and resolves to the last release that allowed it. So once the floor moves, a 3.10 user running `pip install -U compose-lint` keeps a frozen linter behind a green pipeline, with nothing printed in either direction and no channel left through which to tell them.

```
warning: Python 3.10 reaches end-of-life in October 2026, and compose-lint will require 3.11+ before its 1.0 release. You are on Python 3.10.14.
  Upgrade to 3.11+, or pin compose-lint==0.21.0 to stay on this line.
```

**Nothing else changes.** `requires-python`, the CI matrix, the classifiers, and the lockfiles are untouched — 3.10 stays fully supported until #643 lands. Per `docs/compatibility.md`, the warning goes to stderr and touches neither stdout nor the exit code, so JSON and SARIF consumers are unaffected.

### Both version numbers are read at runtime

`sys.version_info` for the interpreter, `__version__` for the pin advice. A literal in the pin would send everyone to one release regardless of what they hold, which is worse than no advice: it is the version *they* are on that still supports their interpreter.

### No release is named as the one that drops support

It is not chosen yet — only "before 1.0" is. The message anchors on upstream EOL and the 1.0 milestone instead, neither of which goes stale. `test_names_no_release_as_the_one_that_drops_support` strips the pin advice and asserts no remaining `0.x` token, so a version cannot be written in later by accident.

`docs/ROADMAP.md` is the cautionary example this follows: it promised a "release bump to 0.4.x or later" and was still promising it at 0.21.0. That line is now stated as a milestone, with a note saying why.

### Policy gap closed

The deprecation lifecycle was scoped to *"a flag, config key, output field, or rule"*, and the Python-versions section set its own MINOR/MAJOR rule without referencing it — so neither section claimed this case. The lifecycle now lists supported Python versions, step 2 names "the interpreter the tool is running on" so *used* has meaning, and the Python-versions section explains why the warning matters more here than for a flag.

### Commits

1. `5cf3baf` — bring interpreter drops under the deprecation lifecycle (`compatibility.md`, `ROADMAP.md`)
2. `68738dd` — the warning itself (`cli.py`, tests, `CHANGELOG.md`)

### Verification

`ruff check src/ tests/`, `ruff format --check src/ tests/`, `mypy src/`, and `pytest` all pass — 2176 passed, 9 skipped, up 7 from the baseline. `scripts/check_changelog_unreleased.py` passes with the new `Deprecated` section.

`tests/test_python_deprecation.py` is written to be deleted wholesale when the floor moves; its module docstring says so, since a test that outlives its subject becomes an argument for keeping the code.
