### PR TITLE
Attribute merged parse errors to their source file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A parse error in an automatically merged `compose.override.yml` is now
+  reported against the file that actually failed in text, JSON, and SARIF. It
+  previously named the base file at a line number that did not exist there
+  ([#666](https://github.com/tmatens/compose-lint/issues/666)).
+
 - Every Compose substitution operator now resolves against a sibling `.env`,
   not just `${VAR:-default}` and `${VAR-default}`. `${VAR:?err}`, `${VAR?err}`,
   `${VAR:+alt}` and `${VAR+alt}` fetched the `.env` value and then discarded it,

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -45,6 +45,7 @@ from compose_lint.formatters.text import format_findings as format_text
 from compose_lint.models import Finding, Severity
 from compose_lint.parser import (
     ComposeError,
+    ComposeFileError,
     ComposeNotApplicableError,
     coverage_gaps,
     load_compose,
@@ -154,6 +155,8 @@ def _report_parse_error(filepath: str, exc: FileNotFoundError | ComposeError) ->
     here — ``ComposeNotApplicableError`` is not an error (ADR-013) and is
     handled separately by each caller.
     """
+    if isinstance(exc, ComposeFileError):
+        filepath = exc.path
     reason = "file not found" if isinstance(exc, FileNotFoundError) else str(exc)
     emit(f"Error: {filepath}: {reason}")
     return reason
@@ -708,7 +711,8 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
             emit(f"{filepath}: {e}")
             continue
         except (FileNotFoundError, ComposeError) as e:
-            parse_errors.append((filepath, _report_parse_error(filepath, e)))
+            error_path = e.path if isinstance(e, ComposeFileError) else filepath
+            parse_errors.append((error_path, _report_parse_error(filepath, e)))
             continue
 
         coverage_errors.extend(

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -46,6 +46,14 @@ class ComposeError(Exception):
     """Raised when a file is not a valid Docker Compose file."""
 
 
+class ComposeFileError(ComposeError):
+    """A Compose error attributed to one file in a multi-file load."""
+
+    def __init__(self, path: str | Path, message: str) -> None:
+        super().__init__(message)
+        self.path = str(path)
+
+
 class ComposeNotApplicableError(ComposeError):
     """Raised when a file parses as YAML but is not a v2/v3 Compose file.
 
@@ -1376,7 +1384,15 @@ def load_merged(paths: list[str | Path], *, use_env: bool = True) -> Merged:
     Later paths override earlier ones, which is the order Compose itself uses
     for ``-f a -f b`` and for a base file plus its ``compose.override.yml``.
     """
-    return merge_documents([load_document(p, use_env=use_env) for p in paths])
+    documents: list[Document] = []
+    for path in paths:
+        try:
+            documents.append(load_document(path, use_env=use_env))
+        except ComposeNotApplicableError:
+            raise
+        except ComposeError as exc:
+            raise ComposeFileError(path, str(exc)) from exc
+    return merge_documents(documents)
 
 
 def merge_patched(

--- a/tests/test_overlay_merge.py
+++ b/tests/test_overlay_merge.py
@@ -156,6 +156,14 @@ def test_parse_error_names_the_invalid_overlay(tmp_path: Path) -> None:
     assert "Error: compose.yml: Invalid YAML:" not in result.stderr
     assert json.loads(result.stdout)["errors"][0]["file"] == "compose.override.yml"
 
+    sarif_result = run_cli("check", "--format", "sarif", cwd=tmp_path)
+    assert sarif_result.returncode == 2
+    notification = json.loads(sarif_result.stdout)["runs"][0]["invocations"][0][
+        "toolExecutionNotifications"
+    ][0]
+    artifact = notification["locations"][0]["physicalLocation"]["artifactLocation"]
+    assert artifact["uri"] == "compose.override.yml"
+
 
 def test_findings_name_the_file_they_came_from(tmp_path: Path) -> None:
     """A finding whose evidence is in the overlay must say so.

--- a/tests/test_overlay_merge.py
+++ b/tests/test_overlay_merge.py
@@ -142,6 +142,21 @@ def test_merge_warning_does_not_change_the_exit_code(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
 
 
+def test_parse_error_names_the_invalid_overlay(tmp_path: Path) -> None:
+    """A malformed overlay must not be reported as a malformed base file."""
+    _write_pair(
+        tmp_path,
+        "services:\n  web:\n    image: myapp:1.0\n",
+        "services:\n  web:\n    image: [\n",
+    )
+    result = run_cli("check", "--format", "json", cwd=tmp_path)
+
+    assert result.returncode == 2
+    assert "Error: compose.override.yml: Invalid YAML:" in result.stderr
+    assert "Error: compose.yml: Invalid YAML:" not in result.stderr
+    assert json.loads(result.stdout)["errors"][0]["file"] == "compose.override.yml"
+
+
 def test_findings_name_the_file_they_came_from(tmp_path: Path) -> None:
     """A finding whose evidence is in the overlay must say so.
 


### PR DESCRIPTION
## Summary

Preserve the path of the document that fails during a multi-file Compose load so text, JSON, and SARIF errors name the malformed override instead of the valid base file. Adds an end-to-end regression test for both stderr and JSON output.

## Why

A parse failure in an automatically merged `compose.override.yml` was reported against `compose.yml`, sending users to an unrelated file and sometimes to a line that does not exist there.

Closes #666

## Type of change

- [ ] New rule (`CL-XXXX`)
- [x] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / CI / release tooling
- [ ] Other:

## Checklist

- [x] Commits are signed (GitHub shows **Verified**)
- [x] One logical change per commit; no unrelated changes bundled in
- [x] `ruff check`, `ruff format --check`, `mypy src/`, and `pytest` all pass locally
- [x] New/changed behavior has tests (positive **and** negative cases for rules)
- [x] Docs updated where behavior changed (`README.md`, `docs/rules/CL-XXXX.md`, `CHANGELOG.md`) — N/A; no documented contract changes
- [x] No AI attribution anywhere (commits, comments, docs)

## New rule only

N/A — this is not a new rule.

## Breaking changes

None

## Test results

- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- `mypy src/`
- `pytest` — 2,331 passed, 25 skipped
