### PR TITLE
Point the release announcement step at the release notes

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -363,7 +363,14 @@ After approval, `publish` and `docker-publish` run in parallel.
 - [ ] **Fresh `[Unreleased]` section** — already inserted by
       `release-prep.yml` as part of the release bump PR. No follow-up
       PR needed.
-- [ ] Announce in Discussions if the release has user-visible changes.
+- [ ] **Call out user-visible changes in the GitHub release notes** —
+      deprecations, new or tightened rules, and behaviour changes. The
+      release notes are the announcement channel: Discussions are not
+      enabled on this repo, so an item pointing there was one no releaser
+      could ever tick. Findings that are new because coverage tightened
+      deserve a sentence naming the escape hatches (`--fail-on`, pinning),
+      since `docs/compatibility.md` treats them as MINOR rather than
+      breaking and a pinned CI user will meet them without warning.
 
 ## If something goes wrong
 


### PR DESCRIPTION
The last item of the post-release checklist in `docs/RELEASING.md` read:

```
- [ ] Announce in Discussions if the release has user-visible changes.
```

Discussions are not enabled on this repo:

```
$ gh api repos/tmatens/compose-lint --jq '.has_discussions'
false

$ gh api repos/tmatens/compose-lint/discussions
gh: Discussions are disabled for this repo (HTTP 410)
```

So the step asked the releaser to do something they could not do.

**The cost is not the missed announcement.** It is the last box in a long, load-bearing checklist — the easiest one to skip quietly — and a checklist carrying one knowingly-impossible step teaches its reader that the other boxes are advisory too. `RELEASING.md` only works if every item is real, and it has genuinely important ones in it (the Docker Hub token scope, the demo-GIF post-publish ordering, the `uv pip compile` flag form Renovate parses).

The intent behind the step was real and had no other home, so it moves to the channel that already exists — the GitHub release notes — rather than being deleted. Tightened-coverage releases additionally get a pointer to the escape hatches, since `docs/compatibility.md` classes new findings as MINOR and a pinned CI user meets them with no other warning. That applies to the next few releases specifically: the Python 3.10 deprecation (#650) and, later, the `.env` reading in ADR-026 (#646).

### Related, deliberately not fixed here

`.github/ISSUE_TEMPLATE/config.yml` has the same stale assumption, and there it is **user-facing**:

```yaml
  - name: Question or discussion
    url: https://github.com/tmatens/compose-lint/discussions
```

That URL 404s for anyone who clicks it. With `blank_issues_enabled: false` and no question template among `bug_report` / `feature_request` / `rule_proposal`, a user who wants to ask a question currently has no route at all.

Left out of this PR because the fix is a routing decision rather than a stale-doc correction — enable Discussions, allow blank issues, or point the link at something real. Worth its own change either way.

### Verification

Docs-only. `ruff check src/ tests/`, `ruff format --check src/ tests/`, `mypy src/`, and `pytest` all pass (2169 passed, 9 skipped), unchanged from `main`.
