### PR TITLE
Select documents the way Compose does, reading COMPOSE_FILE from .env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Upgrading
 
+**A `.env` beside a Compose file now chooses which documents are linted.**
+Compose reads a sibling `.env` for `COMPOSE_FILE`, which replaces its file
+discovery *and* suppresses the automatic `compose.override.yml` merge. compose-
+lint read neither, so a project configured that way had its real documents
+ungraded while an override Compose never loads contributed findings — under a
+warning stating that Compose merges it automatically, which was false there.
+
+Expect the reported file list to change on such projects, in both directions.
+`--no-env` restores the previous selection exactly, including that false merge.
+A `.env` can only *add* documents to a file you named on the command line, never
+remove it, so nothing you asked for is skipped ([ADR-026](docs/adr/026-read-the-sibling-env-file.md)).
+
+
 **Files with a `compose.override.yml` beside them are now graded as the
 configuration Compose runs.** `docker compose up` merges that overlay with no
 flag and no opt-in, and compose-lint read only the base — so a control-socket
@@ -21,6 +34,19 @@ documented MINOR behaviour for tightened coverage; pin the version or gate on
 the previous single-file grading exactly.
 
 ### Added
+- `check` and `fix` read `COMPOSE_FILE` and `COMPOSE_PATH_SEPARATOR` from a
+  `.env` in the Compose file's own directory, select the documents it names, and
+  merge them in its order. The run states what it selected and why on stderr,
+  and the header names every document read. The ambient shell environment stays
+  out of scope: a `COMPOSE_FILE` exported in a session and never written down is
+  host state, and honouring it would make the same checkout lint differently
+  depending on who ran the command. The separator defaults to `:` on every
+  platform rather than to the host's, because a `.env` naming two documents
+  describes the project wherever it is linted from; Compose's own default is
+  the host's path separator, so this deliberately differs on a Windows lint
+  host, in the same direction ADR-023 already took for path semantics.
+- `--no-env` ignores a sibling `.env` entirely, reproducing the previous file
+  selection.
 
 - Contract tests pin the JSON envelope and the SARIF log shape, the two
   surfaces `docs/compatibility.md` freezes at 1.0 that nothing enforced.
@@ -58,6 +84,10 @@ the previous single-file grading exactly.
   either direction. This is the last chance to say so.
 
 ### Fixed
+- An overlay is no longer merged into a project whose `.env` sets
+  `COMPOSE_FILE`. Compose does not load `compose.override.yml` when
+  `COMPOSE_FILE` is set, so those findings described a document that never runs,
+  and the accompanying warning asserted the opposite.
 
 - CL-0005 includes a non-default protocol in a long-syntax port's evidence.
   Two publishings of one container port that differ only by protocol — the

