### PR TITLE
Give the credential rules a remediation path from an env_file:

### DIFF
--- a/docs/rules/CL-0020.md
+++ b/docs/rules/CL-0020.md
@@ -101,6 +101,39 @@ secrets:
     # or external: true if managed via `docker secret create`
 ```
 
+### Coming from an `env_file:`
+
+The same fix applies, because the destination is the same: an `env_file:` value
+lands in the container's process environment exactly as an `environment:` value
+does. Three things are worth knowing on the way.
+
+**It is worth doing even when the file is already gitignored.** The gain is not
+that the value leaves git — it may have left already — but that it leaves the
+*process environment*. A secret declared under `secrets:` is mounted at
+`/run/secrets/<name>` as a file, so it appears in none of the four surfaces
+listed above. An `env_file:` value appears in all four.
+
+**Do not point `secrets: file:` at the env file itself.** A file-sourced secret
+is mounted byte-for-byte, so an env-file-style source gives the workload the
+whole line — `POSTGRES_PASSWORD=hunter2` and its trailing newline — as the
+password, rather than `hunter2` (verified against a live container). The source
+file holds the *value alone*, nothing else:
+
+```
+# secrets/db_password.txt  -- the whole file, no key, no quotes
+hunter2
+```
+
+**If the file is your `.env`, split its two jobs.** A `.env` supplies `${VAR}`
+interpolation to the document; naming it in `env_file:` *additionally* pushes
+every key in it into the container. Those are different jobs and only the second
+one is graded here. Keep `.env` for interpolation, put container configuration in
+its own `env_file:`, and put credentials in `secrets:`.
+
+A placeholder value is not exempt, and should not be: `changeme` in a committed
+env file is what every fresh clone deploys until someone remembers to change it.
+The fix is the same.
+
 For images that don't support `*_FILE` env vars, have the entrypoint read `/run/secrets/<name>` at startup and export the value into the workload's environment before launching the main process. The credential is still in env at the workload level, but it is not in the Compose file or the daemon's view of the container's static config.
 
 ## ATT&CK coverage

--- a/docs/rules/CL-0021.md
+++ b/docs/rules/CL-0021.md
@@ -99,7 +99,13 @@ services:
       DATABASE_URL: postgresql://app:${DB_PASSWORD}@db/app
 ```
 
-This pulls the credential from the operator's environment instead of committing it to the file. Less secure than option 1 (the credential still ends up in container env), but a meaningful improvement over a literal value and a one-line change.
+This pulls the credential out of the document. Compose resolves `${DB_PASSWORD}` from the sibling `.env` or the operator's shell, and compose-lint deliberately does not resolve a `.env` value into `environment:` ([ADR-026](../adr/026-read-the-sibling-env-file.md) §2) — so following this advice does not trip the rule that gave it.
+
+**One condition:** the file supplying `DB_PASSWORD` must not also be named in an `env_file:` for this service. `env_file: .env` merges every key in that file into the container's process environment, so the credential lands back where it started and [CL-0020](CL-0020.md) reports it — correctly ([ADR-027](../adr/027-grade-env-file-where-the-document-routes-it.md)). Keep `.env` for interpolation *or* name it in `env_file:` for container config; doing both undoes this fix.
+
+Less secure than option 1 in any case — the credential still ends up in container env — but a meaningful improvement over a literal value, and a one-line change.
+
+Options 1 and 2 apply unchanged when the connection string was written in an `env_file:` rather than in `environment:`; see [CL-0020's migration notes](CL-0020.md#coming-from-an-env_file) for the two traps on that path.
 
 ## ATT&CK coverage
 


### PR DESCRIPTION
CL-0020 and CL-0021 fire on `env_file:` keys as of ADR-027, but both **Fix**
sections still assumed the credential was written in `environment:`. One of them
was worse than incomplete.

## The wrong advice

CL-0021's option 3 said:

> `DATABASE_URL: postgresql://app:${DB_PASSWORD}@db/app`
> This pulls the credential from the operator's environment instead of
> committing it to the file.

For a project whose service names `env_file: .env` — and **496 of the 924 corpus
`env_file:` references name `.env` itself** — that is false. The merge puts the
credential straight back into the container's process environment, where CL-0020
now correctly reports it. The advice traded one finding for another and explained
neither.

It now carries the condition that makes it true: keep `.env` for interpolation
*or* name it in `env_file:` for container config, not both. ADR-026 §2 still
guarantees a `.env` value never turns CL-0021 on, so option 3 remains sound for a
project that uses `.env` purely for interpolation — which is the case the
guarantee was written for.

## The trap, verified rather than assumed

CL-0020 gains migration notes for the shapes its fix text did not cover. The one
worth the PR on its own: **do not point `secrets: file:` at the existing env
file.** A file-sourced secret is mounted byte-for-byte, so the workload receives
`POSTGRES_PASSWORD=hunter2` *and its trailing newline* as the password rather
than `hunter2`. Verified against a live container per the rule-doc convention:

```
ENVSTYLE:   M Y K E Y = s e n t i n e l v a l u e \n     <- secrets: file: ./app.env
VALUEONLY:  s e n t i n e l v a l u e                    <- what it must contain
```

That is the obvious move for exactly the users this release newly flags, and it
fails in a way that looks like a wrong password rather than a mistake in the
migration.

## Also covered

- **Why bother when the env file is already gitignored** — the gain is that the
  value leaves the *process environment*, not that it leaves git. A `secrets:`
  mount appears in none of the four surfaces the rule lists; an `env_file:` value
  appears in all four.
- **A `.env` doing double duty** should have its two jobs split.
- **A placeholder is not exempt**, and should not be: a committed `changeme` is
  what every fresh clone deploys.
- Options 1 and 2 of CL-0021 apply unchanged from an `env_file:` source, with a
  pointer to CL-0020's notes for the traps.

ADR-027 argued that firing on `env_file:` "punishes nobody's documented fix".
That claim was ahead of the documentation it rested on until this PR.

Refs #665
