### PR TITLE
Document the .env support and say when a value nobody supplied left rules unevaluated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,14 @@ the previous single-file grading exactly.
   the host's path separator, so this deliberately differs on a Windows lint
   host, in the same direction ADR-023 already took for path semantics.
 - `--no-env` ignores a sibling `.env` entirely, reproducing the previous file
-  selection.
+  selection. A run that skips one says so, because an escape hatch that
+  silently changes what is graded is the failure the hatch exists to prevent.
+- A note when a bind source is *only* unresolved references (`"${MOUNT}:/data"`
+  with nothing supplying `MOUNT`). Compose refuses to start a project with an
+  empty bind source, so the document being graded is not one that deploys and
+  the mount rules were never evaluated for it. Deliberately narrow — 3.3% of a
+  5,417-file corpus, against the 22% that carry *some* defaultless `${VAR}` —
+  and it is a note on stderr, so the exit code is unchanged.
 
 - Contract tests pin the JSON envelope and the SARIF log shape, the two
   surfaces `docs/compatibility.md` freezes at 1.0 that nothing enforced.

--- a/README.md
+++ b/README.md
@@ -268,6 +268,9 @@ check options:
                                could not be resolved, instead of failing (exit 2)
   --no-merge-overrides         Lint each file alone instead of merging the
                                `compose.override.yml` Compose merges beside it
+  --no-env                     Ignore a `.env` sitting beside the Compose file,
+                               which Compose reads for COMPOSE_FILE and for
+                               `${VAR}` values
   --config PATH                Path to config file (default: .compose-lint.yml)
   --strict-config              Treat config diagnostics (unknown rule id or key) as errors, not warnings
   --explain CL-XXXX            Print the full documentation for a single rule
@@ -276,6 +279,9 @@ check options:
 fix options:
   --apply                      Write fixes in place (default: print a dry-run diff)
   --only CL-XXXX               Restrict fixes to the named rule(s); repeatable
+  --no-merge-overrides         Fix each file alone instead of merging the
+                               `compose.override.yml` Compose merges beside it
+  --no-env                     Ignore a `.env` sitting beside the Compose file
   --config PATH                Path to config file (suppressions are honored)
   --strict-config              Treat config diagnostics (unknown rule id or key) as errors, not warnings
 
@@ -383,6 +389,15 @@ CI log that renders ANSI.
 | 2 | compose-lint couldn't run, or couldn't see the whole stack (invalid args, file not found, invalid Compose file, a rule crashed, or a coverage gap — see below) |
 
 **Overlays are merged.** `docker compose up` loads a `compose.override.yml` sitting beside the base file and merges it, with no flag and no opt-in, so the merged pair is what actually runs. compose-lint grades that pair: the run header names both documents, findings report the file their evidence is written in, and the exit code is unaffected because merging is coverage achieved, not a gap ([ADR-025](docs/adr/025-lint-the-merged-configuration.md)). `--no-merge-overrides` grades the base alone. `fix` edits only findings written in the file it is fixing; anything from the overlay is left for manual review.
+
+**A sibling `.env` is read, because Compose reads it.** `docker compose` loads a `.env` from the Compose file's own directory and uses it for two things, and compose-lint follows both ([ADR-026](docs/adr/026-read-the-sibling-env-file.md)):
+
+- **`COMPOSE_FILE` chooses the documents.** It replaces discovery *and* suppresses the automatic override merge, so a project configured that way is graded as the file set Compose actually loads. For a file you name on the command line, a `.env` can only *add* documents, never drop the one you asked for.
+- **`${VAR}` resolves to what the `.env` supplies.** `volumes: ["${MOUNT}:/data"]` with `MOUNT=/var/run/docker.sock` is a control-socket mount, and is now graded as one. A supplied value beats a written default, matching Compose; a name the `.env` does not define stays unresolved rather than guessed.
+
+Two deliberate limits. Values under `environment:` are **never** resolved from a `.env` — that is where secrets live, the only rules reading them grade sensitivity rather than deployment, and resolving there would make CL-0021 flag the very pattern its own fix text recommends. And references *inside* the `.env` are not expanded from your shell, so nothing about the machine running the lint reaches a finding.
+
+The run header names the `.env` it read, so two machines that read different ones produce a visible difference rather than a mystery. `--no-env` ignores it entirely. The ambient shell environment is out of scope: a `COMPOSE_FILE` exported in a session and never written down would make the same checkout lint differently depending on who ran the command.
 
 **Coverage gaps.** Beyond that overlay, compose-lint follows no references out of a file, so `include:` and cross-file `extends: {file: ...}` leave part of the stack unlinted. Reporting a pass over a partial view is the one failure mode a merge gate cannot have, so a gap is an error: exit 2, a JSON `errors[]` entry, and a SARIF `toolExecutionNotifications` record. Lint the merged output (`docker compose config`) to cover everything, or pass `--allow-partial-coverage` to accept the gap and grade what is visible.
 

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -50,6 +50,7 @@ from compose_lint.parser import (
     load_compose,
     load_merged,
     merge_patched,
+    unresolved_mount_sources,
 )
 
 
