### PR TITLE
Add the .env reader, derived from the Compose binary

### DIFF
--- a/src/compose_lint/_env_file.py
+++ b/src/compose_lint/_env_file.py
@@ -1,0 +1,443 @@
+"""Read the ``.env`` Compose reads beside a Compose file.
+
+Compose loads a ``.env`` from the *project directory* — the first Compose
+file's parent, not the shell's working directory — and uses it for two
+unrelated jobs: supplying interpolation values, and (via ``COMPOSE_FILE``)
+choosing which documents get loaded at all. compose-lint reads it for the same
+two reasons, under [ADR-026](../../docs/adr/026-read-the-sibling-env-file.md):
+*use files as Docker Compose would, when run in that file's directory.*
+
+Every rule below was derived from ``docker compose config`` (Compose 5.4.0,
+client-side, no daemon) rather than from the format's prose, because the
+``.env`` grammar is godotenv's and is nowhere normatively specified for
+Compose. The table is the contract:
+
+==========================  ==========================  ====================
+written                     Compose ships               note
+==========================  ==========================  ====================
+``K=v``                     ``v``
+``K = v``                   ``v``                       key and value trimmed
+``export K=v``              ``v``                       prefix consumed
+``K="v w"``                 ``v w``                     quotes stripped
+``K='v w'``                 ``v w``                     quotes stripped
+``K=v # trail``             ``v``                       unquoted: comment
+``K="v # trail"``           ``v # trail``               quoted: literal
+``K=``                      empty
+``K``                       empty                       key with no ``=``
+``K=a=b``                   ``a=b``                     first ``=`` splits
+``K=first`` then ``K=…``    last one wins
+``K="a\\nb"``                ``a``/newline/``b``          double: escapes
+``K='a\\nb'``                ``a\\nb``                    single: literal
+``K=a\\nb``                  ``a\\nb``                    unquoted: literal
+``A=one`` / ``K=${A}-two``  ``one-two``                 expands, in order
+``A=one`` / ``K=$A-two``    ``one-two``                 bare form too
+``K='${A}'``                ``${A}``                    single: no expansion
+``K=${LATER}`` first        empty                       **no forward refs**
+``K=${MISSING:-d}``         ``d``                       defaults apply
+``K=a$$b``                  ``a$b``                     ``$$`` escapes a dollar
+==========================  ==========================  ====================
+
+The values returned are what Compose *ships*, not how ``docker compose config``
+prints them. That command re-escapes a literal dollar on output so its own
+document round-trips — a value of ``a$b`` is printed ``a$$b`` — so a caller
+comparing against ``config`` output has to decode it, and a caller injecting one
+of these values into a document must not run interpolation over it again.
+
+Two deliberate divergences from Compose, both required by ADR-026:
+
+1. **No process-environment fallback.** Compose resolves a reference it cannot
+   find in the ``.env`` against the shell, so a ``.env`` carrying
+   ``DATA=${HOME}/data`` imports the lint host's environment — the exact
+   leak [ADR-023](../../docs/adr/023-deploy-host-independent-claims.md)
+   forbids, arriving through a file rather than through an env lookup. Such a
+   value is reported *unresolved* rather than resolved against this machine, so
+   the rule that would have consumed it stays silent. Conservative in the same
+   direction the parser already takes for a defaultless ``${VAR}``.
+
+2. **Malformed lines are skipped, not fatal.** Compose refuses the whole file
+   (``failed to read .env: line 1: key cannot contain a space``) and starts
+   nothing. compose-lint is not the thing being started, and failing a lint run
+   over a stray line in a file the user did not ask us to lint trades a report
+   for nothing. Skipped lines are recorded so a caller can say so.
+
+Only the values a run actually needs are kept, per ADR-026 §5. The bytes are
+still scanned — there is no seeking to one key — so the honest claim is that
+values the run does not need are discarded rather than parsed into it, never
+that the file is not read.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from compose_lint._safe_read import UnsafeFileError, read_text_bounded
+from compose_lint.rules._interpolation import _default_of, _matching_brace
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+    from pathlib import Path
+
+__all__ = ["ENV_FILENAME", "EnvFile", "parse_env", "read_env"]
+
+ENV_FILENAME = ".env"
+
+# A `.env` is a hand-written settings file, not a document. Compose's own is
+# conventionally a few dozen lines; this bounds the pathological case well above
+# anything real, and far below `_safe_read.MAX_FILE_BYTES`, because nothing here
+# needs megabytes and the file is attacker-authorable in a pull request.
+MAX_ENV_BYTES = 256 * 1024
+
+# `export ` is consumed as a prefix, matching godotenv: the file is often
+# `source`d by a shell as well, and the keyword is part of that idiom rather
+# than part of the key.
+_EXPORT_RE = re.compile(r"^\s*export\s+")
+
+# A key Compose accepts. It rejects a key containing a space outright, which is
+# how the malformed case above is detected; anchoring the whole name is a
+# stricter test that also catches the empty key in a leading `=value`.
+_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.-]*$")
+
+# An unquoted value ends at an unescaped `#`, which starts a trailing comment.
+# Quoted values do not -- `K="v # trail"` keeps the hash.
+_UNQUOTED_COMMENT_RE = re.compile(r"\s+#.*$")
+
+# Escapes a double-quoted value processes. Single-quoted and unquoted values
+# carry the backslash through literally (verified: `K=a\nb` ships `a\nb`).
+_DOUBLE_QUOTE_ESCAPES = {
+    "n": "\n",
+    "t": "\t",
+    "r": "\r",
+    '"': '"',
+    "\\": "\\",
+    "$": "$",
+}
+
+
+@dataclass(frozen=True)
+class EnvFile:
+    """What a ``.env`` supplies, narrowed to what the caller asked for.
+
+    ``values`` carries only keys that resolved *and* were wanted. A key whose
+    value referenced something this module will not resolve — an undefined name,
+    a forward reference, or anything that would have come from the process
+    environment — is named in ``unresolved`` instead, so a caller can tell
+    "the file does not set this" from "the file sets this to something we
+    decline to guess". Both mean the same thing to a rule (nothing to
+    substitute); they differ in what the run can honestly say about coverage.
+    """
+
+    values: Mapping[str, str]
+    unresolved: frozenset[str]
+    skipped_lines: tuple[int, ...]
+
+    def __bool__(self) -> bool:
+        return bool(self.values)
+
+
+@dataclass(frozen=True)
+class _Entry:
+    """One ``KEY=value`` as written, before any expansion."""
+
+    key: str
+    raw: str
+    expands: bool  # false for a single-quoted value
+
+
+def read_env(directory: Path, wanted: Iterable[str] | None = None) -> EnvFile | None:
+    """Read ``directory/.env``, or ``None`` if there is not one.
+
+    ``directory`` is the project directory — the Compose file's own parent,
+    which is where Compose looks. A ``.env`` beside the *shell's* working
+    directory is deliberately not consulted: verified that Compose ignores it
+    when ``-f`` names a file elsewhere, and reading it would make the run depend
+    on where it was launched from rather than on the project.
+
+    An unreadable ``.env`` is treated as absent rather than fatal, for the same
+    reason a malformed line is skipped: the file is not the artifact under
+    lint, and a FIFO or an over-cap file committed as one should not take the
+    report down with it.
+    """
+    path = directory / ENV_FILENAME
+    try:
+        text = read_text_bounded(path, max_bytes=MAX_ENV_BYTES)
+    except (FileNotFoundError, UnsafeFileError, UnicodeDecodeError, OSError):
+        return None
+    return parse_env(text, wanted)
+
+
+def parse_env(text: str, wanted: Iterable[str] | None = None) -> EnvFile:
+    """Parse ``.env`` text, resolving only what ``wanted`` needs.
+
+    ``wanted`` is the set of names the run will actually look up. ``None`` means
+    all of them, which is what a test or an exploratory caller wants; a real run
+    passes the fixed ``COMPOSE_*`` allowlist plus the names its Compose
+    documents reference. Whatever is passed is closed over the ``.env``'s own
+    references first, because a wanted value may be built from an unwanted one
+    (``WANTED=${BASE}/docker.sock`` needs ``BASE``), and a filter applied before
+    that closure would silently unresolve it.
+    """
+    entries, skipped = _scan(text)
+    needed = _closure(entries, wanted)
+    values, unresolved = _resolve(entries, needed)
+    return EnvFile(
+        values=values,
+        unresolved=frozenset(unresolved),
+        skipped_lines=tuple(skipped),
+    )
+
+
+def _split_env_lines(text: str) -> list[str]:
+    """Split a ``.env`` the way Compose does: on ``\\n`` alone.
+
+    Deliberately **not** ``str.splitlines()`` and not
+    :func:`compose_lint._lines.split_lines`. Both break on more than Compose
+    does, and here that is a correctness and a security problem rather than a
+    style one. Probed against ``docker compose config``:
+
+    ===========  =========================================================
+    character    Compose
+    ===========  =========================================================
+    ``\\n``       line break
+    ``\\r\\n``     line break (the ``\\r`` is trailing whitespace, trimmed)
+    ``\\r``       **not** a break -- ``K=v\\rJ=w`` sets ``K`` to ``v\\rJ=w``
+    ``\\f``       not a break
+    U+0085       not a break
+    U+2028       not a break
+    ===========  =========================================================
+
+    A splitter that breaks on any of the last four sees entries Compose never
+    sees. That is the same failure the add-only rule in ADR-026 §4 exists to
+    prevent, arriving by a different route: a ``.env`` carrying
+    ``K=v\\rCOMPOSE_FILE=decoy.yml`` would offer compose-lint a ``COMPOSE_FILE``
+    that Compose itself does not read.
+
+    ``str.splitlines()`` is additionally banned in ``src/`` by
+    ``tests/test_line_space_guard.py``, whose reasoning is about agreeing with
+    PyYAML. A ``.env`` is not a YAML document and its authority is godotenv, so
+    this agrees with that authority instead — and satisfies the guard by not
+    calling ``splitlines`` at all.
+    """
+    return text.split("\n")
+
+
+def _scan(text: str) -> tuple[list[_Entry], list[int]]:
+    """Split text into entries as written, plus the lines that are not entries.
+
+    Nothing is expanded here. Separating the scan from the resolution is what
+    lets the closure be computed before any value is built, so an unwanted
+    secret is never assembled — only its raw line is briefly in hand, which is
+    unavoidable for any parser that has to find the key at all.
+    """
+    entries: list[_Entry] = []
+    skipped: list[int] = []
+    # `\ufeff` is a BOM on the first line; Compose tolerates one (verified), and
+    # left in place it would become part of the first key.
+    for number, line in enumerate(_split_env_lines(text.lstrip("\ufeff")), start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        stripped = _EXPORT_RE.sub("", stripped)
+        key, separator, raw = stripped.partition("=")
+        key = key.strip()
+        if not _KEY_RE.match(key):
+            # Compose refuses the whole file here; see the module docstring for
+            # why this does not.
+            skipped.append(number)
+            continue
+        if not separator:
+            # `K` with no `=` ships empty, exactly as `K=` does (verified).
+            entries.append(_Entry(key=key, raw="", expands=False))
+            continue
+        entries.append(_entry(key, raw.strip()))
+    return entries, skipped
+
+
+def _entry(key: str, raw: str) -> _Entry:
+    """Build one entry, applying the quoting rules for its style."""
+    if len(raw) >= 2 and raw[0] == raw[-1] == "'":
+        return _Entry(key=key, raw=raw[1:-1], expands=False)
+    if len(raw) >= 2 and raw[0] == raw[-1] == '"':
+        return _Entry(key=key, raw=_unescape(raw[1:-1]), expands=True)
+    return _Entry(key=key, raw=_UNQUOTED_COMMENT_RE.sub("", raw), expands=True)
+
+
+def _unescape(value: str) -> str:
+    """Process the escapes a double-quoted value carries.
+
+    Only the recognized set is consumed. An unrecognized escape keeps its
+    backslash rather than dropping it, so a Windows path written
+    ``"C:\\Users\\me"`` survives instead of becoming ``C:Usersme``.
+    """
+    out: list[str] = []
+    index = 0
+    while index < len(value):
+        char = value[index]
+        if char == "\\" and index + 1 < len(value):
+            following = value[index + 1]
+            if following in _DOUBLE_QUOTE_ESCAPES:
+                out.append(_DOUBLE_QUOTE_ESCAPES[following])
+                index += 2
+                continue
+        out.append(char)
+        index += 1
+    return "".join(out)
+
+
+def _references(value: str) -> set[str]:
+    """Every name ``value`` interpolates, including inside a default.
+
+    The grammar comes from :mod:`compose_lint.rules._interpolation` so the two
+    readers of ``${...}`` cannot drift; only the question differs. That module
+    asks what a document ships with no ``.env``; this one asks which names a
+    ``.env`` entry depends on.
+    """
+    found: set[str] = set()
+    index = 0
+    while index < len(value):
+        if value[index] != "$" or index + 1 >= len(value):
+            index += 1
+            continue
+        following = value[index + 1]
+        if following == "$":  # escaped literal dollar, not a reference
+            index += 2
+            continue
+        if following == "{":
+            close = _matching_brace(value, index + 1)
+            if close is None:
+                index += 1
+                continue
+            interior = value[index + 2 : close]
+            name = re.match(r"[A-Za-z_][A-Za-z0-9_]*", interior)
+            if name is not None:
+                found.add(name.group())
+            default = _default_of(interior)
+            if default is not None:
+                found |= _references(default)
+            index = close + 1
+            continue
+        name = re.match(r"[A-Za-z_][A-Za-z0-9_]*", value[index + 1 :])
+        if name is not None:
+            found.add(name.group())
+            index += 1 + len(name.group())
+            continue
+        index += 1
+    return found
+
+
+def _closure(entries: list[_Entry], wanted: Iterable[str] | None) -> set[str] | None:
+    """Grow ``wanted`` until it contains everything needed to resolve it.
+
+    ``None`` (meaning "all keys") is passed straight through — there is nothing
+    to close over when nothing is excluded.
+    """
+    if wanted is None:
+        return None
+    by_key = {entry.key: entry for entry in entries}
+    needed = set(wanted)
+    pending = list(needed)
+    while pending:
+        entry = by_key.get(pending.pop())
+        if entry is None or not entry.expands:
+            continue
+        for name in _references(entry.raw):
+            if name not in needed:
+                needed.add(name)
+                pending.append(name)
+    return needed
+
+
+def _resolve(
+    entries: list[_Entry], needed: set[str] | None
+) -> tuple[dict[str, str], set[str]]:
+    """Expand entries in file order, which is the order Compose expands them.
+
+    Order is load-bearing, not incidental: a reference to a key defined *later*
+    resolves to empty in Compose (verified), so resolution is a single forward
+    pass rather than a fixpoint. Here such a reference leaves the value
+    unresolved instead of empty — the divergence in the module docstring — which
+    keeps a value the tool cannot honestly build out of the rules' hands.
+
+    A later duplicate key overwrites an earlier one, and an entry that fails to
+    resolve removes any earlier successful binding for that key, so nothing
+    downstream can read a stale value for a name the file went on to redefine.
+    """
+    values: dict[str, str] = {}
+    unresolved: set[str] = set()
+    for entry in entries:
+        resolved = entry.raw if not entry.expands else _expand(entry.raw, values)
+        if resolved is None:
+            unresolved.add(entry.key)
+            values.pop(entry.key, None)
+            continue
+        unresolved.discard(entry.key)
+        values[entry.key] = resolved
+    if needed is not None:
+        values = {key: value for key, value in values.items() if key in needed}
+        unresolved &= needed
+    return values, unresolved
+
+
+def _expand(value: str, defined: Mapping[str, str]) -> str | None:
+    """Substitute references against ``defined``, or ``None`` if any is unknown.
+
+    ``None`` rather than an empty string is the whole of divergence 1: Compose
+    would fall back to the process environment and then to empty, and both of
+    those answers describe the machine running the lint rather than the project
+    being linted.
+    """
+    out: list[str] = []
+    index = 0
+    while index < len(value):
+        char = value[index]
+        if char != "$" or index + 1 >= len(value):
+            out.append(char)
+            index += 1
+            continue
+        following = value[index + 1]
+        if following == "$":
+            # `$$` is the escape, and the value it produces carries a single
+            # literal dollar: `K=a$$b` ships `a$b`, and `K=a$$A` ships `a$A`
+            # with `A` deliberately not expanded. Verified by decoding
+            # `docker compose config`, which re-escapes a literal dollar on the
+            # way out (it prints `a$$b`) so its own output round-trips.
+            out.append("$")
+            index += 2
+            continue
+        if following == "{":
+            close = _matching_brace(value, index + 1)
+            if close is None:
+                out.append(char)
+                index += 1
+                continue
+            substituted = _substitute(value[index + 2 : close], defined)
+            if substituted is None:
+                return None
+            out.append(substituted)
+            index = close + 1
+            continue
+        name = re.match(r"[A-Za-z_][A-Za-z0-9_]*", value[index + 1 :])
+        if name is None:
+            out.append(char)
+            index += 1
+            continue
+        if name.group() not in defined:
+            return None
+        out.append(defined[name.group()])
+        index += 1 + len(name.group())
+    return "".join(out)
+
+
+def _substitute(interior: str, defined: Mapping[str, str]) -> str | None:
+    """Resolve one ``${...}`` interior against ``defined``."""
+    name = re.match(r"[A-Za-z_][A-Za-z0-9_]*", interior)
+    if name is None:
+        return None
+    key = name.group()
+    if key in defined:
+        return defined[key]
+    default = _default_of(interior)
+    if default is None:
+        return None  # nothing to fall back to but the host's environment
+    return _expand(default, defined)

--- a/tests/test_env_file.py
+++ b/tests/test_env_file.py
@@ -1,0 +1,272 @@
+"""Tests for the ``.env`` reader.
+
+Two halves. The unit tests below pin the behaviour compose-lint promises,
+including the two places it deliberately diverges from Compose. The
+differential suite in ``test_env_semantics.py`` re-derives the grammar from the
+``docker compose`` binary, so a Compose release that changes it fails there
+rather than silently mis-resolving a user's stack.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from typing import TYPE_CHECKING
+
+from compose_lint._env_file import MAX_ENV_BYTES, EnvFile, parse_env, read_env
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+def values(text: str, wanted: list[str] | None = None) -> dict[str, str]:
+    return dict(parse_env(text, wanted).values)
+
+
+class TestGrammar:
+    """The shapes a hand-written ``.env`` comes in."""
+
+    def test_plain_pair(self) -> None:
+        assert values("K=v") == {"K": "v"}
+
+    def test_key_and_value_are_trimmed(self) -> None:
+        assert values("  K  =  v  ") == {"K": "v"}
+
+    def test_export_prefix_is_consumed(self) -> None:
+        assert values("export K=v") == {"K": "v"}
+
+    def test_comments_and_blank_lines_are_ignored(self) -> None:
+        assert values("# note\n\n\t\nK=v\n  # trailing note\n") == {"K": "v"}
+
+    def test_first_equals_splits(self) -> None:
+        assert values("K=a=b") == {"K": "a=b"}
+
+    def test_key_without_equals_is_empty(self) -> None:
+        """Compose ships this as empty rather than leaving the key unset."""
+        assert values("K") == {"K": ""}
+
+    def test_empty_value(self) -> None:
+        assert values("K=") == {"K": ""}
+
+    def test_last_duplicate_wins(self) -> None:
+        assert values("K=first\nK=second") == {"K": "second"}
+
+    def test_crlf_and_bom_are_tolerated(self) -> None:
+        assert values("\ufeffK=v\r\nJ=w\r\n") == {"K": "v", "J": "w"}
+
+
+class TestLineBreaks:
+    """Only ``\\n`` ends a line. Everything else stays inside the value.
+
+    A splitter that breaks on more than Compose does would see entries Compose
+    never reads \u2014 including a ``COMPOSE_FILE`` it never honours, which is the
+    ADR-026 section 4 failure arriving through the lexer.
+    """
+
+    def test_bare_carriage_return_is_not_a_break(self) -> None:
+        assert values("K=v\rJ=w\n") == {"K": "v\rJ=w"}
+
+    def test_form_feed_is_not_a_break(self) -> None:
+        assert values("K=v\fJ=w\n") == {"K": "v\fJ=w"}
+
+    def test_next_line_u0085_is_not_a_break(self) -> None:
+        assert values("K=v\x85J=w\n") == {"K": "v\x85J=w"}
+
+    def test_line_separator_u2028_is_not_a_break(self) -> None:
+        assert values("K=v\u2028J=w\n") == {"K": "v\u2028J=w"}
+
+    def test_a_smuggled_key_is_not_seen(self) -> None:
+        """The case that motivates the rule, stated as itself."""
+        parsed = parse_env("K=v\rCOMPOSE_FILE=decoy.yml\n")
+        assert "COMPOSE_FILE" not in parsed.values
+
+
+class TestQuoting:
+    """Quoting decides three separate things: trailing comments, escapes, expansion."""
+
+    def test_double_quotes_are_stripped(self) -> None:
+        assert values('K="v w"') == {"K": "v w"}
+
+    def test_single_quotes_are_stripped(self) -> None:
+        assert values("K='v w'") == {"K": "v w"}
+
+    def test_unquoted_value_ends_at_a_comment(self) -> None:
+        assert values("K=v # trail") == {"K": "v"}
+
+    def test_quoted_value_keeps_a_hash(self) -> None:
+        assert values('K="v # trail"') == {"K": "v # trail"}
+
+    def test_double_quotes_process_escapes(self) -> None:
+        assert values('K="a\\nb"') == {"K": "a\nb"}
+
+    def test_single_quotes_do_not(self) -> None:
+        assert values("K='a\\nb'") == {"K": "a\\nb"}
+
+    def test_unquoted_does_not(self) -> None:
+        assert values("K=a\\nb") == {"K": "a\\nb"}
+
+    def test_unrecognized_escape_keeps_its_backslash(self) -> None:
+        """A Windows path must survive: dropping the backslash mangles it."""
+        assert values('K="C:\\Users\\me"') == {"K": "C:\\Users\\me"}
+
+
+class TestExpansion:
+    """Expansion runs in file order, against what the file has defined so far."""
+
+    def test_braced_reference(self) -> None:
+        assert values("A=one\nK=${A}-two") == {"A": "one", "K": "one-two"}
+
+    def test_bare_reference(self) -> None:
+        assert values("A=one\nK=$A-two") == {"A": "one", "K": "one-two"}
+
+    def test_single_quotes_suppress_expansion(self) -> None:
+        assert values("A=one\nK='${A}'") == {"A": "one", "K": "${A}"}
+
+    def test_default_applies_when_undefined(self) -> None:
+        assert values("K=${MISSING:-dflt}") == {"K": "dflt"}
+
+    def test_forward_reference_does_not_resolve(self) -> None:
+        """Compose resolves top-down; a later key is not yet defined."""
+        parsed = parse_env("K=${LATER}\nLATER=x")
+        assert "K" not in parsed.values
+        assert "K" in parsed.unresolved
+        assert parsed.values["LATER"] == "x"
+
+    def test_escaped_dollar_ships_one_literal_dollar(self) -> None:
+        assert values("K=a$$b") == {"K": "a$b"}
+
+    def test_escaped_dollar_suppresses_the_reference_after_it(self) -> None:
+        assert values("A=one\nK=a$$A") == {"A": "one", "K": "a$A"}
+
+
+class TestDivergesFromCompose:
+    """The two places mimicking Compose would be wrong. See ADR-026."""
+
+    def test_unknown_reference_is_unresolved_not_empty(self) -> None:
+        """Compose falls back to the shell, then to empty. Both describe the
+        lint host rather than the project, so neither is claimed."""
+        parsed = parse_env("K=${SOME_SHELL_VAR}/tail")
+        assert parsed.values == {}
+        assert parsed.unresolved == {"K"}
+
+    def test_the_process_environment_is_never_consulted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The name is set in this very process, and must still not be found."""
+        monkeypatch.setenv("CL_TEST_ENV_LEAK", "leaked")
+        parsed = parse_env("K=${CL_TEST_ENV_LEAK}")
+        assert "leaked" not in str(parsed.values)
+        assert parsed.unresolved == {"K"}
+
+    def test_malformed_line_is_skipped_not_fatal(self) -> None:
+        """Compose refuses the whole file; a lint run keeps going and says so."""
+        parsed = parse_env("this is not a pair\nK=v\n")
+        assert parsed.values == {"K": "v"}
+        assert parsed.skipped_lines == (1,)
+
+    def test_orphan_equals_is_skipped(self) -> None:
+        parsed = parse_env("=orphan\nK=v\n")
+        assert parsed.values == {"K": "v"}
+        assert parsed.skipped_lines == (1,)
+
+    def test_a_redefinition_that_fails_clears_the_earlier_value(self) -> None:
+        """Nothing downstream should read a value the file went on to replace."""
+        parsed = parse_env("K=good\nK=${UNKNOWN}")
+        assert parsed.values == {}
+        assert parsed.unresolved == {"K"}
+
+
+class TestWantedSetFilter:
+    """Only what the run needs is retained (ADR-026 section 5)."""
+
+    def test_unwanted_keys_are_dropped(self) -> None:
+        text = "SECRET=hunter2\nWANTED=v\n"
+        assert values(text, ["WANTED"]) == {"WANTED": "v"}
+
+    def test_closure_pulls_in_what_a_wanted_value_needs(self) -> None:
+        """WANTED cannot resolve without BASE, so BASE is needed even though
+        the Compose document never names it."""
+        text = "SECRET=hunter2\nBASE=/var/run\nWANTED=${BASE}/docker.sock\n"
+        parsed = parse_env(text, ["WANTED"])
+        assert parsed.values["WANTED"] == "/var/run/docker.sock"
+        assert "SECRET" not in parsed.values
+
+    def test_closure_follows_a_chain(self) -> None:
+        text = "A=1\nB=${A}2\nC=${B}3\nUNUSED=x\n"
+        parsed = parse_env(text, ["C"])
+        assert parsed.values["C"] == "123"
+        assert "UNUSED" not in parsed.values
+
+    def test_closure_reaches_through_a_default(self) -> None:
+        text = "FALLBACK=/fallback\nK=${MISSING:-${FALLBACK}}\n"
+        assert parse_env(text, ["K"]).values["K"] == "/fallback"
+
+    def test_wanting_nothing_keeps_nothing(self) -> None:
+        assert values("SECRET=hunter2", []) == {}
+
+    def test_none_means_everything(self) -> None:
+        assert values("A=1\nB=2", None) == {"A": "1", "B": "2"}
+
+    def test_unresolved_is_narrowed_to_the_wanted_set(self) -> None:
+        parsed = parse_env("OTHER=${NOPE}\nK=v\n", ["K"])
+        assert parsed.unresolved == frozenset()
+
+
+class TestReadEnv:
+    """Reading is bounded, located in the project directory, and never fatal."""
+
+    def test_reads_the_sibling_file(self, tmp_path: Path) -> None:
+        (tmp_path / ".env").write_text("K=v\n", encoding="utf-8", newline="")
+        parsed = read_env(tmp_path)
+        assert parsed is not None
+        assert parsed.values == {"K": "v"}
+
+    def test_absent_file_is_none(self, tmp_path: Path) -> None:
+        assert read_env(tmp_path) is None
+
+    def test_only_the_projects_env_is_read(self, tmp_path: Path) -> None:
+        """A `.env` beside the shell's cwd is not the project's; Compose
+        ignores it, and reading it would make the run depend on where it
+        was launched from."""
+        project = tmp_path / "project"
+        project.mkdir()
+        (tmp_path / ".env").write_text("K=from-cwd\n", encoding="utf-8", newline="")
+        (project / ".env").write_text("K=from-project\n", encoding="utf-8", newline="")
+        parsed = read_env(project)
+        assert parsed is not None
+        assert parsed.values == {"K": "from-project"}
+
+    def test_oversized_file_is_treated_as_absent(self, tmp_path: Path) -> None:
+        (tmp_path / ".env").write_text(
+            "K=" + "x" * (MAX_ENV_BYTES + 1), encoding="utf-8", newline=""
+        )
+        assert read_env(tmp_path) is None
+
+    def test_a_fifo_does_not_hang_the_run(self, tmp_path: Path) -> None:
+        if not hasattr(os, "mkfifo"):
+            return
+        os.mkfifo(tmp_path / ".env")
+        assert stat.S_ISFIFO((tmp_path / ".env").stat().st_mode)
+        assert read_env(tmp_path) is None
+
+    def test_non_utf8_is_treated_as_absent(self, tmp_path: Path) -> None:
+        (tmp_path / ".env").write_bytes(b"K=\xff\xfe\n")
+        assert read_env(tmp_path) is None
+
+    def test_wanted_set_applies_through_read(self, tmp_path: Path) -> None:
+        (tmp_path / ".env").write_text(
+            "SECRET=hunter2\nK=v\n", encoding="utf-8", newline=""
+        )
+        parsed = read_env(tmp_path, ["K"])
+        assert parsed is not None
+        assert parsed.values == {"K": "v"}
+
+
+class TestEnvFile:
+    def test_is_falsy_when_it_supplies_nothing(self) -> None:
+        assert not EnvFile(values={}, unresolved=frozenset(), skipped_lines=())
+
+    def test_is_truthy_when_it_supplies_something(self) -> None:
+        assert EnvFile(values={"K": "v"}, unresolved=frozenset(), skipped_lines=())

--- a/tests/test_env_semantics.py
+++ b/tests/test_env_semantics.py
@@ -1,0 +1,196 @@
+"""Differential test: does our ``.env`` reader agree with Docker Compose?
+
+The grammar in ``compose_lint._env_file`` was derived by probing ``docker
+compose config``, because ``.env`` is godotenv's format and is nowhere
+normatively specified for Compose. Comments rot and probes get forgotten, so
+this re-derives the same behaviour from the real binary on every run: a Compose
+release that changes how a ``.env`` is read fails here rather than silently
+mis-resolving a user's stack.
+
+The comparison is on the **resolved value**, asked the only way Compose will
+answer it — put ``${K}`` in a Compose document, run ``config``, read back what
+came out. That is exactly the question a rule ends up asking.
+
+Cases where we deliberately diverge live in ``test_env_file.py`` and are listed
+in ``DIVERGENT`` below with the reason, so the split is visible in one place
+rather than being an unexplained gap in coverage.
+
+Skipped when the ``docker compose`` CLI is unavailable, so the suite still runs
+in environments without it.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from compose_lint._env_file import parse_env
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _compose_cli_works() -> bool:
+    """Whether ``docker compose`` can actually run, not merely whether it exists.
+
+    ``shutil.which`` alone is not enough: the Windows runners carry a ``docker``
+    on PATH that cannot serve ``compose``, and a bare presence check turned that
+    into a fixture failure rather than a skip.
+    """
+    if shutil.which("docker") is None:
+        return False
+    try:
+        return (
+            subprocess.run(
+                ["docker", "compose", "version"],
+                capture_output=True,
+                timeout=30,
+            ).returncode
+            == 0
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _compose_cli_works(),
+    reason="differential .env test needs a working docker compose CLI",
+)
+
+_COMPOSE = """\
+services:
+  s:
+    image: i
+    environment:
+      OUT: "${K}"
+"""
+
+# Every case is `.env` text defining K. The assertion is that Compose and this
+# module ship the same string for `${K}`.
+AGREED = [
+    pytest.param("K=v", id="plain"),
+    pytest.param("  K  =  v  ", id="trimmed"),
+    pytest.param("export K=v", id="export-prefix"),
+    pytest.param('K="v w"', id="double-quoted"),
+    pytest.param("K='v w'", id="single-quoted"),
+    pytest.param("K=v # trail", id="unquoted-trailing-comment"),
+    pytest.param('K="v # trail"', id="quoted-hash-is-literal"),
+    pytest.param("# note\nK=v", id="leading-comment"),
+    pytest.param("K=", id="empty-value"),
+    pytest.param("K", id="no-equals"),
+    pytest.param("K=a=b", id="first-equals-splits"),
+    pytest.param("K=first\nK=second", id="last-duplicate-wins"),
+    pytest.param('K="a\\nb"', id="double-quote-escapes"),
+    pytest.param("K='a\\nb'", id="single-quote-literal"),
+    pytest.param("K=a\\nb", id="unquoted-literal"),
+    pytest.param("A=one\nK=${A}-two", id="braced-reference"),
+    pytest.param("A=one\nK=$A-two", id="bare-reference"),
+    pytest.param("A=one\nK='${A}'", id="single-quotes-suppress-expansion"),
+    pytest.param("K=${MISSING:-dflt}", id="default-applies"),
+    pytest.param("BASE=/var/run\nK=${BASE}/docker.sock", id="chained"),
+    pytest.param("﻿K=v", id="bom"),
+    pytest.param("K=v\r", id="crlf"),
+    pytest.param("K=v\rJ=w", id="bare-cr-is-not-a-break"),
+    pytest.param("K=v\fJ=w", id="form-feed-is-not-a-break"),
+    pytest.param("K=v\x85J=w", id="u0085-is-not-a-break"),
+    pytest.param("K=v J=w", id="u2028-is-not-a-break"),
+    pytest.param("K=a$$b", id="escaped-dollar"),
+    pytest.param("A=one\nK=a$$A", id="escaped-dollar-suppresses-reference"),
+    pytest.param("K='cost $5 total'", id="literal-dollar-in-single-quotes"),
+]
+
+# Deliberate divergences, with the reason each one exists. Listed rather than
+# omitted so the gap is legible; the behaviour itself is asserted in
+# test_env_file.py.
+DIVERGENT = {
+    "K=${SOME_UNDEFINED_NAME}": (
+        "Compose falls back to the process environment and then to empty; "
+        "both describe the lint host rather than the project (ADR-026)."
+    ),
+    "K=${LATER}\nLATER=x": (
+        "Compose ships empty for a forward reference; we report it unresolved "
+        "rather than claim a value the file does not build."
+    ),
+    "this is not a pair\nK=v": (
+        "Compose refuses the whole file; a lint run skips the line and "
+        "continues, because the .env is not the artifact under lint."
+    ),
+}
+
+
+def _compose_resolves(directory: Path, env_text: str) -> str | None:
+    """Ground truth: what Compose itself substitutes for ``${K}``.
+
+    ``None`` means Compose refused the file. That is a real answer for one of
+    the divergences below, not a broken fixture, so it is returned rather than
+    skipped — an earlier version called ``pytest.skip`` here and the malformed
+    case silently never ran.
+    """
+    # Explicit UTF-8 and no newline translation: the default is the locale
+    # encoding, which is cp1252 on the Windows runners and cannot encode the
+    # BOM or U+0085 these fixtures are made of. A differential test compares
+    # byte-level behaviour, so the bytes must be the ones written here on every
+    # platform rather than whatever the local codec produced.
+    (directory / "compose.yml").write_text(_COMPOSE, encoding="utf-8", newline="")
+    (directory / ".env").write_text(env_text, encoding="utf-8", newline="")
+    result = subprocess.run(
+        ["docker", "compose", "config"],
+        cwd=directory,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        return None
+    document = yaml.safe_load(result.stdout)
+    return _decode_dollars(str(document["services"]["s"]["environment"]["OUT"]))
+
+
+def _decode_dollars(rendered: str) -> str:
+    """Undo the literal-dollar escaping ``config`` applies on the way out.
+
+    ``config`` emits a document that must round-trip through Compose's own
+    interpolation, so a value carrying a literal ``$`` is printed ``$$``. A
+    value of ``${A}`` prints as ``$${A}``. Comparing against the printed form
+    would make the reader assert Compose's *serialisation*, not the value it
+    ships, and would have flagged a correct implementation as a disagreement.
+    """
+    return rendered.replace("$$", "$")
+
+
+@pytest.mark.parametrize("env_text", AGREED)
+def test_agrees_with_compose(env_text: str, tmp_path: Path) -> None:
+    theirs = _compose_resolves(tmp_path, env_text)
+    assert theirs is not None, f"compose refused an AGREED fixture: {env_text!r}"
+    ours = parse_env(env_text, ["K"]).values.get("K", "")
+    assert ours == theirs, (
+        f"disagreement for {env_text!r}: compose ships {theirs!r}, we ship {ours!r}"
+    )
+
+
+@pytest.mark.parametrize("env_text", sorted(DIVERGENT))
+def test_divergences_are_still_divergences(env_text: str, tmp_path: Path) -> None:
+    """The listed cases must keep differing, and for the recorded reason.
+
+    If Compose ever changes to match us, this fails and the entry should move
+    to ``AGREED`` — a divergence that no longer exists is a comment claiming a
+    difference the code no longer makes.
+    """
+    theirs = _compose_resolves(tmp_path, env_text)
+    parsed = parse_env(env_text, ["K"])
+    reason = DIVERGENT[env_text]
+
+    if theirs is None:
+        # Compose refused the whole file. We keep the well-formed lines.
+        assert parsed.values == {"K": "v"}, reason
+        assert parsed.skipped_lines, reason
+        return
+
+    # Compose resolved it to empty by falling back to the host; we decline to.
+    assert theirs == "", reason
+    assert "K" not in parsed.values, f"{reason} -- but we shipped a value"
+    assert parsed.unresolved == {"K"}, reason


### PR DESCRIPTION
First commit of #646, under [ADR-026](https://github.com/tmatens/compose-lint/blob/main/docs/adr/026-read-the-sibling-env-file.md). **Nothing is wired to it yet** — both halves of that decision (`COMPOSE_FILE` selection and interpolation values) need a parser first, so it lands alone and changes no behaviour and no finding.

### Derived from the binary, not from documentation

The `.env` grammar is godotenv's and is nowhere normatively specified for Compose, so every rule was probed against `docker compose config` (5.4.0, client-side, no daemon) and written into a table in the module docstring. `tests/test_env_semantics.py` then re-derives the same behaviour from the real binary on every run — the same discipline `tests/test_merge_semantics.py` applies to the merge table — so a Compose release that changes how a `.env` is read fails there instead of silently mis-resolving a stack.

**Two probes changed the implementation.**

**`$$` is an escape**, so `K=a$$b` ships `a$b` and `K=a$$A` ships `a$A` with `A` deliberately unexpanded. The differential test initially read `docker compose config` output literally and reported a disagreement that wasn't one: that command *re-escapes* a literal dollar on the way out so its own document round-traps (a value of `a$b` prints as `a$$b`). The reader now decodes that, because asserting Compose's serialisation would have flagged a correct implementation as wrong.

**Only `\n` ends a line.** A bare `\r`, a form feed, U+0085 and U+2028 all stay *inside* the value — verified for each. `str.splitlines()` breaks on every one of them, which makes this a security bug rather than a style one:

```python
parse_env("K=v\rCOMPOSE_FILE=decoy.yml\n")   # COMPOSE_FILE must NOT appear
```

A splitter that breaks on `\r` would offer compose-lint a `COMPOSE_FILE` that Compose itself never reads — the ADR-026 §4 failure arriving through the lexer rather than through the file list. Found because `tests/test_line_space_guard.py` bans `str.splitlines()` in `src/`; its stated reason is agreeing with PyYAML, which doesn't apply to a `.env`, but following it to the right authority (godotenv) surfaced the real defect.

### Deliberate divergences, listed rather than omitted

Both are required by ADR-026, and `DIVERGENT` in the differential suite names each with its reason, so the gap in coverage is legible instead of unexplained:

1. **No process-environment fallback** (§3). Compose resolves an unknown reference against the shell, so a `.env` carrying `DATA=${HOME}/data` imports the lint host. Such a value is reported *unresolved* rather than resolved against this machine.
2. **A malformed line is skipped, not fatal** (§5). Compose refuses the whole file (`failed to read .env: line 1: key cannot contain a space`); a lint run keeps the well-formed lines, because the `.env` is not the artifact under lint.

That test also asserts the divergences *remain* divergences — if Compose changes to match, it fails and the case moves to `AGREED`.

### Retention

Only the wanted keys and the closure needed to resolve them are kept (§5): `WANTED=${BASE}/docker.sock` pulls in `BASE` even though no Compose document names it, while a `SECRET` nobody asked for is dropped. Reads go through `read_text_bounded` with a 256 KB cap — a FIFO, an oversized file, or non-UTF-8 is treated as absent rather than taking the run down.

### Verification

`ruff check src/ tests/`, `ruff format --check src/ tests/`, `mypy src/`, and `pytest` all pass — **2258 passed, 9 skipped**, up 82. No CHANGELOG entry: nothing calls this module yet, so there is no user-visible change to announce; that lands with the behaviour.

One note on the differential suite: an earlier version called `pytest.skip` whenever Compose exited non-zero, which silently disabled the malformed-line case — Compose refusing the file *is* the expected result there. It now returns `None` and the test asserts on it, so the suite reports 0 skips rather than a hidden gap.
