### PR TITLE
Tell contributors how to claim an issue

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,13 @@ reasonable thing to want — it just isn't something this project can offer.
   not accepted.
 - **Larger changes**: open an issue to discuss first so you don't sink time into
   a change that doesn't fit the project's scope.
+- **Claiming an issue**: comment on it saying you're taking it, and check for an
+  existing claim before you start. Issues here are not formally assigned, so that
+  comment thread is the only record — it is what keeps two people from writing the
+  same patch. If a claim has gone quiet for a couple of weeks, say so on the issue
+  and go ahead. Issues labelled
+  [`good first issue`](https://github.com/tmatens/compose-lint/labels/good%20first%20issue)
+  are scoped to be self-contained and are the best place to start.
 
 See [AGENTS.md](AGENTS.md) for the full design philosophy — especially the
 sections on rule grounding, severity assignment, and what's explicitly out of


### PR DESCRIPTION
## Summary

Adds a **Claiming an issue** bullet to `## Before you start`: comment on an issue to take it, check for an existing claim first, and what to do when a claim has gone quiet.

## Why

Issues here are not formally assigned, so the comment thread is the only record that anyone is working on one. Nothing said so, which leaves two contributors free to write the same patch and one of them to waste the effort. That is a real cost on a project whose `good first issue` tickets are deliberately scoped to be picked up cold by someone who has not been following along.

The stale-claim sentence exists so the convention cannot park an issue indefinitely: a claim that has gone quiet for a couple of weeks can be taken over by saying so on the issue.

## Type of change

- [ ] New rule (`CL-XXXX`)
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [x] Documentation
- [ ] Build / CI / release tooling
- [ ] Other:

## Origin

- [x] Personal contribution
- [ ] Contributed on behalf of an employer or client
- [ ] Produced primarily by an automated agent

Wording is the maintainer's own draft, committed and rebased with agent assistance; the text is unchanged from the original.

## Checklist

- [x] Commits are signed (GitHub shows **Verified**)
- [x] One logical change per commit; no unrelated changes bundled in
- [x] `ruff check`, `ruff format --check`, `mypy src/`, and `pytest` all pass locally
- [ ] User-visible behavior change has a `CHANGELOG.md` entry under `[Unreleased]`
- [x] `tests/corpus_snapshot.json.gz` is **not** in this PR (a maintainer regenerates it)
- [x] No AI credit lines in commit messages (`Co-Authored-By`, "generated by")

Docs-only: nothing version-visible, nothing executable, so no CHANGELOG entry and no tests.

## Testing

Verified the change is purely additive against current `main` — `git diff origin/main -- CONTRIBUTING.md` shows the seven added lines and zero removals. This matters because the draft predated #684: it was written against the pre-#684 file, so committing it naively would have reverted the **This project is unpaid** section. The two insertions sit ten lines apart and merge cleanly.

## Breaking changes

None. Documentation only.
