### PR TITLE
Resolve ${VAR} from a sibling .env, except under environment:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ lint read neither, so a project configured that way had its real documents
 ungraded while an override Compose never loads contributed findings — under a
 warning stating that Compose merges it automatically, which was false there.
 
+Values are resolved from it too, so a `${VAR}` a rule consumes now grades as
+what deploys rather than as unknowable. Expect new findings on such projects,
+including CRITICAL ones, and some existing findings to disappear where the
+`.env` supplies a value that clears them (a pinned image tag, for instance) —
+the documented MINOR behaviour for tightened coverage.
+
 Expect the reported file list to change on such projects, in both directions.
 `--no-env` restores the previous selection exactly, including that false merge.
 A `.env` can only *add* documents to a file you named on the command line, never
@@ -84,6 +90,12 @@ the previous single-file grading exactly.
   either direction. This is the last chance to say so.
 
 ### Fixed
+- Credential rules are unaffected by a `.env`. A value there is never
+  substituted into an `environment:` value, so `POSTGRES_PASSWORD: "${PW}"`
+  stays clean however `PW` is set — otherwise CL-0021 would flag the exact
+  pattern its own fix text recommends. A written default is still graded:
+  `${PW:-changeme}` ships to every clone and keeps firing. Names referenced only
+  from `environment:` are not read out of the `.env` at all.
 - An overlay is no longer merged into a project whose `.env` sets
   `COMPOSE_FILE`. Compose does not load `compose.override.yml` when
   `COMPOSE_FILE` is set, so those findings described a document that never runs,

--- a/docs/adr/026-read-the-sibling-env-file.md
+++ b/docs/adr/026-read-the-sibling-env-file.md
@@ -147,6 +147,26 @@ at a different layer.
    patterns) and errs generous: a false "do not resolve" costs one finding, a false
    "resolve" is the disclosure TFLint's rule exists to prevent.
 
