### PR TITLE
Make a severity upgrade MINOR with a one-release runway (ADR-031)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   outrun, permanently: 3.11's October 2027 EOL will be a routine MINOR,
   not a forced 2.0.
 
+- **The compatibility policy is now part of the contract**
+  ([ADR-030](docs/adr/030-the-policy-is-part-of-the-contract.md)). Amending
+  it requires an ADR; clarifications ship in any release, tightenings are a
+  MINOR, and loosenings are a MAJOR and never retroactive — the promise can
+  no longer be weakened by a docs-only patch. Alongside it, the PATCH
+  definition is clarified (a false-positive fix removes *incorrect* findings
+  and stays a PATCH) and the severity-upgrade rule records its sanctioned
+  MINOR alternative, the ADR-028 split pattern.
+
 ### Removed
 
 - **The Python 3.10 deprecation warning** added in 0.22.0. It existed to reach

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and stays a PATCH) and the severity-upgrade rule records its sanctioned
   MINOR alternative, the ADR-028 split pattern.
 
+- **A post-1.0 severity upgrade is a MINOR with a one-release runway, not a
+  MAJOR** ([ADR-031](docs/adr/031-severity-upgrades-are-minor-with-runway.md)).
+  The release before the move announces it; the next MINOR applies it; the
+  two-axis derivation model must produce the new number either way. A new
+  HIGH rule already fails a threshold-gated pipeline as a MINOR, so
+  upgrades-as-MAJOR guarded a door the contract holds open elsewhere —
+  while making it impossible to correct an under-graded risk signal without
+  a 2.0. Deliberately the watch-and-see position: under ADR-030, tightening
+  to MAJOR later is cheap, and the reverse would not have been.
+
 ### Removed
 
 - **The Python 3.10 deprecation warning** added in 0.22.0. It existed to reach

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -87,6 +87,13 @@ Once `1.0.0` ships, the contract tightens:
 - **MINOR** (`1.2.3 → 1.3.0`) — additive or backward-compatible
   changes. New rules, new CLI flags, new config keys, severity
   *downgrades*, new formatters, additive fields in JSON/SARIF output.
+  Severity *upgrades* too, with ADR-031's one-release runway: announce
+  in release N under `Changed`, apply in N+1 — and only when the
+  derivation model produces the new number. Where only a *subset* of a
+  rule's matches deserves the higher tier, prefer the split pattern
+  (CL-0011 → CL-0024): the subset becomes a new rule ID, and existing
+  suppressions of the old ID never silently cover the more dangerous
+  rule (ADR-028).
   **New rules are intentionally MINOR, not MAJOR**, following the
   Hadolint / ShellCheck / ruff convention. Users who need
   deterministic results across upgrades should pin the version; the
@@ -99,13 +106,6 @@ Once `1.0.0` ships, the contract tightens:
     see `AGENTS.md`).
   - Changing the exit-code contract (e.g., adding a new non-zero
     exit code, changing the default `--fail-on` threshold).
-  - Severity *upgrades* on existing rules (`LOW → HIGH` can newly
-    fail CI for pinned users). The sanctioned MINOR alternative is the
-    split pattern (CL-0011 → CL-0024, CL-0013 → CL-0025): move the
-    higher-tier subset into a *new* rule ID, which is a rule addition —
-    and existing suppressions of the old ID never silently cover the
-    new, more dangerous rule (ADR-028 records why that direction is the
-    safe one).
   - Restructuring JSON/SARIF output in a way that removes or renames
     existing fields.
   - Dropping support for a Python version *off-schedule* — before its
@@ -122,7 +122,7 @@ Once `1.0.0` ships, the contract tightens:
 | Add a new rule                               | MINOR   | MINOR    |
 | Add a new CLI flag                           | MINOR   | MINOR    |
 | Downgrade a rule's severity (HIGH → MEDIUM)  | MINOR   | MINOR    |
-| Upgrade a rule's severity (LOW → HIGH)       | MINOR   | MAJOR    |
+| Upgrade a rule's severity (LOW → HIGH)       | MINOR   | MINOR, announced one release ahead (ADR-031) |
 | Tighten an existing rule (new true positive) | MINOR   | MINOR    |
 | Remove or rename a CLI flag                  | MINOR   | MAJOR    |
 | Retire a rule ID                             | MINOR   | MAJOR    |

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -79,9 +79,11 @@ slot does the work that MAJOR does post-1.0.
 Once `1.0.0` ships, the contract tightens:
 
 - **PATCH** (`1.2.3 → 1.2.4`) — bug fixes that don't change which
-  findings are emitted for a given input. If the set of findings a
-  user sees on an unchanged Compose file could change, it's not a
-  patch.
+  *correct* findings are emitted for a given input. Removing findings
+  the old behavior emitted in error — a false positive, a crash — is a
+  fix (the cheat sheet below says so too); if the set of correct
+  findings a user sees on an unchanged Compose file could change, it's
+  not a patch.
 - **MINOR** (`1.2.3 → 1.3.0`) — additive or backward-compatible
   changes. New rules, new CLI flags, new config keys, severity
   *downgrades*, new formatters, additive fields in JSON/SARIF output.
