### PR TITLE
Credit outside contributors in the changelog and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,10 +109,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unchanged, and v1-shaped or own-config overlays keep their current
   behavior until their separate error path lands (#673).
 
+  Thanks [@krishna3554](https://github.com/krishna3554) ([#675](https://github.com/tmatens/compose-lint/pull/675)).
+
 - A parse error in an automatically merged `compose.override.yml` is now
   reported against the file that actually failed in text, JSON, and SARIF. It
   previously named the base file at a line number that did not exist there
   ([#666](https://github.com/tmatens/compose-lint/issues/666)).
+
+  Thanks [@nightcityblade](https://github.com/nightcityblade) ([#670](https://github.com/tmatens/compose-lint/pull/670)).
 
 - Every Compose substitution operator now resolves against a sibling `.env`,
   not just `${VAR:-default}` and `${VAR-default}`. `${VAR:?err}`, `${VAR?err}`,
@@ -132,6 +136,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CL-0020 now exempts additional credential-shaped quantity knobs, including
   work factors, retry counters, lengths, strength values, and cost knobs when
   their values are bare quantities ([#681](https://github.com/tmatens/compose-lint/issues/681)).
+
+  Thanks [@AdhravRai](https://github.com/AdhravRai) ([#685](https://github.com/tmatens/compose-lint/pull/685)).
 
 ## [0.22.0] - 2026-08-22
 
@@ -1331,6 +1337,8 @@ The diff catches the moved-waiver case, which no warning can reach.
   dotless `compose-lint.yml` that `init -o` can write — with either extension.
   **Note** environment specific files, e.g. `compose-dev.yml`, still match, but
   files with prefixes, e.g. `dev-compose.yml`, no longer do.
+
+  Thanks [@jhomer-hscl](https://github.com/jhomer-hscl) ([#495](https://github.com/tmatens/compose-lint/pull/495)).
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -293,6 +293,10 @@ check fails on a commit you did not write.
 
 - **Keep PRs small.** Easier to review, easier to revert, easier to bisect.
   A PR that touches 5 files is almost always better than one that touches 30.
+- **You get credited.** When a merged PR produces a user-visible change, its
+  `CHANGELOG.md` entry names you and links your PR, and that text becomes the
+  GitHub Release body verbatim. You do not need to add the line yourself —
+  the releaser does it. Tell us if you'd rather not be named.
 - **Don't mix refactors with behavior changes.** Land the refactor first, then
   the behavior change, in separate PRs.
 - **Update tests.** New rules need positive and negative tests. Bug fixes need

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -164,6 +164,21 @@ version number.
       Changelog — the three shapes that have reached a release candidate.
       **That checks shape, not completeness:** it cannot know a PR went
       undocumented, so the cross-check above is still yours to do.
+- [ ] **Every entry authored by someone other than a maintainer credits
+      them.** Append `Thanks [@handle](https://github.com/handle)
+      ([#NNN](https://github.com/tmatens/compose-lint/pull/NNN)).` as its own
+      indented paragraph at the end of the entry. The GitHub Release body is
+      generated verbatim from this section, and it is the only announcement
+      channel this repo has, so an uncredited entry is a contribution that
+      never gets publicly acknowledged. The same `gh pr list --search
+      "merged:>..."` cross-check above surfaces the authors — anyone who is
+      not a maintainer gets a line. Bots (`renovate[bot]`,
+      `dependabot[bot]`, `github-actions[bot]`) never do, and neither do
+      maintainers' own PRs: the credit marks *someone else did this*, which
+      is what makes it worth reading. (0.23.0 shipped three outside
+      contributions with no attribution and had to be corrected after the
+      fact — release bodies are editable, so fix it there too if this is
+      caught late.)
 - [ ] `.vex/compose-lint.openvex.json` is current: any new pip (or other
       stripped-component) CVE that a scanner now reports against the image
       is either covered by an existing `not_affected` statement with


### PR DESCRIPTION
## What

Adds `Thanks @handle (#NNN)` attribution to the four `CHANGELOG.md` entries authored by someone other than the maintainer, and makes it a repeatable step instead of a habit.

| PR | Author | Shipped in |
|---|---|---|
| #495 | @jhomer-hscl | 0.15.2 |
| #670 | @nightcityblade | 0.23.0 |
| #675 | @krishna3554 | 0.23.0 |
| #685 | @AdhravRai | 0.23.0 |

## Why

`publish.yml` generates the GitHub Release body verbatim from the matching `CHANGELOG.md` section, and with Discussions disabled that body is this project's only announcement channel. So an entry with no attribution is a contribution that is never publicly acknowledged — the names existed only in `git log`. For a first-time contributor that public credit is essentially the whole of what an unpaid project can pay them.

## The practice

- **`docs/RELEASING.md`** — a pre-release checklist item, placed beside the existing "`[Unreleased]` covers every user-facing PR" cross-check because the same `gh pr list --search "merged:>..."` command surfaces the authors. Bots and maintainers' own PRs are explicitly excluded: the credit marks *someone else did this*, which is what makes it worth reading.
- **`CONTRIBUTING.md`** — a line under PR expectations so contributors know the credit is coming, that they don't have to add it themselves, and that they can decline being named.

## Notes

- The already-released 0.15.2 entry is amended too. This edits a published section of the changelog, which is a docs correction rather than a history rewrite — the alternative was leaving a contributor permanently uncredited.
- The published **0.23.0** and **0.15.2** GitHub Release bodies are being edited separately. They are mutable after the fact, so the correction needs no new tag.
- Docs-only. `scripts/check_changelog_unreleased.py` passes, and the self-referencing version-pin check finds no stale pins (the bare `0.23.0` in the new RELEASING.md prose does not match any of its three pin patterns).