+   *Amended (#646):* the mechanism named here was a `str` subclass carrying the
+   written spelling, read by the credential rules and the formatters. It does not
+   work, because a subclass does not survive string operations: CL-0021 splits a
+   list-form `environment` entry on `=` and CL-0001 splits a volume on `:`, so the
+   marker is gone in exactly the places that need it. What replaces it is
+   positional and strictly stronger — **a `.env` value is never substituted into an
+   `environment:` value at all.** That subtree is the one place in a Compose
+   document whose values are payload rather than configuration, and the only rules
+   that read one are CL-0020 and CL-0021 (verified: no other rule touches
+   `environment` values). Nothing has to remember to unwrap anything, and the
+   guarantee holds for the mapping and list spellings alike. It also strengthens
+   §5: names referenced only from `environment:` are excluded from the wanted set,
+   so a credential the file externalises is never read out of the `.env` at all.
+
+   The output half of the original mechanism is narrowed by the same finding. A
+   `.env` value can still reach a report through a rule that grades a deployment
+   property — CL-0001 naming the mount source it resolved to — because that *is*
+   the finding. What is guaranteed is that nothing under `environment:`, which is
+   where secrets live, is ever resolved, so none of it can be printed.
+
 3. **`.env` chains do not expand from the process environment.** Compose resolves
    `FROM_SHELL=${SOME_SHELL_VAR}/tail` against the shell; compose-lint leaves it
    unknowable, exactly as it leaves a defaultless `${VAR}` in the compose file. This

--- a/src/compose_lint/_selection.py
+++ b/src/compose_lint/_selection.py
@@ -31,7 +31,7 @@ committing one file. In bare discovery there is no named file to protect and
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 
@@ -105,6 +105,12 @@ class Selection:
     groups: tuple[DocumentGroup, ...] = ()
     consumed: frozenset[str] = frozenset()
     notes: tuple[str, ...] = field(default=())
+    # Every `.env` that will be read for this run, so the header can say so.
+    # ADR-026 §5: a read that is announced is the declared input ADR-023
+    # clause 2 permits; an unannounced one is the kind it forbids, and it is
+    # also what makes a laptop-versus-CI difference a diff rather than a
+    # mystery.
+    env_files: tuple[str, ...] = ()
 
     def is_consumed(self, path: str) -> bool:
         """Whether ``path`` is already being graded inside another group."""
@@ -149,6 +155,8 @@ def _plan_discovered(
     file list Compose would load.
     """
     selected, notes = _compose_file_entries(directory, read_env_files=read_env_files)
+    env_file = env_file_for(directory, read_env_files=read_env_files)
+    env_files = (env_file,) if env_file else ()
     if selected is not None:
         return Selection(
             groups=(
@@ -156,9 +164,11 @@ def _plan_discovered(
             ),
             consumed=frozenset(_key(path) for path in selected[1:]),
             notes=tuple(notes),
+            env_files=env_files,
         )
     discovered = [name for name in COMPOSE_FILENAMES if (directory / name).is_file()]
-    return _pair_with_overrides(discovered, merge_overrides, notes)
+    selection = _pair_with_overrides(discovered, merge_overrides, notes)
+    return replace(selection, env_files=env_files if discovered else ())
 
 
 def _plan_named(
@@ -169,6 +179,7 @@ def _plan_named(
     consumed: set[str] = set()
     notes: list[str] = []
     planned: set[str] = set()
+    env_files: list[str] = []
 
     for path in named:
         if _key(path) in planned:
@@ -178,6 +189,9 @@ def _plan_named(
             directory, read_env_files=read_env_files
         )
         notes.extend(file_notes)
+        env_file = env_file_for(directory, read_env_files=read_env_files)
+        if env_file is not None and env_file not in env_files:
+            env_files.append(env_file)
 
         if selected is None:
             group = _with_override(path, merge_overrides)
@@ -203,7 +217,10 @@ def _plan_named(
         consumed.update(_key(entry) for entry in group.overlays)
 
     return Selection(
-        groups=tuple(groups), consumed=frozenset(consumed), notes=tuple(notes)
+        groups=tuple(groups),
+        consumed=frozenset(consumed),
+        notes=tuple(notes),
+        env_files=tuple(env_files),
     )
 
 
@@ -230,6 +247,14 @@ def _with_override(path: str, merge_overrides: bool) -> DocumentGroup:
     if not candidate.is_file():
         return DocumentGroup(path)
     return DocumentGroup(path, (str(candidate),))
+
+
+def env_file_for(directory: Path, *, read_env_files: bool) -> str | None:
+    """The ``.env`` that will be read for ``directory``, if there is one."""
+    if not read_env_files:
+        return None
+    candidate = directory / ENV_FILENAME
+    return str(candidate) if candidate.is_file() else None
 
 
 def _compose_file_entries(

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -630,6 +630,7 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
                 args.fail_on,
                 __version__,
                 merged=overlay_of,
+                env_files=selection.env_files,
             ),
             flush=True,
         )
@@ -648,7 +649,7 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
         merged: Merged | None = None
         try:
             if overlays:
-                merged = load_merged([filepath, *overlays])
+                merged = load_merged([filepath, *overlays], use_env=not args.no_env)
                 data, lines = merged.data, merged.lines
                 # Not a coverage gap — coverage was achieved, not missed — so
                 # this warns without touching the exit code. What it must never
@@ -672,7 +673,7 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
                     "configuration."
                 )
             else:
-                data, lines = load_compose(filepath)
+                data, lines = load_compose(filepath, use_env=not args.no_env)
         except ComposeNotApplicableError as e:
             # v1 / fragment file: not malformed, just outside what we lint.
             # Per ADR-013 this is exit 0 (skipped, not a parse error). Must
@@ -924,7 +925,7 @@ def _atomic_write(path: Path, content: str) -> None:
 
 
 def _merged_reparser(
-    filepath: str, overlays: list[str] | None
+    filepath: str, overlays: list[str] | None, *, use_env: bool = True
 ) -> Callable[[str], tuple[dict[str, Any], dict[str, int]]] | None:
     """Re-parse hook that merges a candidate patch with its overlay.
 
@@ -937,7 +938,7 @@ def _merged_reparser(
         return None
 
     def reparse(candidate: str) -> tuple[dict[str, Any], dict[str, int]]:
-        return merge_patched(candidate, filepath, overlays)
+        return merge_patched(candidate, filepath, overlays, use_env=use_env)
 
     return reparse
 
@@ -983,14 +984,14 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
         overlays = fix_overlay_of.get(filepath)
         try:
             if overlays:
-                merged = load_merged([filepath, *overlays])
+                merged = load_merged([filepath, *overlays], use_env=not args.no_env)
                 data, lines = merged.data, merged.lines
                 emit(
                     f"note: {filepath}: merged {', '.join(overlays)} before "
                     "linting. Only findings written in this file can be fixed here."
                 )
             else:
-                data, lines = load_compose(filepath)
+                data, lines = load_compose(filepath, use_env=not args.no_env)
         except ComposeNotApplicableError as e:
             # v1 / fragment file: skipped, not an error (ADR-013). Must precede
             # the ComposeError clause below — it is a subclass.
@@ -1099,7 +1100,7 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
             # the candidate is re-merged with the overlay before they are
             # checked. Verifying the patched base alone would compare a
             # single-file result against a merged one.
-            reparse=_merged_reparser(filepath, overlays),
+            reparse=_merged_reparser(filepath, overlays, use_env=not args.no_env),
             fixable=_is_local if overlays else None,
         )
         if verify_error is not None:

--- a/src/compose_lint/formatters/text.py
+++ b/src/compose_lint/formatters/text.py
@@ -157,6 +157,7 @@ def format_header(
     fail_on: Severity,
     version: str,
     merged: dict[str, list[str]] | None = None,
+    env_files: tuple[str, ...] = (),
 ) -> str:
     """Format a branded run header showing the tool version and active parameters.
 
@@ -179,8 +180,18 @@ def format_header(
         else _sanitize_line(f)
         for f in files
     ]
+    # The `.env` is stated because it changes what the run grades and what a
+    # value resolves to (ADR-026 §5). Two machines that read different ones
+    # produce different findings, and the header is what makes that a diff
+    # instead of a mystery.
+    env_str = (
+        f"  {sep}  env: {', '.join(_sanitize_line(f) for f in env_files)}"
+        if env_files
+        else ""
+    )
     params = (
         f"files: {', '.join(shown)}"
+        f"{env_str}"
         f"  {sep}  config: {config_str}"
         f"  {sep}  fail-on: {fail_on.value}"
     )

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -4,15 +4,19 @@ from __future__ import annotations
 
 import re
 from pathlib import Path, PurePath
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import yaml
 
+from compose_lint._env_file import read_env
 from compose_lint._lines import find_ambiguous_break
 from compose_lint._merge import Document, Merged, merge_documents, merge_values
 from compose_lint._safe_read import UnsafeFileError, read_text_bounded
 from compose_lint.config import KNOWN_TOP_LEVEL_KEYS
-from compose_lint.rules._interpolation import substitute_defaults
+from compose_lint.rules._interpolation import reference_names, substitute_defaults
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 
 class _LinesKey:
@@ -861,8 +865,15 @@ def coverage_gaps(data: dict[str, Any]) -> list[str]:
     return gaps
 
 
-def _substitute_interpolation_defaults(data: Any) -> None:
-    """Rewrite every string leaf to the value Compose ships with no ``.env``.
+# The one subtree a `.env` value never reaches. See the function below for why
+# position rather than a marker on the value is the robust test.
+ENVIRONMENT_KEY = "environment"
+
+
+def _substitute_interpolation_defaults(
+    data: Any, env: Mapping[str, str] | None = None
+) -> None:
+    """Rewrite every string leaf to the value Compose ships.
 
     Classification has to happen *after* canonicalization, not before. With
     substitution wired into a single call site (bind sources), every other rule
@@ -878,39 +889,98 @@ def _substitute_interpolation_defaults(data: Any) -> None:
     ``lines`` map is keyed by the raw key path, and rewriting a key would break
     every line lookup that indexes it.
 
-    A reference with no default (``${VAR}``) is left exactly as written:
-    :func:`substitute_defaults` returns ``None`` for it, and inventing a value
-    would invent a finding. Walks are memoized by ``id`` so a document built
-    from YAML aliases is visited once per distinct object rather than once per
-    path through the alias graph.
+    A reference with no default (``${VAR}``) is left exactly as written unless
+    ``env`` supplies it: :func:`substitute_defaults` returns ``None`` for it, and
+    inventing a value would invent a finding. Walks are memoized by ``id`` so a
+    document built from YAML aliases is visited once per distinct object rather
+    than once per path through the alias graph.
+
+    **``environment:`` values are never resolved from ``env``** (ADR-026 §2).
+    Everywhere else in a Compose document a value describes *what is deployed* --
+    a mount source, a port, an image, a privilege -- and a ``.env`` is entitled to
+    answer that. An ``environment:`` value is the payload itself, and the only
+    rules that read one (CL-0020, CL-0021) grade *how sensitive it is*, which is
+    a question about the document rather than the deployment. Resolving there
+    would make CL-0021 flag the very pattern its own fix text recommends:
+    ``DATABASE_URL: postgres://user:${DB_PASSWORD}@host/db`` is the remediation,
+    and a ``.env`` supplying ``DB_PASSWORD`` would turn it back into a finding.
+
+    Skipping by position rather than by marking the value is deliberate. ADR-026
+    §2 described a ``str`` subclass carrying the written spelling, but a subclass
+    does not survive string operations: CL-0021 splits a list-form entry on
+    ``=`` and CL-0001 splits a volume on ``:``, so the marker would be gone in
+    exactly the places that need it. ``environment:`` is the one subtree whose
+    values are payload by definition, which makes position the robust test.
+    The ADR is amended to match.
+
+    Written defaults are unaffected there: ``${PW:-changeme}`` still resolves,
+    because a default is committed in the file and ships to every clone.
     """
     seen: set[int] = set()
 
-    def resolve(value: str) -> str:
-        substituted = substitute_defaults(value)
+    def resolve(value: str, supplied: Mapping[str, str] | None) -> str:
+        substituted = substitute_defaults(value, supplied)
         return value if substituted is None else substituted
 
-    def walk(node: Any) -> None:
+    def walk(node: Any, supplied: Mapping[str, str] | None) -> None:
         if isinstance(node, dict):
             if id(node) in seen:
                 return
             seen.add(id(node))
             for key, value in node.items():
+                below = None if key == ENVIRONMENT_KEY else supplied
                 if isinstance(value, str):
-                    node[key] = resolve(value)
+                    node[key] = resolve(value, below)
                 else:
-                    walk(value)
+                    walk(value, below)
         elif isinstance(node, list):
             if id(node) in seen:
                 return
             seen.add(id(node))
             for index, value in enumerate(node):
                 if isinstance(value, str):
-                    node[index] = resolve(value)
+                    node[index] = resolve(value, supplied)
                 else:
-                    walk(value)
+                    walk(value, supplied)
 
-    walk(data)
+    walk(data, env)
+
+
+def _referenced_names(data: Any) -> set[str]:
+    """Every ``${VAR}`` name a rule could consume, for the wanted-set filter.
+
+    ``environment:`` is skipped for the same reason substitution skips it: a
+    ``.env`` value never reaches there, so retaining one would keep a secret the
+    run has no use for (ADR-026 §5).
+    """
+    seen: set[int] = set()
+    found: set[str] = set()
+
+    def walk(node: Any, under_env: bool) -> None:
+        if isinstance(node, dict):
+            if id(node) in seen:
+                return
+            seen.add(id(node))
+            for key, value in node.items():
+                below = under_env or key == ENVIRONMENT_KEY
+                if isinstance(value, str):
+                    if not below:
+                        found.update(reference_names(value))
+                else:
+                    walk(value, below)
+        elif isinstance(node, list):
+            if id(node) in seen:
+                return
+            seen.add(id(node))
+            for value in node:
+                if isinstance(value, str):
+                    if not under_env:
+                        found.update(reference_names(value))
+                else:
+                    walk(value, under_env)
+
+    walk(data, False)
+    return found
 
 
 def _split_short_volume(volume: str) -> tuple[str, str, str]:
@@ -977,7 +1047,7 @@ def _resolve_bind_sources(data: dict[str, Any], base_dir: Path) -> None:
 
 
 def load_compose(
-    path: str | Path,
+    path: str | Path, *, use_env: bool = True
 ) -> tuple[dict[str, Any], dict[str, int]]:
     """Load and validate a Docker Compose file.
 
@@ -1021,11 +1091,15 @@ def load_compose(
     # through a symlinked directory, "../etc" is the parent of the *link* path,
     # not of the link's target. Resolving physically named a different host path
     # than the one Compose actually mounts, in either direction.
-    return loads(content, base_dir=filepath.absolute().parent)
+    return loads(content, base_dir=filepath.absolute().parent, use_env=use_env)
 
 
 def _loads_full(
-    content: str, base_dir: Path | None = None, *, merging: bool = False
+    content: str,
+    base_dir: Path | None = None,
+    *,
+    merging: bool = False,
+    use_env: bool = True,
 ) -> tuple[dict[str, Any], dict[str, int], frozenset[str], frozenset[str]]:
     """Parse and validate Compose from an in-memory string.
 
@@ -1112,7 +1186,19 @@ def _loads_full(
         # Canonicalize before anything classifies: rules and the extends and
         # bind-source passes below all see the value the file actually ships
         # (see that function's docstring for why this is document-wide).
-        _substitute_interpolation_defaults(data)
+        #
+        # The `.env` is read *after* the document is parsed, because only the
+        # document says which names are worth reading (ADR-026 §5). The names
+        # come from outside `environment:` alone, so a credential the file
+        # externalises is never even retained.
+        supplied: Mapping[str, str] | None = None
+        if use_env and base_dir is not None:
+            wanted = _referenced_names(data)
+            if wanted:
+                parsed_env = read_env(base_dir, wanted)
+                if parsed_env is not None and parsed_env.values:
+                    supplied = parsed_env.values
+        _substitute_interpolation_defaults(data, supplied)
         _resolve_in_file_extends(data)
         if base_dir is not None:
             _resolve_bind_sources(data, base_dir)
@@ -1127,18 +1213,18 @@ def _loads_full(
 
 
 def loads(
-    content: str, base_dir: Path | None = None
+    content: str, base_dir: Path | None = None, *, use_env: bool = True
 ) -> tuple[dict[str, Any], dict[str, int]]:
     """Parse Compose from a string, returning ``(data, lines)``.
 
     The public string entry point. :func:`_loads_full` additionally reports the
     paths deleted by ``!reset``, which only a merge needs.
     """
-    data, lines, _, _ = _loads_full(content, base_dir=base_dir)
+    data, lines, _, _ = _loads_full(content, base_dir=base_dir, use_env=use_env)
     return data, lines
 
 
-def load_document(path: str | Path) -> Document:
+def load_document(path: str | Path, *, use_env: bool = True) -> Document:
     """Load one Compose file as a :class:`Document` ready to merge.
 
     The merge-aware sibling of :func:`load_compose`: same parse, same
@@ -1155,24 +1241,24 @@ def load_document(path: str | Path) -> Document:
     except OSError as e:
         raise ComposeError(f"Cannot read file: {e}") from e
     data, lines, resets, overrides = _loads_full(
-        content, base_dir=filepath.absolute().parent, merging=True
+        content, base_dir=filepath.absolute().parent, merging=True, use_env=use_env
     )
     return Document(
         path=str(path), data=data, lines=lines, resets=resets, overrides=overrides
     )
 
 
-def load_merged(paths: list[str | Path]) -> Merged:
+def load_merged(paths: list[str | Path], *, use_env: bool = True) -> Merged:
     """Load and merge several Compose files into the configuration Compose runs.
 
     Later paths override earlier ones, which is the order Compose itself uses
     for ``-f a -f b`` and for a base file plus its ``compose.override.yml``.
     """
-    return merge_documents([load_document(p) for p in paths])
+    return merge_documents([load_document(p, use_env=use_env) for p in paths])
 
 
 def merge_patched(
-    patched: str, base_path: str | Path, overlays: list[str]
+    patched: str, base_path: str | Path, overlays: list[str], *, use_env: bool = True
 ) -> tuple[dict[str, Any], dict[str, int]]:
     """Re-merge a candidate patch of ``base_path`` with its overlay documents.
 
@@ -1183,7 +1269,7 @@ def merge_patched(
     """
     base_dir = Path(base_path).absolute().parent
     data, lines, resets, overrides = _loads_full(
-        patched, base_dir=base_dir, merging=True
+        patched, base_dir=base_dir, merging=True, use_env=use_env
     )
     candidate = Document(
         path=str(base_path),
@@ -1192,5 +1278,7 @@ def merge_patched(
         resets=resets,
         overrides=overrides,
     )
-    merged = merge_documents([candidate, *(load_document(p) for p in overlays)])
+    merged = merge_documents(
+        [candidate, *(load_document(p, use_env=use_env) for p in overlays)]
+    )
     return merged.data, merged.lines

--- a/src/compose_lint/rules/_interpolation.py
+++ b/src/compose_lint/rules/_interpolation.py
@@ -11,8 +11,12 @@ anything literal at all, which :func:`ships_no_literal` answers.
 from __future__ import annotations
 
 import re
+from typing import TYPE_CHECKING
 
 from compose_lint._limits import MAX_SCAN_LEN
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 # Upper bound on a scalar these regexes will scan. Both the pattern below and
 # the two in `substitute_defaults` are quadratic on pathological input (measured
@@ -103,8 +107,10 @@ def _matching_brace(value: str, start: int) -> int | None:
     return None
 
 
-def _resolve_defaults(value: str, depth: int = 0) -> str | None:
-    """Rewrite each ``${VAR:-default}`` to its default, innermost first.
+def _resolve_defaults(
+    value: str, depth: int = 0, env: Mapping[str, str] | None = None
+) -> str | None:
+    """Rewrite each reference to its value: ``env`` first, then its default.
 
     A single regex pass cannot do this. With the default written ``[^}]*`` it
     stops at the *first* ``}``, which for a nested reference is the inner one:
@@ -133,6 +139,7 @@ def _resolve_defaults(value: str, depth: int = 0) -> str | None:
     """
     if depth > _MAX_NESTING:
         return None
+    lookup: Mapping[str, str] = env or {}
     out: list[str] = []
     i = 0
     end = len(value)
@@ -147,9 +154,15 @@ def _resolve_defaults(value: str, depth: int = 0) -> str | None:
             if following == "{":
                 close = _matching_brace(value, i + 1)
                 if close is not None:
-                    default = _default_of(value[i + 2 : close])
+                    interior = value[i + 2 : close]
+                    supplied = _supplied(interior, lookup)
+                    if supplied is not None:
+                        out.append(supplied)
+                        i = close + 1
+                        continue
+                    default = _default_of(interior)
                     if default is not None:
-                        resolved = _resolve_defaults(default, depth + 1)
+                        resolved = _resolve_defaults(default, depth + 1, env)
                         if resolved is None:
                             return None
                         out.append(resolved)
@@ -158,9 +171,78 @@ def _resolve_defaults(value: str, depth: int = 0) -> str | None:
                     out.append(value[i : close + 1])  # no default; as written
                     i = close + 1
                     continue
+            name = _BARE_NAME_RE.match(value, i + 1)
+            if name is not None and name.group() in lookup:
+                out.append(lookup[name.group()])
+                i = name.end()
+                continue
         out.append(char)
         i += 1
     return "".join(out)
+
+
+# The name in a bare `$VAR` reference. Only consulted when a `.env` supplies
+# that name: without one the value is left as written, exactly as before.
+_BARE_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def reference_names(value: str) -> set[str]:
+    """Every variable name ``value`` interpolates, defaults included.
+
+    The wanted-set filter (ADR-026 §5) needs this before anything is resolved:
+    only the names a document could consume are read out of a ``.env``, and
+    everything else is discarded rather than parsed into the run.
+    """
+    if len(value) > _MAX_SCAN_LEN:
+        return set()
+    found: set[str] = set()
+    index = 0
+    while index < len(value):
+        if value[index] != "$" or index + 1 >= len(value):
+            index += 1
+            continue
+        following = value[index + 1]
+        if following == "$":  # escaped literal dollar, not a reference
+            index += 2
+            continue
+        if following == "{":
+            close = _matching_brace(value, index + 1)
+            if close is None:
+                index += 1
+                continue
+            interior = value[index + 2 : close]
+            head = _REF_HEAD_RE.match(interior)
+            if head is not None:
+                found.add(head.group(1))
+            default = _default_of(interior)
+            if default is not None:
+                found |= reference_names(default)
+            index = close + 1
+            continue
+        name = _BARE_NAME_RE.match(value, index + 1)
+        if name is None:
+            index += 1
+            continue
+        found.add(name.group())
+        index = name.end()
+    return found
+
+
+def _supplied(interior: str, env: Mapping[str, str]) -> str | None:
+    """What ``env`` supplies for a ``${...}`` interior, or ``None``.
+
+    A supplied value beats a written default, which is Compose's precedence --
+    the default applies only when the variable is unset. Operators that carry
+    no default (``:?``/``?``, ``:+``/``+``) are left to the caller, because
+    what they ship is not the variable's value.
+    """
+    head = _REF_HEAD_RE.match(interior)
+    if head is None:
+        return None
+    operator = head.group(2)
+    if operator is not None and operator not in _DEFAULT_OPERATORS:
+        return None
+    return env.get(head.group(1))
 
 
 def _default_of(interior: str) -> str | None:
@@ -171,8 +253,13 @@ def _default_of(interior: str) -> str | None:
     return interior[head.end() :]
 
 
-def substitute_defaults(value: str) -> str | None:
-    """Resolve ``${VAR:-default}`` to its default, or ``None`` if unresolvable.
+def substitute_defaults(value: str, env: Mapping[str, str] | None = None) -> str | None:
+    """Resolve ``${VAR}`` against ``env`` and ``${VAR:-default}`` to its default.
+
+    ``env`` is what a sibling ``.env`` supplies (ADR-026). It wins over a
+    written default, because that is Compose's own precedence: the default
+    applies only when the variable is unset. Without it the function answers
+    the narrower question it always did -- what the document ships on its own.
 
     With no ``.env`` and no exported variable, Compose substitutes the default,
     so the default *is* the configuration the file ships: it is what a fresh
@@ -194,7 +281,7 @@ def substitute_defaults(value: str) -> str | None:
     escaped = value.replace("$$", "")
     if not _VAR_REF_RE.search(escaped):
         return value  # nothing to substitute
-    resolved = _resolve_defaults(value)
+    resolved = _resolve_defaults(value, env=env)
     if resolved is None:
         return None  # nested deeper than we resolve -- not knowable
     if _VAR_NO_DEFAULT_RE.search(resolved.replace("$$", "")):

--- a/tests/test_env_interpolation.py
+++ b/tests/test_env_interpolation.py
@@ -1,0 +1,187 @@
+"""A sibling ``.env`` supplies interpolation values (ADR-026 §2).
+
+The gap this closes is the one issue #646 opened on: ``volumes: ["${MOUNT}:/data"]``
+with a ``.env`` setting ``MOUNT=/var/run/docker.sock`` deploys the control socket,
+and CL-0001 — the highest-severity rule in the tool — was silent on it.
+
+``TestCredentialRulesAreUnaffected`` is the other half, and the more important
+one to keep: a ``.env`` must never turn a credential rule *on*.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from compose_lint.engine import run_rules
+from compose_lint.parser import load_compose
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def write(directory: Path, name: str, text: str) -> Path:
+    path = directory / name
+    path.write_text(text, encoding="utf-8", newline="")
+    return path
+
+
+def rules_fired(directory: Path, *, use_env: bool = True) -> set[str]:
+    data, lines = load_compose(directory / "compose.yml", use_env=use_env)
+    return {f.rule_id for f in run_rules(data, lines) if not f.suppressed}
+
+
+def evidence_for(directory: Path, rule_id: str) -> set[str]:
+    data, lines = load_compose(directory / "compose.yml")
+    return {f.evidence for f in run_rules(data, lines) if f.rule_id == rule_id}
+
+
+class TestDeploymentValuesResolve:
+    """Values that describe what is deployed are resolved from the `.env`."""
+
+    def test_the_issue_646_reproduction(self, tmp_path: Path) -> None:
+        write(
+            tmp_path,
+            "compose.yml",
+            'services:\n  web:\n    image: i\n    volumes: ["${MOUNT}:/data"]\n',
+        )
+        write(tmp_path, ".env", "MOUNT=/var/run/docker.sock\n")
+        assert "CL-0001" in rules_fired(tmp_path)
+
+    def test_silent_without_the_env(self, tmp_path: Path) -> None:
+        """Unchanged behaviour: nothing is invented for an unsupplied name."""
+        write(
+            tmp_path,
+            "compose.yml",
+            'services:\n  web:\n    image: i\n    volumes: ["${MOUNT}:/data"]\n',
+        )
+        assert "CL-0001" not in rules_fired(tmp_path)
+
+    def test_no_env_opts_out(self, tmp_path: Path) -> None:
+        write(
+            tmp_path,
+            "compose.yml",
+            'services:\n  web:\n    image: i\n    volumes: ["${MOUNT}:/data"]\n',
+        )
+        write(tmp_path, ".env", "MOUNT=/var/run/docker.sock\n")
+        assert "CL-0001" not in rules_fired(tmp_path, use_env=False)
+
+    def test_a_supplied_value_beats_a_written_default(self, tmp_path: Path) -> None:
+        """Compose's own precedence: the default applies only when unset."""
+        write(
+            tmp_path,
+            "compose.yml",
+            'services:\n  web:\n    image: i\n    volumes: ["${M:-/tmp}:/data"]\n',
+        )
+        write(tmp_path, ".env", "M=/var/run/docker.sock\n")
+        assert "CL-0001" in rules_fired(tmp_path)
+
+    def test_a_supplied_value_can_also_clear_a_finding(self, tmp_path: Path) -> None:
+        """The gap runs both ways: a pinned tag retires a CL-0004."""
+        write(tmp_path, "compose.yml", 'services:\n  web:\n    image: "app:${TAG}"\n')
+        write(tmp_path, ".env", "TAG=1.2.3\n")
+        assert "CL-0004" not in rules_fired(tmp_path)
+
+    def test_a_segment_reference_resolves(self, tmp_path: Path) -> None:
+        """The commonest real shape: a directory from the `.env`, a fixed leaf.
+
+        The resolved path is what reaches the rule, so the evidence is the
+        joined value rather than the reference the file carries.
+        """
+        write(
+            tmp_path,
+            "compose.yml",
+            'services:\n  web:\n    image: i\n    volumes: ["${D}/docker.sock:/x"]\n',
+        )
+        write(tmp_path, ".env", "D=/var/run\n")
+        assert "/var/run/docker.sock" in evidence_for(tmp_path, "CL-0001")
+
+    def test_a_chained_env_value_resolves(self, tmp_path: Path) -> None:
+        write(
+            tmp_path,
+            "compose.yml",
+            'services:\n  web:\n    image: i\n    volumes: ["${SOCK}:/x"]\n',
+        )
+        write(tmp_path, ".env", "BASE=/var/run\nSOCK=${BASE}/docker.sock\n")
+        assert "CL-0001" in rules_fired(tmp_path)
+
+
+class TestCredentialRulesAreUnaffected:
+    """ADR-026 §2 as amended: a `.env` value never reaches `environment:`.
+
+    Without this the tool contradicts itself — CL-0021's own fix text offers
+    `postgres://user:${DB_PASSWORD}@host/db` as the remediation, so a `.env`
+    supplying `DB_PASSWORD` would flag the advice the rule just gave.
+    """
+
+    @pytest.mark.parametrize("spelling", ["mapping", "list"])
+    def test_a_supplied_password_does_not_fire_cl0020(
+        self, tmp_path: Path, spelling: str
+    ) -> None:
+        """Both spellings, because a `str` marker would survive only one."""
+        env_block = (
+            '      POSTGRES_PASSWORD: "${PW}"'
+            if spelling == "mapping"
+            else '      - "POSTGRES_PASSWORD=${PW}"'
+        )
+        write(
+            tmp_path,
+            "compose.yml",
+            "services:\n  db:\n    image: postgres:16\n"
+            f"    environment:\n{env_block}\n",
+        )
+        write(tmp_path, ".env", "PW=hunter2\n")
+        assert "CL-0020" not in rules_fired(tmp_path)
+
+    def test_a_supplied_connection_string_does_not_fire_cl0021(
+        self, tmp_path: Path
+    ) -> None:
+        write(
+            tmp_path,
+            "compose.yml",
+            "services:\n  app:\n    image: i\n    environment:\n"
+            '      DATABASE_URL: "${DB_URL}"\n',
+        )
+        write(tmp_path, ".env", "DB_URL=postgres://u:realpass@db/x\n")
+        assert "CL-0021" not in rules_fired(tmp_path)
+
+    def test_a_literal_still_fires(self, tmp_path: Path) -> None:
+        write(
+            tmp_path,
+            "compose.yml",
+            "services:\n  db:\n    image: postgres:16\n    environment:\n"
+            '      POSTGRES_PASSWORD: "hunter2"\n',
+        )
+        write(tmp_path, ".env", "PW=irrelevant\n")
+        assert "CL-0020" in rules_fired(tmp_path)
+
+    def test_a_written_default_still_fires(self, tmp_path: Path) -> None:
+        """A default is committed and ships to every clone, so it is the
+        file's own weak credential — unlike a value from a sibling."""
+        write(
+            tmp_path,
+            "compose.yml",
+            "services:\n  db:\n    image: postgres:16\n    environment:\n"
+            '      POSTGRES_PASSWORD: "${PW:-changeme}"\n',
+        )
+        write(tmp_path, ".env", "OTHER=x\n")
+        assert "CL-0020" in rules_fired(tmp_path)
+
+    def test_the_secret_is_never_read_out_of_the_env(self, tmp_path: Path) -> None:
+        """ADR-026 §5: a name referenced only from `environment:` is not even
+        in the wanted set, so its value is never retained."""
+        from compose_lint.parser import _referenced_names
+
+        data, _ = load_compose(
+            write(
+                tmp_path,
+                "compose.yml",
+                "services:\n  db:\n    image: i\n    environment:\n"
+                '      POSTGRES_PASSWORD: "${PW}"\n    volumes: ["${M}:/x"]\n',
+            ).parent
+            / "compose.yml"
+        )
+        names = _referenced_names(data)
+        assert "M" in names
+        assert "PW" not in names


### PR DESCRIPTION
Third and last commit of #646, under [ADR-026](https://github.com/tmatens/compose-lint/blob/main/docs/adr/026-read-the-sibling-env-file.md) §2. Builds on the reader (#655) and selection (#656).

Closes the gap the issue opened on:

```yaml
# compose.yml                  # .env
volumes: ["${MOUNT}:/data"]    MOUNT=/var/run/docker.sock
```

`docker compose config` resolves that to a bind mount of the control socket. compose-lint reported **zero CL-0001** — its highest-severity rule, silent. **22.0% of the corpus** carries a defaultless `${VAR}` in a value a rule consumes; 2,042 volume-mount sources do.

A supplied value beats a written default (Compose's own precedence — the default applies only when unset), and a name the `.env` does not define stays unresolved rather than guessed. `--no-env` opts out.

The gap runs both ways, as ADR-025's did: `image: "app:${TAG}"` with `TAG=1.2.3` **retires** a CL-0004 that was a false positive.

### ⚠️ ADR-026 §2's stated mechanism does not work, and is amended here

The ADR specified a `str` subclass carrying the written spelling, read by the credential rules and the formatters. **A subclass does not survive string operations.** CL-0021 splits a list-form `environment` entry on `=`; CL-0001 splits a volume on `:`. The marker is gone in exactly the places that need it, so the guarantee would have silently held for `environment: {PW: "${PW}"}` and silently failed for `environment: ["PW=${PW}"]` — the more common spelling.

What replaces it is positional and strictly stronger: **a `.env` value is never substituted into an `environment:` value at all.** That subtree is the one place in a Compose document whose values are payload rather than configuration, and the only rules that read one are CL-0020 and CL-0021 — verified, no other rule touches `environment` values. Nothing has to remember to unwrap anything, and both spellings are covered (the test is parametrised over them for that reason).

It also strengthens §5: a name referenced only from `environment:` is excluded from the wanted set, so **a credential the file externalises is never read out of the `.env` at all**.

ADR-026 is amended in place with an `*Amended (#646)*` note, following the precedent ADR-023 set for its own #602 amendment. The note also narrows the output half honestly: a `.env` value *can* still reach a report through a rule grading a deployment property — CL-0001 naming the mount source it resolved to — because that is the finding. What is guaranteed is that nothing under `environment:` is ever resolved, so none of it can be printed.

### Why the carve-out is not optional

Without it the tool contradicts itself. CL-0021's own fix text offers:

> Acceptable as an interim step: pull the credential from process env via substitution, e.g. `DATABASE_URL: postgres://user:${DB_PASSWORD}@host/db`

A user who follows that advice and puts `DB_PASSWORD` in `.env` would be flagged by the rule that gave it. Verified before and after:

| | before | after |
|---|---|---|
| `POSTGRES_PASSWORD: "hunter2"` | CL-0020 | CL-0020 ✓ unchanged |
| `POSTGRES_PASSWORD: "${PW}"` + `.env` | clean | clean ✓ |
| `POSTGRES_PASSWORD: "${PW:-changeme}"` | CL-0020 | CL-0020 ✓ unchanged |
| `DATABASE_URL: "${DB_URL}"` + `.env` | clean | clean ✓ |

A written default keeps firing: it is committed and ships to every clone, so it is the file's own weak credential, unlike a value from a sibling.

### Header

`files: compose.yml · env: .env · config: none · fail-on: high`

A read nobody is told about is the undeclared input ADR-023 clause 2 forbids, and stating it is what turns a laptop-versus-CI difference into a diff rather than a mystery.

### Verification

All four gates: ruff, format, mypy, **2301 passed, 10 skipped** (up 13). The corpus snapshot is unchanged, as expected — corpus files have no `.env` beside them, so nothing without one changes behaviour.