--- a/src/compose_lint/_selection.py
+++ b/src/compose_lint/_selection.py
@@ -1,0 +1,309 @@
+"""Decide which documents a run grades, the way Compose decides it.
+
+``docker compose up`` picks its documents three ways, in this order of
+precedence: an explicit ``-f``, a ``COMPOSE_FILE`` in the environment, and
+otherwise discovery of a canonical filename plus the ``compose.override.yml``
+sitting beside it. compose-lint follows the same shape under
+[ADR-026](../../docs/adr/026-read-the-sibling-env-file.md) — *use files as
+Docker Compose would, when run in that file's directory* — with the ambient
+shell deliberately left out, because a ``COMPOSE_FILE`` exported in someone's
+session and never written down is host state by any reading.
+
+Two consequences are easy to miss and both are load-bearing.
+
+**``COMPOSE_FILE`` suppresses the override merge.** It replaces discovery
+outright, and ``compose.override.yml`` is something discovery finds, so Compose
+does not load it (verified). ADR-025 shipped that merge as unconditional, which
+made compose-lint report findings from a document Compose never reads, under a
+warning asserting that Compose merges it automatically.
+
+**A named file is never dropped.** ADR-026 §4: ``.env`` may *expand* what is
+graded, never shrink it for a file the user named. A runtime does what it is
+told; a gate must not let the artifact under inspection define its own scope,
+which is ShellCheck's reason for refusing to let a checked script enable
+``external-sources`` for itself. Both first-party integrations pass explicit
+file lists — pre-commit appends filenames, ``action.yml`` passes
+``TARGET_FILES`` — so without this rule a contributor could shrink a CI gate by
+committing one file. In bare discovery there is no named file to protect and
+``COMPOSE_FILE`` replaces discovery exactly as Compose does.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING
+
+from compose_lint._env_file import ENV_FILENAME, read_env
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+__all__ = [
+    "COMPOSE_FILE_KEYS",
+    "DocumentGroup",
+    "Selection",
+    "plan_documents",
+]
+
+# The names Compose discovers when nothing selects files for it.
+COMPOSE_FILENAMES = [
+    "compose.yml",
+    "compose.yaml",
+    "docker-compose.yml",
+    "docker-compose.yaml",
+]
+
+# The overlay Compose merges automatically when it sits beside a base file.
+# Compose pairs the spelling: `compose.yml` takes `compose.override.yml`, and
+# `docker-compose.yaml` takes `docker-compose.override.yaml`.
+OVERRIDE_FILENAMES = {
+    "compose.yml": "compose.override.yml",
+    "compose.yaml": "compose.override.yaml",
+    "docker-compose.yml": "docker-compose.override.yml",
+    "docker-compose.yaml": "docker-compose.override.yaml",
+}
+
+# The only keys read from a `.env` for selection. Fixed and tiny on purpose:
+# the wanted-set filter (ADR-026 §5) needs to know what to keep before anything
+# else about the project is known, and this is that list.
+COMPOSE_FILE_KEYS = ("COMPOSE_FILE", "COMPOSE_PATH_SEPARATOR")
+
+# Compose's default separator is the host's path separator, which would make the
+# same `.env` select different documents on a Windows lint host than on the
+# Linux host the stack deploys to. ADR-023 §1 already settled that question for
+# path semantics -- "lexical segment math in POSIX notation on every platform" --
+# and the same reasoning applies: the separator is a property of the project,
+# not of the machine reading it. A Windows drive letter is not a counter-example,
+# because an absolute entry is refused by `_resolve_entry` either way.
+DEFAULT_PATH_SEPARATOR = ":"
+
+
+@dataclass(frozen=True)
+class DocumentGroup:
+    """One project: the file a run reports against, plus what merges into it."""
+
+    primary: str
+    overlays: tuple[str, ...] = ()
+    # Why the overlays are being merged. The report has to say, and the two
+    # reasons are not interchangeable: a discovered override is merged
+    # "because Compose merges it automatically", which is exactly the sentence
+    # that was false when a COMPOSE_FILE was in play.
+    selected_by_env: bool = False
+
+    @property
+    def paths(self) -> list[str]:
+        """Every document in merge order, base first."""
+        return [self.primary, *self.overlays]
+
+
+@dataclass(frozen=True)
+class Selection:
+    """What a run will grade, and what it should say about how it decided."""
+
+    groups: tuple[DocumentGroup, ...] = ()
+    consumed: frozenset[str] = frozenset()
+    notes: tuple[str, ...] = field(default=())
+
+    def is_consumed(self, path: str) -> bool:
+        """Whether ``path`` is already being graded inside another group."""
+        return _key(path) in self.consumed
+
+
+def _key(path: str | Path) -> str:
+    """A stable identity for a path, so the same file is not graded twice."""
+    return str(Path(path).absolute())
+
+
+def plan_documents(
+    files: Iterable[str],
+    *,
+    read_env_files: bool = True,
+    merge_overrides: bool = True,
+) -> Selection:
+    """Group ``files`` into the projects Compose would load them as.
+
+    ``files`` empty means discovery, which is the bare ``compose-lint check``
+    case. ``read_env_files=False`` is ``--no-env`` and reproduces the previous
+    behaviour exactly; ``merge_overrides=False`` is ``--no-merge-overrides``.
+    """
+    named = list(files)
+    if not named:
+        return _plan_discovered(
+            Path(), read_env_files=read_env_files, merge_overrides=merge_overrides
+        )
+    return _plan_named(
+        named, read_env_files=read_env_files, merge_overrides=merge_overrides
+    )
+
+
+def _plan_discovered(
+    directory: Path, *, read_env_files: bool, merge_overrides: bool
+) -> Selection:
+    """Discovery: no file was named, so ``COMPOSE_FILE`` may replace it wholly.
+
+    This is the one path where honouring ``COMPOSE_FILE`` can *reduce* what is
+    graded, and it is safe there precisely because nothing was named — the user
+    asked "what does this project lint to", and the project's own answer is the
+    file list Compose would load.
+    """
+    selected, notes = _compose_file_entries(directory, read_env_files=read_env_files)
+    if selected is not None:
+        return Selection(
+            groups=(
+                DocumentGroup(selected[0], tuple(selected[1:]), selected_by_env=True),
+            ),
+            consumed=frozenset(_key(path) for path in selected[1:]),
+            notes=tuple(notes),
+        )
+    discovered = [name for name in COMPOSE_FILENAMES if (directory / name).is_file()]
+    return _pair_with_overrides(discovered, merge_overrides, notes)
+
+
+def _plan_named(
+    named: list[str], *, read_env_files: bool, merge_overrides: bool
+) -> Selection:
+    """Explicit paths: ``COMPOSE_FILE`` may add documents, never remove one."""
+    groups: list[DocumentGroup] = []
+    consumed: set[str] = set()
+    notes: list[str] = []
+    planned: set[str] = set()
+
+    for path in named:
+        if _key(path) in planned:
+            continue
+        directory = Path(path).parent
+        selected, file_notes = _compose_file_entries(
+            directory, read_env_files=read_env_files
+        )
+        notes.extend(file_notes)
+
+        if selected is None:
+            group = _with_override(path, merge_overrides)
+        elif any(_key(entry) == _key(path) for entry in selected):
+            # The project the .env describes contains this file, so grade the
+            # project. Merge order is COMPOSE_FILE's, not the order the paths
+            # happened to arrive in.
+            group = DocumentGroup(
+                selected[0], tuple(selected[1:]), selected_by_env=True
+            )
+        else:
+            # ADR-026 §4: the named file is not in the project's own list, so
+            # something disagrees. Grade what was asked for, and say so rather
+            # than silently dropping it.
+            notes.append(
+                f"{path}: COMPOSE_FILE in {ENV_FILENAME} does not include this "
+                "file, so it was graded on its own. Nothing was skipped."
+            )
+            group = _with_override(path, merge_overrides)
+
+        groups.append(group)
+        planned.update(_key(entry) for entry in group.paths)
+        consumed.update(_key(entry) for entry in group.overlays)
+
+    return Selection(
+        groups=tuple(groups), consumed=frozenset(consumed), notes=tuple(notes)
+    )
+
+
+def _pair_with_overrides(
+    discovered: list[str], merge_overrides: bool, notes: list[str]
+) -> Selection:
+    """The pre-ADR-026 behaviour: each base file plus its sibling override."""
+    groups = [_with_override(path, merge_overrides) for path in discovered]
+    consumed = {_key(entry) for group in groups for entry in group.overlays}
+    return Selection(
+        groups=tuple(groups), consumed=frozenset(consumed), notes=tuple(notes)
+    )
+
+
+def _with_override(path: str, merge_overrides: bool) -> DocumentGroup:
+    """Pair ``path`` with the overlay Compose would merge into it, if any."""
+    if not merge_overrides:
+        return DocumentGroup(path)
+    base = Path(path)
+    override_name = OVERRIDE_FILENAMES.get(base.name)
+    if override_name is None:
+        return DocumentGroup(path)
+    candidate = base.parent / override_name
+    if not candidate.is_file():
+        return DocumentGroup(path)
+    return DocumentGroup(path, (str(candidate),))
+
+
+def _compose_file_entries(
+    directory: Path, *, read_env_files: bool
+) -> tuple[list[str] | None, list[str]]:
+    """The document list ``directory``'s ``.env`` selects, and what to say.
+
+    ``None`` means no list applies — there is no ``.env``, it sets no
+    ``COMPOSE_FILE``, or the one it sets was refused. A refusal falls back to
+    the default behaviour rather than honouring part of the list, because a
+    partially-honoured ``COMPOSE_FILE`` grades a set Compose never loads, which
+    is the failure this whole mechanism exists to remove.
+    """
+    if not read_env_files:
+        return None, []
+    parsed = read_env(directory, COMPOSE_FILE_KEYS)
+    if parsed is None:
+        return None, []
+    raw = parsed.values.get("COMPOSE_FILE")
+    if not raw:
+        return None, []
+
+    separator = parsed.values.get("COMPOSE_PATH_SEPARATOR") or DEFAULT_PATH_SEPARATOR
+    entries = [part for part in raw.split(separator) if part.strip()]
+    resolved: list[str] = []
+    for entry in entries:
+        candidate = _resolve_entry(directory, entry.strip())
+        if candidate is None:
+            return None, [
+                f"{directory / ENV_FILENAME}: COMPOSE_FILE names {entry.strip()!r}, "
+                "which is outside the project directory or missing, so the whole "
+                "list was ignored and file selection fell back to the default."
+            ]
+        resolved.append(candidate)
+    if not resolved:
+        return None, []
+
+    note = (
+        f"{directory / ENV_FILENAME}: COMPOSE_FILE selects "
+        f"{', '.join(Path(path).name for path in resolved)}"
+    )
+    if len(resolved) > 1:
+        note += ", merged in that order"
+    return resolved, [note + "."]
+
+
+def _resolve_entry(directory: Path, entry: str) -> str | None:
+    """Resolve one ``COMPOSE_FILE`` entry, or ``None`` if it must be refused.
+
+    Refused when the entry is absolute, when it climbs out of the project
+    directory, or when no such file exists. The first two are the traversal
+    guard ADR-026 §4 requires: the ``.env`` is content inside the artifact being
+    linted, and a list that reaches outside the project would let it choose what
+    the linter opens. The third is refused because Compose fails on it too — a
+    project whose ``COMPOSE_FILE`` names a file that is not there does not start.
+
+    The climb test is lexical and POSIX-spelled, matching ADR-023 §1: whether an
+    entry escapes is a property of what it says, not of the lint host's
+    filesystem, and resolving it physically would follow the lint host's
+    symlinks to answer a question about the project.
+    """
+    if os.path.isabs(entry) or (len(entry) > 1 and entry[1] == ":"):
+        return None  # absolute POSIX path, or a Windows drive-qualified one
+    parts: list[str] = []
+    for part in PurePosixPath(entry.replace("\\", "/")).parts:
+        if part == "..":
+            if not parts:
+                return None  # climbs out of the project directory
+            parts.pop()
+        elif part not in (".", ""):
+            parts.append(part)
+    if not parts:
+        return None
+    candidate = directory.joinpath(*parts)
+    if not candidate.is_file():
+        return None
+    return str(candidate)

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -15,7 +15,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn
 
 from compose_lint import __version__
+from compose_lint._env_file import ENV_FILENAME
 from compose_lint._output import emit, emit_block
+from compose_lint._selection import Selection, plan_documents
 from compose_lint.config import ConfigError, load_config
 from compose_lint.config_emit import render_config
 from compose_lint.engine import filter_findings, run_rules
@@ -68,45 +70,29 @@ if TYPE_CHECKING:
     from compose_lint._merge import Merged
 
 
-_COMPOSE_FILENAMES = [
-    "compose.yml",
-    "compose.yaml",
-    "docker-compose.yml",
-    "docker-compose.yaml",
-]
+def _plan(args: argparse.Namespace) -> Selection:
+    """Decide which documents this run grades, and say how it decided.
 