@@ -98,7 +100,12 @@ Once `1.0.0` ships, the contract tightens:
   - Changing the exit-code contract (e.g., adding a new non-zero
     exit code, changing the default `--fail-on` threshold).
   - Severity *upgrades* on existing rules (`LOW → HIGH` can newly
-    fail CI for pinned users).
+    fail CI for pinned users). The sanctioned MINOR alternative is the
+    split pattern (CL-0011 → CL-0024, CL-0013 → CL-0025): move the
+    higher-tier subset into a *new* rule ID, which is a rule addition —
+    and existing suppressions of the old ID never silently cover the
+    new, more dangerous rule (ADR-028 records why that direction is the
+    safe one).
   - Restructuring JSON/SARIF output in a way that removes or renames
     existing fields.
   - Dropping support for a Python version *off-schedule* — before its

--- a/docs/adr/030-the-policy-is-part-of-the-contract.md
+++ b/docs/adr/030-the-policy-is-part-of-the-contract.md
@@ -1,0 +1,44 @@
+# ADR-030: The Compatibility Policy Is Part of the Contract
+
+**Status:** Accepted
+
+**Context:** `docs/compatibility.md` promises users what stays stable and how
+change is signalled; users choose version ranges (`>=1.0,<2`, unpinned Action
+majors) based on those promises. But the policy said nothing about changing
+*itself*. Under the bump table a policy edit is a docs-only change — a PATCH —
+so the promise could be weakened by the one release class that asserts
+"nothing changed": reclassify severity upgrades as MINOR in a patch release,
+and the next MINOR breaks the user who chose their range because the old
+policy said upgrades were MAJOR. [ADR-029](029-scheduled-python-drops-are-minor.md)
+showed the mechanism in the benign direction — an ADR amending the policy —
+but nothing recorded what an amendment may do post-1.0 or what it costs.
+
+**Decision:** The policy is part of the 1.0 surface. Amendments require an
+ADR, and the required bump follows the amendment's direction:
+
+- **Clarification** (same obligations, better words) — any release.
+- **Tightening** (promising more) — MINOR.
+- **Loosening** (promising less) — **MAJOR**, never retroactive: a change
+  already shipped is judged under the policy in force when it shipped.
+
+**Rationale:** A loosening breaks exactly the users the contract exists for —
+those who relied on the stronger promise when choosing how to depend on the
+tool — which is the definition of a MAJOR. The alternative (loosenings take
+effect after an announced runway, as a MINOR) was considered and declined:
+it would let the promise erode by increments, and the maintainer judged that
+a contract whose weakenings are cheap is not much of a contract. The cost is
+accepted knowingly: a future ADR-029-shaped change — one that *relaxes* a
+bump rule, however well-argued — waits for a 2.0 once 1.0 ships. That is the
+last pre-1.0 window closing deliberately, the same shape as ADR-028's
+reclamation window.
+
+**Consequences:**
+
+- `docs/compatibility.md` gains the "Changing this policy" section stating
+  the rule; the PATCH definition in `docs/RELEASING.md` is clarified (a
+  false-positive fix removes *incorrect* findings and stays a PATCH), and
+  the severity-upgrade MAJOR bullet records the sanctioned MINOR
+  alternative — the ADR-028 split pattern — so the pressure valve is a
+  documented design choice rather than a loophole.
+- Any further loosening anyone wants (severity-upgrade semantics included)
+  must land **before 1.0** or wait for 2.0.

