### PR TITLE
Record three scope boundaries: --project-directory, the loader's UTF-8/single-document assumptions, and what exit 0 does not claim

### DIFF
--- a/docs/adr/003-yaml-parsing.md
+++ b/docs/adr/003-yaml-parsing.md
@@ -16,3 +16,27 @@
 - Compose files use YAML 1.1 in practice. PyYAML's YAML 1.1 support matches Docker's own parser behavior.
 - Line numbers are captured via a `LineLoader(SafeLoader)` subclass (~30 lines). Parsed output is plain `dict`/`list`, so rules have no parser coupling.
 - The parser can be swapped later without touching rule code since the interface is `load_compose(path) -> (data, lines)`.
+
+**Known divergences from Compose's loader:**
+
+Two documents Compose accepts are refused by this parser. Both were measured against
+Docker Compose 5.4.0 and neither occurs in the 5,417-file corpus, so both are recorded
+as boundaries rather than tracked as defects.
+
+- **Multi-document streams.** Compose loads a `---`-separated stream and merges every
+  document into one project — a service defined only in the second document is part of
+  the deployment, in either document order. `LineLoader` uses `yaml.load`, so
+  compose-lint refuses the file with `Invalid YAML: expected a single document in the
+  stream` and exit 2. A leading `---` start marker and a trailing `...` end marker are
+  both handled and unaffected. Corpus incidence: 0 of 5,417 — 127 files contain a `---`
+  line, but every one of those markers sits inside a block scalar rather than opening a
+  document.
+- **Non-UTF-8 encodings.** A UTF-16-encoded Compose file parses cleanly for Compose and
+  is refused here with `Invalid encoding: file is not valid UTF-8` and exit 2. A UTF-8
+  BOM and CRLF line endings are both handled and produce unchanged findings; a file
+  with an invalid UTF-8 byte is refused by *both* tools. Corpus incidence: 0 of 5,417.
+
+Both fail loudly at exit 2 with an accurate message, which is what keeps them
+boundaries: a stack in either shape is unlintable rather than mis-linted, so neither
+can produce the silent false negative ADR-023 treats as the worst outcome. That is the
+whole reason they are cheap to leave open — a reader is told, and a CI gate stops.

--- a/docs/adr/006-exit-codes.md
+++ b/docs/adr/006-exit-codes.md
@@ -11,3 +11,12 @@
 - Default behavior is strict (fail on high/critical) but teams can relax with `--fail-on critical` or tighten with `--fail-on low`.
 - Exit 2 for file/config errors distinguishes "your compose file has issues" from "compose-lint itself couldn't run."
 - A rule that raises is isolated rather than aborting the run (the failure is reported to stderr and the sweep continues), and maps to exit 2 for the same reason: it means compose-lint itself couldn't complete the analysis, not that the file failed the lint. This keeps a crash from being silently truncated mid-sweep or mistaken for a clean exit-1 findings result.
+- Exit 0 means "no findings at or above the threshold", not "Docker Compose would run
+  this project". compose-lint is not a schema validator, and two ordinary shapes make
+  the difference visible: `env_file: [missing.env]` and an unset `${VAR:?required}`
+  each make `docker compose config` exit 1 and refuse the project outright, while
+  compose-lint exits 0 (both verified against Docker Compose 5.4.0). The verdict is not
+  wrong — a project that cannot deploy has no deployment to grade — but "clean" is a
+  generous word for it, and a pipeline that treats exit 0 as "safe to ship" is reading
+  a claim this tool does not make. Validation is `docker compose config`'s job and
+  running both is the intended arrangement.

--- a/docs/adr/026-read-the-sibling-env-file.md
+++ b/docs/adr/026-read-the-sibling-env-file.md
@@ -239,6 +239,20 @@ what a named file grades — and that has not been designed. Recorded here rathe
 decided, because a reader of this ADR will reasonably ask what else was in that file;
 the measurement is in [#659](https://github.com/tmatens/compose-lint/issues/659).
 
+Also out of scope: **`--project-directory`.** Compose reads `.env` from the *project
+directory*, which defaults to the base directory of the first Compose file but is
+overridable, and the flag relocates the read: with `stack/.env` setting
+`BIND=127.0.0.1` and a parent `.env` setting `BIND=0.0.0.0`,
+`docker compose -f stack/compose.yml config` yields `host_ip: 127.0.0.1` while
+`--project-directory .` yields `host_ip: 0.0.0.0` (verified). compose-lint reads the
+sibling `.env` and so reports the first, which is the deployment the file describes on
+its own. Honouring the flag is the same category the paragraph above already excludes
+for `--env-file`: a flag on someone's deploy command, absent from every file under
+inspection, that would make the same checkout lint differently depending on how it is
+invoked. Named here because the governing principle — *use files as Docker Compose
+would, when run in that file's directory* — is stated in terms of a directory, and a
+reader is entitled to know which one wins when the two disagree.
+
 **Alternatives considered:**
 
 - **Keep the current rule, document it.** The gap stays exactly as silent as it is,


### PR DESCRIPTION
Three boundaries that were true but unwritten, found while probing where compose-lint's view of a Compose file diverges from the effective configuration Docker Compose assembles. Every claim here was verified against `docker compose config` (Docker Compose 5.4.0, Linux) rather than read from documentation.

Docs only — no source changes, no behaviour change.

## What each commit records

**ADR-026 — `--project-directory` is out of scope.** The out-of-scope paragraph names the ambient shell, `COMPOSE_ENV_FILES` and `--env-file`, but not the flag that relocates the `.env` read by moving the project directory out from under the Compose file. Since the governing principle is stated in terms of *"that file's directory"*, a reader hits the question directly. Verified: with `stack/.env` setting `BIND=127.0.0.1` and a parent `.env` setting `BIND=0.0.0.0`, `docker compose -f stack/compose.yml config` yields `host_ip: 127.0.0.1` and `--project-directory .` yields `host_ip: 0.0.0.0`. Same category as `--env-file`, excluded for the same reason.

**ADR-003 — the two loader shapes Compose accepts and this parser refuses.** ADR-003 claimed PyYAML "matches Docker's own parser behavior" without naming where it does not.

- *Multi-document streams* — Compose merges every `---`-separated document into one project, in either document order; compose-lint exits 2 with `expected a single document in the stream`.
- *Non-UTF-8 encodings* — a UTF-16 file parses cleanly for Compose and exits 2 here.

Both measured at **0 of 5,417 corpus files**, and both fail loudly at exit 2, so a stack in either shape is unlintable rather than mis-linted — no silent false negative is reachable through them. The commit also records the adjacent cases that *do* work (leading `---`, trailing `...`, UTF-8 BOM, CRLF, and invalid-UTF-8 refused by both tools), because without that list a reader cannot tell how wide the gap is.

**ADR-006 — what exit 0 does not claim.** `env_file: [missing.env]` and an unset `${VAR:?required}` each make Compose refuse the project while compose-lint exits 0. Not a wrong verdict — a project that cannot deploy has no deployment to grade — but the exit-code contract is what a CI pipeline keys on, so the boundary belongs beside the codes rather than inferred from the non-goal in CLAUDE.md.

## Deliberately not in this PR

- **`env_file:` credentials are silently missed** — the real gap, tracked in #665 as a decision issue. Not a doc fix.
- **`${VAR:?err}` / `${VAR:+alt}` discard the sibling `.env` value** — a defect, tracked in #664.
- **`label_file:`** — recommended for whatever ADR resolves #665, since it is the same file-reference shape. Recording it here would put it in the wrong document.

## Testing

`pytest -k "adr or doc or surface"` — 267 passed, 3 skipped.