+    Running `docker compose up` with no `-f` loads the base file *and* a sibling
+    `compose.override.yml`, with no flag and no opt-in — unless a `.env` sets
+    `COMPOSE_FILE`, which replaces discovery and suppresses that pairing.
+    Linting the wrong set grades a document nobody deploys in either direction:
+    a socket mount added by an overlay is missed entirely, and an overlay
+    Compose never loads contributes findings against a stack that does not run
+    it.
 
-# The overlay Compose merges automatically when it sits beside a base file.
-# Compose pairs the spelling: `compose.yml` takes `compose.override.yml`, and
-# `docker-compose.yaml` takes `docker-compose.override.yaml`.
-_OVERRIDE_FILENAMES = {
-    "compose.yml": "compose.override.yml",
-    "compose.yaml": "compose.override.yaml",
-    "docker-compose.yml": "docker-compose.override.yml",
-    "docker-compose.yaml": "docker-compose.override.yaml",
-}
-
-
-def _discover_compose_files() -> list[str]:
-    """Find Compose files in the current directory."""
-    return [name for name in _COMPOSE_FILENAMES if Path(name).is_file()]
-
-
-def _sibling_override(filepath: str) -> str | None:
-    """The override Compose would merge into ``filepath``, if it exists.
-
-    Running `docker compose up` with no `-f` loads the base file *and* this
-    overlay, with no flag and no opt-in, so the merged pair is the configuration
-    that actually runs. Linting the base alone grades a document nobody deploys:
-    a socket mount added by the overlay is missed entirely, and the base's own
-    absence findings are judged against hardening the overlay may have removed.
+    The notes are stderr-only and never touch the exit code. What was read and
+    what it selected is the declared input ADR-023 clause 2 requires; a run that
+    silently changed its own file set would be the undeclared kind.
     """
-    base = Path(filepath)
-    override_name = _OVERRIDE_FILENAMES.get(base.name)
-    if override_name is None:
-        return None
-    candidate = base.parent / override_name
-    return str(candidate) if candidate.is_file() else None
+    selection = plan_documents(
+        args.files,
+        read_env_files=not args.no_env,
+        merge_overrides=not args.no_merge_overrides,
+    )
+    for note in selection.notes:
+        emit(f"note: {note}")
+    return selection
 
 
 def _attribute_sources(
@@ -271,6 +257,17 @@ def _add_check_subparser(
             "file is deliberately graded in isolation"
         ),
     )
