### PR TITLE
Error on a v1 or own-config overlay instead of passing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A v1-shaped or compose-lint-config overlay is now an error instead of a
+  silent pass.** Either one in a merge set made compose-lint skip the whole
+  project and report `PASS` at exit 0, dropping every finding in the base file.
+  Docker Compose *refuses* a project that includes either, so unlike the
+  fragment case (#671) there is no configuration to grade and merging is not
+  the answer: the run now exits 2 and names the file that caused it. The
+  own-config half mattered most — a file whose entire purpose is to disable
+  rules could, if named in `COMPOSE_FILE`, silence the linter completely
+  rather than disabling one rule
+  ([#673](https://github.com/tmatens/compose-lint/issues/673)).
+
+  This also settles the second defect in #671: the skip handler attributed the
+  message to the primary path, so a valid v2 base was reported as the
+  unlintable file. The error now names the overlay.
+
+  A file linted **on its own** is unchanged — a bare v1 file or a stray
+  `.compose-lint.yml` in a sweep still skips quietly at exit 0, which is
+  ADR-013 and the reason that policy exists. Only the merge-set case moves.
+  Projects that were passing on an overlay Compose would reject will start
+  failing, which is the point: they were never graded.
+
 - A fragment overlay carrying only top-level structural keys such as
   `volumes:` or `networks:`, or just `{}`, now merges into the linted
   configuration instead of skipping the whole project. Compose folds it

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -65,6 +65,15 @@ class ComposeNotApplicableError(ComposeError):
     See ADR-013.
     """
 
+    def __init__(self, message: str, *, reason: str | None = None) -> None:
+        super().__init__(message)
+        # The descriptive clause without the "Skipped:" framing. A merge set
+        # reports these buckets as errors rather than skips (#673), and
+        # "Error: ...: Skipped: ..." reads as a contradiction. Carrying the
+        # reason separately lets the merge path reframe it without matching
+        # on message text — the same reason ComposeFragmentError exists.
+        self.reason = reason if reason is not None else message
+
 
 class ComposeFragmentError(ComposeNotApplicableError):
     """A structural fragment: parses as YAML but carries no `services:` key.
@@ -150,12 +159,13 @@ def _classify_missing_services(data: dict[str, Any]) -> ComposeError:
 
     non_meta = [k for k in data if not _is_meta(k)]
     if non_meta and all(k in KNOWN_TOP_LEVEL_KEYS for k in non_meta):
-        return ComposeNotApplicableError(
-            "Skipped: file appears to be a compose-lint config "
+        reason = (
+            "file appears to be a compose-lint config "
             f"(top-level {', '.join(f'{k!r}' for k in sorted(non_meta))} and no "
             "'services:' key), not a Compose file. compose-lint reads its config "
             "via --config; it is not a lint target."
         )
+        return ComposeNotApplicableError(f"Skipped: {reason}", reason=reason)
     if not non_meta:
         # Own subtype so a merge can fold the fragment into its base while
         # v1 and own-config stay errors (#671).
@@ -170,12 +180,13 @@ def _classify_missing_services(data: dict[str, Any]) -> ComposeError:
         and any(marker in data[k] for marker in _V1_SERVICE_MARKERS)
         for k in non_meta
     ):
-        return ComposeNotApplicableError(
-            "Skipped: file appears to be Compose v1 "
+        reason = (
+            "file appears to be Compose v1 "
             "(services declared at the top level, no 'services:' wrapper). "
             "Docker retired Compose v1 in 2023; compose-lint targets v2/v3. "
             "Migrate the file under a top-level `services:` key to enable linting."
         )
+        return ComposeNotApplicableError(f"Skipped: {reason}", reason=reason)
     return ComposeError("Not a valid Compose file: missing 'services' key")
 
 
@@ -1344,13 +1355,36 @@ def load_merged(paths: list[str | Path], *, use_env: bool = True) -> Merged:
     *every* document is a fragment still raises
     :class:`ComposeNotApplicableError` — there is nothing to lint, and
     merging them would report a vacuous PASS under the primary path.
+
+    The other two not-applicable buckets go the opposite way (#673). A
+    v1-shaped or own-config document anywhere in the set raises
+    :class:`ComposeFileError`, naming the file that caused it, because
+    Compose refuses such a project outright: there is no deployable
+    configuration for ADR-025 to grade, so a skip at exit 0 would claim a
+    stack passed that was never read. Linted on its own each still skips
+    quietly, which is ADR-013 and unchanged.
     """
     documents: list[Document] = []
     for path in paths:
         try:
             documents.append(load_document(path, use_env=use_env))
-        except ComposeNotApplicableError:
-            raise
+        except ComposeNotApplicableError as exc:
+            # A v1-shaped or own-config document in a merge set is an error,
+            # not a skip (#673). Compose refuses a project that includes
+            # either, so there is no configuration to grade — reporting the
+            # project as PASS at exit 0 asserted a stack was cleared when it
+            # was never read. Attributing it to `path` also fixes the second
+            # defect in #671: the skip handler named the primary file when the
+            # overlay beside it was the unlintable one.
+            #
+            # A fragment cannot arrive here. `load_document` parses with
+            # merging=True, under which `_validate_compose` admits the
+            # fragment bucket instead of raising, which is what #671 shipped.
+            raise ComposeFileError(
+                path,
+                f"{exc.reason} Docker Compose refuses a project that includes "
+                "it, so there is no merged configuration to lint.",
+            ) from exc
         except ComposeError as exc:
             raise ComposeFileError(path, str(exc)) from exc
     merged = merge_documents(documents)

--- a/tests/test_overlay_merge.py
+++ b/tests/test_overlay_merge.py
@@ -547,12 +547,13 @@ def test_all_fragment_merge_set_still_skips(tmp_path: Path) -> None:
     assert "no 'services:' key" in result.stderr
 
 
-def test_v1_shaped_overlay_still_skips(tmp_path: Path) -> None:
-    """Only the fragment bucket merges; v1 keeps today's behaviour.
+def test_v1_shaped_overlay_is_an_error_not_a_skip(tmp_path: Path) -> None:
+    """A v1-shaped overlay errors at exit 2 rather than passing (#673).
 
-    Compose refuses a v1-shaped document outright, so merging one would grade
-    a configuration that never deploys. Its separate error path is #673's
-    job; here it must behave exactly as before #671.
+    The fragment bucket merges; this one cannot. Compose refuses a project
+    that includes a v1-shaped document, so there is no configuration to
+    grade — and reporting PASS at exit 0 claimed the base file had been
+    cleared when it was never read.
     """
     _write_pair(
         tmp_path,
@@ -561,9 +562,46 @@ def test_v1_shaped_overlay_still_skips(tmp_path: Path) -> None:
     )
     result = run_cli("check", cwd=tmp_path)
 
-    assert result.returncode == 0
-    assert "Skipped" in result.stderr
+    assert result.returncode == 2
     assert "Compose v1" in result.stderr
+    assert "PASS" not in result.stdout
+
+
+def test_v1_overlay_error_names_the_overlay_not_the_base(tmp_path: Path) -> None:
+    """The error names the file that caused it — #671's second defect.
+
+    The single-file skip handler attributed the message to the primary path,
+    so a perfectly valid v2 base was reported as the v1 file. Nothing pinned
+    that until the bucket became an error with a path attached.
+    """
+    _write_pair(
+        tmp_path,
+        BASE_PRIVILEGED,
+        'web:\n  ports: ["8080:80"]\n',
+    )
+    result = run_cli("check", cwd=tmp_path)
+
+    assert "Error: compose.override.yml:" in result.stderr
+    assert "Error: compose.yml:" not in result.stderr
+
+
+def test_own_config_overlay_is_an_error_not_a_skip(tmp_path: Path) -> None:
+    """An overlay that is compose-lint's own config errors too (#673).
+
+    Worth its own case rather than folding into the v1 one: this file's whole
+    purpose is to disable rules, so the old behaviour let a file named in
+    COMPOSE_FILE silence the linter entirely instead of disabling one rule.
+    """
+    _write_pair(
+        tmp_path,
+        BASE_PRIVILEGED,
+        "rules:\n  CL-0002:\n    enabled: false\n",
+    )
+    result = run_cli("check", cwd=tmp_path)
+
+    assert result.returncode == 2
+    assert "compose-lint config" in result.stderr
+    assert "PASS" not in result.stdout
 
 
 def test_include_only_overlay_is_not_admitted_as_a_fragment(tmp_path: Path) -> None:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -11,6 +11,7 @@ import pytest
 from compose_lint.parser import (
     _LINES,
     ComposeError,
+    ComposeFileError,
     ComposeFragmentError,
     ComposeNotApplicableError,
     _collect_lines,
@@ -678,23 +679,55 @@ class TestFragmentOverlayMerging:
             load_merged([base, over])
         assert not isinstance(excinfo.value, ComposeNotApplicableError)
 
-    def test_v1_shaped_overlay_still_raises(self, tmp_path: Path) -> None:
-        # Only the fragment bucket merges. A v1-shaped overlay keeps raising
-        # so its separate error path (#673) decides what happens next.
+    def test_v1_shaped_overlay_raises_a_file_error(self, tmp_path: Path) -> None:
+        # Only the fragment bucket merges. A v1-shaped overlay is an error
+        # attributed to its own path (#673), never a skip: Compose refuses a
+        # project that includes it, so nothing is left to grade.
         base = tmp_path / "compose.yml"
         over = tmp_path / "compose.override.yml"
         base.write_text("services:\n  web:\n    image: nginx\n")
         over.write_text('web:\n  ports: ["8080:80"]\n')
 
-        with pytest.raises(ComposeNotApplicableError, match="Compose v1"):
+        with pytest.raises(ComposeFileError, match="Compose v1") as excinfo:
             load_merged([base, over])
+        # Not a skip: the CLI routes ComposeNotApplicableError to exit 0.
+        assert not isinstance(excinfo.value, ComposeNotApplicableError)
+        assert excinfo.value.path == str(over)
 
-    def test_own_config_overlay_still_raises(self, tmp_path: Path) -> None:
-        # Same boundary for the own-config bucket: never merged, never silent.
+    def test_own_config_overlay_raises_a_file_error(self, tmp_path: Path) -> None:
+        # Same answer for the own-config bucket: never merged, never silent.
         base = tmp_path / "compose.yml"
         over = tmp_path / "compose.override.yml"
         base.write_text("services:\n  web:\n    image: nginx\n")
         over.write_text("rules:\n  CL-0003:\n    enabled: false\n")
 
-        with pytest.raises(ComposeNotApplicableError, match="compose-lint config"):
+        with pytest.raises(ComposeFileError, match="compose-lint config") as excinfo:
             load_merged([base, over])
+        assert not isinstance(excinfo.value, ComposeNotApplicableError)
+        assert excinfo.value.path == str(over)
+
+    def test_v1_base_beside_a_valid_overlay_also_errors(self, tmp_path: Path) -> None:
+        # The mirror case. Which half is unlintable does not matter: Compose
+        # refuses the project either way, so neither ordering may pass.
+        base = tmp_path / "compose.yml"
+        over = tmp_path / "compose.override.yml"
+        base.write_text('web:\n  ports: ["8080:80"]\n')
+        over.write_text("services:\n  web:\n    image: nginx\n")
+
+        with pytest.raises(ComposeFileError, match="Compose v1") as excinfo:
+            load_merged([base, over])
+        assert excinfo.value.path == str(base)
+
+    def test_skip_message_keeps_its_framing_for_a_single_file(
+        self, tmp_path: Path
+    ) -> None:
+        # ADR-013 is unchanged for a file linted on its own: still a skip, and
+        # still worded as one. The merge path reframes via `reason` precisely
+        # so "Error: ...: Skipped: ..." can never be printed.
+        solo = tmp_path / "compose.yml"
+        solo.write_text('web:\n  ports: ["8080:80"]\n')
+
+        with pytest.raises(ComposeNotApplicableError) as excinfo:
+            load_compose(solo)
+        assert str(excinfo.value).startswith("Skipped: ")
+        assert not excinfo.value.reason.startswith("Skipped: ")


### PR DESCRIPTION
## Summary

A v1-shaped or own-config document in a merge set now raises `ComposeFileError` instead of propagating `ComposeNotApplicableError` out of `load_merged`. The CLI already routes that to exit 2 and attributes it to `exc.path`, so the run reports the refusal Compose would give and names the file that caused it.

The two buckets now carry their bare `reason` alongside the skip-framed message, so the merge path can reframe without matching on message text — the same reasoning that gave the fragment bucket its own subtype in #671.

## Why

`Fixes #673`. #671 fixed the third bucket by *merging* it, which is right for a fragment because Compose merges one too. It is the wrong answer here: Compose refuses a project containing either of these, verified in the issue against Compose 5.4.0, so there is no configuration to grade and a merge would grade something that never deploys.

The own-config half is worth stating plainly: a file whose entire purpose is to disable rules could, if named in `COMPOSE_FILE`, silence the linter completely rather than disabling one rule.

This also settles the **second defect in #671**, which #675 deliberately left open. The skip handler attributed its message to the primary path, so a valid v2 base was reported as the unlintable file. An error carrying a path fixes it, and there is now a test pinning it.

## Verification

Both reproductions from the issue, run against this branch:

```console
$ compose-lint check compose.yml          # v1-shaped compose.override.yml
Error: compose.override.yml: file appears to be Compose v1 (services declared at the
top level, no 'services:' wrapper). ... Docker Compose refuses a project that includes
it, so there is no merged configuration to lint.
⚠ ERROR  ·  1 file could not be parsed
$ echo $?
2
```

```console
$ compose-lint check compose.yml          # COMPOSE_FILE=compose.yml:cl.yml
Error: cl.yml: file appears to be a compose-lint config (top-level 'rules' and no
'services:' key), not a Compose file. ... Docker Compose refuses a project that
includes it, so there is no merged configuration to lint.
$ echo $?
2
```

Single-file behaviour, which must not change:

```console
$ compose-lint check compose.yml          # a bare v1 file, linted alone
compose.yml: Skipped: file appears to be Compose v1 ...
✓ PASS  ·  threshold: high
$ echo $?
0
```

## Tests

Three existing tests asserted the old behaviour and are updated rather than deleted — `test_v1_shaped_overlay_still_skips`, `test_v1_shaped_overlay_still_raises`, `test_own_config_overlay_still_raises`. Their comments pointed at #673 as the issue that would decide this, so they were written to be changed here.

New coverage:

- v1 overlay → exit 2, no `PASS` on stdout.
- own-config overlay → exit 2 (its own case, not folded in — the rule-silencing hole is what makes it worth pinning separately).
- the error names `compose.override.yml` and **not** `compose.yml` (#671's second defect).
- a v1 *base* beside a valid overlay errors too, attributed to the base — which half is unlintable must not matter.
- the single-file message keeps its `Skipped:` framing while `reason` does not carry it, so `Error: ...: Skipped: ...` cannot be printed.

`2447 passed, 10 skipped`. `ruff check`, `ruff format --check`, `mypy src/` (strict) all clean.

`tests/test_action_contract.py` is deselected locally — it shells out to the action entrypoint and returns 127 in a worktree, and passes on an unmodified main checkout. A parser edit cannot produce "command not found"; CI runs it properly.

## One question for you

**Does ADR-013 want amending?** It records the not-applicable policy as "a per-file skip with **exit 0**", written for sweep and single-file use. Two changes have now carved merge-set exceptions into it — #671 (fragment merges) and this one (v1/own-config errors) — and neither is reflected there.

I have deliberately **not** touched the ADR: it is your decision record, #675 set the precedent of not amending it, and doing it here would bundle a fix for #671's omission into this PR. If you want it recorded, a follow-up amending ADR-013 once for both departures seems better than doing half of it here.

## Type of change

- [ ] New rule (`CL-XXXX`)
- [x] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / CI / release tooling
- [ ] Other:

## Origin

- [ ] Personal contribution
- [ ] Contributed on behalf of an employer or client
- [x] Produced primarily by an automated agent

## Checklist

- [x] Commits are signed (GitHub shows **Verified**)
- [x] Commits carry a `Signed-off-by:` trailer (`git commit -s`) — separate from signing
- [x] One logical change per commit; no unrelated changes bundled in
- [x] `ruff check`, `ruff format --check`, `mypy src/`, and `pytest` all pass locally
- [x] New/changed behavior has tests (positive **and** negative cases)
- [x] User-visible behavior change has a `CHANGELOG.md` entry under `[Unreleased]`
- [ ] Docs updated where behavior changed (`README.md`, `docs/rules/CL-XXXX.md`)
- [x] `tests/corpus_snapshot.json.gz` is **not** in this PR (a maintainer regenerates it)
- [x] No AI credit lines in commit messages (`Co-Authored-By`, "generated by")

**This touches a parse/skip predicate, so the corpus snapshot needs regenerating by you.** Drift should be zero — the corpus is filename-filtered and contains no sibling files, so no merge sets — but that is a prediction, not a measurement, and this is exactly the kind of change the snapshot exists to check.

## Breaking changes

Behaviourally yes, and deliberately. A project whose overlay is v1-shaped or is compose-lint's own config used to exit 0 and now exits 2. Those projects were never graded — the old exit 0 asserted a clean stack that had not been read — and Docker Compose refuses them outright, so nothing that deploys today changes verdict. Unlike #671, #648, #657 and #668, this is not "more findings"; it is a pass becoming an error, so it belongs in the release notes rather than being folded in as tightened coverage.
