### PR TITLE
Make the compatibility policy part of the contract (ADR-030)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   outrun, permanently: 3.11's October 2027 EOL will be a routine MINOR,
   not a forced 2.0.
 
+- **The compatibility policy is now part of the contract**
+  ([ADR-030](docs/adr/030-the-policy-is-part-of-the-contract.md)). Amending
+  it requires an ADR; clarifications ship in any release, tightenings are a
+  MINOR, and loosenings are a MAJOR and never retroactive — the promise can
+  no longer be weakened by a docs-only patch. Alongside it, the PATCH
+  definition is clarified (a false-positive fix removes *incorrect* findings
+  and stays a PATCH) and the severity-upgrade rule records its sanctioned
+  MINOR alternative, the ADR-028 split pattern.
+
 ### Removed
 
 - **The Python 3.10 deprecation warning** added in 0.22.0. It existed to reach

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -79,9 +79,11 @@ slot does the work that MAJOR does post-1.0.
 Once `1.0.0` ships, the contract tightens:
 
 - **PATCH** (`1.2.3 → 1.2.4`) — bug fixes that don't change which
-  findings are emitted for a given input. If the set of findings a
-  user sees on an unchanged Compose file could change, it's not a
-  patch.
+  *correct* findings are emitted for a given input. Removing findings
+  the old behavior emitted in error — a false positive, a crash — is a
+  fix (the cheat sheet below says so too); if the set of correct
+  findings a user sees on an unchanged Compose file could change, it's
+  not a patch.
 - **MINOR** (`1.2.3 → 1.3.0`) — additive or backward-compatible
   changes. New rules, new CLI flags, new config keys, severity
   *downgrades*, new formatters, additive fields in JSON/SARIF output.
@@ -98,7 +100,12 @@ Once `1.0.0` ships, the contract tightens:
   - Changing the exit-code contract (e.g., adding a new non-zero
     exit code, changing the default `--fail-on` threshold).
   - Severity *upgrades* on existing rules (`LOW → HIGH` can newly
-    fail CI for pinned users).
+    fail CI for pinned users). The sanctioned MINOR alternative is the
+    split pattern (CL-0011 → CL-0024, CL-0013 → CL-0025): move the
+    higher-tier subset into a *new* rule ID, which is a rule addition —
+    and existing suppressions of the old ID never silently cover the
+    new, more dangerous rule (ADR-028 records why that direction is the
+    safe one).
   - Restructuring JSON/SARIF output in a way that removes or renames
     existing fields.
   - Dropping support for a Python version *off-schedule* — before its

--- a/docs/adr/030-the-policy-is-part-of-the-contract.md
+++ b/docs/adr/030-the-policy-is-part-of-the-contract.md
@@ -1,0 +1,44 @@
+# ADR-030: The Compatibility Policy Is Part of the Contract
+
+**Status:** Accepted
+
+**Context:** `docs/compatibility.md` promises users what stays stable and how
+change is signalled; users choose version ranges (`>=1.0,<2`, unpinned Action
+majors) based on those promises. But the policy said nothing about changing
+*itself*. Under the bump table a policy edit is a docs-only change — a PATCH —
+so the promise could be weakened by the one release class that asserts
+"nothing changed": reclassify severity upgrades as MINOR in a patch release,
+and the next MINOR breaks the user who chose their range because the old
+policy said upgrades were MAJOR. [ADR-029](029-scheduled-python-drops-are-minor.md)
+showed the mechanism in the benign direction — an ADR amending the policy —
+but nothing recorded what an amendment may do post-1.0 or what it costs.
+
+**Decision:** The policy is part of the 1.0 surface. Amendments require an
+ADR, and the required bump follows the amendment's direction:
+
+- **Clarification** (same obligations, better words) — any release.
+- **Tightening** (promising more) — MINOR.
+- **Loosening** (promising less) — **MAJOR**, never retroactive: a change
+  already shipped is judged under the policy in force when it shipped.
+
+**Rationale:** A loosening breaks exactly the users the contract exists for —
+those who relied on the stronger promise when choosing how to depend on the
+tool — which is the definition of a MAJOR. The alternative (loosenings take
+effect after an announced runway, as a MINOR) was considered and declined:
+it would let the promise erode by increments, and the maintainer judged that
+a contract whose weakenings are cheap is not much of a contract. The cost is
+accepted knowingly: a future ADR-029-shaped change — one that *relaxes* a
+bump rule, however well-argued — waits for a 2.0 once 1.0 ships. That is the
+last pre-1.0 window closing deliberately, the same shape as ADR-028's
+reclamation window.
+
+**Consequences:**
+
+- `docs/compatibility.md` gains the "Changing this policy" section stating
+  the rule; the PATCH definition in `docs/RELEASING.md` is clarified (a
+  false-positive fix removes *incorrect* findings and stays a PATCH), and
+  the severity-upgrade MAJOR bullet records the sanctioned MINOR
+  alternative — the ADR-028 split pattern — so the pressure valve is a
+  documented design choice rather than a loophole.
+- Any further loosening anyone wants (severity-upgrade semantics included)
+  must land **before 1.0** or wait for 2.0.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -75,6 +75,21 @@ Two things are never reused or quietly repurposed:
 - **Exit-code meanings** — `0` / `1` / `2` keep their meanings; adding a new
   non-zero code is a MAJOR change.
 
+## Changing this policy
+
+This policy is itself part of the 1.0 surface: users choose version ranges
+based on what it promises, so the promise cannot be quietly rewritten by a
+"docs-only" release. Amendments require an ADR
+([ADR-030](adr/030-the-policy-is-part-of-the-contract.md)), and the bump an
+amendment requires depends on its direction:
+
+- **Clarifications** — same obligations, better words — may ship in any
+  release.
+- **Tightenings** — promising more than before — are a MINOR.
+- **Loosenings** — promising less than before — are a **MAJOR**, and are
+  never retroactive: a change already shipped is judged under the policy in
+  force when it shipped.
+
 ## Operating systems
 
 Linux is the fully gated platform: every PR runs the complete suite there


### PR DESCRIPTION
Closes the meta-loophole: the compatibility policy promises what users rely on when choosing version ranges, but a policy edit was classified as docs-only — a PATCH — so the promise could be weakened by the one release class that asserts nothing changed.

**The rule (new `Changing this policy` section + ADR-030):** amendments require an ADR;
- **clarifications** (same obligations) — any release
- **tightenings** (promising more) — MINOR
- **loosenings** (promising less) — **MAJOR**, never retroactive

The runway-then-MINOR alternative was considered and declined (recorded in the ADR): a contract whose weakenings are cheap is not much of a contract. Consequence accepted knowingly: any future ADR-029-shaped relaxation lands before 1.0 or waits for 2.0 — this is the last pre-1.0 window closing deliberately, same shape as ADR-028's.

**Two clarifications ride along** (both cheap now, contract-adjacent later):
- PATCH definition no longer contradicts its own cheat sheet — a false-positive fix removes *incorrect* findings and stays a PATCH
- The severity-upgrade MAJOR bullet documents the sanctioned MINOR alternative: the ADR-028 split pattern (new ID for the higher tier, so old suppressions never silently cover the more dangerous rule)