### PR TITLE
Make a scheduled Python-EOL drop MINOR post-1.0 (ADR-029)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now 3.11–3.14, and the lockfiles are regenerated at the new floor (the only
   change is that 3.10-only backport dependencies drop out; no version moves).
 
+- **A scheduled Python-EOL drop is now MINOR, post-1.0 included**
+  ([ADR-029](docs/adr/029-scheduled-python-drops-are-minor.md)). MAJOR
+  signals surprise; a drop whose date CPython published years ahead, that
+  warned on stderr for at least 180 days and one MINOR of grace, and that
+  ships no earlier than upstream EOL, surprises nobody — and
+  `requires-python` cannot break an existing environment (pip resolves an
+  affected interpreter to the last release that allowed it). An
+  off-schedule drop stays MAJOR. This closes the trap #643 had to
+  outrun, permanently: 3.11's October 2027 EOL will be a routine MINOR,
+  not a forced 2.0.
+
 ### Removed
 
 - **The Python 3.10 deprecation warning** added in 0.22.0. It existed to reach

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -101,7 +101,9 @@ Once `1.0.0` ships, the contract tightens:
     fail CI for pinned users).
   - Restructuring JSON/SARIF output in a way that removes or renames
     existing fields.
-  - Dropping support for a Python version listed in `pyproject.toml`.
+  - Dropping support for a Python version *off-schedule* — before its
+    upstream EOL, or without ADR-029's announcement runway. A *scheduled*
+    drop is MINOR (see the cheat sheet).
 
 ### Judgment-call cheat sheet
 
@@ -118,7 +120,8 @@ Once `1.0.0` ships, the contract tightens:
 | Remove or rename a CLI flag                  | MINOR   | MAJOR    |
 | Retire a rule ID                             | MINOR   | MAJOR    |
 | Change the default `--fail-on` threshold     | MINOR   | MAJOR    |
-| Drop a Python version                        | MINOR   | MAJOR    |
+| Drop a Python version on schedule (ADR-029)  | MINOR   | MINOR    |
+| Drop a Python version off-schedule           | MINOR   | MAJOR    |
 | Add a field to JSON/SARIF output             | MINOR   | MINOR    |
 | Remove or rename a JSON/SARIF field          | MINOR   | MAJOR    |
 | Remove or rename a config key                | MINOR   | MAJOR    |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -122,7 +122,7 @@ Pursue based on user demand after v1.0.
 
 ## Python version support
 
-Track current CPython: add new minor versions to the CI matrix within ~3 months of each October release, drop versions at upstream end-of-life. Adding a version is additive (PATCH per `docs/RELEASING.md`); dropping a version is a MINOR pre-1.0 and a MAJOR post-1.0.
+Track current CPython: add new minor versions to the CI matrix within ~3 months of each October release, drop versions at upstream end-of-life. Adding a version is additive (PATCH per `docs/RELEASING.md`); a scheduled drop — announced ≥180 days ahead with the runtime warning, shipping no earlier than upstream EOL — is a MINOR at any point ([ADR-029](adr/029-scheduled-python-drops-are-minor.md)). The eol-watch workflow files the announcement issue when a floor enters its final 180 days.
 
 | Version | Released  | EOL       | In matrix as of |
 |---------|-----------|-----------|-----------------|

