### PR TITLE
Fire CL-0020 and CL-0021 on the keys an env_file: contributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- A note when a service names an `env_file:`. Compose merges those files into
-  the container's process environment, so a credential written in one reaches
-  every surface CL-0020 describes while never appearing in the document —
-  moving a line out of `environment:` silenced CL-0020 and CL-0021 without
-  changing what deploys. The files are still not opened; the note states what
-  was not evaluated, so the gap is visible rather than silent
-  ([#665](https://github.com/tmatens/compose-lint/issues/665)).
+- **CL-0020 and CL-0021 now read the `env_file:` targets a service names**, and
+  fire on a credential written in one. Compose merges those files into the
+  container's process environment, so moving a line out of `environment:` and
+  into an `env_file:` silenced both rules without changing what deploys — the
+  silent false negative
+  ([#665](https://github.com/tmatens/compose-lint/issues/665)) opened on. The
+  decision and its grounding are
+  [ADR-027](docs/adr/027-grade-env-file-where-the-document-routes-it.md): a
+  value is graded where the document routes it, and an `env_file:` is a
+  declaration that every key in the named file becomes a literal in that
+  service's process environment.
 
-  Stderr only, like the unread-`.env` and unresolved-mount-source notes. No
-  finding, exit code, or machine-readable output changes: 415 of the 5,417-file
-  corpus (8.6% of those that lint) now carry the note and none of their results
-  moved.
+  Files clean on 0.22.0 may report new HIGH findings. This is the documented
+  MINOR behaviour, with the documented escape hatches: pin the version, or gate
+  on `--fail-on`. 414 of the 5,417-file corpus (7.64%) name an `env_file:`, and
+  496 of the 924 references name the sibling `.env` itself.
+
+  **No credential value reaches any output surface.** `evidence` is the key
+  name, as it always was, and the message names the key and the file. The text
+  formatter no longer reads — let alone excerpts — a file that is not a Compose
+  document, so the line a key was written on is never printed.
+
+  Paths resolving outside the project directory are refused rather than read,
+  and say so on stderr. Compose reads them; an `env_file:` naming a lint-host
+  path in a pull request would otherwise put that host's key names into a
+  report.
+
+- A note when an `env_file:` target contributed nothing, naming which one and
+  why: absent, unreadable, outside the project directory, or a path still
+  carrying an unresolved `${VAR}`. A *required* target's absence says Compose
+  refuses to start such a project, so the credential rules went unevaluated; an
+  optional one's absence says Compose ships the service without it, which is the
+  configuration that was graded. This replaces the blanket note added earlier in
+  this release cycle, which told every service naming an `env_file:` that the
+  rules had not been evaluated — true when nothing was opened, misleading beside
+  the findings that now fire. Stderr only, and it never touches the exit code.
+
+### Changed
+
+- `--no-env` now covers both env files beside the Compose file: the sibling
+  `.env` and every `env_file:` a service names. The flag's promise is that it
+  reproduces the previous release's behaviour, and after this change that
+  behaviour includes the `env_file:` read.
 
 ### Fixed
 

--- a/src/compose_lint/_service_env.py
+++ b/src/compose_lint/_service_env.py
@@ -56,6 +56,7 @@ __all__ = [
     "ServiceEnvFiles",
     "Unread",
     "UnreadEnvFile",
+    "describe_unread",
     "env_file_refs",
     "resolve_env_files",
 ]
@@ -200,8 +201,6 @@ def _classify(ref: EnvFileRef, base_dir: Path) -> tuple[Path | None, Unread | No
 def resolve_env_files(
     data: dict[str, Any],
     base_dir: Path,
-    *,
-    read_dotenv: bool = True,
 ) -> dict[str, ServiceEnvFiles]:
     """Read every service's ``env_file:`` targets, keyed by service name.
 
@@ -213,7 +212,12 @@ def resolve_env_files(
     so those names have to be in scope; reading the ``.env`` in full to supply
     them would quietly retire ADR-026 §5's retention guarantee, so the env files
     are scanned for their references first and the ``.env`` read is narrowed to
-    those. ``read_dotenv=False`` is ``--no-env``.
+    those.
+
+    ``--no-env`` is handled by not calling this at all, rather than by a flag
+    here: it means "do not read the env files beside this one", and an
+    ``env_file:`` target read while the ``.env`` went unread would be a third
+    behaviour nobody asked for.
     """
     services = data.get("services")
     if not isinstance(services, dict):
@@ -237,7 +241,7 @@ def resolve_env_files(
     if not plans:
         return {}
 
-    supplied = _dotenv_scope(plans, texts, base_dir, read_dotenv=read_dotenv)
+    supplied = _dotenv_scope(plans, texts, base_dir)
 
     resolved: dict[str, ServiceEnvFiles] = {}
     for name, plan in plans.items():
@@ -263,12 +267,8 @@ def _dotenv_scope(
     plans: dict[str, list[tuple[EnvFileRef, Path | None, Unread | None]]],
     texts: dict[Path, str | None],
     base_dir: Path,
-    *,
-    read_dotenv: bool,
 ) -> Mapping[str, str]:
     """The ``.env`` values the env files chain to, and nothing else."""
-    if not read_dotenv:
-        return {}
     wanted: set[str] = set()
     for plan in plans.values():
         for ref, path, _refusal in plan:
@@ -336,3 +336,57 @@ def _environment_keys(env_block: Any) -> set[str]:
             elif isinstance(item, dict):
                 keys |= {key for key in item if isinstance(key, str)}
     return keys
+
+
+def describe_unread(resolved: Mapping[str, ServiceEnvFiles]) -> list[str]:
+    """One stderr note per target that contributed nothing, per service.
+
+    Replaces the blanket note #669 shipped, which said the credential rules
+    "were not evaluated" for *every* service naming an ``env_file:`` because
+    none was opened. Most now are, so the note has to say which target was
+    missed and why — a note that fires beside the findings it claims are
+    missing is worse than no note at all.
+
+    The wording distinguishes the two absent cases, which is the first of the
+    two questions ADR-027 left open. Only a *required* target's absence means
+    the project cannot deploy — ``docker compose config`` exits 1 — and only
+    then is there a configuration compose-lint failed to grade. An optional
+    target's absence is the deployed configuration, so the note states what
+    Compose does and claims no missed evaluation.
+
+    Notes never touch the exit code, like the unread-``.env`` and
+    unresolved-mount-source notes they sit beside.
+    """
+    unevaluated = "so CL-0020 and CL-0021 were not evaluated for its keys"
+    notes: list[str] = []
+    for service in sorted(resolved):
+        for entry in resolved[service].unread:
+            path = repr(entry.path)
+            if entry.reason is Unread.ABSENT and entry.required:
+                notes.append(
+                    f"service '{service}' reads {path}, which is not present. "
+                    "Compose refuses to start a project whose required "
+                    f"env_file is missing, {unevaluated}"
+                )
+            elif entry.reason is Unread.ABSENT:
+                notes.append(
+                    f"service '{service}' reads {path}, which is not present "
+                    "and not required. Compose starts the service without it, "
+                    "which is the configuration graded here"
+                )
+            elif entry.reason is Unread.UNREADABLE:
+                notes.append(
+                    f"service '{service}' reads {path}, which could not be "
+                    f"read, {unevaluated}"
+                )
+            elif entry.reason is Unread.OUTSIDE_PROJECT:
+                notes.append(
+                    f"service '{service}' reads {path}, which resolves outside "
+                    f"the project directory and is not opened, {unevaluated}"
+                )
+            else:
+                notes.append(
+                    f"service '{service}' reads {path}, whose path is still "
+                    f"unresolved and names no file, {unevaluated}"
+                )
+    return notes

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -18,6 +18,7 @@ from compose_lint import __version__
 from compose_lint._env_file import ENV_FILENAME
 from compose_lint._output import emit, emit_block
 from compose_lint._selection import Selection, plan_documents
+from compose_lint._service_env import describe_unread, resolve_env_files
 from compose_lint.config import ConfigError, load_config
 from compose_lint.config_emit import render_config
 from compose_lint.engine import filter_findings, run_rules
@@ -51,7 +52,6 @@ from compose_lint.parser import (
     load_compose,
     load_merged,
     merge_patched,
-    unread_env_files,
     unresolved_mount_sources,
 )
 
@@ -292,10 +292,13 @@ def _add_check_subparser(
         action="store_true",
         default=False,
         help=(
-            "ignore a '.env' sitting beside the Compose file. Compose reads it "
+            "ignore the env files beside the Compose file: the sibling '.env' "
+            "and every 'env_file:' a service names. Compose reads the '.env' "
             "to choose which documents to load (COMPOSE_FILE), so this "
             "reproduces the previous file selection exactly -- including "
-            "merging an override that COMPOSE_FILE would have suppressed"
+            "merging an override that COMPOSE_FILE would have suppressed -- "
+            "and leaves CL-0020 and CL-0021 blind to any credential an "
+            "'env_file:' supplies"
         ),
     )
     verbosity = check.add_mutually_exclusive_group()
@@ -377,10 +380,13 @@ def _add_fix_subparser(
         action="store_true",
         default=False,
         help=(
-            "ignore a '.env' sitting beside the Compose file. Compose reads it "
+            "ignore the env files beside the Compose file: the sibling '.env' "
+            "and every 'env_file:' a service names. Compose reads the '.env' "
             "to choose which documents to load (COMPOSE_FILE), so this "
             "reproduces the previous file selection exactly -- including "
-            "merging an override that COMPOSE_FILE would have suppressed"
+            "merging an override that COMPOSE_FILE would have suppressed -- "
+            "and leaves CL-0020 and CL-0021 blind to any credential an "
+            "'env_file:' supplies"
         ),
     )
     fix.add_argument(
@@ -720,7 +726,15 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
         )
         for note in unresolved_mount_sources(data):
             emit(f"note: {filepath}: {note}")
-        for note in unread_env_files(data):
+        # `--no-env` covers both env files beside the document, per ADR-027 §8:
+        # the flag's promise is that it reproduces the previous release, and
+        # after this change that release read `env_file:` targets too.
+        service_env_files = (
+            {}
+            if args.no_env
+            else resolve_env_files(data, Path(filepath).absolute().parent)
+        )
+        for note in describe_unread(service_env_files):
             emit(f"note: {filepath}: {note}")
         seen_services.update(data.get("services", {}).keys())
 
@@ -744,6 +758,7 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
             severity_overrides=severity_overrides,
             excluded_services=excluded_services,
             on_error=_record_rule_error,
+            env_files=service_env_files,
         )
         if merged is not None:
             findings = _attribute_sources(findings, merged, filepath)

--- a/src/compose_lint/engine.py
+++ b/src/compose_lint/engine.py
@@ -10,7 +10,9 @@ from compose_lint.models import Finding, Severity
 from compose_lint.rules import get_registered_rules
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping
+
+    from compose_lint._service_env import ServiceEnvFiles
 
 
 def _default_rule_error(rule_id: str, service_name: str, exc: Exception) -> None:
@@ -28,6 +30,7 @@ def run_rules(
     severity_overrides: dict[str, Severity] | None = None,
     excluded_services: dict[str, dict[str, str | None]] | None = None,
     on_error: Callable[[str, str, Exception], None] | None = None,
+    env_files: Mapping[str, ServiceEnvFiles] | None = None,
 ) -> list[Finding]:
     """Run all registered rules against the parsed Compose data.
 
@@ -35,6 +38,13 @@ def run_rules(
     those findings are marked suppressed with an appropriate reason. A
     global disable takes precedence over per-service exclusions (see
     ADR-010). Returns findings sorted by line number (None-line last).
+
+    ``env_files`` carries what each service's ``env_file:`` targets contribute
+    (ADR-027). It reaches rules through :meth:`BaseRule.check_env_file_keys`
+    rather than through ``service_config``, because those keys are not in the
+    document: merging them into the ``environment:`` a rule sees would put
+    values in the parsed document that nobody wrote there, and would expose
+    them to every rule rather than the two that grade them.
 
     A rule that raises is isolated rather than allowed to abort the whole
     run: the failure is reported via ``on_error`` (defaulting to a stderr
@@ -64,6 +74,13 @@ def run_rules(
                 rule_findings = list(
                     rule.check(service_name, service_config, data, lines)
                 )
+                contributed = (env_files or {}).get(service_name)
+                if contributed is not None and contributed.keys:
+                    rule_findings += list(
+                        rule.check_env_file_keys(
+                            service_name, contributed.keys, service_config
+                        )
+                    )
             except Exception as exc:  # noqa: BLE001 - isolate a crashing rule
                 report_error(rule_id, service_name, exc)
                 continue

--- a/src/compose_lint/formatters/text.py
+++ b/src/compose_lint/formatters/text.py
@@ -286,6 +286,14 @@ def format_findings(
     extra_sources: dict[str, list[str] | None] = {}
     if not quiet:
         for f in findings:
+            # Only a Compose *document* is ever opened here. A finding whose
+            # evidence sits in an `env_file:` names a file of deployed values,
+            # and the excerpt would print the credential the rule exists to
+            # keep out of every output surface (ADR-027 §5). Skipping the read
+            # rather than only the render is the stronger guarantee: the
+            # contents never enter the formatter at all.
+            if not f.source_is_document:
+                continue
             if f.source_file and f.source_file not in extra_sources:
                 extra_sources[f.source_file] = _read_source_lines(f.source_file)
 
@@ -369,9 +377,13 @@ def format_findings(
                 f"{message}{suffix}"
             )
             if f.source_file:
+                whence = (
+                    "merged into this run"
+                    if f.source_is_document
+                    else "read for this run"
+                )
                 out.append(
-                    f"          {_colorize('in:', _DIM)} {f.source_file}"
-                    f" (merged into this run)"
+                    f"          {_colorize('in:', _DIM)} {f.source_file} ({whence})"
                 )
 
             excerpt_source = (
@@ -379,6 +391,7 @@ def format_findings(
             )
             if (
                 excerpt_source is not None
+                and f.source_is_document
                 and f.rule_id in _PRESENCE_RULES
                 and f.line is not None
             ):

--- a/src/compose_lint/models.py
+++ b/src/compose_lint/models.py
@@ -89,6 +89,15 @@ class Finding:
     # file is not the one named in the report. None on a single-file run, which
     # is every run today, so no existing output shape changes.
     source_file: str | None = None
+    # Whether `source_file` names a Compose *document* this run graded. False
+    # when the evidence lives in a file the run merely read -- an `env_file:`
+    # target, whose lines are deployed values rather than document text. The
+    # text formatter never excerpts one: a credential rule's finding is about
+    # the key, and printing the line would print the value the rule exists to
+    # keep out of every output surface (ADR-027 §5). Deliberately not emitted
+    # in JSON or SARIF -- it describes where the tool may look, not anything a
+    # consumer grades, so the output contract does not move.
+    source_is_document: bool = True
 
 
 @dataclass(frozen=True)

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -12,7 +12,6 @@ from compose_lint._env_file import read_env
 from compose_lint._lines import find_ambiguous_break
 from compose_lint._merge import Document, Merged, merge_documents, merge_values
 from compose_lint._safe_read import UnsafeFileError, read_text_bounded
-from compose_lint._service_env import env_file_refs
 from compose_lint.config import KNOWN_TOP_LEVEL_KEYS
 from compose_lint.rules._interpolation import (
     reference_names,
@@ -1041,62 +1040,6 @@ def unresolved_mount_sources(data: dict[str, Any]) -> list[str]:
                     "that deploys and the mount rules were not evaluated for it."
                 )
     return notes
-
-
-def unread_env_files(data: dict[str, Any]) -> list[str]:
-    """Services whose ``env_file:`` targets were never read, per service.
-
-    Compose loads each named file and merges its keys into the container's
-    process environment, so a credential written there reaches every surface
-    CL-0020's documentation names -- ``docker inspect``, the daemon's view of
-    the static config, and any container with daemon access -- while never
-    appearing in the document. Moving one line from ``environment:`` into an
-    ``env_file:`` therefore silences CL-0020 and CL-0021 without changing what
-    deploys, which is the silent false negative ADR-023 ranks worst.
-
-    Reported as a note rather than a coverage gap, and the distinction is the
-    whole design question. ``--allow-partial-coverage`` governs *services* left
-    ungraded: an unresolved ``include:`` hides a whole service and a cross-file
-    ``extends:`` grades one against a fraction of its keys, so any rule may be
-    wrong and exit 2 is proportionate. Here the service is fully graded and
-    exactly two rules are blind to one subtree. Weighing the same, 420 of the
-    5,417-file corpus (7.75%) name an ``env_file:``, so making it fatal would
-    newly fail one CI run in thirteen -- the shape ``docs/compatibility.md``
-    calls a MAJOR, over a gap that was silent in every release to date.
-
-    So the note states what was not evaluated and leaves the exit code alone,
-    which is the treatment ADR-026 §6 gives an unread ``.env`` and
-    :func:`unresolved_mount_sources` gives a value nobody supplied. Resolving
-    the files properly is a separate decision, because reporting on what is
-    inside one runs into ADR-026 §2's rule against echoing a supplied value.
-    """
-    notes: list[str] = []
-    services = data.get("services")
-    if not isinstance(services, dict):
-        return notes
-    for name, config in sorted(services.items()):
-        if not isinstance(config, dict):
-            continue
-        paths = _env_file_paths(config.get("env_file"))
-        if not paths:
-            continue
-        listed = ", ".join(repr(path) for path in paths)
-        notes.append(
-            f"service '{name}' reads {listed}, which compose-lint does not "
-            "open. Values it supplies reach the container environment, so "
-            "CL-0020 and CL-0021 were not evaluated for them."
-        )
-    return notes
-
-
-def _env_file_paths(value: Any) -> list[str]:
-    """Every path an ``env_file:`` names, in written order.
-
-    A thin projection of :func:`compose_lint._service_env.env_file_refs`, which
-    is the one reader of the three legal spellings, so the note below and the
-    resolution that acts on it can never disagree about what a service names.
-    """
-    return [ref.path for ref in env_file_refs(value)]
 
 
 def _split_short_volume(volume: str) -> tuple[str, str, str]:

--- a/src/compose_lint/rules/CL0020_credential_env_keys.py
+++ b/src/compose_lint/rules/CL0020_credential_env_keys.py
@@ -13,6 +13,8 @@ from compose_lint.rules._interpolation import ships_no_literal
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from compose_lint._service_env import EnvFileKey
+
 OWASP_REF = (
     "https://cheatsheetseries.owasp.org/cheatsheets/"
     "Docker_Security_Cheat_Sheet.html#rule-12-utilize-docker-secrets-for-sensitive-data-management"
@@ -292,6 +294,67 @@ class CredentialEnvKeysRule(BaseRule):
                     "a gitignored file or `external: true`. Otherwise, have "
                     "the entrypoint read the secret file at startup and "
                     "export the value into the workload's environment."
+                ),
+                references=[OWASP_REF, COMPOSE_SECRETS_REF],
+            )
+
+    def check_env_file_keys(
+        self,
+        service_name: str,
+        keys: tuple[EnvFileKey, ...],
+        service_config: dict[str, Any],
+    ) -> Iterator[Finding]:
+        """Grade the keys an ``env_file:`` contributes, on the same tests.
+
+        Every gate above applies unchanged, because the question is the same
+        one: a credential-shaped key holding a literal value in a container's
+        process environment. Only the route differs, and ADR-027's whole
+        argument is that the route is not what the rule grades.
+
+        The value never reaches the output. ``evidence`` is the key, the
+        message names the key and the file, and ``source_is_document=False``
+        stops the text formatter excerpting the line the key was written on --
+        which is the one place a value could otherwise have been printed.
+        """
+        del service_config  # shadowed keys are removed before this is called
+        for entry in keys:
+            key_upper = entry.key.upper()
+            if not _matches_credential_pattern(key_upper):
+                continue
+            if _is_exempt_key(key_upper):
+                continue
+            if _is_quantity_knob(key_upper, entry.value):
+                continue
+            if not _is_literal_credential_value(entry.value):
+                continue
+
+            yield Finding(
+                rule_id="CL-0020",
+                severity=Severity.HIGH,
+                service=service_name,
+                evidence=entry.key,
+                message=(
+                    f"Service reads credential-shaped env key '{entry.key}' "
+                    f"with a literal value from '{entry.source_file}'. "
+                    "Compose merges that file into the container's process "
+                    "environment, where it is exposed via `docker inspect`, "
+                    "`/proc/<pid>/environ`, `docker compose config`, process "
+                    "listings, and CI logs — any process or operator with "
+                    "daemon access can read them."
+                ),
+                line=entry.line or None,
+                source_file=entry.source_file,
+                source_is_document=False,
+                fix=(
+                    f"Move '{entry.key}' out of '{entry.source_file}' and into "
+                    "Compose's `secrets:` primitive. If the image supports the "
+                    "`*_FILE` convention (Postgres, MySQL, MariaDB, MinIO, "
+                    f"etc.), set `{entry.key}_FILE: /run/secrets/<name>` and "
+                    "declare the secret under the top-level `secrets:` block "
+                    "sourced from a gitignored file or `external: true`. "
+                    "Otherwise, have the entrypoint read the secret file at "
+                    "startup and export the value into the workload's "
+                    "environment."
                 ),
                 references=[OWASP_REF, COMPOSE_SECRETS_REF],
             )

--- a/src/compose_lint/rules/CL0021_connection_string_credentials.py
+++ b/src/compose_lint/rules/CL0021_connection_string_credentials.py
@@ -13,6 +13,8 @@ from compose_lint.rules._interpolation import ships_no_literal
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from compose_lint._service_env import EnvFileKey
+
 OWASP_REF = (
     "https://cheatsheetseries.owasp.org/cheatsheets/"
     "Docker_Security_Cheat_Sheet.html#rule-12-utilize-docker-secrets-for-sensitive-data-management"
@@ -229,6 +231,61 @@ class ConnectionStringCredentialsRule(BaseRule):
                     f"`{key}: {scheme}://user:" + "${DB_PASSWORD}@host/db`. "
                     "RFC 3986 §3.2.1 also deprecates passing passwords in "
                     "URI userinfo regardless of Docker context."
+                ),
+                references=[OWASP_REF, COMPOSE_SECRETS_REF, RFC3986_REF],
+            )
+
+    def check_env_file_keys(
+        self,
+        service_name: str,
+        keys: tuple[EnvFileKey, ...],
+        service_config: dict[str, Any],
+    ) -> Iterator[Finding]:
+        """Grade the values an ``env_file:`` contributes, on the same test.
+
+        The exposure surface is the one this rule already describes: the value
+        lands in the container's process environment either way, and where it
+        was written is not what the rule grades (ADR-027).
+
+        The credential itself never reaches the output. ``evidence`` is the
+        key, the message names the key, the scheme and the file, and
+        ``source_is_document=False`` stops the text formatter excerpting the
+        line — which for this rule would print the whole connection string.
+        """
+        del service_config  # shadowed keys are removed before this is called
+        for entry in keys:
+            match = _find_inline_credential(entry.value)
+            if match is None:
+                continue
+            scheme, _, _ = match
+
+            yield Finding(
+                rule_id="CL-0021",
+                severity=Severity.HIGH,
+                service=service_name,
+                evidence=entry.key,
+                message=(
+                    f"Service reads env var '{entry.key}' from "
+                    f"'{entry.source_file}' containing an inline credential in "
+                    f"a {scheme}:// connection string "
+                    "(scheme://user:password@host). Compose merges that file "
+                    "into the container's process environment, where it is "
+                    "exposed via `docker inspect`, `/proc/<pid>/environ`, "
+                    "`docker compose config`, process listings, and CI logs — "
+                    "any process or operator with daemon access can read them."
+                ),
+                line=entry.line or None,
+                source_file=entry.source_file,
+                source_is_document=False,
+                fix=(
+                    "Remove the literal password from the connection string. "
+                    "Preferred: store the credential in Compose `secrets:` and "
+                    "reassemble the URL in the workload's entrypoint. "
+                    "Acceptable as an interim step: pull the credential from "
+                    "process env via substitution, e.g. "
+                    f"`{entry.key}: {scheme}://user:" + "${DB_PASSWORD}@host/db`. "
+                    "RFC 3986 §3.2.1 also deprecates passing passwords in URI "
+                    "userinfo regardless of Docker context."
                 ),
                 references=[OWASP_REF, COMPOSE_SECRETS_REF, RFC3986_REF],
             )

--- a/src/compose_lint/rules/__init__.py
+++ b/src/compose_lint/rules/__init__.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from compose_lint._service_env import EnvFileKey
     from compose_lint.models import Finding, RuleMetadata, TextEdit
 
 _registry: list[type[BaseRule]] = []
@@ -36,6 +37,26 @@ class BaseRule(abc.ABC):
 
         Yields Finding objects for each issue detected.
         """
+
+    def check_env_file_keys(
+        self,
+        service_name: str,
+        keys: tuple[EnvFileKey, ...],
+        service_config: dict[str, Any],
+    ) -> Iterator[Finding]:
+        """Check the keys a service's ``env_file:`` targets contribute.
+
+        Separate from :meth:`check` because these keys are not in the document:
+        they are values Compose merges into the container's process environment
+        from a file the document names (ADR-027). Only the two credential rules
+        implement it — an ``env_file:`` value reaches the process environment
+        and nothing else, verified against Compose, so no rule that grades a
+        deployment property has anything to read here.
+
+        The default yields nothing, so a rule that does not care is unaffected
+        and no existing rule had to change.
+        """
+        return iter(())
 
     def fix(
         self,

--- a/tests/test_env_file_notes.py
+++ b/tests/test_env_file_notes.py
@@ -1,18 +1,22 @@
-"""Say when an ``env_file:`` left the credential rules unevaluated.
+"""Say what an ``env_file:`` left unevaluated — now that most are evaluated.
 
-Compose merges each named file into the container's process environment, so a
-credential written there reaches every surface CL-0020's documentation names
-while never appearing in the document. Moving one line out of ``environment:``
-and into an ``env_file:`` silences CL-0020 and CL-0021 without changing what
-deploys (issue #665).
+#669 shipped a blanket note: every service naming an ``env_file:`` was told the
+credential rules had not been evaluated for it, because no target was opened.
+ADR-027 opens them, so the note has to become specific. A note that fires beside
+the findings it claims are missing is worse than no note at all.
 
-These pin the note, not a resolution: the files are still not opened. What the
-note buys is that the gap is stated rather than silent, which is the half of the
-problem that needs no decision about echoing a supplied value (ADR-026 §2).
+What remains noted is what still contributed nothing, and the wording separates
+the two absent cases. Only a *required* target's absence means the project
+cannot deploy — ``docker compose config`` exits 1 — and only then is there a
+configuration compose-lint failed to grade. An optional target's absence *is*
+the deployed configuration.
 
-A note and not a coverage gap, deliberately — see ``unread_env_files`` for the
-weighing. The exit-code assertions below are the load-bearing half of that
-choice, because 7.75% of the corpus names an ``env_file:``.
+Still a note and not a coverage gap: the service is graded either way, and the
+exit-code assertions at the end are the load-bearing half of that choice,
+because 7.64% of the corpus names an ``env_file:``.
+
+The three legal spellings are read in one place and tested there
+(``test_service_env.py``); this module is about what the run says.
 """
 
 from __future__ import annotations
@@ -21,7 +25,9 @@ import subprocess
 import sys
 from typing import TYPE_CHECKING
 
-from compose_lint.parser import loads, unread_env_files
+import pytest
+
+from compose_lint._service_env import describe_unread, resolve_env_files
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -29,90 +35,99 @@ if TYPE_CHECKING:
 _SAFE = "services:\n  web:\n    image: i:1\n"
 
 
-def notes_for(document: str) -> list[str]:
-    data, _ = loads(document)
-    return unread_env_files(data)
+def notes_for(directory: Path, document: str) -> list[str]:
+    import yaml
+
+    data = yaml.safe_load(document)
+    return describe_unread(resolve_env_files(data, directory))
 
 
-class TestTheThreeSpellings:
-    """All three legal spellings of ``env_file:`` are seen, not just the common one."""
+class TestWhatIsNoted:
+    def test_a_missing_required_target_says_compose_would_refuse(
+        self, tmp_path: Path
+    ) -> None:
+        (note,) = notes_for(tmp_path, f"{_SAFE}    env_file: secrets.env\n")
+        assert "'web'" in note
+        assert "secrets.env" in note
+        assert "refuses to start" in note
+        assert "CL-0020" in note and "CL-0021" in note
 
-    def test_a_bare_string_is_noted(self) -> None:
-        assert notes_for(f"{_SAFE}    env_file: secrets.env\n")
-
-    def test_a_list_of_strings_is_noted(self) -> None:
-        assert notes_for(f"{_SAFE}    env_file: [a.env, b.env]\n")
-
-    def test_the_mapping_form_is_noted(self) -> None:
-        """The newer spelling, and the one reading only strings would miss."""
-        assert notes_for(
+    def test_a_missing_optional_target_claims_no_missed_evaluation(
+        self, tmp_path: Path
+    ) -> None:
+        """Compose ships the service without it, so that is what was graded."""
+        (note,) = notes_for(
+            tmp_path,
             f"{_SAFE}    env_file:\n      - path: secrets.env\n"
-            "        required: false\n"
+            "        required: false\n",
+        )
+        assert "not required" in note
+        assert "CL-0020" not in note, (
+            "nothing was missed: the absent file is the deployed configuration"
         )
 
-    def test_a_mixed_list_reports_every_path(self) -> None:
-        note = notes_for(
-            f"{_SAFE}    env_file:\n      - plain.env\n      - path: mapped.env\n"
-        )[0]
-        assert "plain.env" in note
-        assert "mapped.env" in note
+    def test_a_target_outside_the_project_says_it_was_not_opened(
+        self, tmp_path: Path
+    ) -> None:
+        (note,) = notes_for(tmp_path, f"{_SAFE}    env_file: ../outside.env\n")
+        assert "outside the project directory" in note
+        assert "CL-0020" in note
 
-    def test_paths_keep_their_written_order(self) -> None:
-        """Compose merges later files over earlier ones, so order is not cosmetic."""
-        note = notes_for(f"{_SAFE}    env_file: [first.env, second.env]\n")[0]
-        assert note.index("first.env") < note.index("second.env")
+    def test_an_unresolved_path_says_it_names_no_file(self, tmp_path: Path) -> None:
+        (note,) = notes_for(tmp_path, f'{_SAFE}    env_file: ["${{W}}.env"]\n')
+        assert "names no file" in note
+
+    def test_an_unreadable_target_is_noted(self, tmp_path: Path) -> None:
+        (tmp_path / "secrets.env").write_bytes(b"K=\xff\xfe\n")
+        (note,) = notes_for(tmp_path, f"{_SAFE}    env_file: secrets.env\n")
+        assert "could not be read" in note
+
+    def test_one_note_per_unread_target(self, tmp_path: Path) -> None:
+        notes = notes_for(tmp_path, f"{_SAFE}    env_file: [a.env, b.env]\n")
+        assert len(notes) == 2
+
+    def test_services_are_reported_in_a_stable_order(self, tmp_path: Path) -> None:
+        notes = notes_for(
+            tmp_path,
+            "services:\n"
+            "  zebra:\n    image: i:1\n    env_file: z.env\n"
+            "  alpha:\n    image: i:1\n    env_file: a.env\n",
+        )
+        assert "'alpha'" in notes[0]
+        assert "'zebra'" in notes[1]
 
 
 class TestWhatIsNotNoted:
-    """The note has to stay a signal; it fires on 7.75% of real files as it is."""
+    """The note has to stay a signal, and a read file is not a gap."""
 
-    def test_a_service_without_env_file_is_silent(self) -> None:
-        assert notes_for(f"{_SAFE}    environment:\n      A: b\n") == []
+    def test_a_target_that_was_read_is_silent(self, tmp_path: Path) -> None:
+        (tmp_path / "secrets.env").write_text("A=b\n", encoding="utf-8")
+        assert notes_for(tmp_path, f"{_SAFE}    env_file: secrets.env\n") == []
 
-    def test_an_empty_env_file_names_nothing(self) -> None:
-        assert notes_for(f"{_SAFE}    env_file: []\n") == []
+    def test_a_service_without_env_file_is_silent(self, tmp_path: Path) -> None:
+        assert notes_for(tmp_path, f"{_SAFE}    environment:\n      A: b\n") == []
 
-    def test_a_mapping_entry_without_a_path_is_skipped(self) -> None:
-        assert notes_for(f"{_SAFE}    env_file:\n      - required: false\n") == []
+    def test_an_empty_env_file_names_nothing(self, tmp_path: Path) -> None:
+        assert notes_for(tmp_path, f"{_SAFE}    env_file: []\n") == []
 
-    def test_a_document_with_no_services_is_silent(self) -> None:
-        """Called on a mapping directly: `loads` rejects a fragment first (ADR-013),
-        so this guards the function for any other caller."""
-        assert unread_env_files({"volumes": {"data": {}}}) == []
+    def test_a_document_with_no_services_is_silent(self, tmp_path: Path) -> None:
+        assert describe_unread(resolve_env_files({"volumes": {}}, tmp_path)) == []
 
-    def test_a_non_mapping_service_is_skipped(self) -> None:
-        assert unread_env_files({"services": {"web": "nonsense"}}) == []
-
-
-class TestTheNoteItself:
-    def test_it_names_the_service_and_the_rules_it_blinded(self) -> None:
-        note = notes_for(f"{_SAFE}    env_file: secrets.env\n")[0]
-        assert "'web'" in note
-        assert "secrets.env" in note
-        assert "CL-0020" in note
-        assert "CL-0021" in note
-
-    def test_one_note_per_service_carrying_one(self) -> None:
-        notes = notes_for(
-            "services:\n"
-            "  a:\n    image: i:1\n    env_file: a.env\n"
-            "  b:\n    image: i:1\n    env_file: b.env\n"
-            "  c:\n    image: i:1\n"
-        )
-        assert len(notes) == 2
+    def test_a_non_mapping_service_is_skipped(self, tmp_path: Path) -> None:
+        data = {"services": {"web": "nonsense"}}
+        assert describe_unread(resolve_env_files(data, tmp_path)) == []
 
 
-class TestItDoesNotTouchTheExitCode:
-    """The distinction from a coverage gap, asserted rather than described.
+class TestEndToEnd:
+    """The exit-code contract, and that a read file actually reaches the rules."""
 
-    An unresolved ``include:`` exits 2 because a whole service went ungraded.
-    Here the service is graded and two rules are blind to one subtree, on 7.75%
-    of real files — making that fatal would newly fail one CI run in thirteen.
-    """
-
-    def _run(self, directory: Path, document: str) -> subprocess.CompletedProcess[str]:
+    @staticmethod
+    def _run(
+        directory: Path, document: str, env_text: str | None = None
+    ) -> subprocess.CompletedProcess[str]:
         (directory / "compose.yml").write_text(document, encoding="utf-8")
-        (directory / "secrets.env").write_text("A=b\n", encoding="utf-8")
+        if env_text is not None:
+            (directory / "secrets.env").write_text(env_text, encoding="utf-8")
         return subprocess.run(
             [sys.executable, "-m", "compose_lint", "check", "compose.yml"],
             cwd=directory,
@@ -121,25 +136,70 @@ class TestItDoesNotTouchTheExitCode:
             timeout=60,
         )
 
-    def test_a_clean_file_still_exits_zero(self, tmp_path: Path) -> None:
+    _HARDENED = (
+        "services:\n  web:\n    image: i:1@sha256:" + "0" * 64 + "\n"
+        "    env_file: secrets.env\n"
+        "    read_only: true\n    cap_drop: [ALL]\n"
+        "    security_opt: ['no-new-privileges:true']\n"
+        "    mem_limit: 1g\n    cpus: 1\n    pids_limit: 100\n"
+    )
+
+    def test_a_clean_env_file_leaves_a_clean_run_clean(self, tmp_path: Path) -> None:
+        result = self._run(tmp_path, self._HARDENED, "A=b\n")
+        assert result.returncode == 0, result.stderr
+        assert "secrets.env" not in result.stderr, "nothing to say about a read file"
+
+    def test_a_credential_in_the_file_is_now_reported(self, tmp_path: Path) -> None:
+        """The whole point of ADR-027: this exited 0 before it."""
+        result = self._run(tmp_path, self._HARDENED, "POSTGRES_PASSWORD=hunter2\n")
+        assert result.returncode == 1, result.stderr
+        assert "CL-0020" in result.stdout
+        assert "POSTGRES_PASSWORD" in result.stdout
+        assert "secrets.env" in result.stdout
+
+    def test_the_value_is_never_printed(self, tmp_path: Path) -> None:
+        """ADR-027 §5. The key names the finding; the value must not appear."""
+        result = self._run(tmp_path, self._HARDENED, "POSTGRES_PASSWORD=hunter2\n")
+        assert "hunter2" not in result.stdout
+        assert "hunter2" not in result.stderr
+
+    def test_a_connection_string_is_never_printed(self, tmp_path: Path) -> None:
         result = self._run(
-            tmp_path,
-            "services:\n  web:\n    image: i:1@sha256:"
-            + "0" * 64
-            + "\n    env_file: secrets.env\n"
-            "    read_only: true\n    cap_drop: [ALL]\n"
-            "    security_opt: ['no-new-privileges:true']\n"
-            "    mem_limit: 1g\n    cpus: 1\n    pids_limit: 100\n",
+            tmp_path, self._HARDENED, "DATABASE_URL=postgres://u:hunter2@db/x\n"
+        )
+        assert result.returncode == 1, result.stderr
+        assert "CL-0021" in result.stdout
+        assert "hunter2" not in result.stdout
+        assert "hunter2" not in result.stderr
+
+    def test_no_env_leaves_the_file_unread(self, tmp_path: Path) -> None:
+        (tmp_path / "compose.yml").write_text(self._HARDENED, encoding="utf-8")
+        (tmp_path / "secrets.env").write_text(
+            "POSTGRES_PASSWORD=hunter2\n", encoding="utf-8"
+        )
+        result = subprocess.run(
+            [sys.executable, "-m", "compose_lint", "check", "--no-env", "compose.yml"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            timeout=60,
         )
         assert result.returncode == 0, result.stderr
-        assert "env_file" in result.stderr or "secrets.env" in result.stderr
+        assert "CL-0020" not in result.stdout
+
+    @pytest.mark.parametrize("required", ["true", "false"])
+    def test_a_missing_target_is_not_a_coverage_gap(
+        self, required: str, tmp_path: Path
+    ) -> None:
+        document = (
+            f"{_SAFE}    env_file:\n      - path: secrets.env\n"
+            f"        required: {required}\n"
+        )
+        result = self._run(tmp_path, document)
+        assert result.returncode != 2, result.stderr
+        assert "--allow-partial-coverage" not in result.stderr
 
     def test_the_note_goes_to_stderr_not_stdout(self, tmp_path: Path) -> None:
         result = self._run(tmp_path, f"{_SAFE}    env_file: secrets.env\n")
         assert "secrets.env" in result.stderr
         assert "secrets.env" not in result.stdout
-
-    def test_it_is_not_an_error_and_not_a_coverage_gap(self, tmp_path: Path) -> None:
-        result = self._run(tmp_path, f"{_SAFE}    env_file: secrets.env\n")
-        assert result.returncode != 2, result.stderr
-        assert "--allow-partial-coverage" not in result.stderr

--- a/tests/test_service_env.py
+++ b/tests/test_service_env.py
@@ -114,12 +114,6 @@ class TestResolution:
         resolved = resolve_env_files(_document("app.env"), tmp_path)
         assert _keys(resolved) == {"K": "dotvalue-tail"}
 
-    def test_no_env_leaves_the_dotenv_unread(self, tmp_path: Path) -> None:
-        (tmp_path / ".env").write_text("FROMDOTENV=dotvalue\n", encoding="utf-8")
-        (tmp_path / "app.env").write_text("K=${FROMDOTENV}-tail\n", encoding="utf-8")
-        resolved = resolve_env_files(_document("app.env"), tmp_path, read_dotenv=False)
-        assert _keys(resolved) == {}, "the value is unresolvable without the .env"
-
     def test_records_the_line_a_key_was_written_on(self, tmp_path: Path) -> None:
         (tmp_path / "app.env").write_text(
             "# a comment\nFIRST=1\nPW=hunter2\n", encoding="utf-8"


### PR DESCRIPTION
The behaviour change ADR-027 decided, and the one that closes #665. A credential
moved out of `environment:` and into an `env_file:` reaches the identical
container process environment; both rules went silent on it.

```console
$ cat secrets.env
POSTGRES_PASSWORD=hunter2

$ compose-lint check compose.yml          # before
exit 0

$ compose-lint check compose.yml          # after
    3  HIGH  CL-0020  Service reads credential-shaped env key 'POSTGRES_PASSWORD'
                      with a literal value from 'secrets.env'. …
          in: secrets.env (read for this run)
```

## How the keys reach the rules

Through a new `BaseRule.check_env_file_keys`, not through `service_config`.
Merging them into the `environment:` a rule sees would put values in the parsed
document that nobody wrote there, and would expose them to all thirty rules
instead of the two that grade them. The default implementation yields nothing,
so no existing rule changed.

Every gate is the one already there — same key patterns, same exemptions, same
literal-value test, same connection-string scan. Only the route differs, and the
ADR's argument is that the route is not what the rules grade.

## A disclosure path had to be closed to ship this

Both rules are in `_PRESENCE_RULES`, so the text formatter excerpts the source
line a finding points at. For an `env_file:` finding that is **the line the
credential is written on** — `PW=hunter2`, printed in full, by the rule whose
entire purpose is keeping it out of output. ADR-027 §5 promises this cannot
happen; without this change the promise would have been false on the first run.

Findings now carry `source_is_document=False`, and the formatter **skips the
read entirely** rather than only the render, so the file's contents never enter
it. The flag is deliberately not emitted in JSON or SARIF — it describes where
the tool may look, not anything a consumer grades, so the output contract does
not move. Pinned by `test_the_value_is_never_printed` and
`test_a_connection_string_is_never_printed`.

## The #669 note is narrowed here, not later

A note saying the credential rules "were not evaluated" firing *beside the
findings they now produce* is worse than no note, so it could not wait for a
follow-up PR. What remains noted is what still contributed nothing, and the two
absent cases are worded differently — only a **required** target's absence means
`docker compose config` exits 1 and a configuration went ungraded; an optional
one's absence is the deployed configuration. That settles the first of the two
questions ADR-027 left open. The second (malformed lines) is still open.

## Also

`--no-env` now covers both env files (§8) — its promise is to reproduce the
previous release, and that release read `env_file:` targets.

Verified over 200 corpus files naming an `env_file:`: no crashes, and the two
exit-2s are pre-existing `include:` coverage gaps that `main` hits identically.

Closes #665
