### PR TITLE
Point the corpus instructions at the scripts that exist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -285,9 +285,16 @@ too, so set those up before your first commit.
 `tests/corpus_snapshot.json.gz` locks compose-lint's output across a corpus
 of real-world Compose files so unintended rule drift is visible in PR diffs.
 
-- Generate a corpus locally with the helper scripts at
-  `~/.cache/compose-lint-corpus/scripts/` (out of tree by design — see
-  `LICENSE-corpus.md`). Set `COMPOSE_LINT_BIN` to your in-repo binary.
+- The corpus **data** is out of tree by design: compose files, lint runs and
+  the index are third-party content and live at `~/.cache/compose-lint-corpus/`
+  (see `LICENSE-corpus.md`). The **scripts** are in git at `scripts/corpus/` —
+  its README has the fetch pipeline.
+- Refresh a run before generating or verifying anything. `python
+  scripts/corpus/run.py` lints every corpus file into `runs/<timestamp>/`, and
+  `scripts/snapshot.py` reads the newest run it finds — so without this step
+  both commands below grade whatever was linted last, which may be a different
+  build of compose-lint entirely. It defaults to `.venv/bin/compose-lint`; set
+  `COMPOSE_LINT_BIN` to point at another build.
 - **Maintainers** regenerate it after a rule change, via
   `python scripts/snapshot.py generate`, and commit the updated
   `tests/corpus_snapshot.json.gz` separately from the change it checks.


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md`'s corpus section pointed at helper scripts in `~/.cache/compose-lint-corpus/scripts/`, which does not exist. Corrects the location and adds the run step the rest of the section depends on.

## Why

Two problems, one found while chasing the other.

**The path is wrong.** It conflated two things `scripts/corpus/README.md` keeps carefully apart — *"Data lives outside the repo at `~/.cache/compose-lint-corpus/` (compose files, lint runs, index). Only this code is in git."* The data is out of tree because it is third-party content; the scripts are in git at `scripts/corpus/`. A contributor following the instruction finds an empty path and no way to produce a corpus run.

**The run step was missing entirely.** Both `snapshot.py generate` and `snapshot.py verify` read the *newest* run under `runs/`. Without `python scripts/corpus/run.py` first, they grade whatever happened to be linted last — possibly by a different build of compose-lint.

That is not hypothetical. The snapshot regenerated in #691 had been stale since 0.9.0, and the only run in the local cache came from a branch build rather than `main`. The instructions never said to make a fresh one.

## Type of change

- [ ] New rule (`CL-XXXX`)
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [x] Documentation
- [ ] Build / CI / release tooling
- [ ] Other:

## Origin

- [ ] Personal contribution
- [ ] Contributed on behalf of an employer or client
- [x] Produced primarily by an automated agent

## Checklist

- [x] Commits are signed (GitHub shows **Verified**)
- [x] Commits carry a `Signed-off-by:` trailer (`git commit -s`) — separate from signing
- [x] One logical change per commit; no unrelated changes bundled in
- [ ] User-visible behavior change has a `CHANGELOG.md` entry under `[Unreleased]`
- [x] `tests/corpus_snapshot.json.gz` is **not** in this PR (a maintainer regenerates it)
- [x] No AI credit lines in commit messages (`Co-Authored-By`, "generated by")

No CHANGELOG entry: contributor documentation, nothing version-visible.

## Testing

Every path named in the new text was checked to exist: `scripts/corpus/` and its `README.md`, `scripts/corpus/run.py`, `scripts/snapshot.py`. The `COMPOSE_LINT_BIN` default (`<repo>/.venv/bin/compose-lint`) is read from `run.py` rather than assumed, which is why it is now described as an override rather than a required step.

## Breaking changes

None. Documentation only.
