### PR TITLE
Resolve and read a service's env_file: targets

### DIFF
--- a/src/compose_lint/_env_file.py
+++ b/src/compose_lint/_env_file.py
@@ -88,7 +88,7 @@ for three reasons, each derived from the binary the same way:
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from compose_lint._safe_read import UnsafeFileError, read_text_bounded
@@ -101,6 +101,7 @@ if TYPE_CHECKING:
 __all__ = [
     "ENV_FILENAME",
     "EnvFile",
+    "env_file_references",
     "parse_env",
     "parse_env_file",
     "read_env",
@@ -157,6 +158,10 @@ class EnvFile:
     values: Mapping[str, str]
     unresolved: frozenset[str]
     skipped_lines: tuple[int, ...]
+    # Where each resolved key was written, 1-indexed. Populated by
+    # :func:`parse_env_file` and left empty by :func:`parse_env`, which has no
+    # caller that needs it.
+    lines: Mapping[str, int] = field(default_factory=dict)
 
     def __bool__(self) -> bool:
         return bool(self.values)
@@ -175,6 +180,11 @@ class _Entry:
     # (both verified against Compose 5.4.0). Recorded here so one scanner can
     # serve both readers.
     bare: bool = False
+    # 1-indexed line this entry was written on. Only the ``env_file:`` reader
+    # keeps it: a finding about a key in one of those files points at the key
+    # (ADR-027 §6), while a ``.env`` value is only ever reported through the
+    # document position that consumed it.
+    line: int = 0
 
 
 def read_env(directory: Path, wanted: Iterable[str] | None = None) -> EnvFile | None:
@@ -281,7 +291,7 @@ def _scan(text: str, *, raw: bool = False) -> tuple[list[_Entry], list[int]]:
             if not separator or not _KEY_RE.match(key):
                 skipped.append(number)
                 continue
-            entries.append(_Entry(key=key, raw=value, expands=False))
+            entries.append(_Entry(key=key, raw=value, expands=False, line=number))
             continue
         stripped = _EXPORT_RE.sub("", stripped)
         key, separator, value = stripped.partition("=")
@@ -292,19 +302,23 @@ def _scan(text: str, *, raw: bool = False) -> tuple[list[_Entry], list[int]]:
             skipped.append(number)
             continue
         if not separator:
-            entries.append(_Entry(key=key, raw="", expands=False, bare=True))
+            entries.append(
+                _Entry(key=key, raw="", expands=False, bare=True, line=number)
+            )
             continue
-        entries.append(_entry(key, value.strip()))
+        entries.append(_entry(key, value.strip(), number))
     return entries, skipped
 
 
-def _entry(key: str, raw: str) -> _Entry:
+def _entry(key: str, raw: str, line: int = 0) -> _Entry:
     """Build one entry, applying the quoting rules for its style."""
     if len(raw) >= 2 and raw[0] == raw[-1] == "'":
-        return _Entry(key=key, raw=raw[1:-1], expands=False)
+        return _Entry(key=key, raw=raw[1:-1], expands=False, line=line)
     if len(raw) >= 2 and raw[0] == raw[-1] == '"':
-        return _Entry(key=key, raw=_unescape(raw[1:-1]), expands=True)
-    return _Entry(key=key, raw=_UNQUOTED_COMMENT_RE.sub("", raw), expands=True)
+        return _Entry(key=key, raw=_unescape(raw[1:-1]), expands=True, line=line)
+    return _Entry(
+        key=key, raw=_UNQUOTED_COMMENT_RE.sub("", raw), expands=True, line=line
+    )
 
 
 def _unescape(value: str) -> str:
@@ -548,8 +562,32 @@ def parse_env_file(
     entries, skipped = _scan(text, raw=raw)
     own = {entry.key for entry in entries}
     values, unresolved = _resolve(entries, own, initial=defined, bare_is_empty=False)
+    # Last definition wins, so the line recorded is the one whose value shipped.
+    lines = {entry.key: entry.line for entry in entries if entry.key in values}
     return EnvFile(
         values=values,
         unresolved=frozenset(unresolved),
         skipped_lines=tuple(skipped),
+        lines=lines,
     )
+
+
+def env_file_references(text: str, *, raw: bool = False) -> set[str]:
+    """Every name an ``env_file:``'s values interpolate.
+
+    Exists so that the sibling ``.env`` can be read for exactly the names an
+    ``env_file:`` chains to, instead of being read in full. Compose resolves an
+    ``env_file:`` value against the ``.env`` (verified: ``K=${FROMDOTENV}-tail``
+    ships the ``.env``'s value), so those names have to be in scope — but
+    ADR-026 §5 keeps the ``.env`` read narrowed to what a run needs, and reading
+    it wholesale to serve this would quietly retire that guarantee. Scanning the
+    env file first costs one extra pass and keeps both promises intact.
+
+    Nothing is resolved here, so no value is assembled.
+    """
+    entries, _ = _scan(text, raw=raw)
+    found: set[str] = set()
+    for entry in entries:
+        if entry.expands:
+            found |= _references(entry.raw)
+    return found

--- a/src/compose_lint/_service_env.py
+++ b/src/compose_lint/_service_env.py
@@ -1,0 +1,338 @@
+"""Resolve and read the ``env_file:`` targets a service names.
+
+Where :mod:`compose_lint._env_file` knows the *grammar* of an env file, this
+module knows which ones a document points at, whether compose-lint will open
+them, and what the result contributes to a service's process environment. It is
+the file-selection half of
+[ADR-027](../../docs/adr/027-grade-env-file-where-the-document-routes-it.md).
+
+Compose's own behaviour was derived from the binary (5.4.0) and is followed
+except where the ADR says otherwise:
+
+===========================  ==========================================
+written                      Compose
+===========================  ==========================================
+``env_file: app.env``        read, relative to the Compose file's parent
+``env_file: [a.env, b.env]`` read in order; later wins
+``path:`` / ``required:``    the mapping spelling; missing + required aborts
+``format: raw``              a different grammar (see ``_env_file``)
+``env_file: ["${W}.env"]``   the path interpolates, from ``.env``
+``env_file: ../out.env``     read
+``env_file: /etc/app.env``   read
+``environment:``             wins over every ``env_file:`` key
+===========================  ==========================================
+
+Two of those rows are deliberately not followed. A path that leaves the project
+directory is refused rather than read (ADR-027 §7): Compose reads it, but an
+``env_file: /home/runner/.aws/credentials`` added in a pull request would put
+lint-host key *names* into a report through the one field the credential rules
+emit, which is the leak ADR-023 exists to prevent. And an absent file is a note
+rather than a fatal error, because compose-lint is not the thing being started —
+though what the note *says* differs by ``required:``, since only one of the two
+means the project cannot deploy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from compose_lint._env_file import (
+    MAX_ENV_BYTES,
+    env_file_references,
+    parse_env_file,
+    read_env,
+)
+from compose_lint._safe_read import UnsafeFileError, read_text_bounded
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from pathlib import Path
+
+__all__ = [
+    "EnvFileKey",
+    "EnvFileRef",
+    "ServiceEnvFiles",
+    "Unread",
+    "UnreadEnvFile",
+    "env_file_refs",
+    "resolve_env_files",
+]
+
+
+class Unread(Enum):
+    """Why a named ``env_file:`` did not contribute anything."""
+
+    #: The path still carries a ``${VAR}`` nothing supplied, so it names no file.
+    UNRESOLVED_PATH = "unresolved-path"
+    #: The path resolves outside the project directory (ADR-027 §7).
+    OUTSIDE_PROJECT = "outside-project"
+    #: Named, inside the project, and not there. Compose aborts when required.
+    ABSENT = "absent"
+    #: Present but unreadable: over the byte cap, undecodable, a FIFO, a device.
+    UNREADABLE = "unreadable"
+
+
+@dataclass(frozen=True)
+class EnvFileRef:
+    """One ``env_file:`` target as the document writes it."""
+
+    path: str
+    required: bool
+    raw: bool
+
+
+@dataclass(frozen=True)
+class EnvFileKey:
+    """One key an ``env_file:`` contributes to a service's environment."""
+
+    key: str
+    value: str
+    #: The file as the document wrote it, which is what a report should name —
+    #: not the lint host's absolute path, which is not a fact about the project.
+    source_file: str
+    #: 1-indexed line within that file.
+    line: int
+
+
+@dataclass(frozen=True)
+class UnreadEnvFile:
+    """A target that was named but contributed nothing, and why."""
+
+    path: str
+    reason: Unread
+    required: bool
+
+
+@dataclass(frozen=True)
+class ServiceEnvFiles:
+    """What one service's ``env_file:`` targets contribute.
+
+    ``keys`` is what actually reaches the container: files applied in written
+    order with a later one winning, and anything the service's own
+    ``environment:`` also sets removed, because Compose's precedence means such
+    a key contributes nothing (verified). Dropping it here is also what keeps
+    CL-0020 from reporting the same credential twice — it already grades the
+    ``environment:`` spelling.
+    """
+
+    keys: tuple[EnvFileKey, ...]
+    unread: tuple[UnreadEnvFile, ...]
+
+    def __bool__(self) -> bool:
+        return bool(self.keys or self.unread)
+
+
+def env_file_refs(value: Any) -> list[EnvFileRef]:
+    """Every target an ``env_file:`` names, in written order.
+
+    Three spellings are legal and all three appear in the corpus: a bare string,
+    a list of strings, and a list of mappings carrying ``path:`` alongside
+    ``required:`` / ``format:``. The mapping form is the newer one and is the
+    easiest to miss — 29 corpus files use it, and reading only the string forms
+    would report a service as covered precisely where the author reached for the
+    more explicit syntax.
+    """
+    if isinstance(value, str):
+        return [EnvFileRef(path=value, required=True, raw=False)] if value else []
+    if not isinstance(value, list):
+        return []
+    refs: list[EnvFileRef] = []
+    for entry in value:
+        if isinstance(entry, str) and entry:
+            refs.append(EnvFileRef(path=entry, required=True, raw=False))
+        elif isinstance(entry, dict):
+            path = entry.get("path")
+            if isinstance(path, str) and path:
+                refs.append(
+                    EnvFileRef(
+                        path=path,
+                        required=entry.get("required", True) is not False,
+                        raw=entry.get("format") == "raw",
+                    )
+                )
+    return refs
+
+
+def _project_relative(path: str) -> list[str] | None:
+    """``path`` as cleaned segments under the project, or ``None`` if it leaves.
+
+    Segment math, never the lint host's path semantics: whether a document
+    reaches outside its own project is a fact about the document, and ADR-023
+    requires it to read the same on every platform. A leading ``/``, a drive
+    letter, a ``~``, or any ``..`` that climbs past the start all leave.
+
+    Cleaning is lexical and happens before anything touches the filesystem,
+    because Compose's is too: ``conf/../app.env`` reads ``app.env`` even when
+    ``conf`` does not exist (verified against Compose 5.4.0). Joining the
+    uncleaned path instead would have reported that file absent on POSIX, where
+    the kernel resolves ``..`` component by component.
+    """
+    if path.startswith(("/", "~", "\\\\")) or (len(path) > 1 and path[1] == ":"):
+        return None
+    segments: list[str] = []
+    for segment in path.replace("\\", "/").split("/"):
+        if segment in ("", "."):
+            continue
+        if segment == "..":
+            if not segments:
+                return None
+            segments.pop()
+            continue
+        segments.append(segment)
+    return segments or None
+
+
+def _classify(ref: EnvFileRef, base_dir: Path) -> tuple[Path | None, Unread | None]:
+    """The lint-host path to open, or why there is not one."""
+    if "$" in ref.path:
+        # Anything the document or its `.env` could supply is already
+        # substituted by the time this runs, so a surviving `$` means the name
+        # is unknowable from the files (ADR-026 divergence 1).
+        return None, Unread.UNRESOLVED_PATH
+    segments = _project_relative(ref.path)
+    if segments is None:
+        return None, Unread.OUTSIDE_PROJECT
+    return base_dir.joinpath(*segments), None
+
+
+def resolve_env_files(
+    data: dict[str, Any],
+    base_dir: Path,
+    *,
+    read_dotenv: bool = True,
+) -> dict[str, ServiceEnvFiles]:
+    """Read every service's ``env_file:`` targets, keyed by service name.
+
+    Services naming no target are absent from the result rather than present and
+    empty, so a caller can ask the cheap question first.
+
+    The sibling ``.env`` is read for exactly the names the env files chain to,
+    and no others. Compose resolves an ``env_file:`` value against the ``.env``,
+    so those names have to be in scope; reading the ``.env`` in full to supply
+    them would quietly retire ADR-026 §5's retention guarantee, so the env files
+    are scanned for their references first and the ``.env`` read is narrowed to
+    those. ``read_dotenv=False`` is ``--no-env``.
+    """
+    services = data.get("services")
+    if not isinstance(services, dict):
+        return {}
+
+    plans: dict[str, list[tuple[EnvFileRef, Path | None, Unread | None]]] = {}
+    texts: dict[Path, str | None] = {}
+    for name, config in services.items():
+        if not isinstance(config, dict):
+            continue
+        refs = env_file_refs(config.get("env_file"))
+        if not refs:
+            continue
+        plan = []
+        for ref in refs:
+            path, refusal = _classify(ref, base_dir)
+            if path is not None and path not in texts:
+                texts[path] = _read_text(path)
+            plan.append((ref, path, refusal))
+        plans[name] = plan
+    if not plans:
+        return {}
+
+    supplied = _dotenv_scope(plans, texts, base_dir, read_dotenv=read_dotenv)
+
+    resolved: dict[str, ServiceEnvFiles] = {}
+    for name, plan in plans.items():
+        config = services[name]
+        resolved[name] = _resolve_one(plan, texts, supplied, config)
+    return resolved
+
+
+def _read_text(path: Path) -> str | None:
+    """The file's text, or ``None`` when it cannot be read.
+
+    Absent and unreadable are separated by the caller, which tests the path;
+    here they collapse, because the byte cap and the safe-read guard are the
+    same in both cases.
+    """
+    try:
+        return read_text_bounded(path, max_bytes=MAX_ENV_BYTES)
+    except (FileNotFoundError, UnsafeFileError, UnicodeDecodeError, OSError):
+        return None
+
+
+def _dotenv_scope(
+    plans: dict[str, list[tuple[EnvFileRef, Path | None, Unread | None]]],
+    texts: dict[Path, str | None],
+    base_dir: Path,
+    *,
+    read_dotenv: bool,
+) -> Mapping[str, str]:
+    """The ``.env`` values the env files chain to, and nothing else."""
+    if not read_dotenv:
+        return {}
+    wanted: set[str] = set()
+    for plan in plans.values():
+        for ref, path, _refusal in plan:
+            text = texts.get(path) if path is not None else None
+            if text is not None:
+                wanted |= env_file_references(text, raw=ref.raw)
+    if not wanted:
+        return {}
+    parsed = read_env(base_dir, wanted)
+    return parsed.values if parsed is not None else {}
+
+
+def _resolve_one(
+    plan: list[tuple[EnvFileRef, Path | None, Unread | None]],
+    texts: dict[Path, str | None],
+    supplied: Mapping[str, str],
+    config: dict[str, Any],
+) -> ServiceEnvFiles:
+    """Apply one service's targets in order, then remove what it overrides."""
+    scope: dict[str, str] = dict(supplied)
+    contributed: dict[str, EnvFileKey] = {}
+    unread: list[UnreadEnvFile] = []
+
+    for ref, path, refusal in plan:
+        if refusal is not None or path is None:
+            unread.append(
+                UnreadEnvFile(ref.path, refusal or Unread.UNRESOLVED_PATH, ref.required)
+            )
+            continue
+        text = texts.get(path)
+        if text is None:
+            reason = Unread.ABSENT if not path.exists() else Unread.UNREADABLE
+            unread.append(UnreadEnvFile(ref.path, reason, ref.required))
+            continue
+        parsed = parse_env_file(text, defined=scope, raw=ref.raw)
+        for key, value in parsed.values.items():
+            scope[key] = value
+            contributed[key] = EnvFileKey(
+                key=key,
+                value=value,
+                source_file=ref.path,
+                line=parsed.lines.get(key, 0),
+            )
+
+    for key in _environment_keys(config.get("environment")):
+        contributed.pop(key, None)
+
+    return ServiceEnvFiles(keys=tuple(contributed.values()), unread=tuple(unread))
+
+
+def _environment_keys(env_block: Any) -> set[str]:
+    """Every key the service's own ``environment:`` sets, in either spelling.
+
+    A bare ``KEY`` in the list form counts: Compose sources it from its own
+    environment, and that still takes precedence over an ``env_file:`` value
+    (the key is set either way, just not from the file).
+    """
+    keys: set[str] = set()
+    if isinstance(env_block, dict):
+        keys |= {key for key in env_block if isinstance(key, str)}
+    elif isinstance(env_block, list):
+        for item in env_block:
+            if isinstance(item, str):
+                keys.add(item.split("=", 1)[0])
+            elif isinstance(item, dict):
+                keys |= {key for key in item if isinstance(key, str)}
+    return keys

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -12,6 +12,7 @@ from compose_lint._env_file import read_env
 from compose_lint._lines import find_ambiguous_break
 from compose_lint._merge import Document, Merged, merge_documents, merge_values
 from compose_lint._safe_read import UnsafeFileError, read_text_bounded
+from compose_lint._service_env import env_file_refs
 from compose_lint.config import KNOWN_TOP_LEVEL_KEYS
 from compose_lint.rules._interpolation import (
     reference_names,
@@ -1091,26 +1092,11 @@ def unread_env_files(data: dict[str, Any]) -> list[str]:
 def _env_file_paths(value: Any) -> list[str]:
     """Every path an ``env_file:`` names, in written order.
 
-    Three spellings are legal and all three appear in the corpus: a bare string,
-    a list of strings, and a list of mappings carrying ``path:`` alongside
-    ``required:`` / ``format:``. The mapping form is the newer one and is the
-    easiest to miss -- 38 corpus files use it, and reading only the string forms
-    would report a service as covered precisely where the author reached for the
-    more explicit syntax.
+    A thin projection of :func:`compose_lint._service_env.env_file_refs`, which
+    is the one reader of the three legal spellings, so the note below and the
+    resolution that acts on it can never disagree about what a service names.
     """
-    if isinstance(value, str):
-        return [value] if value else []
-    if not isinstance(value, list):
-        return []
-    paths: list[str] = []
-    for entry in value:
-        if isinstance(entry, str) and entry:
-            paths.append(entry)
-        elif isinstance(entry, dict):
-            path = entry.get("path")
-            if isinstance(path, str) and path:
-                paths.append(path)
-    return paths
+    return [ref.path for ref in env_file_refs(value)]
 
 
 def _split_short_volume(volume: str) -> tuple[str, str, str]:

--- a/tests/test_service_env.py
+++ b/tests/test_service_env.py
@@ -1,0 +1,352 @@
+"""Tests for resolving and reading a service's ``env_file:`` targets.
+
+The unit tests pin what compose-lint promises; ``TestAgreesWithCompose`` at the
+end re-derives the precedence and scoping rules from the ``docker compose``
+binary, so a release that changes them fails here rather than silently
+mis-reading a user's stack. That class skips without a working CLI, and every
+promise it checks is also pinned by a unit test above, so a Docker-less leg
+still covers the behaviour.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from compose_lint._env_file import MAX_ENV_BYTES
+from compose_lint._service_env import (
+    EnvFileRef,
+    Unread,
+    env_file_refs,
+    resolve_env_files,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _document(env_file: object, environment: object = None) -> dict:
+    service: dict = {"image": "i", "env_file": env_file}
+    if environment is not None:
+        service["environment"] = environment
+    return {"services": {"s": service}}
+
+
+def _keys(resolved: dict, service: str = "s") -> dict[str, str]:
+    return {key.key: key.value for key in resolved[service].keys}
+
+
+class TestEnvFileRefs:
+    """The three legal spellings, which is the one place they are read."""
+
+    def test_bare_string(self) -> None:
+        assert env_file_refs("app.env") == [
+            EnvFileRef(path="app.env", required=True, raw=False)
+        ]
+
+    def test_list_of_strings_keeps_written_order(self) -> None:
+        assert [ref.path for ref in env_file_refs(["a.env", "b.env"])] == [
+            "a.env",
+            "b.env",
+        ]
+
+    def test_mapping_form_carries_required_and_format(self) -> None:
+        refs = env_file_refs(
+            [{"path": "a.env", "required": False, "format": "raw"}, {"path": "b.env"}]
+        )
+        assert refs == [
+            EnvFileRef(path="a.env", required=False, raw=True),
+            EnvFileRef(path="b.env", required=True, raw=False),
+        ]
+
+    @pytest.mark.parametrize(
+        "value", [None, "", [], [""], [{}], [{"path": ""}], 7, {"path": "a.env"}]
+    )
+    def test_nothing_named(self, value: object) -> None:
+        assert env_file_refs(value) == []
+
+
+class TestResolution:
+    def test_a_service_naming_nothing_is_absent_from_the_result(
+        self, tmp_path: Path
+    ) -> None:
+        data = {"services": {"s": {"image": "i"}}}
+        assert resolve_env_files(data, tmp_path) == {}
+
+    def test_reads_a_target_relative_to_the_compose_file(self, tmp_path: Path) -> None:
+        (tmp_path / "app.env").write_text("PW=hunter2\n", encoding="utf-8")
+        resolved = resolve_env_files(_document("app.env"), tmp_path)
+        assert _keys(resolved) == {"PW": "hunter2"}
+
+    def test_reads_a_subdirectory(self, tmp_path: Path) -> None:
+        (tmp_path / "conf").mkdir()
+        (tmp_path / "conf" / "app.env").write_text("PW=hunter2\n", encoding="utf-8")
+        resolved = resolve_env_files(_document("conf/app.env"), tmp_path)
+        assert _keys(resolved) == {"PW": "hunter2"}
+        assert resolved["s"].keys[0].source_file == "conf/app.env", (
+            "the report names the path as written, not the lint host's"
+        )
+
+    def test_a_later_file_wins(self, tmp_path: Path) -> None:
+        (tmp_path / "a.env").write_text("K=first\n", encoding="utf-8")
+        (tmp_path / "b.env").write_text("K=second\n", encoding="utf-8")
+        resolved = resolve_env_files(_document(["a.env", "b.env"]), tmp_path)
+        assert _keys(resolved) == {"K": "second"}
+        assert resolved["s"].keys[0].source_file == "b.env"
+
+    def test_an_earlier_files_name_is_in_scope_for_a_later_one(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "a.env").write_text("BASE=/opt\n", encoding="utf-8")
+        (tmp_path / "b.env").write_text("P=${BASE}/p\n", encoding="utf-8")
+        resolved = resolve_env_files(_document(["a.env", "b.env"]), tmp_path)
+        assert _keys(resolved) == {"BASE": "/opt", "P": "/opt/p"}
+
+    def test_a_sibling_dotenv_is_in_scope(self, tmp_path: Path) -> None:
+        (tmp_path / ".env").write_text("FROMDOTENV=dotvalue\n", encoding="utf-8")
+        (tmp_path / "app.env").write_text("K=${FROMDOTENV}-tail\n", encoding="utf-8")
+        resolved = resolve_env_files(_document("app.env"), tmp_path)
+        assert _keys(resolved) == {"K": "dotvalue-tail"}
+
+    def test_no_env_leaves_the_dotenv_unread(self, tmp_path: Path) -> None:
+        (tmp_path / ".env").write_text("FROMDOTENV=dotvalue\n", encoding="utf-8")
+        (tmp_path / "app.env").write_text("K=${FROMDOTENV}-tail\n", encoding="utf-8")
+        resolved = resolve_env_files(_document("app.env"), tmp_path, read_dotenv=False)
+        assert _keys(resolved) == {}, "the value is unresolvable without the .env"
+
+    def test_records_the_line_a_key_was_written_on(self, tmp_path: Path) -> None:
+        (tmp_path / "app.env").write_text(
+            "# a comment\nFIRST=1\nPW=hunter2\n", encoding="utf-8"
+        )
+        resolved = resolve_env_files(_document("app.env"), tmp_path)
+        lines = {key.key: key.line for key in resolved["s"].keys}
+        assert lines == {"FIRST": 2, "PW": 3}
+
+    def test_the_mapping_form_is_read(self, tmp_path: Path) -> None:
+        (tmp_path / "app.env").write_text("PW=hunter2\n", encoding="utf-8")
+        resolved = resolve_env_files(
+            _document([{"path": "app.env", "required": False}]), tmp_path
+        )
+        assert _keys(resolved) == {"PW": "hunter2"}
+
+    def test_raw_format_is_honoured(self, tmp_path: Path) -> None:
+        (tmp_path / "app.env").write_text('PW="quoted"\n', encoding="utf-8")
+        resolved = resolve_env_files(
+            _document([{"path": "app.env", "format": "raw"}]), tmp_path
+        )
+        assert _keys(resolved) == {"PW": '"quoted"'}
+
+    def test_two_services_sharing_a_file_both_get_it(self, tmp_path: Path) -> None:
+        (tmp_path / "app.env").write_text("PW=hunter2\n", encoding="utf-8")
+        data = {
+            "services": {
+                "a": {"image": "i", "env_file": "app.env"},
+                "b": {"image": "i", "env_file": "app.env"},
+            }
+        }
+        resolved = resolve_env_files(data, tmp_path)
+        assert _keys(resolved, "a") == _keys(resolved, "b") == {"PW": "hunter2"}
+
+
+class TestEnvironmentPrecedence:
+    """``environment:`` wins, so the file contributes nothing for that key."""
+
+    def test_mapping_spelling_shadows(self, tmp_path: Path) -> None:
+        (tmp_path / "app.env").write_text("K=from-file\nJ=kept\n", encoding="utf-8")
+        resolved = resolve_env_files(
+            _document("app.env", {"K": "from-environment"}), tmp_path
+        )
+        assert _keys(resolved) == {"J": "kept"}
+
+    def test_list_spelling_shadows(self, tmp_path: Path) -> None:
+        (tmp_path / "app.env").write_text("K=from-file\nJ=kept\n", encoding="utf-8")
+        resolved = resolve_env_files(
+            _document("app.env", ["K=from-environment"]), tmp_path
+        )
+        assert _keys(resolved) == {"J": "kept"}
+
+    def test_a_bare_list_entry_shadows(self, tmp_path: Path) -> None:
+        """``- K`` sets the key from Compose's environment, which still wins."""
+        (tmp_path / "app.env").write_text("K=from-file\nJ=kept\n", encoding="utf-8")
+        resolved = resolve_env_files(_document("app.env", ["K"]), tmp_path)
+        assert _keys(resolved) == {"J": "kept"}
+
+
+class TestUnread:
+    def test_absent_and_required(self, tmp_path: Path) -> None:
+        resolved = resolve_env_files(_document("nope.env"), tmp_path)
+        (unread,) = resolved["s"].unread
+        assert (unread.path, unread.reason, unread.required) == (
+            "nope.env",
+            Unread.ABSENT,
+            True,
+        )
+
+    def test_absent_and_optional(self, tmp_path: Path) -> None:
+        resolved = resolve_env_files(
+            _document([{"path": "nope.env", "required": False}]), tmp_path
+        )
+        (unread,) = resolved["s"].unread
+        assert unread.reason is Unread.ABSENT
+        assert unread.required is False, (
+            "only a required target's absence means the project cannot deploy"
+        )
+
+    def test_an_unresolved_path_names_no_file(self, tmp_path: Path) -> None:
+        resolved = resolve_env_files(_document("${WHICH}.env"), tmp_path)
+        (unread,) = resolved["s"].unread
+        assert unread.reason is Unread.UNRESOLVED_PATH
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "../outside.env",
+            "conf/../../outside.env",
+            "/etc/app.env",
+            "~/.aws/credentials",
+            "C:/Users/me/app.env",
+        ],
+    )
+    def test_a_path_outside_the_project_is_refused(
+        self, path: str, tmp_path: Path
+    ) -> None:
+        """Compose reads all of these. ADR-027 §7 does not."""
+        resolved = resolve_env_files(_document(path), tmp_path)
+        (unread,) = resolved["s"].unread
+        assert unread.reason is Unread.OUTSIDE_PROJECT
+
+    def test_a_climb_that_returns_inside_is_not_refused(self, tmp_path: Path) -> None:
+        """``conf/../app.env`` never leaves, so there is nothing to refuse."""
+        (tmp_path / "app.env").write_text("PW=hunter2\n", encoding="utf-8")
+        resolved = resolve_env_files(_document("conf/../app.env"), tmp_path)
+        assert _keys(resolved) == {"PW": "hunter2"}
+
+    def test_over_the_byte_cap_is_unreadable(self, tmp_path: Path) -> None:
+        (tmp_path / "app.env").write_text("K=" + "x" * MAX_ENV_BYTES, encoding="utf-8")
+        resolved = resolve_env_files(_document("app.env"), tmp_path)
+        (unread,) = resolved["s"].unread
+        assert unread.reason is Unread.UNREADABLE
+
+    def test_undecodable_is_unreadable(self, tmp_path: Path) -> None:
+        (tmp_path / "app.env").write_bytes(b"K=\xff\xfe\n")
+        resolved = resolve_env_files(_document("app.env"), tmp_path)
+        (unread,) = resolved["s"].unread
+        assert unread.reason is Unread.UNREADABLE
+
+    def test_a_fifo_is_unreadable(self, tmp_path: Path) -> None:
+        if not hasattr(os, "mkfifo"):
+            pytest.skip("no mkfifo on this platform")
+        os.mkfifo(tmp_path / "app.env")
+        assert stat.S_ISFIFO((tmp_path / "app.env").stat().st_mode)
+        resolved = resolve_env_files(_document("app.env"), tmp_path)
+        (unread,) = resolved["s"].unread
+        assert unread.reason is Unread.UNREADABLE
+
+    def test_one_unread_target_does_not_stop_the_others(self, tmp_path: Path) -> None:
+        (tmp_path / "b.env").write_text("PW=hunter2\n", encoding="utf-8")
+        resolved = resolve_env_files(_document(["nope.env", "b.env"]), tmp_path)
+        assert _keys(resolved) == {"PW": "hunter2"}
+        assert len(resolved["s"].unread) == 1
+
+
+def _compose_cli_works() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    try:
+        return (
+            subprocess.run(
+                ["docker", "compose", "version"], capture_output=True, timeout=30
+            ).returncode
+            == 0
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+@pytest.mark.skipif(
+    not _compose_cli_works(),
+    reason="differential env_file: selection test needs a working docker compose CLI",
+)
+class TestAgreesWithCompose:
+    """Precedence and scoping, re-derived from the binary rather than the docs."""
+
+    @staticmethod
+    def _theirs(directory: Path, document: str) -> dict[str, str] | None:
+        (directory / "compose.yml").write_text(document, encoding="utf-8", newline="")
+        result = subprocess.run(
+            ["docker", "compose", "config"],
+            cwd=directory,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if result.returncode != 0:
+            return None
+        service = yaml.safe_load(result.stdout)["services"]["s"]
+        return {k: str(v) for k, v in (service.get("environment") or {}).items()}
+
+    def test_environment_beats_every_env_file(self, tmp_path: Path) -> None:
+        document = (
+            "services:\n  s:\n    image: i\n    env_file: [a.env]\n"
+            "    environment:\n      K: from-environment\n"
+        )
+        (tmp_path / "a.env").write_text("K=from-file\nJ=kept\n", encoding="utf-8")
+        assert self._theirs(tmp_path, document) == {
+            "K": "from-environment",
+            "J": "kept",
+        }
+        data = yaml.safe_load(document)
+        assert _keys(resolve_env_files(data, tmp_path)) == {"J": "kept"}, (
+            "we drop the shadowed key because the file contributes nothing for it"
+        )
+
+    def test_a_later_file_beats_an_earlier_one(self, tmp_path: Path) -> None:
+        document = "services:\n  s:\n    image: i\n    env_file: [a.env, b.env]\n"
+        (tmp_path / "a.env").write_text("K=first\n", encoding="utf-8")
+        (tmp_path / "b.env").write_text("K=second\n", encoding="utf-8")
+        assert self._theirs(tmp_path, document) == {"K": "second"}
+        data = yaml.safe_load(document)
+        assert _keys(resolve_env_files(data, tmp_path)) == {"K": "second"}
+
+    def test_a_missing_required_target_aborts_the_run(self, tmp_path: Path) -> None:
+        """The state ADR-027 leans on: there is no shipped configuration."""
+        document = "services:\n  s:\n    image: i\n    env_file: [nope.env]\n"
+        assert self._theirs(tmp_path, document) is None
+        data = yaml.safe_load(document)
+        (unread,) = resolve_env_files(data, tmp_path)["s"].unread
+        assert (unread.reason, unread.required) == (Unread.ABSENT, True)
+
+    def test_a_missing_optional_target_ships(self, tmp_path: Path) -> None:
+        document = (
+            "services:\n  s:\n    image: i\n    env_file:\n"
+            "      - path: nope.env\n        required: false\n"
+        )
+        assert self._theirs(tmp_path, document) == {}
+        data = yaml.safe_load(document)
+        (unread,) = resolve_env_files(data, tmp_path)["s"].unread
+        assert (unread.reason, unread.required) == (Unread.ABSENT, False)
+
+    def test_the_path_interpolates_from_the_dotenv(self, tmp_path: Path) -> None:
+        """Compose resolves it; we see it already resolved, or not at all.
+
+        The substitution happens in the parser before this module runs, so the
+        case that reaches here is the *unresolvable* one — which is why the
+        document below supplies no ``.env`` and the expectation is a refusal
+        rather than a read.
+        """
+        document = 'services:\n  s:\n    image: i\n    env_file: ["${WHICH}.env"]\n'
+        (tmp_path / ".env").write_text("WHICH=prod\n", encoding="utf-8")
+        (tmp_path / "prod.env").write_text("PW=prodpass\n", encoding="utf-8")
+        assert self._theirs(tmp_path, document) == {"PW": "prodpass"}
+
+        data = yaml.safe_load(document)
+        (unread,) = resolve_env_files(data, tmp_path)["s"].unread
+        assert unread.reason is Unread.UNRESOLVED_PATH, (
+            "an unsubstituted path names no file; the parser substitutes first"
+        )


### PR DESCRIPTION
Second of the ADR-027 implementation changes, and still not wired to anything:
no rule is fed and no output moves. `_service_env.py` answers which env files a
service names, whether compose-lint will open each, and what the result
contributes to that service's process environment.

## Following Compose, except twice

Derived from the binary (5.4.0): path anchored at the Compose file's parent,
files applied in written order with a later one winning, `required:` honoured,
`format: raw` passed through to the reader, and `environment:` beating every
`env_file:` key. Two rows are deliberately not followed:

- **A path leaving the project directory is refused** (ADR-027 §7). Compose
  reads `../out.env` and `/etc/app.env` happily; an `env_file:` naming a
  lint-host path in a pull request would put that host's key *names* into a
  report through `evidence`, the one field the credential rules emit.
- **An absent file is recorded, not fatal** — but required and optional are
  recorded differently. Only the required case means `docker compose config`
  exits 1 and the project cannot deploy, which is the state the ADR's answer to
  the ADR-023 objection rests on. This is the first of the two loose ends the
  ADR left to implementation; the second (malformed lines) is still open.

## Two things the tests caught

**Paths must be cleaned lexically before touching the filesystem.** Compose
cleans: `conf/../app.env` reads `app.env` even when `conf` does not exist
(verified). Joining the uncleaned path reported that file absent on POSIX, where
the kernel resolves `..` component by component. Pinned by
`test_a_climb_that_returns_inside_is_not_refused`.

**`environment:` shadowing belongs here, not in the rule.** A key the service
also sets contributes nothing from the file, so dropping it keeps the structure
honest — and is what will stop CL-0020 reporting one credential twice. All three
`environment:` spellings shadow, including a bare `- K`.

## Scope preserved

The sibling `.env` is read for exactly the names the env files chain to. Compose
resolves an `env_file:` value against the `.env`, so those names must be in
scope; reading it in full to supply them would quietly retire ADR-026 §5's
retention guarantee. The env files are scanned for their references first
(`env_file_references`, no value assembled) and the `.env` read is narrowed to
those.

`parser._env_file_paths` becomes a projection of the new reader, so the #669
note and the resolution that will replace it cannot disagree about what a
service names.

`TestAgreesWithCompose` re-derives precedence, ordering, and the
required/optional split from the binary; it skips without the CLI, and every
promise it checks is also pinned by a unit test for the Docker-less legs.

Refs #665
