### PR TITLE
Resolve every substitution operator against the sibling .env, not just defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Every Compose substitution operator now resolves against a sibling `.env`,
+  not just `${VAR:-default}` and `${VAR-default}`. `${VAR:?err}`, `${VAR?err}`,
+  `${VAR:+alt}` and `${VAR+alt}` fetched the `.env` value and then discarded it,
+  so a `${BIND:?required}` that Compose resolves to `0.0.0.0` reached the rules
+  as source text and CL-0005 could not fire. The same function also shipped the
+  empty string for `${VAR:-default}` where `.env` sets `VAR=` and Compose ships
+  the default — a `:`-prefixed operator treats an empty value as unset. All
+  eighteen operator/state combinations are now pinned by a differential test
+  against the Compose binary
+  ([#664](https://github.com/tmatens/compose-lint/issues/664)).
+
+  Findings only change for a project that ships a `.env`: with none, every
+  operator was and remains unresolved. The 5,417-file corpus produces a byte-
+  identical result set.
+
 ## [0.22.0] - 2026-08-22
 
 ### Upgrading

--- a/src/compose_lint/rules/_interpolation.py
+++ b/src/compose_lint/rules/_interpolation.py
@@ -39,6 +39,12 @@ _REF_HEAD_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)(:?[-?+])?")
 
 _DEFAULT_OPERATORS = frozenset({":-", "-"})
 
+# The operators that substitute an *alternate* -- text used when the variable is
+# set, the mirror of a default. `${V:+alt}` ships `alt` for a set `V`, so the
+# alternate is a literal the file carries and a reference inside one is a name
+# the run consumes.
+_ALTERNATE_OPERATORS = frozenset({":+", "+"})
+
 # How deep a chain of nested defaults will be resolved. Resolution recurses
 # into each default, so without a bound a scalar of `${A:-` repeated ~1,200
 # times -- 7 KB, under `MAX_SCAN_LEN` -- exhausts the interpreter stack, and
@@ -217,6 +223,13 @@ def reference_names(value: str) -> set[str]:
             default = _default_of(interior)
             if default is not None:
                 found |= reference_names(default)
+            # An alternate is substituted text like a default, so a reference
+            # inside one is a name the run consumes: `${SET:+${OTHER}}` needs
+            # OTHER kept by the ADR-026 §5 wanted-set filter, or resolution
+            # would later find it missing from an env that did read it.
+            alternate = _alternate_of(interior)
+            if alternate is not None:
+                found |= reference_names(alternate)
             index = close + 1
             continue
         name = _BARE_NAME_RE.match(value, index + 1)
@@ -229,26 +242,92 @@ def reference_names(value: str) -> set[str]:
 
 
 def _supplied(interior: str, env: Mapping[str, str]) -> str | None:
-    """What ``env`` supplies for a ``${...}`` interior, or ``None``.
+    """What this ``${...}`` interior resolves to given ``env``, or ``None``.
 
     A supplied value beats a written default, which is Compose's precedence --
-    the default applies only when the variable is unset. Operators that carry
-    no default (``:?``/``?``, ``:+``/``+``) are left to the caller, because
-    what they ship is not the variable's value.
+    the default applies only when the variable is unset.
+
+    Every operator resolves once ``env`` supplies the name, not just the two
+    that carry a default. ``${V:?err}`` with ``V`` set is the plain reference
+    ``${V}``; the error text applies only when it is unset. ``${V:+alt}`` with
+    ``V`` set is the literal ``alt``, written in the file. Reading only ``:-``
+    and ``-`` here left the ``.env`` value fetched and then discarded, so a
+    ``${BIND:?required}`` that Compose resolves to ``0.0.0.0`` reached the rules
+    as source text and CL-0005 could not fire (issue #664).
+
+    The colon distinguishes *unset* from *set but empty*, and the two are not
+    interchangeable -- ``${V:-DEF}`` ships ``DEF`` for an empty ``V`` while
+    ``${V-DEF}`` ships the empty string. Captured from Docker Compose 5.4.0
+    with the name supplied by a sibling ``.env``:
+
+    ==================  ==============  ===========  ==========
+    written             ``V=hello``     ``V=``       unset
+    ==================  ==============  ===========  ==========
+    ``${V:-DEF}``       ``hello``       ``DEF``      ``DEF``
+    ``${V-DEF}``        ``hello``       *empty*      ``DEF``
+    ``${V:?err}``       ``hello``       *refused*    *refused*
+    ``${V?err}``        ``hello``       *empty*      *refused*
+    ``${V:+ALT}``       ``ALT``         *empty*      *empty*
+    ``${V+ALT}``        ``ALT``         ``ALT``      *empty*
+    ==================  ==============  ===========  ==========
+
+    ``None`` means this function does not answer, and the caller falls through
+    to the written default or leaves the reference as written. It covers three
+    distinct cases, all of which must stay unresolved:
+
+    * **The name is not in ``env``.** For ``:-``/``-`` the caller supplies the
+      default. For ``:?``/``?`` Compose refuses the project outright, so there
+      is no configuration to grade. For ``:+``/``+`` Compose ships empty *when
+      nothing else sets the variable* -- but ADR-026 deliberately does not model
+      the ambient shell, so a name absent from ``.env`` is not knowably unset,
+      exactly as it is not for a bare ``${VAR}``.
+    * **``${V:?err}`` with ``V`` empty**, which Compose refuses for the same
+      reason as unset.
+    * **``${V:-DEF}`` with ``V`` empty**, where the written default is what
+      ships and the caller already knows how to reach it.
     """
     head = _REF_HEAD_RE.match(interior)
     if head is None:
         return None
-    operator = head.group(2)
-    if operator is not None and operator not in _DEFAULT_OPERATORS:
+    name, operator = head.group(1), head.group(2)
+    if name not in env:
         return None
-    return env.get(head.group(1))
+    value = env[name]
+    # A ":"-prefixed operator treats an empty value as unset; the bare form
+    # treats it as set. Every divergence in the table above is this one bit.
+    empty = not value
+    if operator is None or operator == "-":
+        return value
+    if operator == ":-":
+        return None if empty else value
+    if operator == ":?":
+        return None if empty else value
+    if operator == "?":
+        return value
+    alternate = interior[head.end() :]
+    if operator == ":+":
+        return "" if empty else alternate
+    return alternate  # "+": set, empty or not, ships the alternate
 
 
 def _default_of(interior: str) -> str | None:
     """The default an interpolation interior carries, or ``None`` if it has none."""
     head = _REF_HEAD_RE.match(interior)
     if head is None or head.group(2) not in _DEFAULT_OPERATORS:
+        return None
+    return interior[head.end() :]
+
+
+def _alternate_of(interior: str) -> str | None:
+    """The alternate a ``:+``/``+`` interior carries, or ``None`` for any other.
+
+    Distinct from :func:`_default_of` because the two substitute under opposite
+    conditions -- a default when the variable is *unset*, an alternate when it
+    is *set* -- so nothing may treat one as the other. Both are substituted
+    text, which is why :func:`reference_names` walks into each.
+    """
+    head = _REF_HEAD_RE.match(interior)
+    if head is None or head.group(2) not in _ALTERNATE_OPERATORS:
         return None
     return interior[head.end() :]
 

--- a/tests/test_interpolation_operators.py
+++ b/tests/test_interpolation_operators.py
@@ -1,0 +1,173 @@
+"""Differential test: do we resolve each substitution operator as Compose does?
+
+Compose has six substitution operators and they differ along two axes: whether
+they substitute when the variable is *unset* (``:-``/``-``) or when it is *set*
+(``:+``/``+``), and whether a leading colon makes an *empty* value count as
+unset. Six spellings times three states of the variable is eighteen answers, and
+they are not derivable from the Compose documentation with enough confidence to
+hand-write — issue #664 was exactly a case where the plausible reading was wrong
+and a ``${BIND:?required}`` resolving to ``0.0.0.0`` reached the rules as source
+text.
+
+So this asks the binary, on every run, rather than pinning a table someone
+transcribed once. A Compose release that changes an operator fails here instead
+of silently mis-resolving a user's stack.
+
+The variable is supplied by a sibling ``.env``, which is the case ADR-026 put in
+scope; the ambient shell stays out of it.
+
+Skipped when the ``docker compose`` CLI is unavailable, so the suite still runs
+in environments without it.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from compose_lint._env_file import parse_env
+from compose_lint.rules._interpolation import substitute_defaults
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _compose_cli_works() -> bool:
+    """Whether ``docker compose`` can actually run, not merely whether it exists."""
+    if shutil.which("docker") is None:
+        return False
+    try:
+        return (
+            subprocess.run(
+                ["docker", "compose", "version"],
+                capture_output=True,
+                timeout=30,
+            ).returncode
+            == 0
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _compose_cli_works(),
+    reason="differential interpolation test needs a working docker compose CLI",
+)
+
+_COMPOSE = """\
+services:
+  s:
+    image: i
+    environment:
+      OUT: "%s"
+"""
+
+# The six operators, written against a variable named V.
+OPERATORS = ["${V:-DEF}", "${V-DEF}", "${V:?err}", "${V?err}", "${V:+ALT}", "${V+ALT}"]
+
+# The three states a sibling `.env` can leave V in. An absent V is spelled with
+# an unrelated key so the file itself is still valid.
+STATES = {"set": "V=hello", "empty": "V=", "absent": "OTHER=x"}
+
+# Cases where Compose refuses the project outright. There is no configuration to
+# grade, so the only correct answer is "unresolved".
+REFUSED = {
+    ("${V:?err}", "empty"),
+    ("${V:?err}", "absent"),
+    ("${V?err}", "absent"),
+}
+
+# Cases where Compose ships a value and we deliberately decline to, with the
+# reason. Listed here so the split is visible in one place rather than being an
+# unexplained gap in coverage.
+DIVERGENT = {
+    ("${V:+ALT}", "absent"): (
+        "Compose ships empty because nothing set V, but ADR-026 does not model "
+        "the ambient shell, so a name absent from .env is not knowably unset -- "
+        "the same call made for a bare ${VAR}."
+    ),
+    ("${V+ALT}", "absent"): (
+        "Same as ${V:+ALT} with V absent: knowing the alternate does not ship "
+        "requires knowing nothing outside the .env set V."
+    ),
+}
+
+
+def _compose_resolves(directory: Path, expression: str, env_text: str) -> str | None:
+    """Ground truth: what Compose substitutes for ``expression``.
+
+    ``None`` means Compose refused the file, which is a real answer for the
+    ``REFUSED`` cases rather than a broken fixture.
+    """
+    (directory / "compose.yml").write_text(
+        _COMPOSE % expression, encoding="utf-8", newline=""
+    )
+    (directory / ".env").write_text(env_text, encoding="utf-8", newline="")
+    result = subprocess.run(
+        ["docker", "compose", "config"],
+        cwd=directory,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        return None
+    document = yaml.safe_load(result.stdout)
+    # `config` prints a literal `$` as `$$` so its output round-trips through
+    # Compose's own interpolation; compare the value, not the serialisation.
+    return str(document["services"]["s"]["environment"]["OUT"]).replace("$$", "$")
+
+
+def _ours(expression: str, env_text: str) -> str | None:
+    return substitute_defaults(expression, parse_env(env_text, ["V"]).values)
+
+
+@pytest.mark.parametrize("state", sorted(STATES))
+@pytest.mark.parametrize("expression", OPERATORS)
+def test_operator_matches_compose(expression: str, state: str, tmp_path: Path) -> None:
+    """Every operator resolves to what Compose ships, or declines for a reason."""
+    theirs = _compose_resolves(tmp_path, expression, STATES[state])
+    ours = _ours(expression, STATES[state])
+
+    if (expression, state) in REFUSED:
+        assert theirs is None, (
+            f"{expression} with V {state} was expected to be refused by Compose, "
+            f"but it shipped {theirs!r} -- move it out of REFUSED"
+        )
+        assert ours is None, (
+            f"{expression} with V {state}: Compose refuses the project, so there "
+            f"is nothing to grade, but we resolved it to {ours!r}"
+        )
+        return
+
+    assert theirs is not None, f"compose refused an unexpected fixture: {expression}"
+
+    if (expression, state) in DIVERGENT:
+        assert ours is None, (
+            f"{expression} with V {state} is recorded as a divergence "
+            f"({DIVERGENT[(expression, state)]}) but we resolved it to {ours!r}. "
+            "If that is now intended, move it out of DIVERGENT."
+        )
+        return
+
+    assert ours == theirs, (
+        f"disagreement for {expression} with V {state}: "
+        f"compose ships {theirs!r}, we ship {ours!r}"
+    )
+
+
+def test_required_operator_resolves_a_supplied_value(tmp_path: Path) -> None:
+    """The regression from #664, end to end.
+
+    ``${BIND:?required}`` with a ``.env`` supplying BIND is the plain reference
+    ``${BIND}``; the error text applies only when it is unset. Reading only the
+    default operators left the value fetched and discarded, so CL-0005 could not
+    see the ``0.0.0.0`` Compose publishes on.
+    """
+    theirs = _compose_resolves(tmp_path, "${BIND:?required}", "BIND=0.0.0.0")
+    assert theirs == "0.0.0.0"
+    assert substitute_defaults("${BIND:?required}", {"BIND": "0.0.0.0"}) == "0.0.0.0"


### PR DESCRIPTION
Closes #664.

#657 taught `substitute_defaults` to resolve `${VAR}` from a sibling `.env`, but the operator table it routes through was never revisited. For four of Compose's six substitution operators the `.env` value was fetched and then discarded, so a reference Compose resolves to something dangerous reached the rules as source text and no rule could classify it.

```yaml
services:
  web:
    image: nginx:1.27
    ports: ['${BIND:?must set}:8080:80']
# .env: BIND=0.0.0.0
```

`docker compose config` publishes on `host_ip: 0.0.0.0`. Before this change compose-lint exited 0 with CL-0005 absent; the same fixture written `${BIND:-0.0.0.0}` fired it correctly, which is what located the fault.

## What was wrong

`_supplied` returned `None` for any operator outside `{":-", "-"}`. The module comment justified it:

> `":?"/"?"` and `":+"/"+"` do not: they carry an error message or an alternate, so a reference spelled with one has no default to resolve to.

Correct, and irrelevant once `env` can supply the name — `${V:?err}` with `V` set *is* `${V}` with `V` set. The `env` argument simply never reached the branch.

**A second bug in the same function surfaced while fixing it.** The colon distinguishes *unset* from *set but empty*, and `_supplied` ignored the difference: `${V:-DEF}` with `.env: V=` ships `DEF` from Compose and shipped the empty string here.

## What it does now

Captured from Docker Compose 5.4.0, with the name supplied by a sibling `.env`:

| written | `V=hello` | `V=` | unset |
|---|---|---|---|
| `${V:-DEF}` | `hello` | `DEF` | `DEF` |
| `${V-DEF}` | `hello` | *empty* | `DEF` |
| `${V:?err}` | `hello` | *refused* | *refused* |
| `${V?err}` | `hello` | *empty* | *refused* |
| `${V:+ALT}` | `ALT` | *empty* | *empty* |
| `${V+ALT}` | `ALT` | `ALT` | *empty* |

Two cases stay deliberately unresolved:

- **`${V:?err}` with `V` unset or empty** — Compose refuses the project outright, so there is no configuration to grade.
- **`${V:+alt}` with `V` absent from `.env`** — Compose ships empty *only if nothing else set it*, and ADR-026 does not model the ambient shell. This is the same call already made for a bare `${VAR}`, and it is recorded as a divergence with that reason rather than left as an unexplained gap.

Names inside an alternate are now kept by the ADR-026 §5 wanted-set filter, since an alternate is substituted text exactly as a default is (`${SET:+${OTHER}}` needs `OTHER`).

## Testing

`tests/test_interpolation_operators.py` is a differential test in the style of `test_env_semantics.py`: it re-derives all eighteen operator/state combinations **from the binary on every run** rather than pinning a transcribed table, so a Compose release that changes an operator fails here instead of silently mis-resolving a user's stack. It skips cleanly where the Compose CLI is unavailable. The `REFUSED` and `DIVERGENT` sets are asserted in both directions — if Compose ever starts shipping a value we decline, or stops refusing one we expect it to, the test says so and names the set to move it out of.

- 19 new tests; full suite 2,330 passed, 10 skipped
- `ruff check` / `ruff format --check` / `mypy --strict` clean

## Blast radius

**No finding changes without a `.env`.** With none, `_supplied` returns `None` for every name exactly as before. Verified: `scripts/corpus/run.py` over all 5,417 corpus files produces a **byte-identical** `(rule_id, service, evidence)` set per `content_hash` against the run from `main` — 0 files changed. The corpus is filename-filtered (`scripts/corpus/fetch.py:29`) so it carries no `.env` files, which is precisely why it cannot exercise the fixed path; the differential test is what covers it.

For projects that *do* ship a `.env`, expect new findings, including CRITICAL ones — the documented MINOR behaviour for tightened coverage, consistent with how #657 and #648 shipped. 151 corpus files (2.79%) use `:?`/`?` and 8 (0.15%) use `:+`/`+`, so the population that could newly resolve is real, though how much of it ships a `.env` is not measurable from the corpus.