+    check.add_argument(
+        "--no-env",
+        action="store_true",
+        default=False,
+        help=(
+            "ignore a '.env' sitting beside the Compose file. Compose reads it "
+            "to choose which documents to load (COMPOSE_FILE), so this "
+            "reproduces the previous file selection exactly -- including "
+            "merging an override that COMPOSE_FILE would have suppressed"
+        ),
+    )
     verbosity = check.add_mutually_exclusive_group()
     verbosity.add_argument(
         "-v",
@@ -343,6 +340,17 @@ def _add_fix_subparser(
             "'compose.override.yml' Compose would merge beside it. The merged "
             "view is what actually runs, so this is only right when the base "
             "file is deliberately graded in isolation"
+        ),
+    )
+    fix.add_argument(
+        "--no-env",
+        action="store_true",
+        default=False,
+        help=(
+            "ignore a '.env' sitting beside the Compose file. Compose reads it "
+            "to choose which documents to load (COMPOSE_FILE), so this "
+            "reproduces the previous file selection exactly -- including "
+            "merging an override that COMPOSE_FILE would have suppressed"
         ),
     )
     fix.add_argument(
@@ -591,28 +599,25 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
         emit(f"Error: {e}")
         sys.exit(2)
 
-    if not args.files:
-        args.files = _discover_compose_files()
-        if not args.files:
-            emit(
-                "Error: no Compose files found. Searched for: "
-                "compose.yml, compose.yaml, "
-                "docker-compose.yml, docker-compose.yaml"
-            )
-            sys.exit(2)
-
-    # Pair each base file with the overlay Compose would merge into it. Done
-    # before the sweep so an overlay that is also listed explicitly (a shell
-    # glob expands to it) is linted as part of its pair rather than standalone,
-    # where its absence findings would be false positives against a base that
-    # supplies the hardening.
-    overlay_of: dict[str, str] = {}
-    consumed: set[Path] = set()
-    for candidate in args.files:
-        overlay = None if args.no_merge_overrides else _sibling_override(candidate)
-        if overlay is not None:
-            overlay_of[candidate] = overlay
-            consumed.add(Path(overlay).absolute())
+    selection = _plan(args)
+    if not selection.groups:
+        emit(
+            "Error: no Compose files found. Searched for: "
+            "compose.yml, compose.yaml, "
+            "docker-compose.yml, docker-compose.yaml"
+        )
+        sys.exit(2)
+    args.files = [group.primary for group in selection.groups]
+    overlay_of = {
+        group.primary: list(group.overlays)
+        for group in selection.groups
+        if group.overlays
+    }
+    merge_reason = {
+        group.primary: group.selected_by_env
+        for group in selection.groups
+        if group.overlays
+    }
 
     # Print branded header in text mode before scanning begins. flush=True here
     # (and on the per-file text prints below) keeps block-buffered stdout from
@@ -620,7 +625,7 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
     if args.output_format == "text":
         print(
             format_header(
-                [f for f in args.files if Path(f).absolute() not in consumed],
+                args.files,
                 str(config_path) if config_path else None,
                 args.fail_on,
                 __version__,
@@ -639,23 +644,32 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
     seen_services: set[str] = set()
 
     for filepath in args.files:
-        if Path(filepath).absolute() in consumed:
-            # Linted as the overlay half of a pair below.
-            continue
-        overlay = overlay_of.get(filepath)
+        overlays = overlay_of.get(filepath)
         merged: Merged | None = None
         try:
-            if overlay is not None:
-                merged = load_merged([filepath, overlay])
+            if overlays:
+                merged = load_merged([filepath, *overlays])
                 data, lines = merged.data, merged.lines
                 # Not a coverage gap — coverage was achieved, not missed — so
                 # this warns without touching the exit code. What it must never
                 # do is stay silent: the findings below describe a document that
                 # is not the file named in the report.
+                # The reason is not decoration. "Compose merges it
+                # automatically" is true of a discovered override and false of a
+                # COMPOSE_FILE list, and stating the wrong one is how the
+                # pre-ADR-026 report justified reading a file Compose never
+                # loaded.
+                why = (
+                    f"because COMPOSE_FILE in {ENV_FILENAME} selects them"
+                    if merge_reason.get(filepath)
+                    else "because Compose merges "
+                    + ("them" if len(overlays) > 1 else "it")
+                    + " automatically"
+                )
                 emit(
-                    f"warning: {filepath}: merged {overlay} before linting, "
-                    "because Compose merges it automatically. Findings describe "
-                    "the combined configuration."
+                    f"warning: {filepath}: merged {', '.join(overlays)} before "
+                    f"linting, {why}. Findings describe the combined "
+                    "configuration."
                 )
             else:
                 data, lines = load_compose(filepath)
@@ -910,7 +924,7 @@ def _atomic_write(path: Path, content: str) -> None:
 
 
 def _merged_reparser(
-    filepath: str, overlay: str | None
+    filepath: str, overlays: list[str] | None
 ) -> Callable[[str], tuple[dict[str, Any], dict[str, int]]] | None:
     """Re-parse hook that merges a candidate patch with its overlay.
 
@@ -919,11 +933,11 @@ def _merged_reparser(
     re-merged before the engine sees it. Returns None when nothing is merged,
     which leaves the default single-file re-parse in place.
     """
-    if overlay is None:
+    if not overlays:
         return None
 
     def reparse(candidate: str) -> tuple[dict[str, Any], dict[str, int]]:
-        return merge_patched(candidate, filepath, [overlay])
+        return merge_patched(candidate, filepath, overlays)
 
     return reparse
 
@@ -945,27 +959,20 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
         emit(f"Error: {e}")
         sys.exit(2)
 
-    if not args.files:
-        args.files = _discover_compose_files()
-        if not args.files:
-            emit(
-                "Error: no Compose files found. Searched for: "
-                "compose.yml, compose.yaml, "
-                "docker-compose.yml, docker-compose.yaml"
-            )
-            sys.exit(2)
-
-    # Same pairing as `check`: an overlay listed explicitly is handled as part
-    # of its base's pair rather than fixed on its own.
-    fix_overlay_of: dict[str, str] = {}
-    fix_consumed: set[Path] = set()
-    for candidate_path in args.files:
-        candidate_overlay = (
-            None if args.no_merge_overrides else _sibling_override(candidate_path)
+    selection = _plan(args)
+    if not selection.groups:
+        emit(
+            "Error: no Compose files found. Searched for: "
+            "compose.yml, compose.yaml, "
+            "docker-compose.yml, docker-compose.yaml"
         )
-        if candidate_overlay is not None:
-            fix_overlay_of[candidate_path] = candidate_overlay
-            fix_consumed.add(Path(candidate_overlay).absolute())
+        sys.exit(2)
+    args.files = [group.primary for group in selection.groups]
+    fix_overlay_of = {
+        group.primary: list(group.overlays)
+        for group in selection.groups
+        if group.overlays
+    }
 
     only = set(args.only) if args.only else None
     had_error = False
@@ -973,16 +980,14 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
     touched = False
 
     for filepath in args.files:
-        if Path(filepath).absolute() in fix_consumed:
-            continue
-        overlay = fix_overlay_of.get(filepath)
+        overlays = fix_overlay_of.get(filepath)
         try:
-            if overlay is not None:
-                merged = load_merged([filepath, overlay])
+            if overlays:
+                merged = load_merged([filepath, *overlays])
                 data, lines = merged.data, merged.lines
                 emit(
-                    f"note: {filepath}: merged {overlay} before linting. Only "
-                    "findings written in this file can be fixed here."
+                    f"note: {filepath}: merged {', '.join(overlays)} before "
+                    "linting. Only findings written in this file can be fixed here."
                 )
             else:
                 data, lines = load_compose(filepath)
@@ -1032,8 +1037,8 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
         deferred = len(findings) - len(fixable_findings)
         if deferred:
             emit(
-                f"{filepath}: {deferred} finding(s) come from {overlay} and "
-                "need manual review there"
+                f"{filepath}: {deferred} finding(s) come from "
+                f"{', '.join(overlays or [])} and need manual review there"
             )
         try:
             result = collect_edits(fixable_findings, data, lines, text, only=only)
@@ -1094,8 +1099,8 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
             # the candidate is re-merged with the overlay before they are
             # checked. Verifying the patched base alone would compare a
             # single-file result against a merged one.
-            reparse=_merged_reparser(filepath, overlay),
-            fixable=_is_local if overlay is not None else None,
+            reparse=_merged_reparser(filepath, overlays),
+            fixable=_is_local if overlays else None,
         )
         if verify_error is not None:
             emit_block(render_file_diff(filepath, text, patched, result.caveats))

--- a/src/compose_lint/formatters/text.py
+++ b/src/compose_lint/formatters/text.py
@@ -156,21 +156,25 @@ def format_header(
     config_path: str | None,
     fail_on: Severity,
     version: str,
-    merged: dict[str, str] | None = None,
+    merged: dict[str, list[str]] | None = None,
 ) -> str:
     """Format a branded run header showing the tool version and active parameters.
 
-    ``merged`` maps a base file to the overlay Compose merges into it. The
-    header is the one line that states what was read, so a run that read two
-    documents has to say two: naming only the base was the complaint this
+    ``merged`` maps a base file to the documents merged into it. The header is
+    the one line that states what was read, so a run that read several documents
+    has to say all of them: naming only the base was the complaint this
     behaviour exists to answer, and naming it after the merge lands would just
     move the false claim rather than remove it.
+
+    A list rather than a single overlay because a ``.env`` may set
+    ``COMPOSE_FILE`` and name any number of documents (ADR-026), where the
+    convention-discovered overlay is always at most one.
     """
     sep = _colorize("·", _DIM)
     config_str = _sanitize_line(config_path) if config_path else "none"
     pairs = merged or {}
     shown = [
-        f"{_sanitize_line(f)} + {_sanitize_line(pairs[f])}"
+        " + ".join([_sanitize_line(f), *(_sanitize_line(m) for m in pairs[f])])
         if f in pairs
         else _sanitize_line(f)
         for f in files

--- a/tests/test_discovery_parity.py
+++ b/tests/test_discovery_parity.py
@@ -1,6 +1,6 @@
 """What counts as "a Compose file" is defined in three places (#622).
 
-``_COMPOSE_FILENAMES`` in the CLI, a hand-copied bash list in ``action.yml``,
+``COMPOSE_FILENAMES`` in ``_selection``, a hand-copied bash list in ``action.yml``,
 and a regex in ``.pre-commit-hooks.yaml``. A user who moves between surfaces
 expects the same repository to lint the same way, and nothing held the three
 together.
@@ -34,7 +34,7 @@ from typing import Any
 import pytest
 import yaml
 
-from compose_lint.cli import _COMPOSE_FILENAMES
+from compose_lint._selection import COMPOSE_FILENAMES
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 ACTION = REPO_ROOT / "action.yml"
@@ -91,17 +91,17 @@ def test_the_action_list_is_recognisable() -> None:
 def test_the_action_default_matches_the_cli_exactly() -> None:
     """A hand-copied duplicate is a bug with a delay on it.
 
-    If ``_COMPOSE_FILENAMES`` gains an entry, the action keeps the old list
+    If ``COMPOSE_FILENAMES`` gains an entry, the action keeps the old list
     silently — and reports "no Compose files found" on a repository the CLI
     lints happily.
     """
-    assert _action_default_filenames() == set(_COMPOSE_FILENAMES), (
+    assert _action_default_filenames() == set(COMPOSE_FILENAMES), (
         "action.yml's default discovery list has drifted from "
-        "cli.py's _COMPOSE_FILENAMES; they are the same contract"
+        "_selection.py's COMPOSE_FILENAMES; they are the same contract"
     )
 
 
-@pytest.mark.parametrize("name", _COMPOSE_FILENAMES)
+@pytest.mark.parametrize("name", COMPOSE_FILENAMES)
 def test_the_hook_selects_everything_the_cli_would_lint(name: str) -> None:
     """The hook must never be narrower than the CLI.
 
@@ -122,5 +122,5 @@ def test_the_documented_divergence_is_still_exactly_this(name: str) -> None:
     (and where docs/configuration.md gets updated).
     """
     assert _hook_selects(name), f"the hook no longer selects {name}"
-    assert name not in _COMPOSE_FILENAMES
+    assert name not in COMPOSE_FILENAMES
     assert name not in _action_default_filenames()

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -1,0 +1,259 @@
+"""Tests for which documents a run grades (ADR-026).
+
+The behaviour under test is a security boundary as much as a feature: a `.env`
+is content inside the artifact being linted, so what it is allowed to change
+about the lint's own scope is the whole question. ``TestAddOnly`` is that
+boundary stated as tests.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import PurePath
+from typing import TYPE_CHECKING
+
+import pytest
+
+from compose_lint._selection import plan_documents
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+BASE = "services:\n  web:\n    image: i\n"
+OVERLAY = "services:\n  web:\n    privileged: true\n"
+PROD = "services:\n  web:\n    volumes: ['/var/run/docker.sock:/var/run/docker.sock']\n"
+
+
+def os_name(path: str) -> str:
+    """A group's paths keep the caller's spelling; compare by basename."""
+    return PurePath(path).name
+
+
+def write(directory: Path, name: str, text: str) -> Path:
+    path = directory / name
+    path.write_text(text, encoding="utf-8", newline="")
+    return path
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    """A directory with a base, an overlay, and a prod document."""
+    write(tmp_path, "compose.yml", BASE)
+    write(tmp_path, "compose.override.yml", OVERLAY)
+    write(tmp_path, "compose.prod.yml", PROD)
+    return tmp_path
+
+
+@pytest.fixture
+def in_project(project: Path) -> Path:
+    """Run from inside the project, which is what bare discovery means."""
+    previous = os.getcwd()
+    os.chdir(project)
+    try:
+        yield project
+    finally:
+        os.chdir(previous)
+
+
+class TestDiscovery:
+    """No file named: the pre-ADR-026 behaviour, unchanged."""
+
+    def test_pairs_a_base_with_its_override(self, in_project: Path) -> None:
+        selection = plan_documents([])
+        assert [g.paths for g in selection.groups] == [
+            ["compose.yml", "compose.override.yml"]
+        ]
+        assert not selection.groups[0].selected_by_env
+
+    def test_paths_stay_relative(self, in_project: Path) -> None:
+        """The report names files the way the user does."""
+        assert [g.primary for g in plan_documents([]).groups] == ["compose.yml"]
+
+    def test_no_overlay_when_none_sits_beside(self, tmp_path: Path) -> None:
+        write(tmp_path, "compose.yml", BASE)
+        previous = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            assert [g.paths for g in plan_documents([]).groups] == [["compose.yml"]]
+        finally:
+            os.chdir(previous)
+
+    def test_no_merge_overrides_leaves_the_base_alone(self, in_project: Path) -> None:
+        selection = plan_documents([], merge_overrides=False)
+        assert [g.paths for g in selection.groups] == [["compose.yml"]]
+
+    def test_nothing_found_is_an_empty_selection(self, tmp_path: Path) -> None:
+        previous = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            assert plan_documents([]).groups == ()
+        finally:
+            os.chdir(previous)
+
+
+class TestComposeFile:
+    """A `.env` that names a file list replaces discovery, as Compose does."""
+
+    def test_selects_the_named_documents(self, in_project: Path) -> None:
+        write(in_project, ".env", "COMPOSE_FILE=compose.yml:compose.prod.yml\n")
+        selection = plan_documents([])
+        assert [g.paths for g in selection.groups] == [
+            ["compose.yml", "compose.prod.yml"]
+        ]
+
+    def test_suppresses_the_override_merge(self, in_project: Path) -> None:
+        """The bug ADR-026 exists to fix: Compose does not load the override
+        when COMPOSE_FILE is set, so neither may we."""
+        write(in_project, ".env", "COMPOSE_FILE=compose.yml:compose.prod.yml\n")
+        merged = plan_documents([]).groups[0].paths
+        assert "compose.override.yml" not in merged
+
+    def test_records_that_the_env_chose(self, in_project: Path) -> None:
+        """The report must not claim Compose merges these automatically."""
+        write(in_project, ".env", "COMPOSE_FILE=compose.yml:compose.prod.yml\n")
+        assert plan_documents([]).groups[0].selected_by_env
+
+    def test_announces_what_it_selected(self, in_project: Path) -> None:
+        write(in_project, ".env", "COMPOSE_FILE=compose.yml:compose.prod.yml\n")
+        notes = " ".join(plan_documents([]).notes)
+        assert "COMPOSE_FILE selects" in notes
+        assert "compose.prod.yml" in notes
+
+    def test_honours_a_custom_separator(self, in_project: Path) -> None:
+        write(
+            in_project,
+            ".env",
+            "COMPOSE_PATH_SEPARATOR=,\nCOMPOSE_FILE=compose.yml,compose.prod.yml\n",
+        )
+        assert [g.paths for g in plan_documents([]).groups] == [
+            ["compose.yml", "compose.prod.yml"]
+        ]
+
+    def test_a_single_entry_needs_no_merge(self, in_project: Path) -> None:
+        write(in_project, ".env", "COMPOSE_FILE=compose.prod.yml\n")
+        assert [g.paths for g in plan_documents([]).groups] == [["compose.prod.yml"]]
+
+    def test_order_is_the_lists_order(self, in_project: Path) -> None:
+        """Merge order decides which value wins, so it is not incidental."""
+        write(in_project, ".env", "COMPOSE_FILE=compose.prod.yml:compose.yml\n")
+        assert [g.paths for g in plan_documents([]).groups] == [
+            ["compose.prod.yml", "compose.yml"]
+        ]
+
+    def test_no_env_ignores_it_entirely(self, in_project: Path) -> None:
+        write(in_project, ".env", "COMPOSE_FILE=compose.yml:compose.prod.yml\n")
+        selection = plan_documents([], read_env_files=False)
+        assert [g.paths for g in selection.groups] == [
+            ["compose.yml", "compose.override.yml"]
+        ]
+
+
+class TestRefusals:
+    """A refused list falls back rather than being honoured in part.
+
+    Grading half a COMPOSE_FILE would grade a set Compose never loads, which is
+    the failure the whole mechanism exists to remove.
+    """
+
+    def test_an_entry_outside_the_project_is_refused(self, in_project: Path) -> None:
+        write(in_project, ".env", "COMPOSE_FILE=compose.yml:../escape.yml\n")
+        selection = plan_documents([])
+        assert [g.paths for g in selection.groups] == [
+            ["compose.yml", "compose.override.yml"]
+        ]
+        assert "outside the project directory" in " ".join(selection.notes)
+
+    def test_an_absolute_entry_is_refused(self, in_project: Path) -> None:
+        """The .env must not be able to point the linter at an arbitrary file."""
+        write(in_project, ".env", "COMPOSE_FILE=/etc/passwd\n")
+        selection = plan_documents([])
+        assert selection.groups[0].paths == ["compose.yml", "compose.override.yml"]
+        assert "/etc/passwd" not in str(selection.groups)
+        assert "ignored" in " ".join(selection.notes)
+
+    def test_a_windows_drive_entry_is_refused(self, in_project: Path) -> None:
+        write(in_project, ".env", "COMPOSE_FILE=C:/windows/system32/x.yml\n")
+        selection = plan_documents([])
+        assert selection.groups[0].paths == ["compose.yml", "compose.override.yml"]
+
+    def test_a_missing_entry_is_refused(self, in_project: Path) -> None:
+        """Compose does not start on this either, so nothing is invented."""
+        write(in_project, ".env", "COMPOSE_FILE=compose.yml:absent.yml\n")
+        selection = plan_documents([])
+        assert selection.groups[0].paths == ["compose.yml", "compose.override.yml"]
+        assert "ignored" in " ".join(selection.notes)
+
+    def test_an_empty_value_changes_nothing(self, in_project: Path) -> None:
+        write(in_project, ".env", "COMPOSE_FILE=\n")
+        assert plan_documents([]).groups[0].paths == [
+            "compose.yml",
+            "compose.override.yml",
+        ]
+
+
+class TestAddOnly:
+    """ADR-026 section 4: a `.env` may expand the lint set, never shrink it.
+
+    A runtime does what it is told; a gate must not let the artifact under
+    inspection define its own scope. Both first-party integrations pass explicit
+    file lists, so this is the path that matters in CI.
+    """
+
+    def test_a_named_file_in_the_list_is_graded_as_the_project(
+        self, project: Path
+    ) -> None:
+        write(project, ".env", "COMPOSE_FILE=compose.yml:compose.prod.yml\n")
+        selection = plan_documents([str(project / "compose.yml")])
+        assert [os_name(p) for p in selection.groups[0].paths] == [
+            "compose.yml",
+            "compose.prod.yml",
+        ]
+
+    def test_a_named_file_absent_from_the_list_is_still_graded(
+        self, project: Path
+    ) -> None:
+        """The evasion this rule exists to stop: a committed `.env` must not be
+        able to remove a file from the gate's scope."""
+        write(project, "extra.yml", BASE)
+        write(project, ".env", "COMPOSE_FILE=compose.yml\n")
+        selection = plan_documents([str(project / "extra.yml")])
+        assert [os_name(p) for p in selection.groups[0].paths] == ["extra.yml"]
+        assert "does not include this file" in " ".join(selection.notes)
+        assert "Nothing was skipped" in " ".join(selection.notes)
+
+    def test_a_decoy_cannot_shrink_a_multi_file_gate(self, project: Path) -> None:
+        write(project, "decoy.yml", BASE)
+        write(project, ".env", "COMPOSE_FILE=decoy.yml\n")
+        named = [str(project / "compose.yml"), str(project / "compose.prod.yml")]
+        graded = {os_name(p) for g in plan_documents(named).groups for p in g.paths}
+        assert {"compose.yml", "compose.prod.yml"} <= graded
+
+    def test_a_file_is_not_graded_twice(self, project: Path) -> None:
+        """Naming both halves of one project lints the project once."""
+        write(project, ".env", "COMPOSE_FILE=compose.yml:compose.prod.yml\n")
+        named = [str(project / "compose.yml"), str(project / "compose.prod.yml")]
+        selection = plan_documents(named)
+        assert len(selection.groups) == 1
+
+
+class TestNamedWithoutEnv:
+    """Explicit paths with no `.env` keep behaving exactly as before."""
+
+    def test_pairs_with_the_sibling_override(self, project: Path) -> None:
+        selection = plan_documents([str(project / "compose.yml")])
+        assert [os_name(p) for p in selection.groups[0].paths] == [
+            "compose.yml",
+            "compose.override.yml",
+        ]
+
+    def test_an_overlay_named_explicitly_is_consumed_once(self, project: Path) -> None:
+        """A shell glob expands to both halves; the overlay must not also be
+        graded standalone, where its absence findings would be false."""
+        named = [str(project / "compose.yml"), str(project / "compose.override.yml")]
+        selection = plan_documents(named)
+        assert len(selection.groups) == 1
+        assert selection.is_consumed(str(project / "compose.override.yml"))
+
+    def test_a_non_canonical_name_gets_no_overlay(self, project: Path) -> None:
+        selection = plan_documents([str(project / "compose.prod.yml")])
+        assert [os_name(p) for p in selection.groups[0].paths] == ["compose.prod.yml"]

--- a/tests/test_selection_semantics.py
+++ b/tests/test_selection_semantics.py
@@ -1,0 +1,196 @@
+"""Differential test: does our file selection agree with Docker Compose?
+
+``COMPOSE_FILE`` semantics were derived by probing ``docker compose config``,
+and the load-bearing one is easy to state and easy to forget: setting it
+**suppresses** the automatic ``compose.override.yml`` merge, because it replaces
+discovery and the override is something discovery finds. ADR-025 shipped that
+merge as unconditional, so compose-lint reported a CRITICAL from a document
+Compose never loads.
+
+Comments rot, so this re-derives it from the binary on every run: which
+documents Compose actually merged is read back out of ``config``, and compared
+against the group ``_selection`` planned.
+
+Skipped when the ``docker compose`` CLI is unavailable.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from compose_lint._selection import plan_documents
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+def _compose_cli_works() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    try:
+        return (
+            subprocess.run(
+                ["docker", "compose", "version"], capture_output=True, timeout=30
+            ).returncode
+            == 0
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _compose_cli_works(),
+    reason="differential selection test needs a working docker compose CLI",
+)
+
+# The one place agreement with the *lint host's* Compose is not the goal.
+#
+# Compose defaults COMPOSE_PATH_SEPARATOR to the host's path separator, so a
+# `.env` reading `COMPOSE_FILE=a.yml:b.yml` names two documents on Linux and one
+# oddly-named document on Windows. compose-lint splits on ":" everywhere: the
+# separator is a property of the project, and a Compose file linted on a Windows
+# laptop is overwhelmingly headed for a Linux host. ADR-023 clause 1 settled the
+# same question for path semantics ("POSIX notation on every platform") after
+# issue #588, where matching the host silently broke the highest-severity rules.
+#
+# So cases that are *not* about the default separator set one explicitly, which
+# behaves identically on both platforms and lets the merge and suppression
+# assertions run everywhere. The default itself gets its own case below.
+POSIX_DEFAULT_SEPARATOR = os.pathsep == ":"
+SEP = "COMPOSE_PATH_SEPARATOR=,\n"
+
+# Each document sets a distinct marker, so which ones Compose merged can be read
+# straight out of the effective configuration.
+# Every document carries `image:` so that *any* subset of them is a valid
+# project on its own. Without that, a case selecting one document alone was
+# rejected by Compose and silently skipped rather than compared.
+DOCUMENTS = {
+    "compose.yml": (
+        "services:\n  web:\n    image: i\n    environment:\n      BASE: '1'\n"
+    ),
+    "compose.override.yml": (
+        "services:\n  web:\n    image: i\n    environment:\n      OVERRIDE: '1'\n"
+    ),
+    "compose.prod.yml": (
+        "services:\n  web:\n    image: i\n    environment:\n      PROD: '1'\n"
+    ),
+}
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Iterator[Path]:
+    for name, text in DOCUMENTS.items():
+        (tmp_path / name).write_text(text, encoding="utf-8", newline="")
+    previous = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        os.chdir(previous)
+
+
+def _compose_merged(directory: Path) -> set[str]:
+    """Which documents Compose actually loaded, named by their marker."""
+    result = subprocess.run(
+        ["docker", "compose", "config"],
+        cwd=directory,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"compose rejected the fixture, so nothing was compared: "
+        f"{result.stderr.strip()[:200]}"
+    )
+    env = yaml.safe_load(result.stdout)["services"]["web"].get("environment") or {}
+    markers = {
+        "BASE": "compose.yml",
+        "OVERRIDE": "compose.override.yml",
+        "PROD": "compose.prod.yml",
+    }
+    return {name for key, name in markers.items() if key in env}
+
+
+def write_env(directory: Path, text: str) -> None:
+    (directory / ".env").write_text(text, encoding="utf-8", newline="")
+
+
+def _planned(directory: Path) -> set[str]:
+    from pathlib import PurePath
+
+    return {
+        PurePath(path).name
+        for group in plan_documents([]).groups
+        for path in group.paths
+    }
+
+
+def test_discovery_matches(project: Path) -> None:
+    """No .env: base plus the sibling override, which is ADR-025's behaviour."""
+    assert (
+        _planned(project)
+        == _compose_merged(project)
+        == {
+            "compose.yml",
+            "compose.override.yml",
+        }
+    )
+
+
+def test_compose_file_matches(project: Path) -> None:
+    write_env(project, SEP + "COMPOSE_FILE=compose.yml,compose.prod.yml\n")
+    assert _planned(project) == _compose_merged(project)
+
+
+def test_compose_file_suppresses_the_override(project: Path) -> None:
+    """The whole reason this ADR touched already-shipped behaviour."""
+    write_env(project, SEP + "COMPOSE_FILE=compose.yml,compose.prod.yml\n")
+    merged = _compose_merged(project)
+    assert "compose.override.yml" not in merged
+    assert _planned(project) == merged
+
+
+def test_single_entry_matches(project: Path) -> None:
+    write_env(project, "COMPOSE_FILE=compose.prod.yml\n")
+    assert _planned(project) == _compose_merged(project) == {"compose.prod.yml"}
+
+
+def test_custom_separator_matches(project: Path) -> None:
+    write_env(project, SEP + "COMPOSE_FILE=compose.yml,compose.prod.yml\n")
+    assert _planned(project) == _compose_merged(project)
+
+
+@pytest.mark.skipif(
+    POSIX_DEFAULT_SEPARATOR,
+    reason="the divergence only exists where the host separator is not ':'",
+)
+def test_the_default_separator_deliberately_differs_on_windows(project: Path) -> None:
+    """We split on ":" here and Compose-on-Windows does not. That is the point.
+
+    A `.env` written ``COMPOSE_FILE=a.yml:b.yml`` describes a project that
+    deploys on Linux. Reading it the Windows way would grade a different set of
+    documents than the one that runs -- a finding true only of the lint host,
+    which is what ADR-023 exists to prevent. Asserted rather than skipped so the
+    divergence stays visible and intentional.
+    """
+    write_env(project, "COMPOSE_FILE=compose.yml:compose.prod.yml\n")
+    assert _planned(project) == {"compose.yml", "compose.prod.yml"}
+
+    result = subprocess.run(
+        ["docker", "compose", "config"],
+        cwd=project,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode != 0, (
+        "Compose on this host now reads ':' as a separator too, so the "
+        "divergence is gone and this case belongs with the agreeing ones"
+    )


### PR DESCRIPTION
Second commit of #646, under [ADR-026](https://github.com/tmatens/compose-lint/blob/main/docs/adr/026-read-the-sibling-env-file.md) §1 and §4. Builds on the `.env` reader from #655.

### This is a bug fix as much as a feature

`COMPOSE_FILE` does not merely add documents — it **suppresses the automatic `compose.override.yml` merge**, because it replaces the discovery that finds the override. ADR-025 shipped that merge as unconditional, so on such a project compose-lint reported a CRITICAL from a document Compose never loads, under a warning asserting the opposite.

Before, in a directory with `compose.yml`, `compose.prod.yml`, an override setting `privileged: true`, and `.env` containing `COMPOSE_FILE=compose.yml:compose.prod.yml`:

```
$ docker compose config | grep -cE 'privileged|docker.sock'
2                                    # the socket mount runs; privileged does not

$ compose-lint check
files: compose.yml + compose.override.yml
warning: ... because Compose merges it automatically.     <- false in this project
  3  CRITICAL  CL-0002  Service runs in privileged mode.   <- a document that never runs
                                                           (and the real socket mount: missed)
```

After:

```
note: .env: COMPOSE_FILE selects compose.yml, compose.prod.yml, merged in that order.
files: compose.yml + compose.prod.yml
warning: compose.yml: merged compose.prod.yml before linting, because COMPOSE_FILE in .env selects them.
  4  CRITICAL  CL-0001  Docker runtime socket mounted via '/var/run/docker.sock:...'
```

One invented CRITICAL retired, one real one found. The warning now names the actual reason — "Compose merges it automatically" is true of a discovered override and false of a `COMPOSE_FILE` list, and stating the wrong one is precisely how the old report justified reading a file Compose never opened.

### Add-only is a security boundary, not a preference

ADR-026 §4: a `.env` may **expand** what is graded, never shrink it for a file named on the command line. A runtime does what it is told; a gate must not let the artifact under inspection define its own scope — ShellCheck's reason for refusing to let a checked script enable `external-sources` for itself.

This matters because both first-party integrations pass explicit file lists (pre-commit appends filenames, `action.yml` passes `TARGET_FILES`), so without the rule a contributor could shrink a CI gate by committing one file. `TestAddOnly` states that boundary as tests, including the decoy case.

In bare discovery there is no named file to protect, so `COMPOSE_FILE` replaces discovery exactly as Compose does.

Entries that are absolute, climb out of the project directory, or do not exist are refused — and a refused list falls back **whole** rather than being honoured in part, because grading half a `COMPOSE_FILE` grades a set Compose never loads, which is the failure the mechanism exists to remove.

### One judgement call worth review

The separator defaults to `:` on **every** platform rather than to the host's `os.pathsep`. Compose's own default is platform-dependent, which would make the same `.env` select different documents on a Windows lint host than on the Linux host the stack deploys to. ADR-023 clause 1 already settled the analogous question — "lexical segment math in POSIX notation on every platform" — and a Windows drive letter is not a counter-example because an absolute entry is refused either way. An explicit `COMPOSE_PATH_SEPARATOR` in the `.env` is honoured.

### Also here

- `--no-env` on `check` and `fix`, reproducing the previous selection exactly. Its help text says plainly that this includes reinstating the false merge above — an escape hatch defined as "what the last release did" inherits its bugs, and hiding that would be worse than the bug.
- Discovery and override pairing move from `cli.py` into `_selection.py`, which now owns the whole question. `tests/test_discovery_parity.py` follows the filename table to its new home; the action-vs-CLI contract it guards is unchanged.
- `format_header(merged=...)` takes a list rather than a single overlay, since `COMPOSE_FILE` can name any number of documents.
- Paths keep the caller's spelling. An earlier revision resolved discovery through `Path.cwd()` and turned every reported path absolute — caught by running the real CLI rather than by the suite.

### Verification

`tests/test_selection_semantics.py` re-derives the rules from the `docker compose` binary on every run — same discipline as `test_merge_semantics.py` — by reading back which documents Compose actually merged. Every fixture document carries `image:` so any subset is a valid project; without that, the single-entry case was rejected by Compose and silently skipped rather than compared.

All four gates pass: ruff, format, mypy, and **2288 passed, 9 skipped** (up 30).
