### PR TITLE
Add the env_file: reader, derived from the Compose binary

### DIFF
--- a/src/compose_lint/_env_file.py
+++ b/src/compose_lint/_env_file.py
@@ -64,6 +64,25 @@ Only the values a run actually needs are kept, per ADR-026 §5. The bytes are
 still scanned — there is no seeking to one key — so the honest claim is that
 values the run does not need are discarded rather than parsed into it, never
 that the file is not read.
+
+The module also reads the *other* env file: an ``env_file:`` target, named in
+the document rather than found beside it, under
+[ADR-027](../../docs/adr/027-grade-env-file-where-the-document-routes-it.md).
+The grammar is godotenv's both times, which is why one scanner serves both, but
+the two readers are not interchangeable and :func:`parse_env_file` is separate
+for three reasons, each derived from the binary the same way:
+
+1. **A bare ``KEY`` means different things.** A ``.env`` ships it empty; an
+   ``env_file:`` treats it as a lookup in Compose's own process environment and
+   omits the key when that is unset. So it is reported unresolved rather than
+   empty — claiming the empty string would be claiming a lint-host fact.
+2. **``format: raw`` exists only here**, and is a different grammar rather than
+   a relaxed one: no ``export`` prefix, no trimming, no quote or comment
+   processing, no interpolation.
+3. **Nothing is filtered by wantedness.** Every key in an ``env_file:`` lands in
+   a named service's process environment, so every key is one a rule may grade
+   (ADR-027 §4). The §5 retention claim above does not extend to these files,
+   and the honest statement for them is that every key is examined.
 """
 
 from __future__ import annotations
@@ -79,7 +98,14 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
     from pathlib import Path
 
-__all__ = ["ENV_FILENAME", "EnvFile", "parse_env", "read_env"]
+__all__ = [
+    "ENV_FILENAME",
+    "EnvFile",
+    "parse_env",
+    "parse_env_file",
+    "read_env",
+    "read_env_file",
+]
 
 ENV_FILENAME = ".env"
 
@@ -143,6 +169,12 @@ class _Entry:
     key: str
     raw: str
     expands: bool  # false for a single-quoted value
+    # `KEY` with no `=` at all. The two files disagree about what that means:
+    # a `.env` ships it empty, while an `env_file:` treats it as a lookup in
+    # the process environment and omits the key entirely when it is unset
+    # (both verified against Compose 5.4.0). Recorded here so one scanner can
+    # serve both readers.
+    bare: bool = False
 
 
 def read_env(directory: Path, wanted: Iterable[str] | None = None) -> EnvFile | None:
@@ -222,7 +254,7 @@ def _split_env_lines(text: str) -> list[str]:
     return text.split("\n")
 
 
-def _scan(text: str) -> tuple[list[_Entry], list[int]]:
+def _scan(text: str, *, raw: bool = False) -> tuple[list[_Entry], list[int]]:
     """Split text into entries as written, plus the lines that are not entries.
 
     Nothing is expanded here. Separating the scan from the resolution is what
@@ -238,8 +270,21 @@ def _scan(text: str) -> tuple[list[_Entry], list[int]]:
         stripped = line.strip()
         if not stripped or stripped.startswith("#"):
             continue
+        if raw:
+            # `format: raw` is a different grammar, not a relaxation of this
+            # one: `export` is not a prefix (Compose rejects `export D=v` as a
+            # key containing whitespace), nothing is trimmed, quotes and `#`
+            # are payload, and `$$` is two literal dollars. Verified against
+            # Compose 5.4.0, whose output for `A=v # trail` is `v # trail` and
+            # for `F=  spaced  ` is `  spaced  `.
+            key, separator, value = line.partition("=")
+            if not separator or not _KEY_RE.match(key):
+                skipped.append(number)
+                continue
+            entries.append(_Entry(key=key, raw=value, expands=False))
+            continue
         stripped = _EXPORT_RE.sub("", stripped)
-        key, separator, raw = stripped.partition("=")
+        key, separator, value = stripped.partition("=")
         key = key.strip()
         if not _KEY_RE.match(key):
             # Compose refuses the whole file here; see the module docstring for
