### PR TITLE
Run the lockfile drift gate when ci.yml itself changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,13 @@ jobs:
             dockerfile=true
           fi
           # pyproject.toml is the compile source; the locks are its outputs.
-          if match '^(pyproject\.toml$|requirements[.-].*lock$)'; then
+          # ci.yml is in the locks group because the drift gate's uv
+          # version is pinned *in this file* — a bump of that pin (Renovate
+          # does this) must re-prove the committed locks reproduce
+          # byte-for-byte under the new uv, which is exactly this job. The
+          # 0.12.3->0.12.5 bump (#700) sailed past the gate because this
+          # pattern didn't include it and had to be verified by hand.
+          if match '^(pyproject\.toml$|requirements[.-].*lock$|\.github/workflows/ci\.yml$)'; then
             locks=true
           fi
           {


### PR DESCRIPTION
Pre-1.0 housekeeping item 7. The drift gate's uv version is pinned in ci.yml, so a Renovate bump of that pin (a workflows-only diff) skipped the exact job whose comment demands such bumps be verified — #700 was hand-verified byte-identical instead. ci.yml joins the locks path group; cost is a 5-minute job on ci.yml edits.