--- a/docs/adr/029-scheduled-python-drops-are-minor.md
+++ b/docs/adr/029-scheduled-python-drops-are-minor.md
@@ -1,0 +1,70 @@
+# ADR-029: A Scheduled Python-EOL Drop Is MINOR, Post-1.0 Included
+
+**Status:** Accepted
+
+**Context:** Until this ADR, dropping a supported Python version was MINOR
+pre-1.0 and MAJOR post-1.0. The Python 3.10 drop
+([#643](https://github.com/tmatens/compose-lint/issues/643), shipped ahead of
+the interpreter's October 2026 upstream EOL) showed what that rule costs: the
+ordering of an unrelated release — the 1.0 cut — had to bend around a routine
+calendar event, because landing the drop after 1.0 would have forced a choice
+between a 2.0 that communicates nothing about the tool's contract and carrying
+an end-of-life interpreter inside the stability promise indefinitely. CPython
+minors EOL every October, forever; under the old rule every one of them is a
+potential forced MAJOR, and 3.11 (October 2027) would have recreated the trap
+about a year after any plausible 1.0.
+
+MAJOR exists to signal *surprise*: a pinned, working setup breaks because the
+tool changed underneath it. A Python drop at upstream EOL is the opposite of a
+surprise — the date is published by CPython half a decade in advance, the
+[EOL radar](../../.github/workflows/eol-watch.yml) surfaces it 180 days out,
+the release that announces the deprecation warns on stderr from every run on
+the affected interpreter, and at least one MINOR of grace passes before the
+drop. It is also the *softest* removal the tool performs: `requires-python`
+never breaks an existing environment — pip resolves an affected interpreter to
+the last release that allowed it, so a pinned setup keeps working verbatim and
+even an unpinned `pip install -U` keeps working, frozen, rather than failing.
+
+**Decision:** Dropping a CPython minor is a **MINOR** change at any point in
+the project's life, provided the drop is *scheduled* — all of:
+
+1. The interpreter has reached, or reaches within the release's support
+   window, its published upstream end-of-life; the drop ships **no earlier
+   than the upstream EOL date**.
+2. The deprecation was announced in `CHANGELOG.md` and warned on stderr at
+   runtime, both starting **at least 180 days** before the drop ships (the
+   radar's window — sized so announce → warn → grace → drop runs at a
+   calendar pace, not a version-count pace; the 3.10 cycle's one-day gap
+   between warning release and eligible drop is the failure mode the floor
+   exists to prevent).
+3. At least one MINOR release carried the warning before the release that
+   drops.
+
+A drop that misses any condition — an interpreter dropped before its EOL, or
+without the announcement runway — is **MAJOR**, post-1.0. The schedule is the
+license for the smaller bump.
+
+**Rationale:**
+
+- The pre-EOL exception #643 used was justified by 1.0 ordering pressure that
+  no longer exists once 1.0 ships; anchoring post-1.0 drops to the EOL date
+  keeps the policy defensible against its sharpest criticism (an Ubuntu
+  22.04 user's system Python losing updates while the OS is still supported).
+- This follows the same reasoning as "new findings are not a breaking change"
+  (compatibility.md): the contract promises *no surprises*, not *no change*,
+  and names the escape hatch — pin the version — which a `requires-python`
+  drop uniquely cannot break.
+- A security linter carrying an interpreter that no longer receives security
+  fixes inside its own stability contract is the wrong trade in both
+  directions.
+
+**Consequences:**
+
+- `docs/compatibility.md` (Python versions, deprecation lifecycle),
+  `docs/RELEASING.md` (post-1.0 rules and the cheat sheet) and
+  `docs/ROADMAP.md` (Python version support) are amended alongside this ADR.
+- The deprecation lifecycle's "removal happens only in a MAJOR" gains its one
+  carve-out, stated there: a scheduled interpreter drop per this ADR.
+- The 3.11 drop (EOL October 2027) will be the first exercise: announce and
+  start warning by ~April 2027 (the radar files the issue), drop in the first
+  MINOR on or after the EOL date.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -63,7 +63,9 @@ field, rule, or supported Python version is slated for removal:
 3. **Grace period** — the deprecated surface keeps working for **at least one
    MINOR release** after the announcement.
 4. **Remove** — removal happens only in a **MAJOR** release, listed under
-   `Removed` in `CHANGELOG.md`.
+   `Removed` in `CHANGELOG.md`. One carve-out: a *scheduled* Python
+   interpreter drop ships as a MINOR under the conditions of
+   [ADR-029](adr/029-scheduled-python-drops-are-minor.md).
 
 Two things are never reused or quietly repurposed:
 
@@ -91,9 +93,15 @@ construction.
 
 Supported CPython versions track upstream: a version is added to the matrix
 within ~3 months of its October release (additive), and dropped at upstream
-end-of-life. Dropping a version is a MAJOR change post-1.0. The authoritative
-list is `requires-python` in `pyproject.toml`; see the
-[roadmap](ROADMAP.md#python-version-support) for the schedule.
+end-of-life. A *scheduled* drop — announced and warning at runtime for at
+least 180 days and one MINOR release, shipping no earlier than the upstream
+EOL date — is a **MINOR** change, post-1.0 included
+([ADR-029](adr/029-scheduled-python-drops-are-minor.md)): the date is
+published by CPython years ahead, and the change cannot break a pinned or
+even an unpinned environment (see below). An *unscheduled* drop remains
+MAJOR post-1.0. The authoritative list is `requires-python` in
+`pyproject.toml`; see the [roadmap](ROADMAP.md#python-version-support) for
+the schedule.
 
 A drop follows the [deprecation lifecycle](#deprecation-lifecycle) above: the
 release that announces it warns on stderr when run on that interpreter, and the


### PR DESCRIPTION
The policy piece of the pre-1.0 sequence: a Python support calendar everyone sees coming should not force a 2.0.

**The rule:** dropping a CPython minor is **MINOR at any point** when the drop is *scheduled* — all of:
1. ships **no earlier than the upstream EOL date**;
2. announced in the CHANGELOG **and warning on stderr for ≥180 days** before the drop (the eol-watch radar's window, so the cycle runs at calendar pace — the 3.10 cycle's one-day announce-to-eligible gap is the failure mode the floor prevents);
3. at least one MINOR carried the warning first.

Anything off-schedule (pre-EOL, or without the runway) stays MAJOR post-1.0.

**Why it's sound:** MAJOR signals surprise; an EOL published half a decade ahead surprises nobody, and `requires-python` is the softest removal the tool performs — it cannot break a pinned *or* unpinned environment (pip resolves an affected interpreter to the last allowed release). Same shape as the existing "new findings are not a breaking change" reasoning. The pre-EOL latitude #643 used is deliberately *not* carried into post-1.0: anchoring to the EOL date answers the sharpest criticism (Ubuntu 22.04's system Python outliving 3.10 support).

**Touches:** new ADR-029; compatibility.md (Python versions + the deprecation lifecycle's one carve-out); RELEASING.md (post-1.0 MAJOR list + cheat-sheet rows); ROADMAP (support section); CHANGELOG.

First exercise will be 3.11 (EOL Oct 2027): radar files the announcement issue ~Apr 2027, drop ships in the first MINOR on or after the date.

This is a 1.0 blocker in the practical sense: it must be in force before the freeze closes over the old wording.