@@ -247,10 +292,9 @@ def _scan(text: str) -> tuple[list[_Entry], list[int]]:
             skipped.append(number)
             continue
         if not separator:
-            # `K` with no `=` ships empty, exactly as `K=` does (verified).
-            entries.append(_Entry(key=key, raw="", expands=False))
+            entries.append(_Entry(key=key, raw="", expands=False, bare=True))
             continue
-        entries.append(_entry(key, raw.strip()))
+        entries.append(_entry(key, value.strip()))
     return entries, skipped
 
 
@@ -349,7 +393,11 @@ def _closure(entries: list[_Entry], wanted: Iterable[str] | None) -> set[str] | 
 
 
 def _resolve(
-    entries: list[_Entry], needed: set[str] | None
+    entries: list[_Entry],
+    needed: set[str] | None,
+    *,
+    initial: Mapping[str, str] | None = None,
+    bare_is_empty: bool = True,
 ) -> tuple[dict[str, str], set[str]]:
     """Expand entries in file order, which is the order Compose expands them.
 
@@ -363,9 +411,16 @@ def _resolve(
     resolve removes any earlier successful binding for that key, so nothing
     downstream can read a stale value for a name the file went on to redefine.
     """
-    values: dict[str, str] = {}
+    values: dict[str, str] = dict(initial or {})
     unresolved: set[str] = set()
     for entry in entries:
+        if entry.bare and not bare_is_empty:
+            # An `env_file:` bare key is a process-environment lookup and
+            # nothing else, so there is no file value to ship. Left unresolved
+            # rather than guessed at, for the reason in divergence 1.
+            unresolved.add(entry.key)
+            values.pop(entry.key, None)
+            continue
         resolved = entry.raw if not entry.expands else _expand(entry.raw, values)
         if resolved is None:
             unresolved.add(entry.key)
@@ -441,3 +496,60 @@ def _substitute(interior: str, defined: Mapping[str, str]) -> str | None:
     if default is None:
         return None  # nothing to fall back to but the host's environment
     return _expand(default, defined)
+
+
+def read_env_file(
+    path: Path,
+    *,
+    defined: Mapping[str, str] | None = None,
+    raw: bool = False,
+) -> EnvFile | None:
+    """Read one ``env_file:`` target, or ``None`` if it cannot be read.
+
+    ``None`` covers absent, unreadable, over-cap and undecodable alike, because
+    the caller's next move is the same for all four: say the file was not read
+    and grade nothing from it. Compose distinguishes them — an absent
+    ``required`` target aborts the run — but that distinction is about whether
+    the project deploys, which the caller answers by testing the path, not by
+    reading it.
+
+    ``defined`` seeds the names this file's values may reference: the sibling
+    ``.env`` and every earlier ``env_file:`` on the same service, which is the
+    scope Compose resolves against (verified: ``P=${BASE}/p`` in the second file
+    picks up ``BASE`` from the first). Seeded names are *not* returned — only
+    keys this file writes are, because only those are keys it contributes to the
+    container.
+
+    Unlike :func:`read_env`, nothing is filtered by wantedness. Every key in an
+    ``env_file:`` is deployed into a named service's process environment, so
+    every key is one a rule may grade (ADR-027 §4).
+    """
+    try:
+        text = read_text_bounded(path, max_bytes=MAX_ENV_BYTES)
+    except (FileNotFoundError, UnsafeFileError, UnicodeDecodeError, OSError):
+        return None
+    return parse_env_file(text, defined=defined, raw=raw)
+
+
+def parse_env_file(
+    text: str,
+    *,
+    defined: Mapping[str, str] | None = None,
+    raw: bool = False,
+) -> EnvFile:
+    """Parse one ``env_file:`` target's text.
+
+    ``raw`` is the ``format: raw`` spelling, which is a different grammar rather
+    than a relaxed one — see :func:`_scan`. In both grammars a bare ``KEY`` is
+    Compose's process-environment lookup and is reported unresolved, which is
+    where this reader diverges from :func:`parse_env`: a ``.env`` ships that key
+    empty.
+    """
+    entries, skipped = _scan(text, raw=raw)
+    own = {entry.key for entry in entries}
+    values, unresolved = _resolve(entries, own, initial=defined, bare_is_empty=False)
+    return EnvFile(
+        values=values,
+        unresolved=frozenset(unresolved),
+        skipped_lines=tuple(skipped),
+    )

