### PR TITLE
Document the maintainer side of an outside contribution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,8 @@ Disables still produce suppressed findings. `reason` flows to `suppression_reaso
 
 `ruff check src/ tests/`, `ruff format --check src/ tests/`, `mypy src/` (strict), `pytest`. All four must pass, scoped exactly as written — CI lints only `src/` and `tests/`, and a bare `ruff check` also sweeps `scripts/`, which has known, accepted violations. CI test matrix: Python 3.10–3.14 on ubuntu-24.04.
 
+Running a branch's tests from a `git worktree` needs `PYTHONPATH` pointed at that worktree's `src/`. The dev install is editable and resolves `compose_lint` to the **main checkout's** `src/`, so a bare `pytest` in a worktree grades the branch's tests against `main`'s source and fails in exactly the way a genuinely broken change would. Confirm with `python -c 'import compose_lint; print(compose_lint.__file__)'` before believing a red run.
+
 ## Adding a rule
 
 See CONTRIBUTING.md for the full checklist. Every rule must cite OWASP, CIS, or Docker docs **that demonstrate the need in a container context** — generic host/Linux hardening a container's defaults already neutralize is not enough (see CL-0022/CL-0023). If a container-context source is thin, the rule's premise must be **validated at runtime**: a rule that describes container runtime state gets a check in `scripts/validate_rule_premises.py`, which proves the insecure state is Docker's *default* (for absence rules) or that the flagged config produces the insecure behavior (for presence rules). That suite runs in CI (`rule-premises` job), and asserts the daemon is at Docker's defaults before measuring — a premise measured on a departed posture cannot ground a rule. Every finding must be actionable with specific fix guidance.
@@ -45,6 +47,7 @@ CONTRIBUTING.md is the source of truth for commits, signing, and PRs. Key points
 - One logical change per commit, imperative subject under 72 chars, no Conventional Commits prefixes
 - All commits signed (SSH). Verify with `git log --format='%h %G? %s'` — every commit shows `G`
 - All changes go through a PR, squash-merge to main
+- Maintainer side of an outside contribution — approving fork CI, review states, pre-merge checks — is `docs/MAINTAINING.md`
 - Releases: follow `docs/RELEASING.md` checklist — version lives in both `pyproject.toml` and `src/compose_lint/__init__.py`
 
 ## Rule docs (docs/rules/)

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -1,0 +1,143 @@
+# Maintaining
+
+How a maintainer reviews and merges a contribution from outside the
+repository. [CONTRIBUTING.md](../CONTRIBUTING.md) is the contributor's side of
+the same workflow and stays the source of truth for commits, signing and PR
+expectations; this page covers only what a maintainer does that a contributor
+cannot see.
+
+Related: [CI.md](CI.md) for what each workflow does, [RELEASING.md](RELEASING.md)
+for cutting a release.
+
+## Approving CI on a fork pull request
+
+A pull request from a fork sits with an all-grey checks panel until a maintainer
+approves the workflow run. GitHub offers three settings for this
+(Settings → Actions → General → Fork pull request workflows); this repository
+uses **Require approval for first-time contributors**, defined as users who have
+never had a commit or pull request merged into *this* repository. The status is
+per-repository and permanent once cleared: a contributor's first merge ends the
+gate for every PR they open afterwards.
+
+### What the gate does and does not protect
+
+Approving lets the contributor's code run in CI. It does **not** expose
+anything that a merge would not, because a fork pull request already runs
+without reach into the repository's secrets:
+
+| Property | State on a fork PR |
+|---|---|
+| `GITHUB_TOKEN` | Read-only, regardless of what a job declares |
+| Repository secrets | Unavailable |
+| Runners | GitHub-hosted only |
+| Actions cache | Scoped to the PR's own ref; cannot poison `main`'s |
+| Code Scanning upload | Blocked — forks never hold `security-events: write` |
+
+Four properties of this repository's workflows are what make that true, and each
+is worth preserving:
+
+- **No `pull_request_target` anywhere.** That trigger runs base-branch code with
+  secrets and a write token. A `pull_request_target` workflow that checks out
+  the PR head is the classic "pwn request" and is the single change most likely
+  to turn approval into a real risk.
+- **No secrets referenced in PR-triggered workflows.** `ci.yml`, `codeql.yml`
+  and `docs.yml` reference none at all; `cflite-pr.yml` uses only
+  `secrets.GITHUB_TOKEN`, which is downgraded to read-only for forks.
+- **Deny-all default permissions.** Every workflow sets `permissions: {}` at the
+  top level and each job grants itself the minimum. `docs.yml`'s `pages: write`
+  and `id-token: write` jobs are gated behind `if: github.event_name !=
+  'pull_request'`.
+- **Actions pinned by commit SHA**, and every `${{ github.event.* }}` value
+  passed through an `env:` block rather than interpolated into a `run:` string.
+  The second is what keeps a branch name or PR title from becoming shell code.
+
+### What to look at before approving
+
+Read the diff first — approval is the last point before the contributor's code
+executes. The paths worth slowing down for:
+
+```
+.github/**    action.yml    Dockerfile*    pyproject.toml
+*.lock        scripts/**    .githooks/**   .pre-commit-hooks.yaml
+```
+
+A PR touching only `src/**`, `tests/**`, `docs/**` and `CHANGELOG.md` is the
+ordinary case. Note what that does **not** mean: `src/**` is exactly what the
+test matrix executes, so "safe paths" narrows where to look rather than proving
+the diff benign. There is no automated check that can make this decision, and
+one running from the fork's own tree could be edited by that fork.
+
+### Do not spend an approval on a superseded commit
+
+Each push from a gated contributor re-arms the gate, and approval is bound to
+the head SHA. Approving a commit that is about to be rebased burns the approval
+for nothing. When a PR needs both a rebase and review fixes, post the review
+first so one push clears everything.
+
+## Reviewing
+
+Post findings as a **review**, not a plain issue comment — a review carries a
+state, sets `reviewDecision`, and shows in the Reviewers panel:
+
+```bash
+gh pr review <n> --request-changes --body-file <file>   # blocking findings
+gh pr review <n> --comment         --body-file <file>   # feedback, no verdict
+gh pr review <n> --approve         --body-file <file>
+```
+
+Inline comments anchored to lines go through
+`POST /repos/{owner}/{repo}/pulls/{n}/reviews` with a `comments` array of
+`{path, line, side, body}`. Anchors only work on lines present in the diff, so a
+finding about a file the PR does not touch — a rule doc that needs a matching
+row, say — has to live in the review body.
+
+`dismiss_stale_reviews_on_push` is enabled, so a *changes requested* review
+clears itself when the contributor pushes the fix. There is nothing to dismiss
+by hand.
+
+## Before merging
+
+| Check | How |
+|---|---|
+| No blocking state | `gh pr view <n> --json mergeStateStatus` → `CLEAN` |
+| Checks ran on the **current** head | Compare the run's `head_sha` to `headRefOid`; a green run on a superseded SHA proves nothing |
+| Branch is up to date | `behind_by: 0` — the ruleset sets `strict_required_status_checks_policy` |
+| Review threads | All resolved (CONTRIBUTING asks for this; it is not enforced) |
+| Rule predicates touched | Regenerate `tests/corpus_snapshot.json.gz` yourself and review the drift — contributors are asked to leave it alone |
+
+`ci-ok` is the only required status check: it is a roll-up whose `needs` list
+carries every other job, so one red job shows as two failures (`ci-ok` and the
+job itself) and one real cause.
+
+### What the squash commit will say
+
+Merging is squash-only. The repository is configured with
+`squash_merge_commit_title: COMMIT_OR_PR_TITLE` and
+`squash_merge_commit_message: COMMIT_MESSAGES`, so `main` gets the
+contributor's commit message — **not** the PR description. Two consequences
+worth knowing:
+
+- A `Signed-off-by:` trailer and a `Fixes #N` reference survive into `main`.
+- The PR template's Origin disclosure ("produced primarily by an automated
+  agent") stays on the PR page and out of permanent history, which is what
+  CONTRIBUTING's no-AI-credit rule wants. It is a disclosure, not a credit line;
+  the PR is the right place for it.
+
+GitHub signs the squash commit with its own key, so `main`'s history verifies
+regardless of whether the contributor signed. Their signature is evidence about
+the PR, not about what lands. Note that nothing enforces it server-side: there
+is no `required_signatures` ruleset rule and no CI job, and `.githooks/pre-push`
+only binds contributors who ran `git config core.hooksPath .githooks`.
+
+## Known friction
+
+`strict_required_status_checks_policy` requires a PR to be up to date before
+merging, and Renovate merges digest PRs daily. An external PR that sits for a
+day needs a rebase, the rebase force-push re-arms the approval gate, and the
+maintainer approves a second time. Merging external contributions promptly is
+the cheapest mitigation; a merge queue would remove the requirement entirely,
+at the cost of teaching `ci.yml` the `merge_group` trigger.
+
+Contributor-side friction — the DCO check being invisible until approval, and
+the sign-off guidance that does not work — is tracked in
+[#686](https://github.com/tmatens/compose-lint/issues/686).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,7 +35,7 @@ markdown_extensions:
 
 # Curated nav: user-facing pages only. Everything else in docs/ (ADRs,
 # ROADMAP, CI/RELEASING internals) still builds and stays linkable, just
-# unlisted. Maintainer docs that link outside docs/ (CI.md,
+# unlisted. Maintainer docs that link outside docs/ (CI.md, MAINTAINING.md,
 # SECURITY-EXPECTATIONS.md) are deliberately not in the nav.
 nav:
   - Home: index.md


### PR DESCRIPTION
## Summary

Adds `docs/MAINTAINING.md`, covering the maintainer's half of an outside contribution: when approving CI on a fork PR is safe and what it does not protect, what to read before approving, posting findings as a review state rather than a plain comment, the pre-merge checks, and what the squash commit will actually contain.

Also adds the worktree gotcha to `AGENTS.md`, and lists `MAINTAINING.md` in the mkdocs comment naming the maintainer docs that stay out of the nav.

## Why

The procedure existed only in PR threads. It is the kind of knowledge that is obvious while you are holding it and gone six months later — that a green CI run proves nothing if it graded a superseded SHA, that `squash_merge_commit_message: COMMIT_MESSAGES` is what keeps the PR template's Origin disclosure out of permanent history, that the fork gate is a code-review checkpoint rather than a secrets boundary because a fork PR never had secrets to begin with.

Scope is deliberately narrow: only what a maintainer does that a contributor cannot see. `CONTRIBUTING.md` remains the source of truth for the contributor's half and is linked rather than restated, so the two cannot drift.

The `AGENTS.md` addition is the failure mode that matters most for an agent: the dev install is editable, so `pytest` in a worktree resolves `compose_lint` to the **main** checkout and silently grades a branch's tests against `main`'s source. It reported nine CL-0020 failures on a branch whose tests all pass under its own `src/`. A wrong answer, not an error.

Related to #686, which owns the contributor-side half (the DCO check being invisible until approval, and the `format.signOff` guidance that does not work). Deliberately not duplicated here — this PR does not touch `CONTRIBUTING.md`.

## Type of change

- [ ] New rule (`CL-XXXX`)
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [x] Documentation
- [ ] Build / CI / release tooling
- [ ] Other:

## Origin

- [ ] Personal contribution
- [ ] Contributed on behalf of an employer or client
- [x] Produced primarily by an automated agent

Drafted by Claude Code from a maintainer review session; every claim in the page was verified against the live repository configuration rather than recalled.

## Checklist

- [x] Commits are signed (GitHub shows **Verified**)
- [x] One logical change per commit; no unrelated changes bundled in
- [x] `ruff check`, `ruff format --check`, `mypy src/`, and `pytest` all pass locally
- [x] New/changed behavior has tests (positive **and** negative cases for rules)
- [ ] User-visible behavior change has a `CHANGELOG.md` entry under `[Unreleased]`
- [x] Docs updated where behavior changed (`README.md`, `docs/rules/CL-XXXX.md`)
- [x] `tests/corpus_snapshot.json.gz` is **not** in this PR (a maintainer regenerates it)
- [x] No AI credit lines in commit messages (`Co-Authored-By`, "generated by")

Docs-only, so no CHANGELOG entry and no tests: nothing here is version-visible or executable.

## Testing

Every factual claim was checked against the live configuration rather than written from memory:

- Fork PR token/secret behaviour, `permissions: {}`, the `docs.yml` PR gating, SHA pinning, and the absence of `pull_request_target` — read from `.github/workflows/`.
- `squash_merge_commit_title` / `squash_merge_commit_message`, `dismiss_stale_reviews_on_push`, `strict_required_status_checks_policy`, and `ci-ok` as the sole required check — read from the repo and ruleset APIs.
- The fork-approval option names and their definitions — GitHub's own settings documentation.
- The worktree trap — reproduced: `pytest` in a worktree reported 9 failures against `main`'s `src/`, and 101 passed once `PYTHONPATH` pointed at the worktree.

Docs build: `docs.yml` runs `mkdocs build` without `--strict`, and the new page follows the existing unlisted-maintainer-doc convention (`CI.md` already links outside `docs/` the same way), so the nav stays curated and the build is unaffected.

## Breaking changes

None. Documentation only.