--- a/docs/adr/031-severity-upgrades-are-minor-with-runway.md
+++ b/docs/adr/031-severity-upgrades-are-minor-with-runway.md
@@ -1,0 +1,58 @@
+# ADR-031: Severity Upgrades Are MINOR, With a One-Release Runway
+
+**Status:** Accepted
+
+**Context:** The draft 1.0 contract made a severity *upgrade* a MAJOR, on the
+argument that `LOW → HIGH` can newly fail a threshold-gated CI run. Examined
+against the rest of the contract, that protection was incoherent: a brand-new
+HIGH rule fails the same pipeline the same way, and "new findings are not a
+breaking change" blesses it as MINOR. The MAJOR classification guarded a door
+the contract holds open elsewhere — while freezing errors in the risk signal,
+which for a security linter is the wrong thing to protect. If live evidence
+shows a rule under-graded (a new exploitation technique, a corrected axis —
+exactly what the premise methodology exists to surface), the tool must be able
+to say so without a 2.0.
+
+[ADR-030](030-the-policy-is-part-of-the-contract.md) sharpens the stakes into
+an asymmetry: tightening the contract later is a MINOR; loosening it later is
+a MAJOR. Shipping 1.0 with upgrades-as-MAJOR is therefore the irreversible
+choice — relaxing it on first contact with reality would cost a 2.0 — while
+shipping upgrades-as-MINOR keeps the strict option open forever.
+
+**Decision:** Post-1.0, a severity upgrade is a **MINOR with a one-release
+runway**:
+
+1. **Announce** — the release *before* the move states it in `CHANGELOG.md`
+   under `Changed`: the rule, both tiers, and the release class that will
+   apply it ("in the next MINOR").
+2. **Apply** — the next MINOR ships the new severity, with its own `Changed`
+   entry linking the derivation.
+3. **Derive** — the upgrade is legal only when the two-axis model produces
+   the new number (an axis correction, new live evidence, or a declared
+   override from the closed reason list). Severity never moves on judgment
+   alone; the derivation gate is what makes the smaller bump honest.
+
+Downgrades remain plain MINOR, no runway — they can only turn a red build
+green. Where only a *subset* of a rule's matches deserves the higher tier,
+the split pattern (ADR-028: new ID for the dangerous subset) remains
+preferred over upgrading the whole rule, because it also keeps existing
+suppressions from silently covering the more dangerous rule.
+
+**Deliberately provisional in one direction:** this is the watch-and-see
+position. If observation shows runway upgrades burning users in practice,
+tightening to upgrades-as-MAJOR is a MINOR contract change under ADR-030.
+The reverse migration would have cost a 2.0 — that asymmetry, not certainty
+about the right answer, is why 1.0 ships with this rule.
+
+**Consequences:**
+
+- `docs/compatibility.md` (severity paragraph) and `docs/RELEASING.md`
+  (post-1.0 MINOR/MAJOR lists, cheat sheet) are amended alongside this ADR;
+  the severity-upgrade bullet leaves the MAJOR list.
+- A threshold-gated (`--fail-on`) user sees an upgrade coming one full
+  release ahead; a pinned user is untouched at every step; per-rule
+  disables and suppressions keep working across the move.
+- The maintainer carries one piece of cross-release state per upgrade (the
+  pending announcement). No machinery enforces the runway yet; if a pending
+  move is ever forgotten, the release checklist in RELEASING.md is the
+  backstop, and automating it is worth revisiting on the first miss.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -75,6 +75,21 @@ Two things are never reused or quietly repurposed:
 - **Exit-code meanings** — `0` / `1` / `2` keep their meanings; adding a new
   non-zero code is a MAJOR change.
 
+## Changing this policy
+
+This policy is itself part of the 1.0 surface: users choose version ranges
+based on what it promises, so the promise cannot be quietly rewritten by a
+"docs-only" release. Amendments require an ADR
+([ADR-030](adr/030-the-policy-is-part-of-the-contract.md)), and the bump an
+amendment requires depends on its direction:
+
+- **Clarifications** — same obligations, better words — may ship in any
+  release.
+- **Tightenings** — promising more than before — are a MINOR.
+- **Loosenings** — promising less than before — are a **MAJOR**, and are
+  never retroactive: a change already shipped is judged under the policy in
+  force when it shipped.
+
 ## Operating systems
 
 Linux is the fully gated platform: every PR runs the complete suite there

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -46,8 +46,14 @@ Two escape hatches keep a pipeline deterministic:
   findings surface without failing the build.
 
 A rule's **severity** is part of the contract: post-1.0, *downgrading* a
-severity is a MINOR, but *upgrading* one (which can newly fail a pinned user's
-CI) is a MAJOR.
+severity is a MINOR, and *upgrading* one is a **MINOR with a one-release
+runway** ([ADR-031](adr/031-severity-upgrades-are-minor-with-runway.md)): the
+release before the move announces it under `Changed`, and the next MINOR
+applies it. A pinned user is untouched either way; a threshold-gated
+`--fail-on` user gets a full release of warning instead of a surprise red
+build. Every upgrade must still be *derived* — the two-axis model has to
+produce the new number (an axis correction or a declared override), so a
+severity never moves on judgment alone.
 
 ## Deprecation lifecycle
 


### PR DESCRIPTION
Decision from review of the 1.0 constraints: severity upgrades lean MINOR, watched, with the strict option kept in reserve.

**Stacked on #706** (it rewrites the severity bullets #706 touches); retargets to main when that merges — review the top commit only until then.

**The rule (ADR-031):** announce the upgrade in release N under `Changed` → apply in N+1 → legal only when the two-axis derivation produces the new number. Downgrades stay plain MINOR. Subset-only cases still prefer the ADR-028 split pattern.

**Why this direction:**
- A new HIGH rule already fails a threshold-gated pipeline as MINOR ("new findings are not a breaking change") — upgrades-as-MAJOR guarded a door the contract holds open elsewhere.
- A security linter must be able to correct an under-graded risk signal without a 2.0.
- ADR-030 makes this the reversible choice: tightening to MAJOR later is a MINOR contract change; the reverse would cost a 2.0. Recorded in the ADR as deliberately provisional in one direction.

Pinned users are untouched at every step; `--fail-on` users get one full release of warning; suppressions survive the move.