### PR TITLE
Correct the DCO sign-off guidance and enforce it before push

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -19,4 +19,19 @@ while read local_ref local_sha remote_ref remote_sha; do
       exit 1
     fi
   done < <(git log --format="%H %G?" "${base}..${local_sha}")
+
+  # DCO. Separate from the signature above: signing proves who committed, the
+  # trailer asserts the right to contribute. No git config adds it to every
+  # commit (format.signOff only affects format-patch), so without this check a
+  # missing trailer surfaces in CI — and on a first-time contributor's fork PR,
+  # not until a maintainer approves the run.
+  while IFS=$'\t' read -r sha author_name author_email; do
+    expected="Signed-off-by: ${author_name} <${author_email}>"
+    if ! git log -1 --format='%B' "${sha}" | grep -qiF "${expected}"; then
+      echo "error: commit ${sha} is missing '${expected}'"
+      echo "       add it with 'git commit --amend --signoff', or"
+      echo "       'git rebase --signoff ${base}' for a whole branch"
+      exit 1
+    fi
+  done < <(git log --format='%H%x09%an%x09%ae' "${base}..${local_sha}")
 done

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,6 +36,7 @@ Closes #
 ## Checklist
 
 - [ ] Commits are signed (GitHub shows **Verified**)
+- [ ] Commits carry a `Signed-off-by:` trailer (`git commit -s`) — separate from signing
 - [ ] One logical change per commit; no unrelated changes bundled in
 - [ ] `ruff check`, `ruff format --check`, `mypy src/`, and `pytest` all pass locally
 - [ ] New/changed behavior has tests (positive **and** negative cases for rules)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,17 +218,21 @@ This is the [Developer Certificate of Origin](https://developercertificate.org).
 It is independent of [commit signing](#commit-signing) above: cryptographic
 signing proves *who committed*, DCO asserts *right to contribute*.
 
-Add the trailer automatically with `-s`:
+Add the trailer with `-s`:
 
 ```bash
 git commit -s -m "Your change"
 ```
 
-Or enable it once per-clone so every commit gets signed off:
+There is no git setting that adds it to every commit. `format.signOff` looks
+like one and is not — it only enables `-s` for `git format-patch`, never for
+`git commit`. Git states the reason in its own documentation: adding the
+trailer "should be a conscious act and means that you certify you have the
+rights to submit this work under the same open source license".
 
-```bash
-git config format.signOff true
-```
+What catches a commit that is missing it is the repo's `pre-push` hook, which
+refuses the push before a PR ever exists — provided you ran the
+`git config core.hooksPath .githooks` from [Development setup](#development-setup).
 
 The `Signed-off-by` name and email must match your commit author identity. CI
 will block the PR if any commit is missing a matching trailer. Fix existing


### PR DESCRIPTION
## Summary

Three of the items on #686:

- **`CONTRIBUTING.md`** — removes the `git config format.signOff true` instruction, which does nothing for `git commit`, and says why no such setting exists.
- **`.github/pull_request_template.md`** — adds a `Signed-off-by` checkbox beside the existing signing one.
- **`.githooks/pre-push`** — refuses a commit missing the trailer, beside the existing unsigned-commit check.

## Why

The documented way to get automatic sign-off does not work. `format.signOff` only enables `-s` for `git format-patch`, never for `git commit`, so a contributor who follows the instruction gets no trailer and no warning:

```console
$ git init -q . && git config format.signOff true
$ git commit -q -m "test commit"
$ git log -1 --format='%B'
test commit
```

That compounds with timing. `dco` runs in `ci.yml` on `pull_request`, so for a first-time contributor it cannot report until a maintainer approves the workflow run — the contributor sees an all-grey checks panel and no signal, sometimes for hours. Both external PRs opened so far failed the check on their first run.

There is no config that adds the trailer to every commit, and git argues that is deliberate: the trailer "should be a conscious act and means that you certify you have the rights to submit this work". So this does not automate the trailer. It corrects the claim, and moves the catch as early as it can honestly go — `pre-push` already refuses unsigned commits, and now refuses a missing sign-off beside it, matching against author identity the same way the CI job does.

The template change is the smallest and probably the highest-yield. It carried exactly one signing-shaped checkbox, for cryptographic signing, and #675's contributor ticked it in good faith while their commit had no trailer at all.

Refs #686. The remaining item there — reporting DCO *before* CI approval, via the DCO App or a metadata-only `pull_request_target` precheck — is a design decision and is deliberately not in this PR.

## Type of change

- [ ] New rule (`CL-XXXX`)
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [x] Documentation
- [x] Build / CI / release tooling
- [ ] Other:

## Origin

- [ ] Personal contribution
- [ ] Contributed on behalf of an employer or client
- [x] Produced primarily by an automated agent

## Checklist

- [x] Commits are signed (GitHub shows **Verified**)
- [x] Commits carry a `Signed-off-by:` trailer (`git commit -s`) — separate from signing
- [x] One logical change per commit; no unrelated changes bundled in
- [x] `ruff check`, `ruff format --check`, `mypy src/`, and `pytest` all pass locally
- [ ] User-visible behavior change has a `CHANGELOG.md` entry under `[Unreleased]`
- [x] `tests/corpus_snapshot.json.gz` is **not** in this PR (a maintainer regenerates it)
- [x] No AI credit lines in commit messages (`Co-Authored-By`, "generated by")

No CHANGELOG entry: contributor tooling and docs, nothing version-visible.

## Testing

The `format.signOff` claim was checked against `git help config` and reproduced as shown above.

The hook was exercised on both paths against a real commit on this branch:

- Properly signed and signed-off — hook exits 0, push accepted.
- Same commit with the trailer stripped — hook exits 1 with
  `error: commit 81702e6 is missing 'Signed-off-by: Todd <tmatens@gmail.com>'` and the two remediation commands.

`bash -n` clean. The existing unsigned-commit check is untouched and still runs first.

## Breaking changes

None for contributors who already sign off. Anyone who does not, and who has `core.hooksPath` set, will now be stopped at push instead of by CI — which is the point.
