### PR TITLE
Publish a moving Action major tag from the release pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,11 @@ name: Publish
 on:
   push:
     tags:
-      - "v*"
+      # Full release tags only (annotated, signed, verified below). The
+      # moving major tag (v1, v2, ...) that action-major-tag force-pushes
+      # after a release must NOT re-trigger this pipeline — it is a
+      # lightweight convenience pointer, not a release.
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 # Deny-all at the workflow level; every job declares the scopes it needs.
 permissions: {}
@@ -931,3 +935,39 @@ jobs:
             --head "${branch}" \
             --title "Bump marketplace-smoke pin to ${TAG}" \
             --body-file /tmp/pr-body.md
+
+  # Move the floating Action major tag (uses: tmatens/compose-lint@v1) to
+  # this release once everything above has published and verified. Only for
+  # 1.0.0 and later — v0 releases publish no major tag, mirroring the Docker
+  # metadata rule above (`enable=!v0.`).
+  #
+  # Deliberately a LIGHTWEIGHT tag pushed with the workflow token, not a
+  # signed annotated tag: the SSH release-signing key stays offline with the
+  # maintainer (verify-tag exists to catch tags a stolen credential could
+  # mint, so CI must never hold that key). The signed, immutable claim is
+  # the release tag; the major tag is a mutable convenience pointer and is
+  # documented as such (docs/hardening.md) — consumers who want integrity
+  # pin the SHA or the exact version, exactly as this repo's own workflows
+  # do. Trigger filter above excludes "v1" so this push cannot re-enter the
+  # pipeline. If GitHub's immutable-releases setting is ever enabled, keep
+  # this tag detached from any Release object or the force-push is refused.
+  action-major-tag:
+    needs: verify-release-signatures
+    if: ${{ !startsWith(github.ref_name, 'v0.') }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: true
+      - name: Force-move the major tag to this release
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          major="${TAG%%.*}"   # v1.2.3 -> v1
+          git tag -f "${major}" "${GITHUB_SHA}"
+          git push -f origin "refs/tags/${major}"
+          echo "Moved ${major} -> ${TAG} (${GITHUB_SHA})"

--- a/README.md
+++ b/README.md
@@ -438,6 +438,15 @@ jobs:
           sarif-file: results.sarif
 ```
 
+The `uses:` line pins a commit SHA with the version in a trailing comment —
+the supply-chain-rigorous form (it is what OpenSSF Scorecard grades for, and
+Renovate/Dependabot keep the pin fresh). From 1.0 a floating major tag also
+exists — `uses: tmatens/compose-lint@v1` — for setups that prefer automatic
+updates: it is a mutable pointer moved by the release pipeline, deliberately
+*not* part of the signed-tag guarantee that release tags carry, which is the
+same trade this linter itself prices in CL-0004/CL-0019. Pick the form that
+matches your threat model; the SHA pin is the recommended default.
+
 The `permissions:` blocks are part of the recipe, not decoration. Without them the
 job inherits the repository default, which on many repositories is still
 read-write for every scope — so a linting job that needs only `contents: read`

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -27,6 +27,7 @@ Most of this checklist is now wired into CI. At a glance:
 | PyPI + Docker Hub publish              | `publish.yml`                                      |
 | GitHub Release created from CHANGELOG  | `publish.yml` → `create-release` job               |
 | Marketplace-smoke pin bump PR          | `publish.yml` → `bump-marketplace-smoke-pin` job   |
+| Moving `v1` Action tag (1.0+ releases) | `publish.yml` → `action-major-tag` job (lightweight, unsigned by design — see the job comment) |
 | Merge pin bump PR, re-run smoke        | **Manual**                                         |
 
 Tag creation stays manual on purpose. Tags created by `GITHUB_TOKEN`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -92,7 +92,7 @@ v1.0 is the **stability commitment**: the CLI surface, exit codes, configuration
 - **Grounding + severity audit complete** — _done for severity._ Every rule cites OWASP/CIS/Docker and derives its severity from the documented model (Milestone 3.5). What remains before the freeze is confirming no further severity change is pending that would alter a CI gate.
 - **Documented upgrade/deprecation policy** — the SemVer stability promise (rule additions, severity changes, config and output-shape changes) and the deprecation lifecycle, in [compatibility.md](compatibility.md).
 
-**At GA:** bump the PyPI classifier from `4 - Beta` to `5 - Production/Stable` in the version→1.0.0 commit, and publish a moving `v1` Action tag so users can pin `uses: tmatens/compose-lint@v1`.
+**At GA:** bump the PyPI classifier from `4 - Beta` to `5 - Production/Stable` in the version→1.0.0 commit. The moving `v1` Action tag needs no separate step: publish.yml's `action-major-tag` job force-moves the major tag on every non-v0 release (lightweight and unsigned by design — the signed claim is the release tag; README documents the trade).
 
 ---
 


### PR DESCRIPTION
Implements the roadmap's at-GA `v1` tag promise as machinery, closing pre-1.0 item 2 (decision: option A).

- **Trigger scoped**: publish.yml fires only on `v[0-9]+.[0-9]+.[0-9]+`, so the moving tag can never re-enter the pipeline or hit verify-tag's signed-annotated gate.
- **`action-major-tag` job**: after `verify-release-signatures`, non-v0 only, force-moves the lightweight major tag with the job-scoped workflow token (top-level deny-all preserved → Scorecard Token-Permissions unaffected).
- **Unsigned by design**: the release-signing key stays offline — verify-tag exists to catch stolen-credential tags, so CI must never hold it. The signed immutable claim remains the release tag; the job comment and README both record the trade.
- **README**: SHA pin documented as the recommended default, `@v1` as the convenience tier — same pricing the linter itself applies via CL-0004/CL-0019.
- **Inert until 1.0.0** (every current release is v0.x). No CHANGELOG entry: no released behavior changes.

Mirrors the existing Docker metadata rule that already publishes a moving `:1` image tag for non-v0 releases (publish.yml docker-publish semver patterns).