### PR TITLE
Declare rule_id opaque before the output contract freezes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   retired ID keeps working, `--strict-config` included (a precondition the
   config layer gains before the first such retirement). "Noisy" remains a
   non-reason (ADR-028).
+- **`rule_id` / `ruleId` in machine output is declared opaque.** Every value
+  today matches `CL-\d{4}`, but the pattern was never promised and is now
+  explicitly excluded from the 1.0 contract: match exact ids, not the
+  prefix. Declared before the freeze, while it is still a clarification
+  rather than a contract change; it keeps a future rule source with
+  differently-shaped ids (e.g. shellcheck's `SC` codes, ADR-007) additive.
 
 ### Removed
 

--- a/docs/adr/015-machine-readable-output-contract.md
+++ b/docs/adr/015-machine-readable-output-contract.md
@@ -70,3 +70,13 @@ the auto-fix work in [ADR-014](014-fix-remediation.md).
   envelope makes it a safe additive change whenever one does. Freezing its
   exact shape (count semantics, severity keys) at 1.0 with no demand is
   unnecessary surface.
+
+**Amendment (pre-1.0 freeze):** `rule_id` / `ruleId` is declared an opaque
+string in [compatibility.md](../compatibility.md#the-10-commitment): consumers
+match exact values, not the `CL-` prefix or the four-digit shape. Declared
+before the 1.0 freeze because afterwards it would be a contract loosening —
+a MAJOR under [ADR-030](030-the-policy-is-part-of-the-contract.md) — while
+today it is a clarification of surface no consumer was promised. It keeps a
+future rule source with foreign ids (shellcheck's `SC####`,
+[ADR-007](007-shellcheck-integration.md)) an additive MINOR rather than a
+breaking-change argument.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -17,7 +17,12 @@ SemVer rules below:
 - **Config schema** — the `.compose-lint.yml` keys and their semantics
   ([ADR-010](adr/010-per-service-rule-overrides.md)).
 - **Machine output** — the JSON envelope and the SARIF 2.1.0 log shapes
-  ([ADR-015](adr/015-machine-readable-output-contract.md)).
+  ([ADR-015](adr/015-machine-readable-output-contract.md)). Within them,
+  `rule_id` (JSON) / `ruleId` (SARIF) is an **opaque string**: match exact
+  values, never the `CL-\d{4}` pattern. Every value today happens to match
+  it, but the format is not promised — a future rule source (e.g. the
+  shellcheck integration of [ADR-007](adr/007-shellcheck-integration.md))
+  may emit ids of a different shape as an additive, MINOR change.
 
 ## What is explicitly NOT covered
 


### PR DESCRIPTION
Pre-1.0 item 3, as decided. One-sentence contract addition plus its paper trail.

Every `rule_id`/`ruleId` today matches `CL-\d{4}`; nothing told consumers not to rely on that. Post-freeze, the first differently-shaped id — shellcheck's `SC` codes under ADR-007 being the live candidate — becomes a plausible breaking-change claim, converting an additive integration into a MAJOR argument.

- **compatibility.md**: the machine-output bullet now states ids are opaque strings — match exact values, never the pattern.
- **ADR-015**: amendment note, including *why now*: today this is a clarification of unpromised surface; after the freeze the same sentence is a contract loosening = MAJOR under ADR-030.
- **CHANGELOG**: Changed entry.

Note: compatibility.md is also edited by #706 (different sections — #706 adds a new section before Operating systems, this touches the 1.0-commitment bullet); whichever merges second may need a trivial rebase.