--- a/tests/test_env_file.py
+++ b/tests/test_env_file.py
@@ -1,10 +1,12 @@
-"""Tests for the ``.env`` reader.
+"""Tests for the ``.env`` and ``env_file:`` readers.
 
 Two halves. The unit tests below pin the behaviour compose-lint promises,
-including the two places it deliberately diverges from Compose. The
-differential suite in ``test_env_semantics.py`` re-derives the grammar from the
-``docker compose`` binary, so a Compose release that changes it fails there
-rather than silently mis-resolving a user's stack.
+including the places it deliberately diverges from Compose. The differential
+suites in ``test_env_semantics.py`` and ``test_env_file_semantics.py``
+re-derive both grammars from the ``docker compose`` binary, so a Compose
+release that changes one fails there rather than silently mis-resolving a
+user's stack. Those suites need the CLI and skip without it; these do not, so
+the promised behaviour stays covered on a Docker-less leg.
 """
 
 from __future__ import annotations
@@ -13,7 +15,14 @@ import os
 import stat
 from typing import TYPE_CHECKING
 
-from compose_lint._env_file import MAX_ENV_BYTES, EnvFile, parse_env, read_env
+from compose_lint._env_file import (
+    MAX_ENV_BYTES,
+    EnvFile,
+    parse_env,
+    parse_env_file,
+    read_env,
+    read_env_file,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -270,3 +279,93 @@ class TestEnvFile:
 
     def test_is_truthy_when_it_supplies_something(self) -> None:
         assert EnvFile(values={"K": "v"}, unresolved=frozenset(), skipped_lines=())
+
+
+class TestParseEnvFile:
+    """The ``env_file:`` reader, where it differs from the ``.env`` one."""
+
+    def test_every_key_is_returned_without_a_wanted_filter(self) -> None:
+        """ADR-027 §4: every key is deployed, so every key is graded."""
+        parsed = parse_env_file("PW=hunter2\nUNRELATED=1\n")
+        assert parsed.values == {"PW": "hunter2", "UNRELATED": "1"}
+
+    def test_a_bare_key_is_unresolved_rather_than_empty(self) -> None:
+        """The sharpest divergence from ``parse_env``, which ships it empty.
+
+        Compose treats ``KEY`` with no ``=`` as a lookup in its own process
+        environment and omits the key when that is unset. Claiming an empty
+        value would put a lint-host fact into the document (ADR-023).
+        """
+        parsed = parse_env_file("K\n")
+        assert parsed.values == {}
+        assert parsed.unresolved == frozenset({"K"})
+        assert parse_env("K\n").values == {"K": ""}, "the .env reader is unchanged"
+
+    def test_defined_names_are_in_scope_but_are_not_returned(self) -> None:
+        parsed = parse_env_file("P=${BASE}/p\n", defined={"BASE": "/opt"})
+        assert parsed.values == {"P": "/opt/p"}, "the earlier name resolved"
+        assert "BASE" not in parsed.values, "but it is not this file's key"
+
+    def test_a_key_redefining_a_defined_name_is_returned(self) -> None:
+        parsed = parse_env_file("BASE=/srv\n", defined={"BASE": "/opt"})
+        assert parsed.values == {"BASE": "/srv"}
+
+    def test_no_process_environment_fallback(self) -> None:
+        parsed = parse_env_file("K=${NOT_DEFINED_ANYWHERE}\n")
+        assert parsed.values == {}
+        assert parsed.unresolved == frozenset({"K"})
+
+    def test_a_malformed_line_is_skipped_not_fatal(self) -> None:
+        parsed = parse_env_file("not a pair\nK=v\n")
+        assert parsed.values == {"K": "v"}
+        assert parsed.skipped_lines == (1,)
+
+
+class TestParseEnvFileRawFormat:
+    """``format: raw`` is a different grammar, not a relaxed one."""
+
+    def test_quotes_hashes_and_spacing_are_payload(self) -> None:
+        parsed = parse_env_file('A=v # trail\nB="quoted"\nC=  spaced  \n', raw=True)
+        assert parsed.values == {
+            "A": "v # trail",
+            "B": '"quoted"',
+            "C": "  spaced  ",
+        }
+
+    def test_nothing_interpolates(self) -> None:
+        parsed = parse_env_file("A=one\nK=${A}-two\n", raw=True)
+        assert parsed.values == {"A": "one", "K": "${A}-two"}
+
+    def test_full_line_comments_are_still_skipped(self) -> None:
+        assert parse_env_file("# note\nK=v\n", raw=True).values == {"K": "v"}
+
+    def test_an_export_prefix_is_not_consumed(self) -> None:
+        """And the resulting key has a space, which Compose calls fatal."""
+        parsed = parse_env_file("export D=v\n", raw=True)
+        assert parsed.values == {}
+        assert parsed.skipped_lines == (1,)
+
+
+class TestReadEnvFile:
+    def test_reads_a_file(self, tmp_path: Path) -> None:
+        (tmp_path / "app.env").write_text("K=v\n", encoding="utf-8", newline="")
+        parsed = read_env_file(tmp_path / "app.env")
+        assert parsed is not None
+        assert parsed.values == {"K": "v"}
+
+    def test_absent_is_none(self, tmp_path: Path) -> None:
+        assert read_env_file(tmp_path / "nope.env") is None
+
+    def test_over_cap_is_none(self, tmp_path: Path) -> None:
+        (tmp_path / "app.env").write_text(
+            "K=" + "x" * MAX_ENV_BYTES, encoding="utf-8", newline=""
+        )
+        assert read_env_file(tmp_path / "app.env") is None
+
+    def test_non_utf8_is_none(self, tmp_path: Path) -> None:
+        (tmp_path / "app.env").write_bytes(b"K=\xff\xfe\n")
+        assert read_env_file(tmp_path / "app.env") is None
+
+    def test_a_directory_is_none(self, tmp_path: Path) -> None:
+        (tmp_path / "app.env").mkdir()
+        assert read_env_file(tmp_path / "app.env") is None

--- a/tests/test_env_file_semantics.py
+++ b/tests/test_env_file_semantics.py
@@ -1,0 +1,297 @@
+"""Differential test: does our ``env_file:`` reader agree with Docker Compose?
+
+The sibling of ``test_env_semantics.py``, asking the same question about the
+other file. It is a separate module because the question is asked differently:
+a ``.env`` is interrogated one ``${K}`` at a time, while an ``env_file:``
+contributes the service's whole ``environment:`` mapping, so the ground truth is
+that mapping rather than a single substitution.
+
+The grammar mostly coincides with the ``.env`` one — godotenv, both times — and
+diverges in three places Compose does not document together: a bare ``KEY`` is a
+process-environment lookup rather than an empty value, ``format: raw`` is a
+different grammar rather than a relaxed one, and the resolution scope spans the
+sibling ``.env`` and every earlier ``env_file:`` on the same service. Each is
+re-derived here on every run, so a Compose release that moves one fails the
+suite instead of silently mis-reading a user's stack.
+
+Skipped when the ``docker compose`` CLI is unavailable, like its sibling.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from compose_lint._env_file import parse_env_file
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _compose_cli_works() -> bool:
+    """Whether ``docker compose`` can actually run, not merely whether it exists."""
+    if shutil.which("docker") is None:
+        return False
+    try:
+        return (
+            subprocess.run(
+                ["docker", "compose", "version"],
+                capture_output=True,
+                timeout=30,
+            ).returncode
+            == 0
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _compose_cli_works(),
+    reason="differential env_file: test needs a working docker compose CLI",
+)
+
+_COMPOSE = """\
+services:
+  s:
+    image: i
+    env_file: [app.env]
+"""
+
+_COMPOSE_RAW = """\
+services:
+  s:
+    image: i
+    env_file:
+      - path: app.env
+        format: raw
+"""
+
+# Every case is ``env_file:`` text. The assertion is that Compose and this
+# module contribute the same mapping to the service's environment.
+AGREED = [
+    pytest.param("K=v", id="plain"),
+    pytest.param("  K  =  v  ", id="trimmed"),
+    pytest.param("export K=v", id="export-prefix"),
+    pytest.param('K="v w"', id="double-quoted"),
+    pytest.param("K='v w'", id="single-quoted"),
+    pytest.param("K=v # trail", id="unquoted-trailing-comment"),
+    pytest.param('K="v # trail"', id="quoted-hash-is-literal"),
+    pytest.param("# note\nK=v", id="leading-comment"),
+    pytest.param("K=", id="empty-value"),
+    pytest.param("K=a=b", id="first-equals-splits"),
+    pytest.param("K=first\nK=second", id="last-duplicate-wins"),
+    pytest.param('K="a\\nb"', id="double-quote-escapes"),
+    pytest.param("K='a\\nb'", id="single-quote-literal"),
+    pytest.param("K=a\\nb", id="unquoted-literal"),
+    pytest.param("A=one\nK=${A}-two", id="braced-reference"),
+    pytest.param("A=one\nK=$A-two", id="bare-reference"),
+    pytest.param("A=one\nK='${A}'", id="single-quotes-suppress-expansion"),
+    pytest.param("K=${MISSING:-dflt}", id="default-applies"),
+    pytest.param("BASE=/var/run\nK=${BASE}/docker.sock", id="chained"),
+    pytest.param("\ufeffK=v", id="bom"),
+    pytest.param("K=v\r", id="crlf"),
+    pytest.param("K=a$$b", id="escaped-dollar"),
+    pytest.param("PW=hunter2\nAWS_SECRET_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE", id="pair"),
+]
+
+# ``format: raw`` keeps the bytes: no trimming, no quote stripping, no comment
+# stripping inside a value, and no interpolation at all.
+AGREED_RAW = [
+    pytest.param("K=v", id="raw-plain"),
+    pytest.param("K=v # trail", id="raw-hash-is-payload"),
+    pytest.param('K="quoted"', id="raw-quotes-are-payload"),
+    pytest.param("K=  spaced  ", id="raw-no-trimming"),
+    pytest.param("A=one\nK=${A}-two", id="raw-no-interpolation"),
+    pytest.param("# note\nK=v", id="raw-full-line-comment-still-skipped"),
+    pytest.param("K=a\\nb", id="raw-backslash-literal"),
+]
+
+# Deliberate divergences, with the reason each one exists.
+DIVERGENT = {
+    "K=${SOME_UNDEFINED_NAME}": (
+        "Compose falls back to the process environment and then to empty; both "
+        "describe the lint host rather than the project (ADR-023)."
+    ),
+    "K=${LATER}\nLATER=x": (
+        "Compose ships empty for a forward reference; we report it unresolved "
+        "rather than claim a value the file does not build."
+    ),
+    "K\n": (
+        "A bare key is purely a process-environment lookup. Compose imports the "
+        "lint host's value; we report it unresolved."
+    ),
+    "not a pair\nK=v": (
+        "Compose refuses the whole file and starts nothing; a lint run skips the "
+        "line and grades the rest, because the env file is not the artifact "
+        "under lint."
+    ),
+}
+
+# The one name a divergence needs present in the process environment, so that
+# Compose has something to import and the disagreement is observable at all.
+_HOST_VALUE = "from-the-lint-host"
+
+
+def _compose_environment(
+    directory: Path,
+    env_text: str,
+    *,
+    raw: bool = False,
+    host_env: dict[str, str] | None = None,
+) -> dict[str, str] | None:
+    """Ground truth: the ``environment:`` mapping Compose builds for the service.
+
+    ``None`` means Compose refused the file, which is a real answer for one of
+    the divergences rather than a broken fixture.
+    """
+    document = _COMPOSE_RAW if raw else _COMPOSE
+    (directory / "compose.yml").write_text(document, encoding="utf-8", newline="")
+    (directory / "app.env").write_text(env_text, encoding="utf-8", newline="")
+    result = subprocess.run(
+        ["docker", "compose", "config"],
+        cwd=directory,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=host_env,
+    )
+    if result.returncode != 0:
+        return None
+    parsed = yaml.safe_load(result.stdout)
+    environment = parsed["services"]["s"].get("environment") or {}
+    return {key: _decode_dollars(str(value)) for key, value in environment.items()}
+
+
+def _decode_dollars(rendered: str) -> str:
+    """Undo the literal-dollar escaping ``config`` applies on the way out."""
+    return rendered.replace("$$", "$")
+
+
+@pytest.mark.parametrize("env_text", AGREED)
+def test_agrees_with_compose(env_text: str, tmp_path: Path) -> None:
+    theirs = _compose_environment(tmp_path, env_text)
+    assert theirs is not None, f"compose refused an AGREED fixture: {env_text!r}"
+    ours = dict(parse_env_file(env_text).values)
+    assert ours == theirs, (
+        f"disagreement for {env_text!r}: compose ships {theirs!r}, we ship {ours!r}"
+    )
+
+
+@pytest.mark.parametrize("env_text", AGREED_RAW)
+def test_agrees_with_compose_in_raw_format(env_text: str, tmp_path: Path) -> None:
+    theirs = _compose_environment(tmp_path, env_text, raw=True)
+    assert theirs is not None, f"compose refused an AGREED_RAW fixture: {env_text!r}"
+    ours = dict(parse_env_file(env_text, raw=True).values)
+    assert ours == theirs, (
+        f"disagreement for {env_text!r}: compose ships {theirs!r}, we ship {ours!r}"
+    )
+
+
+@pytest.mark.parametrize("env_text", sorted(DIVERGENT))
+def test_divergences_are_still_divergences(env_text: str, tmp_path: Path) -> None:
+    """The listed cases must keep differing, and for the recorded reason.
+
+    If Compose ever changes to match us, this fails and the entry should move to
+    ``AGREED`` — a divergence that no longer exists is a comment claiming a
+    difference the code no longer makes.
+    """
+    host_env = {**os.environ, "K": _HOST_VALUE}
+    theirs = _compose_environment(tmp_path, env_text, host_env=host_env)
+    parsed = parse_env_file(env_text)
+    reason = DIVERGENT[env_text]
+
+    if theirs is None:
+        # Compose refused the whole file. We keep the well-formed lines.
+        assert parsed.values == {"K": "v"}, reason
+        assert parsed.skipped_lines, reason
+        return
+
+    # Compose supplied a value out of the lint host's environment, or an empty
+    # string once its fallback chain ran out. We decline to do either.
+    assert theirs.get("K") in {_HOST_VALUE, ""}, reason
+    assert "K" not in parsed.values, f"{reason} -- but we shipped a value"
+    assert "K" in parsed.unresolved, reason
+
+
+def test_raw_rejects_an_export_prefix_that_the_default_grammar_accepts(
+    tmp_path: Path,
+) -> None:
+    """``format: raw`` has no ``export`` prefix, and the key then has a space.
+
+    Compose refuses the file outright (``variable 'export D' contains
+    whitespaces``); we skip the line for the same reason we skip any malformed
+    one. Recorded as its own case because it is the sharpest evidence that raw
+    is a different grammar rather than a lenient one — the same bytes are valid
+    in the default format and fatal here.
+    """
+    assert _compose_environment(tmp_path, "export D=v", raw=True) is None
+    parsed = parse_env_file("export D=v", raw=True)
+    assert parsed.values == {}
+    assert parsed.skipped_lines == (1,)
+
+
+def test_resolution_scope_spans_the_sibling_env_and_earlier_files(
+    tmp_path: Path,
+) -> None:
+    """A value may reference a name defined in ``.env`` or an earlier env file.
+
+    Verified against Compose: with ``BASE=/opt`` in the first file, ``P=${BASE}/p``
+    in the second ships ``/opt/p``. The reader takes that scope as ``defined``,
+    and returns only the keys the file itself writes.
+    """
+    (tmp_path / "compose.yml").write_text(
+        "services:\n  s:\n    image: i\n    env_file: [one.env, two.env]\n",
+        encoding="utf-8",
+        newline="",
+    )
+    (tmp_path / "one.env").write_text("BASE=/opt\n", encoding="utf-8", newline="")
+    (tmp_path / "two.env").write_text("P=${BASE}/p\n", encoding="utf-8", newline="")
+    result = subprocess.run(
+        ["docker", "compose", "config"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0
+    theirs = yaml.safe_load(result.stdout)["services"]["s"]["environment"]
+    assert theirs == {"BASE": "/opt", "P": "/opt/p"}
+
+    first = parse_env_file("BASE=/opt\n")
+    second = parse_env_file("P=${BASE}/p\n", defined=first.values)
+    assert dict(first.values) == {"BASE": "/opt"}
+    assert dict(second.values) == {"P": "/opt/p"}, (
+        "an earlier file's name must be in scope, and must not be returned twice"
+    )
+
+
+def test_a_bare_key_at_eof_without_a_newline_is_a_compose_defect(
+    tmp_path: Path,
+) -> None:
+    """Compose reads a trailing bare key as an *unnamed* variable. We do not.
+
+    ``K`` followed by a newline yields ``K: <host value>``; the same byte
+    without the newline yields ``"": K`` — an environment entry with an empty
+    name, holding the key text as its value. Reproduced across both spellings
+    and with a preceding pair, so it is the missing newline and not the file
+    length. Only the bare form is affected: ``K=v`` at EOF is read correctly.
+
+    Not reproduced, and deliberately: an empty-named variable is not a
+    configuration any rule can grade, and matching the defect would mean
+    inventing a key name no author wrote. Recorded as a test so that a Compose
+    release which fixes it is noticed here rather than in a user's report.
+    """
+    host_env = {**os.environ, "K": _HOST_VALUE}
+    assert _compose_environment(tmp_path, "K\n", host_env=host_env) == {
+        "K": _HOST_VALUE
+    }
+    assert _compose_environment(tmp_path, "K", host_env=host_env) == {"": "K"}
+
+    parsed = parse_env_file("K")
+    assert parsed.values == {}
+    assert parsed.unresolved == frozenset({"K"})


### PR DESCRIPTION
First of the implementation changes for ADR-027. Adds `parse_env_file` /
`read_env_file` and nothing that calls them — no path is resolved and no rule is
fed yet, so this ships zero behaviour change.

The grammar is godotenv's, the same authority `_env_file.py` already follows for
`.env`, which is why one scanner serves both. The two files are **not**
interchangeable, and Compose's docs never state the differences together. Each
was derived from the binary (5.4.0):

| | `.env` | `env_file:` |
| --- | --- | --- |
| bare `KEY` (no `=`) | ships empty | process-environment lookup; omitted when unset |
| `format: raw` | n/a | a different grammar: no `export`, no trimming, no quote/comment processing, no interpolation |
| resolution scope | itself | itself + the sibling `.env` + earlier `env_file:`s on the same service |
| retention | only wanted values (ADR-026 §5) | every key (ADR-027 §4) |

A bare key is reported **unresolved** rather than empty — claiming the empty
string would claim a lint-host fact (ADR-023). `format: raw` is sharp enough to
be worth a test of its own: Compose rejects `export D=v` in raw format as a key
containing whitespace, the same bytes it accepts in the default format.

One Compose defect is **recorded rather than reproduced**: a bare key on the
final line with no trailing newline is read as an *unnamed* variable holding the
key text (`"": K`). Verified across both spellings and with a preceding pair, so
it is the missing newline and not the file length; `K=v` at EOF is read
correctly. An empty-named variable is not a configuration any rule can grade, so
matching it would mean inventing a key name no author wrote. `tests/test_env_file_semantics.py`
pins it so a Compose release that fixes it is noticed here rather than in a
user's report.

`tests/test_env_file_semantics.py` re-derives all of the above from the binary on
every run, the way `test_env_semantics.py` already does for `.env`. It skips
without a working `docker compose`, so the same promises are also pinned in
pure-Python unit tests in `tests/test_env_file.py` for the Docker-less legs.

Refs #665
