### PR TITLE
Add a platform end-of-life radar (eol-watch)

### DIFF
--- a/.github/workflows/eol-watch.yml
+++ b/.github/workflows/eol-watch.yml
@@ -1,0 +1,102 @@
+name: Platform end-of-life radar
+
+# Watches the calendar the way vuln-report.yml watches advisories: the
+# Python floor, the Docker base image's Debian release, and the CI runner
+# image all have upstream EOL dates that everyone can see coming — and the
+# Python 3.10 drop (#643) showed they still arrive "suddenly" without a
+# watcher. Post-1.0 the cost of being surprised is a forced MAJOR or an
+# EOL interpreter inside the stability contract, so the radar's window
+# (180 days, in scripts/eol_watch.py) is sized to fit the whole
+# deprecation lifecycle of docs/compatibility.md in front of the date.
+#
+# Also flags a newly released CPython minor missing from ci.yml's matrix,
+# which the ROADMAP commits to adding within ~3 months of release.
+#
+# One rolling issue, same pattern as vuln-report.yml: opened when
+# something is due, updated in place while it stays due, closed by the
+# first clean run. Script exit codes: 0 nothing due, 1 due (report on
+# stdout), 2 the script could not produce a trustworthy answer (network,
+# parse, stale declaration) — 2 fails the run and is reported as its own
+# issue below, because a radar that silently stops sweeping reads as
+# "all clear".
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Monthly is enough: dates move on quarters, and the window is 180 days.
+    - cron: "0 7 3 * *"
+
+permissions: {}
+
+jobs:
+  radar:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # No setup-python: the script is stdlib-only (tomllib needs >=3.11)
+      # and the runner's own interpreter satisfies that. Nothing to install
+      # keeps this job off the lockfile/hash-pinning surface entirely.
+      - name: Sweep
+        id: sweep
+        run: |
+          set -euo pipefail
+          rc=0
+          python3 scripts/eol_watch.py > report.md || rc=$?
+          if [ "${rc}" -gt 1 ]; then
+            echo "::error::eol_watch.py exit ${rc} — no trustworthy answer"
+            exit "${rc}"
+          fi
+          echo "due=${rc}" >> "${GITHUB_OUTPUT}"
+
+      - name: Open, update, or close the rolling issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          DUE: ${{ steps.sweep.outputs.due }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          title="Platform EOL radar: action due"
+          existing=$(gh issue list --state open --search "\"${title}\" in:title" \
+            --json number --jq '.[0].number // empty')
+          if [ "${DUE}" = "1" ]; then
+            printf '\nRun: %s\n' "${RUN_URL}" >> report.md
+            if [ -n "${existing}" ]; then
+              echo "Updating #${existing}"
+              gh issue comment "${existing}" --body-file report.md
+            else
+              echo "Opening new issue"
+              gh issue create --title "${title}" --body-file report.md
+            fi
+          elif [ -n "${existing}" ]; then
+            echo "Nothing due; closing #${existing}"
+            gh issue close "${existing}" --reason completed --comment \
+              "Nothing due within the window any more. Verified by ${RUN_URL}."
+          else
+            echo "Nothing due and no open issue."
+          fi
+
+      - name: Report scheduled failure as issue
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          WORKFLOW: ${{ github.workflow }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          title="Scheduled run failed: ${WORKFLOW}"
+          body=$(printf -- '- Workflow: **%s**\n- Run: %s\n- Commit: %s\n\nThe EOL radar did not complete, so the calendar is unwatched until this is fixed.' \
+            "${WORKFLOW}" "${RUN_URL}" "${GITHUB_SHA}")
+          existing=$(gh issue list --state open --search "\"${title}\" in:title" \
+            --json number --jq '.[0].number // empty')
+          if [ -n "${existing}" ]; then
+            gh issue comment "${existing}" --body "${body}"
+          else
+            gh issue create --title "${title}" --body "${body}"
+          fi

--- a/scripts/eol_watch.py
+++ b/scripts/eol_watch.py
@@ -15,10 +15,20 @@ What it watches, against https://endoflife.date:
 - **python**, new stable minors missing from ci.yml's test matrix — the
   ROADMAP commits to adding one within ~3 months of each October release.
 - **debian**, the Docker runtime base (distroless on Debian, ADR-009).
-- **ubuntu**, the CI runner image.
+- **github-actions-runner-images**, the exact runner labels CI stands on
+  (ubuntu-24.04, and os-smoke's macos-15/windows-2025) — the image
+  calendar, not the OS calendar, because GitHub retires images first.
+- **docker-engine**, the major the rule premises are grounded on: its EOL
+  is the signal to re-ground validate_rule_premises.py on the current
+  engine.
 
-The debian/ubuntu cycles are declared here rather than parsed, because they
-live in a Dockerfile comment and a dozen `runs-on:` lines respectively; each
+PyYAML and the dev dependencies are deliberately absent: they publish no
+support lifecycle (not on endoflife.date), so their risks are watched by
+the tools that fit them — vuln-report.yml for vulnerabilities, Renovate
+for staleness, the CI matrix for new-interpreter compatibility.
+
+Cycles other than the Python floor are declared here rather than parsed,
+because they live in comments, ADR prose, and `runs-on:` lines; each
 declaration carries a grep-able anchor and the script FAILS (exit 2) if the
 anchor no longer appears where it claims to — a stale watch is worse than no
 watch, because it reads as "covered" (the capability-drop-harness lesson:
@@ -201,10 +211,15 @@ def fetch(product: str) -> list[dict]:
         return json.load(resp)
 
 
-def main() -> int:
-    floor = python_floor((REPO / "pyproject.toml").read_text())
-    matrix = ci_matrix((REPO / ".github/workflows/ci.yml").read_text())
-    watches = [
+def build_watches(floor: str) -> list[Watch]:
+    """Every (product, cycle) the project rides on.
+
+    Runner labels are watched as `github-actions-runner-images` cycles, not
+    OS cycles: GitHub retires an image on its own schedule (the ubuntu-20.04
+    runner went 2025-04-15, before the OS did), so the OS calendar is the
+    wrong clock for a `runs-on:` line.
+    """
+    return [
         Watch("python", floor, "requires-python floor (pyproject.toml)"),
         Watch(
             "debian",
@@ -214,13 +229,42 @@ def main() -> int:
             anchor_pattern=r"Debian 13|trixie",
         ),
         Watch(
-            "ubuntu",
-            "24.04",
-            "GitHub Actions CI runner image",
+            "github-actions-runner-images",
+            "ubuntu-24.04",
+            "CI runner image (ci.yml and siblings)",
             anchor_file=".github/workflows/ci.yml",
             anchor_pattern=r"ubuntu-24\.04",
         ),
+        Watch(
+            "github-actions-runner-images",
+            "macos-15",
+            "os-smoke runner image (macOS leg)",
+            anchor_file=".github/workflows/os-smoke.yml",
+            anchor_pattern=r"macos-15",
+        ),
+        Watch(
+            "github-actions-runner-images",
+            "windows-2025",
+            "os-smoke runner image (Windows leg)",
+            anchor_file=".github/workflows/os-smoke.yml",
+            anchor_pattern=r"windows-2025",
+        ),
+        Watch(
+            "docker-engine",
+            "29",
+            "Docker Engine major the rule premises are grounded on (ADR-028); "
+            "when it EOLs, re-ground scripts/validate_rule_premises.py on the "
+            "current engine and update the recorded posture",
+            anchor_file="docs/adr/028-pre-1.0-rule-id-sweep.md",
+            anchor_pattern=r"Docker Engine 29",
+        ),
     ]
+
+
+def main() -> int:
+    floor = python_floor((REPO / "pyproject.toml").read_text())
+    matrix = ci_matrix((REPO / ".github/workflows/ci.yml").read_text())
+    watches = build_watches(floor)
     today = dt.date.today()
     findings: list[Finding] = []
     payloads: dict[str, list[dict]] = {}

--- a/scripts/eol_watch.py
+++ b/scripts/eol_watch.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Report upstream end-of-life dates the project's platform floors are riding toward.
+
+The Python 3.10 drop (#643) showed the failure mode this exists to prevent:
+a platform EOL everyone can see coming still arrives "suddenly" unless
+something is watching the calendar, and post-1.0 the cost of being surprised
+is a forced MAJOR (or carrying an EOL interpreter inside the stability
+contract). Vulnerabilities have vuln-report.yml; release schedules had
+nothing.
+
+What it watches, against https://endoflife.date:
+
+- **python**, the `requires-python` floor — parsed live from pyproject.toml,
+  so the watch moves automatically when the floor does.
+- **python**, new stable minors missing from ci.yml's test matrix — the
+  ROADMAP commits to adding one within ~3 months of each October release.
+- **debian**, the Docker runtime base (distroless on Debian, ADR-009).
+- **ubuntu**, the CI runner image.
+
+The debian/ubuntu cycles are declared here rather than parsed, because they
+live in a Dockerfile comment and a dozen `runs-on:` lines respectively; each
+declaration carries a grep-able anchor and the script FAILS (exit 2) if the
+anchor no longer appears where it claims to — a stale watch is worse than no
+watch, because it reads as "covered" (the capability-drop-harness lesson:
+a check run against the wrong posture returns a confidently wrong answer).
+
+Exit codes: 0 = ran, nothing due. 1 = ran, at least one item due (report on
+stdout, ready for an issue body). 2 = the script itself could not produce a
+trustworthy answer (network, parse, stale anchor). eol-watch.yml turns 1 into
+a rolling issue and treats 2 as a workflow failure.
+
+Offline by design in tests: every function below the __main__ guard is pure
+(today and API payloads are parameters); only fetch()/main() touch the
+network and the filesystem.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime as dt
+import json
+import pathlib
+import re
+import sys
+import tomllib
+import urllib.request
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+API = "https://endoflife.date/api/{product}.json"
+
+# How far ahead of an EOL date an item becomes "due". Six months: long
+# enough to announce a deprecation, ship the warning release, honour the
+# one-MINOR grace period of docs/compatibility.md, and land the drop —
+# the whole #650/#643 sequence — without the calendar forcing the pace.
+WINDOW_DAYS = 180
+
+# ~3 months, the ROADMAP's window for adding a new CPython minor to the
+# CI matrix after its October release.
+MATRIX_ADD_DAYS = 92
+
+
+@dataclasses.dataclass(frozen=True)
+class Watch:
+    """One (product, cycle) pair the project depends on."""
+
+    product: str  # endoflife.date product slug
+    cycle: str  # e.g. "3.11", "13", "24.04"
+    role: str  # why the project cares, verbatim in the report
+    # Prove the declaration still matches the repo: `pattern` must appear in
+    # `anchor_file`. None for cycles parsed live (already self-proving).
+    anchor_file: str | None = None
+    anchor_pattern: str | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class Finding:
+    """One due item, renderable as a report bullet."""
+
+    headline: str
+    detail: str
+
+
+def python_floor(pyproject_text: str) -> str:
+    """The requires-python floor as a cycle string, e.g. ``3.11``."""
+    data = tomllib.loads(pyproject_text)
+    spec = data["project"]["requires-python"]
+    m = re.fullmatch(r">=\s*(\d+\.\d+)", spec)
+    if m is None:
+        raise ValueError(
+            f"requires-python is {spec!r}, not the '>=X.Y' form this watch "
+            "knows how to read — update eol_watch.py alongside the new form"
+        )
+    return m.group(1)
+
+
+def ci_matrix(ci_text: str) -> list[str]:
+    """The python-version matrix of ci.yml's test job."""
+    m = re.search(r'python-version:\s*\[([0-9.", ]+)\]', ci_text)
+    if m is None:
+        raise ValueError("no python-version matrix found in ci.yml")
+    return re.findall(r"\d+\.\d+", m.group(1))
+
+
+def check_anchor(watch: Watch, text: str) -> None:
+    """Fail loudly when a declared cycle no longer matches the repo."""
+    assert watch.anchor_pattern is not None
+    if not re.search(watch.anchor_pattern, text):
+        raise ValueError(
+            f"{watch.product} {watch.cycle}: anchor {watch.anchor_pattern!r} "
+            f"not found in {watch.anchor_file} — the declaration in "
+            "eol_watch.py is stale; update the Watch to match the repo"
+        )
+
+
+def _cycle_row(payload: list[dict], cycle: str) -> dict:
+    for row in payload:
+        if str(row.get("cycle")) == cycle:
+            return row
+    raise ValueError(f"cycle {cycle} not in endoflife.date payload")
+
+
+def _eol_date(row: dict) -> dt.date | None:
+    """The row's EOL as a date; None when not date-bounded (false/None)."""
+    eol = row.get("eol")
+    if isinstance(eol, str):
+        return dt.date.fromisoformat(eol)
+    return None  # false = "no EOL scheduled"; treat as not due
+
+
+def check_eol(watch: Watch, payload: list[dict], today: dt.date) -> Finding | None:
+    """A finding when the watched cycle's EOL is inside the window (or past)."""
+    eol = _eol_date(_cycle_row(payload, watch.cycle))
+    if eol is None:
+        return None
+    days = (eol - today).days
+    if days > WINDOW_DAYS:
+        return None
+    if days < 0:
+        when = f"reached upstream EOL {-days} days ago"
+    else:
+        when = f"reaches upstream EOL in {days} days"
+    return Finding(
+        headline=f"{watch.product} {watch.cycle} {when} ({eol.isoformat()})",
+        detail=(
+            f"Used as: {watch.role}. Per docs/compatibility.md, announce the "
+            "deprecation, warn at runtime, honour one MINOR of grace, then "
+            "move the floor — start now so the calendar does not set the pace."
+        ),
+    )
+
+
+def check_new_python(
+    payload: list[dict], matrix: list[str], today: dt.date
+) -> list[Finding]:
+    """Findings for released stable CPython minors absent from the CI matrix."""
+    findings = []
+    ceiling = max(tuple(int(p) for p in v.split(".")) for v in matrix)
+    for row in payload:
+        cycle = str(row.get("cycle"))
+        release = row.get("releaseDate")
+        if cycle in matrix or not isinstance(release, str):
+            continue
+        try:
+            if tuple(int(p) for p in cycle.split(".")) <= ceiling:
+                continue  # older than the matrix ceiling: dropped, not pending
+        except ValueError:
+            continue  # non-numeric cycle (endoflife.date has none for python)
+        released = dt.date.fromisoformat(release)
+        age = (today - released).days
+        if age < 0:
+            continue  # not released yet
+        overdue = "OVERDUE — " if age > MATRIX_ADD_DAYS else ""
+        findings.append(
+            Finding(
+                headline=(
+                    f"{overdue}Python {cycle} released {age} days ago "
+                    f"({release}) and is not in the CI matrix"
+                ),
+                detail=(
+                    "docs/ROADMAP.md commits to adding each new minor within "
+                    f"~3 months of release; adding one is a PATCH. Matrix: {matrix}."
+                ),
+            )
+        )
+    return findings
+
+
+def render(findings: list[Finding]) -> str:
+    lines = [
+        "Platform end-of-life radar — produced by scripts/eol_watch.py",
+        f"(window: {WINDOW_DAYS} days; data: endoflife.date)",
+        "",
+    ]
+    for f in findings:
+        lines += [f"- **{f.headline}**", f"  {f.detail}"]
+    return "\n".join(lines) + "\n"
+
+
+def fetch(product: str) -> list[dict]:
+    with urllib.request.urlopen(API.format(product=product), timeout=30) as resp:
+        return json.load(resp)
+
+
+def main() -> int:
+    floor = python_floor((REPO / "pyproject.toml").read_text())
+    matrix = ci_matrix((REPO / ".github/workflows/ci.yml").read_text())
+    watches = [
+        Watch("python", floor, "requires-python floor (pyproject.toml)"),
+        Watch(
+            "debian",
+            "13",
+            "Docker runtime base image, distroless on Debian (ADR-009)",
+            anchor_file="Dockerfile",
+            anchor_pattern=r"Debian 13|trixie",
+        ),
+        Watch(
+            "ubuntu",
+            "24.04",
+            "GitHub Actions CI runner image",
+            anchor_file=".github/workflows/ci.yml",
+            anchor_pattern=r"ubuntu-24\.04",
+        ),
+    ]
+    today = dt.date.today()
+    findings: list[Finding] = []
+    payloads: dict[str, list[dict]] = {}
+    for w in watches:
+        if w.anchor_file is not None:
+            check_anchor(w, (REPO / w.anchor_file).read_text())
+        payloads.setdefault(w.product, fetch(w.product))
+        if (f := check_eol(w, payloads[w.product], today)) is not None:
+            findings.append(f)
+    findings += check_new_python(payloads["python"], matrix, today)
+    if not findings:
+        print("Nothing due within the window.")
+        return 0
+    print(render(findings))
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:  # noqa: BLE001 — exit 2 must cover every failure
+        print(f"eol_watch: cannot produce a trustworthy answer: {exc}", file=sys.stderr)
+        sys.exit(2)

--- a/tests/test_eol_watch.py
+++ b/tests/test_eol_watch.py
@@ -1,0 +1,173 @@
+"""scripts/eol_watch.py — the pure logic, offline.
+
+The script's contract is three-valued (0 nothing due / 1 due / 2 cannot
+answer), and the dangerous failure is the third case masquerading as the
+first: a stale declaration or an unparseable floor silently reporting
+"nothing due". These tests pin the loud-failure paths as hard as the
+happy paths.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "eol_watch",
+    pathlib.Path(__file__).resolve().parent.parent / "scripts" / "eol_watch.py",
+)
+assert _SPEC is not None and _SPEC.loader is not None
+eol_watch = importlib.util.module_from_spec(_SPEC)
+sys.modules["eol_watch"] = eol_watch
+_SPEC.loader.exec_module(eol_watch)
+
+TODAY = dt.date(2026, 8, 23)
+
+
+def _python_payload() -> list[dict[str, object]]:
+    return [
+        {"cycle": "3.15", "releaseDate": "2026-10-01", "eol": "2031-10-31"},
+        {"cycle": "3.14", "releaseDate": "2025-10-07", "eol": "2030-10-31"},
+        {"cycle": "3.11", "releaseDate": "2022-10-24", "eol": "2027-10-31"},
+        {"cycle": "3.10", "releaseDate": "2021-10-04", "eol": "2026-10-31"},
+    ]
+
+
+class TestPythonFloor:
+    def test_reads_the_floor(self) -> None:
+        text = '[project]\nrequires-python = ">=3.11"\n'
+        assert eol_watch.python_floor(text) == "3.11"
+
+    def test_unknown_spec_form_fails_loudly(self) -> None:
+        """A form the regex cannot read must raise, never guess.
+
+        `>=3.11,<4` would silently become "no watch on the floor" if the
+        parse returned None anywhere — the stale-anchor failure mode.
+        """
+        text = '[project]\nrequires-python = ">=3.11,<4"\n'
+        with pytest.raises(ValueError, match="requires-python"):
+            eol_watch.python_floor(text)
+
+
+class TestCiMatrix:
+    def test_reads_the_matrix(self) -> None:
+        text = '        python-version: ["3.11", "3.12", "3.13", "3.14"]\n'
+        assert eol_watch.ci_matrix(text) == ["3.11", "3.12", "3.13", "3.14"]
+
+    def test_missing_matrix_fails_loudly(self) -> None:
+        with pytest.raises(ValueError, match="matrix"):
+            eol_watch.ci_matrix("jobs: {}\n")
+
+
+class TestAnchor:
+    def test_stale_declaration_fails_loudly(self) -> None:
+        watch = eol_watch.Watch(
+            "debian", "13", "base", anchor_file="Dockerfile", anchor_pattern=r"trixie"
+        )
+        with pytest.raises(ValueError, match="stale"):
+            eol_watch.check_anchor(watch, "FROM debian:forky-slim\n")
+
+    def test_matching_anchor_passes(self) -> None:
+        watch = eol_watch.Watch(
+            "debian", "13", "base", anchor_file="Dockerfile", anchor_pattern=r"trixie"
+        )
+        eol_watch.check_anchor(watch, "FROM debian:trixie-slim\n")
+
+
+class TestCheckEol:
+    def test_far_eol_is_not_due(self) -> None:
+        watch = eol_watch.Watch("python", "3.11", "floor")
+        assert eol_watch.check_eol(watch, _python_payload(), TODAY) is None
+
+    def test_eol_inside_window_is_due(self) -> None:
+        watch = eol_watch.Watch("python", "3.10", "floor")
+        finding = eol_watch.check_eol(watch, _python_payload(), TODAY)
+        assert finding is not None
+        assert "3.10" in finding.headline
+        assert "2026-10-31" in finding.headline
+
+    def test_past_eol_says_so(self) -> None:
+        watch = eol_watch.Watch("python", "3.10", "floor")
+        finding = eol_watch.check_eol(watch, _python_payload(), dt.date(2026, 12, 1))
+        assert finding is not None
+        assert "ago" in finding.headline
+
+    def test_unscheduled_eol_is_not_due(self) -> None:
+        """endoflife.date uses `false` for "no EOL scheduled" — not a date."""
+        watch = eol_watch.Watch("x", "1", "y")
+        assert eol_watch.check_eol(watch, [{"cycle": "1", "eol": False}], TODAY) is None
+
+    def test_unknown_cycle_fails_loudly(self) -> None:
+        watch = eol_watch.Watch("python", "9.9", "floor")
+        with pytest.raises(ValueError, match="9.9"):
+            eol_watch.check_eol(watch, _python_payload(), TODAY)
+
+
+class TestNewPython:
+    def test_released_minor_missing_from_matrix_is_reported(self) -> None:
+        found = eol_watch.check_new_python(
+            _python_payload(), ["3.11", "3.12", "3.13"], TODAY
+        )
+        # 3.14 released 2025-10, absent, well past the 3-month window. 3.10
+        # is also absent but sits below the matrix ceiling — dropped, not
+        # pending — so it must NOT report here.
+        headlines = " ".join(f.headline for f in found)
+        assert "Python 3.14" in headlines
+        assert "OVERDUE" in headlines
+        assert "3.10" not in headlines
+
+    def test_future_minor_is_ignored(self) -> None:
+        found = eol_watch.check_new_python(
+            _python_payload(), ["3.10", "3.11", "3.14"], dt.date(2026, 9, 1)
+        )
+        assert all("3.15" not in f.headline for f in found)
+
+    def test_fresh_minor_is_reported_without_overdue(self) -> None:
+        found = eol_watch.check_new_python(
+            _python_payload(), ["3.10", "3.11", "3.14"], dt.date(2026, 10, 15)
+        )
+        (f,) = [f for f in found if "3.15" in f.headline]
+        assert "OVERDUE" not in f.headline
+
+    def test_full_matrix_reports_nothing(self) -> None:
+        assert (
+            eol_watch.check_new_python(
+                _python_payload(), ["3.10", "3.11", "3.14", "3.15"], TODAY
+            )
+            == []
+        )
+
+
+class TestAgainstTheRealRepo:
+    """The live declarations stay parseable and anchored, offline."""
+
+    def test_floor_parses(self) -> None:
+        text = (eol_watch.REPO / "pyproject.toml").read_text()
+        assert eol_watch.python_floor(text)
+
+    def test_matrix_parses_and_contains_floor(self) -> None:
+        floor = eol_watch.python_floor((eol_watch.REPO / "pyproject.toml").read_text())
+        matrix = eol_watch.ci_matrix(
+            (eol_watch.REPO / ".github/workflows/ci.yml").read_text()
+        )
+        assert floor in matrix
+
+    def test_declared_anchors_hold(self) -> None:
+        for watch in [
+            eol_watch.Watch("debian", "13", "base", "Dockerfile", r"Debian 13|trixie"),
+            eol_watch.Watch(
+                "ubuntu",
+                "24.04",
+                "runner",
+                ".github/workflows/ci.yml",
+                r"ubuntu-24\.04",
+            ),
+        ]:
+            assert watch.anchor_file is not None
+            eol_watch.check_anchor(
+                watch, (eol_watch.REPO / watch.anchor_file).read_text()
+            )

--- a/tests/test_eol_watch.py
+++ b/tests/test_eol_watch.py
@@ -157,17 +157,14 @@ class TestAgainstTheRealRepo:
         assert floor in matrix
 
     def test_declared_anchors_hold(self) -> None:
-        for watch in [
-            eol_watch.Watch("debian", "13", "base", "Dockerfile", r"Debian 13|trixie"),
-            eol_watch.Watch(
-                "ubuntu",
-                "24.04",
-                "runner",
-                ".github/workflows/ci.yml",
-                r"ubuntu-24\.04",
-            ),
-        ]:
-            assert watch.anchor_file is not None
+        """Every anchored Watch in the real declaration list still matches.
+
+        Iterates build_watches() itself rather than a copy, so adding a
+        watch with a bad anchor fails here before the monthly run does."""
+        floor = eol_watch.python_floor((eol_watch.REPO / "pyproject.toml").read_text())
+        anchored = [w for w in eol_watch.build_watches(floor) if w.anchor_file]
+        assert anchored, "expected at least one anchored watch"
+        for watch in anchored:
             eol_watch.check_anchor(
                 watch, (eol_watch.REPO / watch.anchor_file).read_text()
             )


### PR DESCRIPTION
Stacked on #699 (the script needs `tomllib`, stdlib from 3.11, and its test would fail collection on a 3.10 matrix leg). When #699 merges this retargets to `main` automatically — **review only the top commit until then**.

The Python 3.10 drop showed the failure mode this closes: a platform EOL everyone can see coming still arrives "suddenly" unless something watches the calendar, and post-1.0 the cost of surprise is a forced MAJOR or an EOL interpreter inside the stability contract. Vulnerabilities have vuln-report.yml; release schedules had nothing.

## What it watches (monthly, against endoflife.date)

- **requires-python floor** — parsed live from pyproject.toml so the watch moves when the floor does; due within **180 days** of EOL, sized to fit the whole compatibility.md deprecation lifecycle (announce → warn → one MINOR of grace → drop) in front of the date
- **New CPython minors** missing from ci.yml's matrix (ROADMAP's ~3-month add window) — only *above* the matrix ceiling; older absent minors are dropped, not pending
- **Debian 13** (Docker runtime base, ADR-009) and **ubuntu-24.04** (CI runner) — declared with grep-able anchors that fail the run (exit 2) when the declaration goes stale, because a radar that silently stops sweeping reads as all-clear

## Mechanics

- Exit contract: 0 nothing due / 1 due (report on stdout) / 2 cannot produce a trustworthy answer
- One rolling issue, vuln-report.yml's exact pattern (open when due, comment while due, close on first clean run); exit 2 fails the run and reports as its own issue
- Stdlib-only: no installs, nothing added to the lockfile/hash-pinning surface
- Logic is pure and offline under test (`tests/test_eol_watch.py`, 18 tests, loud-failure paths pinned); only `fetch()`/`main()` touch network/filesystem
- Live run today (pre-#699 tree): correctly reported "python 3.10 reaches upstream EOL in 69 days" and nothing else — the radar would have caught #643's deadline on its own

No CHANGELOG entry: linter behavior is unchanged; this is maintainer-facing CI.