### PR TITLE
Record COMPOSE_PROFILES as out of scope for the .env read

### DIFF
--- a/docs/adr/026-read-the-sibling-env-file.md
+++ b/docs/adr/026-read-the-sibling-env-file.md
@@ -227,6 +227,18 @@ git", which is gitleaks/trufflehog territory and would make compose-lint git-awa
 answer. The advice that *is* actionable already exists and already fires — CL-0020,
 pointing at `secrets:` and the `*_FILE` convention.
 
+Also out of scope: **`COMPOSE_PROFILES`.** A `.env` may set it, and doing so
+activates a profile (verified), so it changes which services Compose starts — the
+same shape of claim `COMPOSE_FILE` makes about which files it loads, from the same
+file. It is left unread because compose-lint grades *every* service in a document
+today, and skipping the ones whose profile is inactive would trade a false positive
+for a silent false negative: 47 CRITICAL findings across the 4,834-file corpus sit on
+profiled services, 29 of them CL-0001, in 153 files that would then report nothing at
+all. Honouring it would need the treatment §4 gives `COMPOSE_FILE` — never narrowing
+what a named file grades — and that has not been designed. Recorded here rather than
+decided, because a reader of this ADR will reasonably ask what else was in that file;
+the measurement is in [#659](https://github.com/tmatens/compose-lint/issues/659).
+
 **Alternatives considered:**
 
 - **Keep the current rule, document it.** The gap stays exactly as silent as it is,


### PR DESCRIPTION
Closes #659 by moving its substance somewhere durable.

ADR-026 settled what compose-lint reads out of a sibling `.env` and listed what it deliberately does not — the ambient shell, `COMPOSE_ENV_FILES`, `--env-file`, and "there is a secret in your `.env`" as a finding. It said nothing about **`COMPOSE_PROFILES`**, which is the other Compose variable in that same file that changes what runs. Anyone reading the decision later will reasonably ask what else was in there, and silence is a worse answer than a stated boundary.

### Why the ADR rather than an open issue

#659 was filed as an observation with no demand signal and no proposed work. An issue is a claim on attention; a scope note is a decision record, and this is the second kind — especially with 1.0 approaching behind a deliberately short list.

Nothing is lost by closing it:

- the measurement stays in the closed issue, linked from the ADR, and is reproducible from the corpus in ~90 seconds
- the differential-testing gotcha is already handled where it bites — `tests/test_selection_semantics.py` excludes profiled services with a comment saying why

### What the note records

That `COMPOSE_PROFILES` in a `.env` **does** activate a profile (verified), so it makes the same shape of claim about which services start that `COMPOSE_FILE` makes about which files load — and that it is left unread deliberately, not merely unimplemented:

> compose-lint grades every service in a document today, and skipping the ones whose profile is inactive would trade a false positive for a silent false negative: 47 CRITICAL findings across the 4,834-file corpus sit on profiled services, 29 of them CL-0001, in 153 files that would then report nothing at all.

It also names what honouring it would require — the §4 treatment `COMPOSE_FILE` gets, never narrowing what a named file grades — so the next person starts from the constraint rather than rediscovering it.

### Verification

Docs-only. `ruff check src/ tests/`, `ruff format --check src/ tests/`, `mypy src/`, and `pytest` all pass — 2311 passed, 10 skipped, unchanged from `main`.
