### PR TITLE
State in CONTRIBUTING that the project is unpaid

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,18 @@
 Thanks for wanting to help. This is a small, focused project, so the bar for
 contributions is clarity and authoritative grounding rather than breadth.
 
+## This project is unpaid
+
+compose-lint is volunteer-maintained. There is no budget, no bounty program,
+and nobody is paid to work on it — the maintainer included. Contributions are
+donated under the project's MIT license and the
+[DCO](#developer-certificate-of-origin).
+
+So offers to implement an issue for a fee are declined, and issues labelled
+`good first issue` or `help wanted` are invitations to contribute, not work
+put out for quote. Wanting to be paid for open-source work is an entirely
+reasonable thing to want — it just isn't something this project can offer.
+
 ## Before you start
 
 - **Bug reports and feature requests**: open an issue using one of the templates.


### PR DESCRIPTION
## Summary

Add a short "This project is unpaid" section to the top of `CONTRIBUTING.md`,
stating that compose-lint is volunteer-maintained, that there is no budget or
bounty program, and that `good first issue` / `help wanted` labels are
invitations to contribute rather than work put out for quote.

## Why

On #681 a contributor offered to implement the fix for a fee. That was a
reasonable thing to ask: `CONTRIBUTING.md`, `README.md` and `.github/` were all
silent on funding, so there was no way to know beforehand. The ask had to be
declined in the issue thread, which is a worse place to learn it than the
contribution guide.

The wording deliberately frames it as a fact about the project's funding rather
than a judgment of the request — wanting to be paid for open-source work is not
unreasonable, it just isn't something this project can offer.

Refs #681

## Type of change

- [x] Documentation

## Origin

- [x] Personal contribution
- [x] Produced primarily by an automated agent

## Checklist

- [x] Commits are signed (GitHub shows **Verified**)
- [x] One logical change per commit; no unrelated changes bundled in
- [x] No AI credit lines in commit messages (`Co-Authored-By`, "generated by")
- [x] `tests/corpus_snapshot.json.gz` is **not** in this PR

Not applicable: no code changes, so no tests, no CHANGELOG entry (nothing
user-visible in the tool's behavior), and no rule/README docs to update.

## Breaking changes

None
