### PR TITLE
Merge a fragment overlay into its base instead of skipping it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A fragment overlay carrying only top-level structural keys such as
+  `volumes:` or `networks:`, or just `{}`, now merges into the linted
+  configuration instead of skipping the whole project. Compose folds it
+  into its base and deploys the result, but compose-lint let the
+  fragment raise out of the merge and reported `PASS` at exit 0 without
+  grading anything in the base file: a two-byte overlay could silence
+  every finding, CRITICAL ones included
+  ([#671](https://github.com/tmatens/compose-lint/issues/671)).
+
+  Findings only move toward coverage here, the same shape that #648,
+  #657 and #668 shipped under: affected projects see previously
+  withheld findings. The merge direction does not care which half
+  holds the `services:` — a fragment *base* beside an overlay that
+  carries them now lints too, where it previously skipped whole. A
+  merge set where every selected file is a
+  fragment still skips at exit 0, files linted on their own are
+  unchanged, and v1-shaped or own-config overlays keep their current
+  behavior until their separate error path lands (#673).
+
 - A parse error in an automatically merged `compose.override.yml` is now
   reported against the file that actually failed in text, JSON, and SARIF. It
   previously named the base file at a line number that did not exist there

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -66,6 +66,19 @@ class ComposeNotApplicableError(ComposeError):
     """
 
 
+class ComposeFragmentError(ComposeNotApplicableError):
+    """A structural fragment: parses as YAML but carries no `services:` key.
+
+    Its own bucket under ADR-013 so a merge can tell it apart from the
+    other not-applicable shapes without matching on message text. Compose
+    folds a fragment overlay into its base and deploys the result, so
+    :func:`load_merged` merges one instead of discarding the project
+    (#671); linted on its own the file is still skipped at exit 0.
+    Subclassing keeps every existing `except ComposeNotApplicableError`
+    working untouched.
+    """
+
+
 # Keys that v2/v3 Compose places at the top level alongside `services:`.
 # A file containing only these (plus any `x-*` extension keys) is treated
 # as a structural fragment when `services:` is absent.
@@ -144,7 +157,9 @@ def _classify_missing_services(data: dict[str, Any]) -> ComposeError:
             "via --config; it is not a lint target."
         )
     if not non_meta:
-        return ComposeNotApplicableError(
+        # Own subtype so a merge can fold the fragment into its base while
+        # v1 and own-config stay errors (#671).
+        return ComposeFragmentError(
             "Skipped: file appears to be a Compose fragment "
             "(no 'services:' key; only top-level structural keys present). "
             "Fragments are typically merged via `extends:` or `-f` overlays "
@@ -615,7 +630,11 @@ def _validate_compose(data: Any, *, merging: bool = False) -> dict[str, Any]:
     """Validate that parsed YAML is a Docker Compose file.
 
     ``merging`` relaxes the per-service check for a document that is one
-    half of a merge, where a service may legitimately carry no body.
+    half of a merge, where a service may legitimately carry no body, and
+    admits a structural fragment as an overlay half: Compose merges such a
+    document as-is and deploys the base unaltered, so refusing it there
+    discarded a lintable project and reported PASS on one that was never
+    graded (#671). Linted on its own the fragment still raises.
     """
     if not isinstance(data, dict):
         raise ComposeError(
@@ -623,7 +642,13 @@ def _validate_compose(data: Any, *, merging: bool = False) -> dict[str, Any]:
         )
 
     if "services" not in data:
-        raise _classify_missing_services(data)
+        classified = _classify_missing_services(data)
+        if merging and isinstance(classified, ComposeFragmentError):
+            # Fragment overlay half: contribute its top-level keys to the
+            # merge. v1-shaped and own-config documents still raise —
+            # Compose refuses those projects outright (#673).
+            return data
+        raise classified
 
     services = data["services"]
     if not isinstance(services, dict):
@@ -1312,6 +1337,13 @@ def load_merged(paths: list[str | Path], *, use_env: bool = True) -> Merged:
 
     Later paths override earlier ones, which is the order Compose itself uses
     for ``-f a -f b`` and for a base file plus its ``compose.override.yml``.
+
+    A structural fragment overlay is merged into the result rather than
+    treated as grounds for skipping the project (#671): the base beside it
+    is perfectly lintable, and ADR-025 grades what Compose runs. A set where
+    *every* document is a fragment still raises
+    :class:`ComposeNotApplicableError` — there is nothing to lint, and
+    merging them would report a vacuous PASS under the primary path.
     """
     documents: list[Document] = []
     for path in paths:
@@ -1321,7 +1353,22 @@ def load_merged(paths: list[str | Path], *, use_env: bool = True) -> Merged:
             raise
         except ComposeError as exc:
             raise ComposeFileError(path, str(exc)) from exc
-    return merge_documents(documents)
+    merged = merge_documents(documents)
+    if "services" not in merged.data:
+        # No document contributed services, so the merged result has none to
+        # lint. v1-shaped and own-config documents never reach here: they
+        # raise from :func:`load_document` above.
+        #
+        # Deliberately a bare ComposeNotApplicableError, not
+        # ComposeFragmentError: this is a condition of the merged *set*
+        # (no document contributed services), not a classification of any
+        # one file, so naming the fragment bucket would misdescribe it.
+        raise ComposeNotApplicableError(
+            "Skipped: merged configuration has no 'services:' key "
+            "(every selected file appears to be a Compose fragment), so "
+            "there are no services to lint."
+        )
+    return merged
 
 
 def merge_patched(
@@ -1333,6 +1380,13 @@ def merge_patched(
     edit to the base file's *text*; the property that has to hold afterwards is
     about the document Compose would run, so the candidate is merged with the
     same overlays before the engine re-runs over it.
+
+    Unlike :func:`load_merged` there is no all-fragment guard on the result.
+    Reaching here requires the same set to have passed through
+    :func:`load_merged` in the fix path, which raises when nothing contributed
+    services — so an all-fragment set cannot get this far unless a fixer
+    deleted every service from the patched base, which none does. If that
+    ever changes, the guard belongs here too.
     """
     base_dir = Path(base_path).absolute().parent
     data, lines, resets, overrides = _loads_full(

--- a/tests/test_overlay_merge.py
+++ b/tests/test_overlay_merge.py
@@ -484,3 +484,139 @@ def test_a_key_the_overlay_republishes_belongs_to_the_overlay(tmp_path: Path) ->
     assert '- "8080:80"' in (tmp_path / "compose.yml").read_text()
     assert "127.0.0.1" not in (tmp_path / "compose.yml").read_text()
     assert "need manual review" in result.stderr
+
+
+BASE_PRIVILEGED = """\
+services:
+  web:
+    image: nginx
+    privileged: true
+"""
+
+
+def test_fragment_override_does_not_skip_the_project(tmp_path: Path) -> None:
+    """A fragment overlay must merge, not skip the project (#671).
+
+    An override carrying only top-level structural keys is ordinary Compose:
+    `docker compose config` accepts it and deploys the base unaltered.
+    compose-lint used to let the fragment raise out of the merge, skip the
+    whole project, and report PASS at exit 0 — dropping every finding in the
+    base file, CRITICAL ones included.
+    """
+    _write_pair(tmp_path, BASE_PRIVILEGED, "volumes:\n  data: {}\n")
+    result = run_cli("check", cwd=tmp_path)
+
+    assert result.returncode == 1, result.stderr
+    assert "CL-0002" in result.stdout
+
+
+def test_networks_only_fragment_overlay_is_merged(tmp_path: Path) -> None:
+    """Same defect through the other structural key."""
+    _write_pair(tmp_path, BASE_PRIVILEGED, "networks:\n  n: {}\n")
+    result = run_cli("check", cwd=tmp_path)
+
+    assert result.returncode == 1, result.stderr
+    assert "CL-0002" in result.stdout
+
+
+def test_empty_mapping_fragment_overlay_is_merged(tmp_path: Path) -> None:
+    """A two-byte `{}` overlay deploys; the base beside it must be graded.
+
+    This is the smallest file that used to turn a failing gate green while
+    changing nothing about what deploys.
+    """
+    _write_pair(tmp_path, BASE_PRIVILEGED, "{}\n")
+    result = run_cli("check", cwd=tmp_path)
+
+    assert result.returncode == 1, result.stderr
+    assert "CL-0002" in result.stdout
+
+
+def test_all_fragment_merge_set_still_skips(tmp_path: Path) -> None:
+    """When no document contributes services there is nothing to lint.
+
+    Merging fragments (#671) must not turn an all-fragment set into a vacuous
+    PASS under the primary path: nothing was graded, so the project still
+    skips at exit 0, with the reason stated.
+    """
+    _write_pair(tmp_path, "volumes:\n  data: {}\n", "networks:\n  n: {}\n")
+    result = run_cli("check", cwd=tmp_path)
+
+    assert result.returncode == 0
+    assert "Skipped" in result.stderr
+    assert "no 'services:' key" in result.stderr
+
+
+def test_v1_shaped_overlay_still_skips(tmp_path: Path) -> None:
+    """Only the fragment bucket merges; v1 keeps today's behaviour.
+
+    Compose refuses a v1-shaped document outright, so merging one would grade
+    a configuration that never deploys. Its separate error path is #673's
+    job; here it must behave exactly as before #671.
+    """
+    _write_pair(
+        tmp_path,
+        BASE_PRIVILEGED,
+        'web:\n  ports: ["8080:80"]\n',
+    )
+    result = run_cli("check", cwd=tmp_path)
+
+    assert result.returncode == 0
+    assert "Skipped" in result.stderr
+    assert "Compose v1" in result.stderr
+
+
+def test_include_only_overlay_is_not_admitted_as_a_fragment(tmp_path: Path) -> None:
+    """An `include:`-only overlay stays a hard error, never a fragment (#516).
+
+    `_classify_missing_services` special-cases include precisely because
+    compose-lint does not resolve it: admitting the file as a harmless
+    fragment would report a clean pass on a deployable stack. This is the one
+    place where widening the fragment bucket would silently undo #516, so the
+    boundary is pinned here.
+    """
+    _write_pair(tmp_path, BASE_PRIVILEGED, "include:\n  - other.yml\n")
+    result = run_cli("check", cwd=tmp_path)
+
+    assert result.returncode == 2
+    assert "uses 'include:'" in result.stderr
+
+
+def test_fragment_base_with_services_in_the_overlay_lints(tmp_path: Path) -> None:
+    """A fragment *base* beside an overlay that carries services lints now.
+
+    The mirror of the headline fix, and as much a gap in #671's direction:
+    before it, this pair skipped whole under the same single-file skip
+    handler. Compose accepts base-plus-overlay regardless of which half holds
+    the services, so grading it is more coverage in the same direction.
+    """
+    _write_pair(
+        tmp_path,
+        "volumes:\n  data: {}\n",
+        "services:\n  web:\n    image: nginx\n    privileged: true\n",
+    )
+    result = run_cli("check", cwd=tmp_path)
+
+    assert result.returncode == 1, result.stderr
+    assert "CL-0002" in result.stdout
+
+
+def test_fix_applies_to_the_base_beside_a_fragment_overlay(tmp_path: Path) -> None:
+    """`fix` runs on a project whose overlay is a fragment, instead of skipping.
+
+    The defect was not check-only: fix reads the pair through load_merged too,
+    so a fragment overlay used to make it drop the entire project and edit
+    nothing. The base's own port finding is fixable without any help from the
+    overlay, and the fragment itself is never a write target.
+    """
+    _write_pair(
+        tmp_path,
+        'services:\n  web:\n    image: myapp:1.0\n    ports:\n      - "8080:80"\n',
+        "volumes:\n  data: {}\n",
+    )
+    overlay_before = (tmp_path / "compose.override.yml").read_text()
+    run_cli("fix", "--apply", cwd=tmp_path)
+
+    after = (tmp_path / "compose.yml").read_text()
+    assert "127.0.0.1:8080:80" in after
+    assert (tmp_path / "compose.override.yml").read_text() == overlay_before

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -11,10 +11,12 @@ import pytest
 from compose_lint.parser import (
     _LINES,
     ComposeError,
+    ComposeFragmentError,
     ComposeNotApplicableError,
     _collect_lines,
     _strip_lines,
     load_compose,
+    load_merged,
     loads,
 )
 
@@ -594,3 +596,105 @@ class TestExtendsResolution:
         )
         assert "extends" in data["services"]["a"]
         assert "extends" in data["services"]["b"]
+
+
+class TestFragmentOverlayMerging:
+    """A structural fragment merges into a set instead of skipping it (#671).
+
+    Single-file behaviour is untouched: linted alone, a fragment still raises
+    the ADR-013 not-applicable error the CLI maps to a skip at exit 0.
+    """
+
+    def test_fragment_has_its_own_subtype(self) -> None:
+        # The fragment bucket needs an identity of its own so a merge can
+        # admit it without matching on message text (#671). v1-shaped and
+        # own-config documents stay distinguishable from it.
+        with pytest.raises(ComposeFragmentError, match="Compose fragment"):
+            load_compose(FIXTURES / "fragment_volumes_only.yml")
+
+    def test_fragment_subtype_is_a_not_applicable_error(self) -> None:
+        # Subclassing keeps every existing
+        # `except ComposeNotApplicableError` working untouched.
+        with pytest.raises(ComposeNotApplicableError) as excinfo:
+            load_compose(FIXTURES / "fragment_volumes_only.yml")
+        assert isinstance(excinfo.value, ComposeFragmentError)
+        assert isinstance(excinfo.value, ComposeError)
+
+    def test_fragment_overlay_merges_into_base(self, tmp_path: Path) -> None:
+        # Compose folds a volumes-only overlay into its base and deploys the
+        # result; load_merged grades that configuration rather than dropping
+        # the project (#671).
+        base = tmp_path / "compose.yml"
+        frag = tmp_path / "compose.override.yml"
+        base.write_text("services:\n  web:\n    image: nginx\n")
+        frag.write_text("volumes:\n  data: {}\n")
+
+        merged = load_merged([base, frag])
+
+        assert merged.data["services"]["web"]["image"] == "nginx"
+        assert merged.data["volumes"] == {"data": {}}
+
+    def test_empty_mapping_overlay_merges_into_base(self, tmp_path: Path) -> None:
+        # `{}` classifies as a fragment (no non-meta keys); merging it must
+        # not lose the services the base contributed.
+        base = tmp_path / "compose.yml"
+        frag = tmp_path / "compose.override.yml"
+        base.write_text("services:\n  web:\n    image: nginx\n")
+        frag.write_text("{}\n")
+
+        merged = load_merged([base, frag])
+
+        assert "web" in merged.data["services"]
+
+    def test_all_fragment_set_raises_not_applicable(self, tmp_path: Path) -> None:
+        # When no document contributes services there is nothing to lint;
+        # merging would report a vacuous PASS under the primary path.
+        first = tmp_path / "compose.yml"
+        second = tmp_path / "compose.override.yml"
+        first.write_text("volumes:\n  data: {}\n")
+        second.write_text("networks:\n  n: {}\n")
+
+        with pytest.raises(
+            ComposeNotApplicableError,
+            match="every selected file appears to be a Compose fragment",
+        ):
+            load_merged([first, second])
+
+    def test_include_only_overlay_is_not_admitted_as_a_fragment(
+        self, tmp_path: Path
+    ) -> None:
+        # #516 established that an include-only file is not a harmless
+        # fragment: compose-lint does not resolve include, so folding one into
+        # the merge would grade a stack whose services it never saw. This pins
+        # the boundary the fragment admission must respect — "services-less"
+        # is not wide enough to admit it, or a later widening of the bucket
+        # would silently undo #516.
+        base = tmp_path / "compose.yml"
+        over = tmp_path / "compose.override.yml"
+        base.write_text("services:\n  web:\n    image: nginx\n")
+        over.write_text("include:\n  - other.yml\n")
+
+        with pytest.raises(ComposeError, match="uses 'include:'") as excinfo:
+            load_merged([base, over])
+        assert not isinstance(excinfo.value, ComposeNotApplicableError)
+
+    def test_v1_shaped_overlay_still_raises(self, tmp_path: Path) -> None:
+        # Only the fragment bucket merges. A v1-shaped overlay keeps raising
+        # so its separate error path (#673) decides what happens next.
+        base = tmp_path / "compose.yml"
+        over = tmp_path / "compose.override.yml"
+        base.write_text("services:\n  web:\n    image: nginx\n")
+        over.write_text('web:\n  ports: ["8080:80"]\n')
+
+        with pytest.raises(ComposeNotApplicableError, match="Compose v1"):
+            load_merged([base, over])
+
+    def test_own_config_overlay_still_raises(self, tmp_path: Path) -> None:
+        # Same boundary for the own-config bucket: never merged, never silent.
+        base = tmp_path / "compose.yml"
+        over = tmp_path / "compose.override.yml"
+        base.write_text("services:\n  web:\n    image: nginx\n")
+        over.write_text("rules:\n  CL-0003:\n    enabled: false\n")
+
+        with pytest.raises(ComposeNotApplicableError, match="compose-lint config"):
+            load_merged([base, over])


### PR DESCRIPTION
## Summary

A structural fragment overlay (`compose.override.yml` carrying only top-level keys such as `volumes:` or `networks:`, or just `{}`) is now merged into the linted configuration instead of raising out of the merge and skipping the whole project. The fragment bucket gets its own error subtype (`ComposeFragmentError(ComposeNotApplicableError)`), `_validate_compose` admits it as a merge half when `merging=True`, and `load_merged` raises an explicit skip when *every* document in the set is a fragment.

Two further coverage moves fall out of the same merge direction, each now described here and pinned by a test:

- If the *base* is the fragment and the overlay carries the `services:` — a pair Compose accepts — the project now lints instead of skipping whole under the same skip handler.
- `fix` is affected too, not just `check`: it reads merged pairs through `load_merged`, so a fragment overlay previously made it drop the project entirely. It now applies base-local fixes and never writes to the fragment.

One boundary is also pinned explicitly: an `include:`-only overlay stays a hard error and is never admitted as a fragment, so a later widening of the bucket cannot silently undo #516.

## Why

Fixes #671. An ordinary override shape made compose-lint report `PASS` at exit 0 on a stack that was never graded: the fragment raised `ComposeNotApplicableError` out of `load_merged`, and the CLI's skip handler written for single files dropped the entire project under the primary path. Docker Compose merges such an overlay as-is and deploys the base unaltered (verified against Compose 5.4.0 for all three shapes in the issue), so a two-byte `{}` override could silence every finding in the base file, CRITICAL ones included. This sits exactly at the intersection ADR-013 and ADR-025 never weighed together, and implements the direction recorded in #674.

Scope kept deliberately narrow per the issue discussion:

- Single-file behaviour unchanged: a fragment linted alone still skips at exit 0.
- v1-shaped and own-config overlays keep raising untouched (#673 owns their separate error path).
- No changes to the classifier heuristic, `_merge.py`, or rule code.
- `tests/corpus_snapshot.json.gz` not touched (filename-filtered corpus contains no sibling files, so no drift is expected here).

## Type of change

- [ ] New rule (`CL-XXXX`)
- [x] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / CI / release tooling
- [ ] Other:

## Origin

- [ ] Personal contribution
- [ ] Contributed on behalf of an employer or client
- [x] Produced primarily by an automated agent

Produced by an autonomous agent (OpenCode) driven by the contributor; the contributor reviewed and approved every change, test result, and this PR text.

## Checklist

- [x] Commits are signed (GitHub shows **Verified**)
- [x] One logical change per commit; no unrelated changes bundled in
- [x] `ruff check`, `ruff format --check`, `mypy src/`, and `pytest` all pass locally
- [x] New/changed behavior has tests (positive **and** negative cases for rules)
- [x] User-visible behavior change has a `CHANGELOG.md` entry under `[Unreleased]`
- [ ] Docs updated where behavior changed (`README.md`, `docs/rules/CL-XXXX.md`)
- [x] `tests/corpus_snapshot.json.gz` is **not** in this PR (a maintainer regenerates it)
- [x] No AI credit lines in commit messages (`Co-Authored-By`, "generated by")

## Testing

All four gates run against this branch (rebased onto current `main`, which moved several merges into `src/compose_lint/parser.py` after the first CI run):

- `ruff check src/ tests/` - passed ("All checks passed!")
- `ruff format --check src/ tests/` - passed (154 files already formatted)
- `mypy src/` - passed (strict, "no issues found in 58 source files")
- `pytest` - **2464 passed, 10 skipped** (skips are environmental: corpus cache env var unset and fuzz seeds rejected by the installed `docker compose`; same counts on unmodified checkout)

New tests cover the acceptance criteria from the issue:

- CLI level (`tests/test_overlay_merge.py`): base with `privileged: true` plus an override of only `volumes:` / only `networks:` / just `{}` each yields CL-0002 at exit 1; an all-fragment merge set still skips at exit 0 with the reason stated; a v1-shaped overlay still skips exactly as before; an `include:`-only overlay stays a hard error at exit 2; a fragment *base* with services in the overlay lints; `fix --apply` fixes the base beside a fragment overlay and leaves the fragment untouched.
- Parser level (`tests/test_parser.py`): the fragment bucket's own subtype (still a `ComposeNotApplicableError`); fragment and empty-mapping overlays merge into the base under `load_merged`; an all-fragment set raises the explicit skip; v1-shaped and own-config overlays still raise; an `include:`-only overlay raises a plain `ComposeError`, never the not-applicable bucket.

Manual end-to-end reproduction of the issue scenario before the fix reported PASS at exit 0; after the fix it reports CL-0002 CRITICAL with FAIL at exit 1, matching the issue's expected output.

## Breaking changes

None. Exit codes and the config contract are unchanged; findings only move toward coverage (projects previously skipped by a fragment overlay now see their withheld findings), the same tightened-coverage shape #648, #657 and #668 shipped under.

