### PR TITLE
Fix two documentation defects #685 exposed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -248,6 +248,35 @@ the fork, and open the PR from that branch back to `main` here. Everything
 below applies the same way; the DCO and commit-signing checks run on fork PRs
 too, so set those up before your first commit.
 
+Add this repository as a second remote when you clone your fork. `origin` is
+**your fork**, not this repository, so any instruction phrased as
+`git rebase origin/main` rebases you onto your fork's copy of `main` — which is
+frozen at whatever it held when you forked. That reports success and changes
+nothing, which is a confusing way to discover the problem.
+
+```bash
+git clone https://github.com/<you>/compose-lint.git
+cd compose-lint
+git remote add upstream https://github.com/tmatens/compose-lint.git
+```
+
+Then `git fetch upstream` and rebase onto `upstream/main`. `main` here moves
+several times a day, and the ruleset requires a PR to be up to date before it
+merges, so expect to rebase before yours lands:
+
+```bash
+git fetch upstream && git rebase upstream/main
+git push --force-with-lease
+```
+
+`git log --oneline -3` afterwards should show this repository's newest commit
+directly beneath yours. If it shows the commit you forked from, the rebase went
+to the wrong base.
+
+Don't use the **Update branch** button instead: it merges rather than rebases,
+and the merge commit it creates carries no `Signed-off-by` trailer, so the DCO
+check fails on a commit you did not write.
+
 1. **Create a branch** from `main`. Name it descriptively:
    `docs/contributor-workflow`, `rules/CL-0011-user-namespaces`,
    `fix/parser-merge-keys`.

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -91,9 +91,18 @@ Inline comments anchored to lines go through
 finding about a file the PR does not touch — a rule doc that needs a matching
 row, say — has to live in the review body.
 
-`dismiss_stale_reviews_on_push` is enabled, so a *changes requested* review
-clears itself when the contributor pushes the fix. There is nothing to dismiss
-by hand.
+A *changes requested* review does **not** clear itself when the contributor
+pushes the fix. `dismiss_stale_reviews_on_push` is enabled on the ruleset, but
+it dismisses stale *approvals* only — GitHub's own wording for it is "dismiss
+stale pull request approvals when new commits are pushed". A changes-requested
+review keeps blocking the merge until you act on it, however many times the
+branch is rebased or amended in between.
+
+Two ways to clear it, and they say different things. Submitting an approving
+review supersedes it, because a reviewer's latest review is the one that counts
+— use this when the findings were addressed. Dismissing it leaves the review in
+place, marked dismissed with a reason — use this when the findings were waived
+or overtaken rather than fixed, since it keeps the objection legible.
 
 ## Before merging
 


### PR DESCRIPTION
## Summary

Two documentation defects that #685 exposed, one commit each.

- `docs/MAINTAINING.md` — corrects what `dismiss_stale_reviews_on_push` actually dismisses.
- `CONTRIBUTING.md` — tells forked contributors to add an `upstream` remote, and rebases against it.

## Why

**Both were wrong in the direction that wastes someone's time.**

`MAINTAINING.md` said a changes-requested review "clears itself when the contributor pushes the fix. There is nothing to dismiss by hand." The setting dismisses stale **approvals** only — GitHub's own wording is *"dismiss stale pull request approvals when new commits are pushed."* A changes-requested review keeps blocking the merge regardless.

#685 demonstrated it twice. The review survived a push of five fixes, then survived a rebase; the PR sat `BLOCKED` both times while the page said no action was needed. A maintainer following that text waits for something that will never happen.

`CONTRIBUTING.md` told external contributors to fork, then left `origin` ambiguous in every instruction below. On a cloned fork `origin` **is the fork**, so `git rebase origin/main` rebases onto the fork's frozen copy of `main`. It reports success and does nothing.

That cost #685 a full round trip. The contributor rebased exactly as asked; their branch stayed nine commits behind, with its parent still the commit they forked from. The bad instruction came from a maintainer review rather than the docs — but the docs are what can stop it recurring, and they were silent on the remote setup that makes the instruction correct.

## What the new text adds

For contributors: the `git remote add upstream` line, the rebase against `upstream/main`, a check that the rebase went to the right base *before* pushing (`git log --oneline -3` should show this repo's newest commit beneath yours), and why **Update branch** is not the shortcut it looks like — it merges rather than rebases, and the merge commit carries no `Signed-off-by`, so DCO fails on a commit the contributor didn't write.

For maintainers: the two ways to clear a changes-requested review and what each one says. Approving supersedes it, which fits findings that were addressed. Dismissing keeps the objection legible, which fits findings waived or overtaken.

## Type of change

- [ ] New rule (`CL-XXXX`)
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [x] Documentation
- [ ] Build / CI / release tooling
- [ ] Other:

## Origin

- [ ] Personal contribution
- [ ] Contributed on behalf of an employer or client
- [x] Produced primarily by an automated agent

## Checklist

- [x] Commits are signed (GitHub shows **Verified**)
- [x] Commits carry a `Signed-off-by:` trailer (`git commit -s`) — separate from signing
- [x] One logical change per commit; no unrelated changes bundled in
- [ ] User-visible behavior change has a `CHANGELOG.md` entry under `[Unreleased]`
- [x] `tests/corpus_snapshot.json.gz` is **not** in this PR (a maintainer regenerates it)
- [x] No AI credit lines in commit messages (`Co-Authored-By`, "generated by")

Two commits because the audiences are different — one page is read by maintainers, the other by contributors — and either is revertible without the other. No CHANGELOG entry: nothing version-visible.

## Testing

Both claims were verified against #685 rather than reasoned about. The review survived two pushes with `mergeStateStatus: BLOCKED` and cleared only on an approving review; the contributor's branch head had parent `89017ff` (their fork's `main`, nine behind) after a rebase they performed exactly as instructed.

## Breaking changes

None. Documentation only.
