### PR TITLE
Replace the unmeasurable-impact claim with the measured floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on `--fail-on`. 414 of the 5,417-file corpus (7.64%) name an `env_file:`, and
   496 of the 924 references name the sibling `.env` itself.
 
+  Measured by rebuilding real projects — fetching the targets their repositories
+  commit and running the rules with and without them — **55% of projects whose
+  env file could be read gained at least one finding**: 538 findings across 90 of
+  163 projects, 491 CL-0020 and 47 CL-0021. That is a floor on a biased sample:
+  only 44% of named targets are committed at all, and the gitignored remainder is
+  where credentials concentrate. If your compose file names an `env_file:` and
+  that file is present when compose-lint runs, expect roughly a coin-flip chance
+  of a new HIGH finding.
+
   **No credential value reaches any output surface.** `evidence` is the key
   name, as it always was, and the message names the key and the file. The text
   formatter no longer reads — let alone excerpts — a file that is not a Compose

--- a/docs/adr/027-grade-env-file-where-the-document-routes-it.md
+++ b/docs/adr/027-grade-env-file-where-the-document-routes-it.md
@@ -250,11 +250,30 @@ says which file it read.
   including on a `.env` compose-lint already reads. The documented MINOR
   behaviour ([compatibility.md](../compatibility.md)), with the documented escape
   hatches: pin the version, or gate on `--fail-on`.
-- **The finding-count impact is unmeasurable on the corpus, and no amount of work
-  makes it measurable.** The corpus is filename-filtered
-  (`scripts/corpus/fetch.py:29`) so it holds no sibling files at all. What is
-  measured is the population that would newly have a file opened: 414 files, 867
-  services, 924 references, 496 of them a `.env` already being read.
+- **The corpus cannot measure this, but a reconstruction can, and did.** The
+  corpus is filename-filtered (`scripts/corpus/fetch.py:29`) so it holds no
+  sibling files: a corpus run reports every target absent and produces notes
+  rather than findings. What it can measure is the population that newly has a
+  file opened — 414 files, 867 services, 924 references, 496 of them a `.env`
+  already being read — and not the finding count.
+
+  That was measured by rebuilding the projects instead: fetching each named
+  target its repository actually commits, staging it beside the compose file,
+  and running the rules twice against the same parsed document, with and without
+  `env_files`. Of 163 projects whose env file could be read, **90 (55%) gained at
+  least one finding, 538 in total — 491 CL-0020 and 47 CL-0021** across 127
+  distinct key names. 83.6% of the values are opaque literals; most of the rest
+  are placeholders (`changeme`, `your_*_here`), which fire by design —
+  [#561](https://github.com/tmatens/compose-lint/issues/561) settled that
+  `AUTH_TOKENS: your_token_here` is a finding.
+
+  **The number is a floor on a biased sample.** Only 44% of named targets are
+  committed to their repository at all; the rest are gitignored, which is where
+  live credentials concentrate and where no measurement reaches. The placeholder
+  rate is itself evidence of that bias — a project that commits an env file is
+  likelier to be committing an example one. The reconstruction is a scratch
+  measurement and is deliberately not part of `scripts/corpus/`: a fetcher that
+  pulls credential-bearing files is not something this repository should ship.
 - ADR-026 line 224 is narrowed, not deleted. "There is a secret in your `.env`"
   remains out of scope. "There is a credential your document routes into a
   container's process environment" is in scope, and always was — only its


### PR DESCRIPTION
ADR-027 claimed the finding-count impact was unmeasurable on the corpus "and no
amount of work makes it measurable". The first half stands. The second was
wrong, and this replaces it with the measurement.

**Why the corpus can't do it:** it is filename-filtered
(`scripts/corpus/fetch.py:29`), so it holds no sibling files at all — every
`env_file:` target resolves to absent and produces a note, not a finding. A
corpus run shows zero change from this release, which is exactly why the ADR
reached for "unmeasurable" in the first place.

**What was done instead:** rebuild the projects. Fetch each named target its
repository actually commits, stage it beside the compose file, then run the rule
engine **twice against the same parsed document** — once without `env_files`
(the pre-ADR-027 behaviour) and once with. The delta is the release's real
impact. Running both halves in-process avoids the confound of using `--no-env`,
which also disables `.env` interpolation and would have moved unrelated findings.

| | |
|---|---|
| Projects whose env file could be read | 163 |
| **Gained ≥1 finding** | **90 (55%)** |
| **New findings** | **538** — 491 CL-0020, 47 CL-0021 |
| Distinct credential-shaped keys | 127 |
| Value shapes | 83.6% opaque literals; most of the rest placeholders |

Placeholders (`changeme`, `your_*_here`) fire **by design** — #561 settled that
`AUTH_TOKENS: your_token_here` is a finding — so they are counted, not discounted.

**Stated as a floor, because it is one.** Only 44% of named targets are committed
to their repository; the gitignored remainder is where live credentials
concentrate and where no measurement reaches. The placeholder rate is itself
evidence of the bias — a project that commits an env file is likelier to be
committing an example one. Both the ADR and the CHANGELOG say so rather than
letting 538 read as a population estimate.

**The reconstruction is not added to `scripts/corpus/`,** and the ADR says why: a
fetcher that pulls credential-bearing files is not something this repository
should ship. It ran from a scratch directory, wrote its cache `0600` inside a
`0700` directory, never printed a value, and was `shred -u`'d afterwards — 206
files destroyed. That leaves the measurement non-reproducible from the tree,
which is a real cost, named in the ADR rather than papered over.

One thing the measurement surfaced is deliberately **not** here: a CL-0020
quantity-knob tuning gap, filed as #681. It sits identically on the
`environment:` surface, so it is not a consequence of this decision and does not
belong in its record.

Refs #665
