### PR TITLE
Say when an env_file: left the credential rules unevaluated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- A note when a service names an `env_file:`. Compose merges those files into
+  the container's process environment, so a credential written in one reaches
+  every surface CL-0020 describes while never appearing in the document —
+  moving a line out of `environment:` silenced CL-0020 and CL-0021 without
+  changing what deploys. The files are still not opened; the note states what
+  was not evaluated, so the gap is visible rather than silent
+  ([#665](https://github.com/tmatens/compose-lint/issues/665)).
+
+  Stderr only, like the unread-`.env` and unresolved-mount-source notes. No
+  finding, exit code, or machine-readable output changes: 415 of the 5,417-file
+  corpus (8.6% of those that lint) now carry the note and none of their results
+  moved.
+
 ### Fixed
 
 - Every Compose substitution operator now resolves against a sibling `.env`,

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -50,6 +50,7 @@ from compose_lint.parser import (
     load_compose,
     load_merged,
     merge_patched,
+    unread_env_files,
     unresolved_mount_sources,
 )
 
@@ -714,6 +715,8 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
             _report_coverage_gaps(filepath, data, fatal=not args.allow_partial_coverage)
         )
         for note in unresolved_mount_sources(data):
+            emit(f"note: {filepath}: {note}")
+        for note in unread_env_files(data):
             emit(f"note: {filepath}: {note}")
         seen_services.update(data.get("services", {}).keys())
 

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -1034,6 +1034,77 @@ def unresolved_mount_sources(data: dict[str, Any]) -> list[str]:
     return notes
 
 
+def unread_env_files(data: dict[str, Any]) -> list[str]:
+    """Services whose ``env_file:`` targets were never read, per service.
+
+    Compose loads each named file and merges its keys into the container's
+    process environment, so a credential written there reaches every surface
+    CL-0020's documentation names -- ``docker inspect``, the daemon's view of
+    the static config, and any container with daemon access -- while never
+    appearing in the document. Moving one line from ``environment:`` into an
+    ``env_file:`` therefore silences CL-0020 and CL-0021 without changing what
+    deploys, which is the silent false negative ADR-023 ranks worst.
+
+    Reported as a note rather than a coverage gap, and the distinction is the
+    whole design question. ``--allow-partial-coverage`` governs *services* left
+    ungraded: an unresolved ``include:`` hides a whole service and a cross-file
+    ``extends:`` grades one against a fraction of its keys, so any rule may be
+    wrong and exit 2 is proportionate. Here the service is fully graded and
+    exactly two rules are blind to one subtree. Weighing the same, 420 of the
+    5,417-file corpus (7.75%) name an ``env_file:``, so making it fatal would
+    newly fail one CI run in thirteen -- the shape ``docs/compatibility.md``
+    calls a MAJOR, over a gap that was silent in every release to date.
+
+    So the note states what was not evaluated and leaves the exit code alone,
+    which is the treatment ADR-026 §6 gives an unread ``.env`` and
+    :func:`unresolved_mount_sources` gives a value nobody supplied. Resolving
+    the files properly is a separate decision, because reporting on what is
+    inside one runs into ADR-026 §2's rule against echoing a supplied value.
+    """
+    notes: list[str] = []
+    services = data.get("services")
+    if not isinstance(services, dict):
+        return notes
+    for name, config in sorted(services.items()):
+        if not isinstance(config, dict):
+            continue
+        paths = _env_file_paths(config.get("env_file"))
+        if not paths:
+            continue
+        listed = ", ".join(repr(path) for path in paths)
+        notes.append(
+            f"service '{name}' reads {listed}, which compose-lint does not "
+            "open. Values it supplies reach the container environment, so "
+            "CL-0020 and CL-0021 were not evaluated for them."
+        )
+    return notes
+
+
+def _env_file_paths(value: Any) -> list[str]:
+    """Every path an ``env_file:`` names, in written order.
+
+    Three spellings are legal and all three appear in the corpus: a bare string,
+    a list of strings, and a list of mappings carrying ``path:`` alongside
+    ``required:`` / ``format:``. The mapping form is the newer one and is the
+    easiest to miss -- 38 corpus files use it, and reading only the string forms
+    would report a service as covered precisely where the author reached for the
+    more explicit syntax.
+    """
+    if isinstance(value, str):
+        return [value] if value else []
+    if not isinstance(value, list):
+        return []
+    paths: list[str] = []
+    for entry in value:
+        if isinstance(entry, str) and entry:
+            paths.append(entry)
+        elif isinstance(entry, dict):
+            path = entry.get("path")
+            if isinstance(path, str) and path:
+                paths.append(path)
+    return paths
+
+
 def _split_short_volume(volume: str) -> tuple[str, str, str]:
     """Split ``source:target[:mode]`` at the separator, ignoring ``${...}``.
 

--- a/tests/test_env_file_notes.py
+++ b/tests/test_env_file_notes.py
@@ -1,0 +1,145 @@
+"""Say when an ``env_file:`` left the credential rules unevaluated.
+
+Compose merges each named file into the container's process environment, so a
+credential written there reaches every surface CL-0020's documentation names
+while never appearing in the document. Moving one line out of ``environment:``
+and into an ``env_file:`` silences CL-0020 and CL-0021 without changing what
+deploys (issue #665).
+
+These pin the note, not a resolution: the files are still not opened. What the
+note buys is that the gap is stated rather than silent, which is the half of the
+problem that needs no decision about echoing a supplied value (ADR-026 §2).
+
+A note and not a coverage gap, deliberately — see ``unread_env_files`` for the
+weighing. The exit-code assertions below are the load-bearing half of that
+choice, because 7.75% of the corpus names an ``env_file:``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+from compose_lint.parser import loads, unread_env_files
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_SAFE = "services:\n  web:\n    image: i:1\n"
+
+
+def notes_for(document: str) -> list[str]:
+    data, _ = loads(document)
+    return unread_env_files(data)
+
+
+class TestTheThreeSpellings:
+    """All three legal spellings of ``env_file:`` are seen, not just the common one."""
+
+    def test_a_bare_string_is_noted(self) -> None:
+        assert notes_for(f"{_SAFE}    env_file: secrets.env\n")
+
+    def test_a_list_of_strings_is_noted(self) -> None:
+        assert notes_for(f"{_SAFE}    env_file: [a.env, b.env]\n")
+
+    def test_the_mapping_form_is_noted(self) -> None:
+        """The newer spelling, and the one reading only strings would miss."""
+        assert notes_for(
+            f"{_SAFE}    env_file:\n      - path: secrets.env\n"
+            "        required: false\n"
+        )
+
+    def test_a_mixed_list_reports_every_path(self) -> None:
+        note = notes_for(
+            f"{_SAFE}    env_file:\n      - plain.env\n      - path: mapped.env\n"
+        )[0]
+        assert "plain.env" in note
+        assert "mapped.env" in note
+
+    def test_paths_keep_their_written_order(self) -> None:
+        """Compose merges later files over earlier ones, so order is not cosmetic."""
+        note = notes_for(f"{_SAFE}    env_file: [first.env, second.env]\n")[0]
+        assert note.index("first.env") < note.index("second.env")
+
+
+class TestWhatIsNotNoted:
+    """The note has to stay a signal; it fires on 7.75% of real files as it is."""
+
+    def test_a_service_without_env_file_is_silent(self) -> None:
+        assert notes_for(f"{_SAFE}    environment:\n      A: b\n") == []
+
+    def test_an_empty_env_file_names_nothing(self) -> None:
+        assert notes_for(f"{_SAFE}    env_file: []\n") == []
+
+    def test_a_mapping_entry_without_a_path_is_skipped(self) -> None:
+        assert notes_for(f"{_SAFE}    env_file:\n      - required: false\n") == []
+
+    def test_a_document_with_no_services_is_silent(self) -> None:
+        """Called on a mapping directly: `loads` rejects a fragment first (ADR-013),
+        so this guards the function for any other caller."""
+        assert unread_env_files({"volumes": {"data": {}}}) == []
+
+    def test_a_non_mapping_service_is_skipped(self) -> None:
+        assert unread_env_files({"services": {"web": "nonsense"}}) == []
+
+
+class TestTheNoteItself:
+    def test_it_names_the_service_and_the_rules_it_blinded(self) -> None:
+        note = notes_for(f"{_SAFE}    env_file: secrets.env\n")[0]
+        assert "'web'" in note
+        assert "secrets.env" in note
+        assert "CL-0020" in note
+        assert "CL-0021" in note
+
+    def test_one_note_per_service_carrying_one(self) -> None:
+        notes = notes_for(
+            "services:\n"
+            "  a:\n    image: i:1\n    env_file: a.env\n"
+            "  b:\n    image: i:1\n    env_file: b.env\n"
+            "  c:\n    image: i:1\n"
+        )
+        assert len(notes) == 2
+
+
+class TestItDoesNotTouchTheExitCode:
+    """The distinction from a coverage gap, asserted rather than described.
+
+    An unresolved ``include:`` exits 2 because a whole service went ungraded.
+    Here the service is graded and two rules are blind to one subtree, on 7.75%
+    of real files — making that fatal would newly fail one CI run in thirteen.
+    """
+
+    def _run(self, directory: Path, document: str) -> subprocess.CompletedProcess[str]:
+        (directory / "compose.yml").write_text(document, encoding="utf-8")
+        (directory / "secrets.env").write_text("A=b\n", encoding="utf-8")
+        return subprocess.run(
+            [sys.executable, "-m", "compose_lint", "check", "compose.yml"],
+            cwd=directory,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+    def test_a_clean_file_still_exits_zero(self, tmp_path: Path) -> None:
+        result = self._run(
+            tmp_path,
+            "services:\n  web:\n    image: i:1@sha256:"
+            + "0" * 64
+            + "\n    env_file: secrets.env\n"
+            "    read_only: true\n    cap_drop: [ALL]\n"
+            "    security_opt: ['no-new-privileges:true']\n"
+            "    mem_limit: 1g\n    cpus: 1\n    pids_limit: 100\n",
+        )
+        assert result.returncode == 0, result.stderr
+        assert "env_file" in result.stderr or "secrets.env" in result.stderr
+
+    def test_the_note_goes_to_stderr_not_stdout(self, tmp_path: Path) -> None:
+        result = self._run(tmp_path, f"{_SAFE}    env_file: secrets.env\n")
+        assert "secrets.env" in result.stderr
+        assert "secrets.env" not in result.stdout
+
+    def test_it_is_not_an_error_and_not_a_coverage_gap(self, tmp_path: Path) -> None:
+        result = self._run(tmp_path, f"{_SAFE}    env_file: secrets.env\n")
+        assert result.returncode != 2, result.stderr
+        assert "--allow-partial-coverage" not in result.stderr


### PR DESCRIPTION
Refs #665 — the first of the two steps that issue proposes, and deliberately not the second.

Moving one line out of `environment:` and into an `env_file:` silences CL-0020 and CL-0021 without changing a byte of what deploys:

```yaml
services:
  db:
    image: postgres:16
    env_file: [secrets.env]
# secrets.env: POSTGRES_PASSWORD=hunter2
```

`docker compose config` shows `hunter2` reaching the container. compose-lint exited 0 with nothing to say. It now says:

```
note: compose.yml: service 'db' reads 'secrets.env', which compose-lint does not
open. Values it supplies reach the container environment, so CL-0020 and CL-0021
were not evaluated for them.
```

The file is still not opened. What this buys is that the gap is **stated instead of silent**, which is the half of #665 that needs no decision about echoing a supplied value.

## The design question, and why I answered it this way

#665 frames this as "`include:` refuses loudly for the same reason", so the obvious move is to add `env_file:` to `coverage_gaps()` and let it exit 2. **I did not**, and the reasoning is in the `unread_env_files` docstring so it does not have to be re-derived later:

`--allow-partial-coverage` governs *services left ungraded*. An unresolved `include:` hides a whole service; a cross-file `extends:` grades one against a fraction of its keys. Any rule may be wrong, so exit 2 is proportionate. Here the service is fully graded and exactly **two** rules are blind to one subtree.

Weighing the same: **415 of 5,417 corpus files carry the note** — 7.66% of the corpus, 8.6% of those that lint. Making that fatal would newly fail one CI run in thirteen, which `docs/compatibility.md` treats as MAJOR-shaped ("upgrading a severity, which can newly fail a pinned user's CI, is a MAJOR"), over a gap that has been silent in every release to date.

So it takes the treatment ADR-026 §6 gives an unread `.env` and `unresolved_mount_sources` gives a value nobody supplied: state what was not evaluated, leave the exit code alone. **If you want it fatal, that is a one-line move** into `coverage_gaps()` — but it should be a deliberate MAJOR, not a side effect of this PR.

Nothing here forecloses step 2. Opening the files still needs its own ADR for the ADR-026 §2 tension.

## Coverage

All three legal spellings, since reading only the common one would report a service as covered precisely where the author reached for the more explicit syntax:

- `env_file: secrets.env`
- `env_file: [a.env, b.env]`
- `env_file: [{path: a.env, required: false}]` — the newer mapping form, 38 corpus files

## Blast radius: none

- **0 files changed findings** across the full 5,417-file corpus (`scripts/corpus/run.py`, diffed on `(rule_id, service, evidence)` per `content_hash` against the run from `main`).
- The note is **stderr only** — asserted, not assumed: `TestItDoesNotTouchTheExitCode` checks a clean file still exits 0, that the text reaches stderr and not stdout, and that the run is neither an error nor a coverage gap.
- No JSON `errors[]` / SARIF `toolExecutionNotifications` entry, so no machine consumer's contract moves.

## Testing

15 new tests. Full suite 2,345 passed, 10 skipped. `ruff check` / `ruff format --check` / `mypy --strict` clean.