@@ -92,7 +93,32 @@ def _plan(args: argparse.Namespace) -> Selection:
     )
     for note in selection.notes:
         emit(f"note: {note}")
+    if args.no_env:
+        _note_env_not_read(selection)
     return selection
+
+
+def _note_env_not_read(selection: Selection) -> None:
+    """Say when a `.env` was there and deliberately skipped (ADR-026 §6).
+
+    An escape hatch that silently changes what is graded is the failure the
+    hatch was meant to prevent, one level up. Nothing here touches the exit
+    code; the point is only that the difference is stated, so a run that
+    disagrees with another machine's can be explained by reading its header
+    and notes instead of guessed at.
+    """
+    skipped = sorted(
+        {
+            str(Path(group.primary).parent / ENV_FILENAME)
+            for group in selection.groups
+            if (Path(group.primary).parent / ENV_FILENAME).is_file()
+        }
+    )
+    for path in skipped:
+        emit(
+            f"note: {path} was not read (--no-env), so it selected no documents "
+            "and supplied no values."
+        )
 
 
 def _attribute_sources(
@@ -687,6 +713,8 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
         coverage_errors.extend(
             _report_coverage_gaps(filepath, data, fatal=not args.allow_partial_coverage)
         )
+        for note in unresolved_mount_sources(data):
+            emit(f"note: {filepath}: {note}")
         seen_services.update(data.get("services", {}).keys())
 
         def _record_rule_error(

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -13,7 +13,11 @@ from compose_lint._lines import find_ambiguous_break
 from compose_lint._merge import Document, Merged, merge_documents, merge_values
 from compose_lint._safe_read import UnsafeFileError, read_text_bounded
 from compose_lint.config import KNOWN_TOP_LEVEL_KEYS
-from compose_lint.rules._interpolation import reference_names, substitute_defaults
+from compose_lint.rules._interpolation import (
+    reference_names,
+    ships_no_literal,
+    substitute_defaults,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -981,6 +985,53 @@ def _referenced_names(data: Any) -> set[str]:
 
     walk(data, False)
     return found
+
+
+def unresolved_mount_sources(data: dict[str, Any]) -> list[str]:
+    """Bind sources that are entirely an unresolved reference, per service.
+
+    Deliberately narrow. 22% of real Compose files carry *some* defaultless
+    ``${VAR}`` in a value a rule reads, and saying so on all of them would be
+    noise. This is the subset where the statement is unarguable: a source that
+    is nothing but references Compose cannot substitute ships an empty source,
+    and Compose then refuses to start at all --
+    ``invalid spec: :/data: empty section between colons`` (verified). So the
+    document being graded is not a configuration that deploys, and CL-0001 was
+    never evaluated for it.
+
+    Reported as a note rather than a coverage gap: ``--allow-partial-coverage``
+    governs stack we *cannot* read, and this is a value nobody supplied. Making
+    it exit 2 would fail a pipeline over a file that was already failing to
+    deploy, which the run is not the right place to discover.
+    """
+    notes: list[str] = []
+    services = data.get("services")
+    if not isinstance(services, dict):
+        return notes
+    for name, config in sorted(services.items()):
+        if not isinstance(config, dict):
+            continue
+        volumes = config.get("volumes")
+        if not isinstance(volumes, list):
+            continue
+        for volume in volumes:
+            source = (
+                _split_short_volume(volume)[0]
+                if isinstance(volume, str)
+                else volume.get("source")
+                if isinstance(volume, dict)
+                else None
+            )
+            if not isinstance(source, str) or not source:
+                continue
+            if ships_no_literal(source):
+                notes.append(
+                    f"service '{name}' mounts '{source}', which nothing "
+                    "supplies a value for. Compose refuses to start a project "
+                    "with an empty bind source, so this is not a configuration "
+                    "that deploys and the mount rules were not evaluated for it."
+                )
+    return notes
 
 
 def _split_short_volume(volume: str) -> tuple[str, str, str]:

--- a/tests/test_unresolved_notes.py
+++ b/tests/test_unresolved_notes.py
@@ -1,0 +1,84 @@
+"""Say when a value nobody supplies left the mount rules unevaluated.
+
+ADR-026 §6. The narrow half of the option-B "coverage signal" the issue
+considered: not every defaultless ``${VAR}`` (22% of real files, which would be
+noise) but the subset where the statement is unarguable — a bind source that is
+*only* references ships an empty source, and Compose then refuses to start the
+project at all.
+
+Measured over the corpus: 3.3% of files, which is the difference between a
+signal and a banner.
+"""
+
+from __future__ import annotations
+
+from compose_lint.parser import loads, unresolved_mount_sources
+
+
+def notes_for(document: str) -> list[str]:
+    data, _ = loads(document)
+    return unresolved_mount_sources(data)
+
+
+class TestUndeployableSources:
+    """A source that resolves to nothing is not a configuration that deploys."""
+
+    def test_a_whole_source_reference_is_noted(self) -> None:
+        assert notes_for(
+            'services:\n  web:\n    image: i\n    volumes: ["${MOUNT}:/data"]\n'
+        )
+
+    def test_the_note_names_the_service_and_the_spelling(self) -> None:
+        note = notes_for(
+            'services:\n  web:\n    image: i\n    volumes: ["${MOUNT}:/data"]\n'
+        )[0]
+        assert "'web'" in note
+        assert "${MOUNT}" in note
+
+    def test_the_long_syntax_is_covered_too(self) -> None:
+        assert notes_for(
+            "services:\n  web:\n    image: i\n    volumes:\n"
+            "      - type: bind\n        source: ${MOUNT}\n        target: /data\n"
+        )
+
+    def test_several_references_still_ship_nothing(self) -> None:
+        assert notes_for(
+            'services:\n  web:\n    image: i\n    volumes: ["${A}${B}:/data"]\n'
+        )
+
+
+class TestQuietWhereTheSourceIsKnowable:
+    """Everything the tool *can* grade stays silent, which is the whole point.
+
+    A note on 22% of real files would be a banner rather than a signal.
+    """
+
+    def test_a_literal_source_is_silent(self) -> None:
+        assert not notes_for(
+            'services:\n  web:\n    image: i\n    volumes: ["/srv:/data"]\n'
+        )
+
+    def test_a_defaulted_reference_is_silent(self) -> None:
+        """It resolves to the default, which is what the file ships."""
+        assert not notes_for(
+            'services:\n  web:\n    image: i\n    volumes: ["${M:-/srv}:/data"]\n'
+        )
+
+    def test_a_segment_reference_is_silent(self) -> None:
+        """``${DATA}/logs`` still ships a non-empty source, so Compose starts;
+        the path is wrong rather than absent, which this note does not claim."""
+        assert not notes_for(
+            'services:\n  web:\n    image: i\n    volumes: ["${DATA}/logs:/x"]\n'
+        )
+
+    def test_a_named_volume_is_silent(self) -> None:
+        assert not notes_for(
+            'services:\n  web:\n    image: i\n    volumes: ["data:/x"]\n'
+            "volumes:\n  data: {}\n"
+        )
+
+    def test_a_service_without_volumes_is_silent(self) -> None:
+        assert not notes_for("services:\n  web:\n    image: i\n")
+
+    def test_a_document_without_services_is_silent(self) -> None:
+        assert not unresolved_mount_sources({})


### PR DESCRIPTION
Finishes #646. Two commits, both small, closing the last gaps after the reader (#655), selection (#656), and interpolation (#657).

### 1. Documentation

Three merged PRs changed which files get linted and what a `${VAR}` resolves to, and **`README.md` mentioned `.env` zero times** — the only way to find out was the CHANGELOG or an ADR. The new paragraph sits beside the one on the overlay merge, which it extends, and states the two deliberate *limits* rather than only the capability:

- values under `environment:` are never resolved from a `.env`
- references inside the `.env` are not expanded from your shell

`fix` was also missing `--no-merge-overrides` from its reference block, so documenting `--no-env` alone would have left its sibling out. Both are added, and a check against `--help` confirms every flag all three subcommands expose now appears: check 11/11, fix 6/6, init 2/2.

### 2. Two silences made loud (ADR-026 §6)

Neither touches the exit code.

**`--no-env` now names the `.env` it skipped.** An escape hatch that quietly changes what is graded is the failure the hatch exists to prevent, one level up.

**A bind source that is *only* unresolved references gets a note.** This is the narrow half of the coverage signal the issue weighed as option B:

```
note: compose.yml: service 'web' mounts '${MOUNT}', which nothing supplies a
      value for. Compose refuses to start a project with an empty bind source,
      so this is not a configuration that deploys and the mount rules were not
      evaluated for it.
```

Verified against Compose, which agrees the project cannot start:

```
$ docker compose config
invalid spec: :/data: empty section between colons
```

**Scoped deliberately.** Not every defaultless `${VAR}` — that is 22% of real files and would be a banner rather than a signal. Only the subset where the statement is unarguable: a source that substitutes to nothing. Measured over the 4,834 parseable corpus files: **159 files, 3.3%**, 497 notes. `TestQuietWhereTheSourceIsKnowable` pins the other side — a literal, a `${M:-/srv}` default, a `${DATA}/logs` segment, and a named volume all stay silent.

**A note, not a coverage gap.** `--allow-partial-coverage` governs stack compose-lint *cannot read*; this is a value nobody supplied. Exiting 2 would fail a pipeline over a file that was already failing to deploy, which a lint run is not the right place to discover.

### Verification

All four gates: ruff, format, mypy, **2311 passed, 10 skipped** (up 10). Both notes were also exercised end to end through the real CLI, including the case where adding the `.env` value makes the note go away.

### After this

#646 can close. Remaining from the wider thread, none of it in scope here: cutting a release (which starts the Python 3.10 grace period #643 is waiting on), and the 3.15 CI matrix entry, which is still unfiled.
