### PR TITLE
Make evidence-refuted rule retirement MINOR via the lifecycle (ADR-032)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a 2.0. Deliberately the watch-and-see position: under ADR-030, tightening
   to MAJOR later is cheap, and the reverse would not have been.
 
+- **Retiring a refuted rule is a MINOR post-1.0, through the deprecation
+  lifecycle** ([ADR-032](docs/adr/032-rule-retirement-is-minor-with-lifecycle.md)).
+  A rule leaves the registry only when live evidence refutes its premise —
+  the bar that removed CL-0012/0015/0023 pre-1.0 — and pricing that removal
+  at a 2.0 would force the tool to keep emitting findings it knows are
+  false. Announce, one MINOR of grace, then remove; the ID stays fallow
+  forever, the doc page stays as a tombstone, and a config referencing the
+  retired ID keeps working, `--strict-config` included (a precondition the
+  config layer gains before the first such retirement). "Noisy" remains a
+  non-reason (ADR-028).
+
 ### Removed
 
 - **The Python 3.10 deprecation warning** added in 0.22.0. It existed to reach

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -102,8 +102,9 @@ Once `1.0.0` ships, the contract tightens:
 - **MAJOR** (`1.2.3 → 2.0.0`) — anything that breaks a pinned,
   working setup:
   - Removing or renaming a CLI flag, subcommand, or config key.
-  - Removing or retiring a rule ID (note: rule IDs are never reused;
-    see `AGENTS.md`).
+  - Retiring a rule *without* the evidence bar and lifecycle of ADR-032
+    (an evidence-refuted retirement through the lifecycle is MINOR; rule
+    IDs are never reused either way — see `AGENTS.md`).
   - Changing the exit-code contract (e.g., adding a new non-zero
     exit code, changing the default `--fail-on` threshold).
   - Restructuring JSON/SARIF output in a way that removes or renames
@@ -125,7 +126,8 @@ Once `1.0.0` ships, the contract tightens:
 | Upgrade a rule's severity (LOW → HIGH)       | MINOR   | MINOR, announced one release ahead (ADR-031) |
 | Tighten an existing rule (new true positive) | MINOR   | MINOR    |
 | Remove or rename a CLI flag                  | MINOR   | MAJOR    |
-| Retire a rule ID                             | MINOR   | MAJOR    |
+| Retire a rule ID (refuted, via lifecycle)    | MINOR   | MINOR (ADR-032) |
+| Retire a rule ID off-lifecycle               | MINOR   | MAJOR    |
 | Change the default `--fail-on` threshold     | MINOR   | MAJOR    |
 | Drop a Python version on schedule (ADR-029)  | MINOR   | MINOR    |
 | Drop a Python version off-schedule           | MINOR   | MAJOR    |

--- a/docs/adr/032-rule-retirement-is-minor-with-lifecycle.md
+++ b/docs/adr/032-rule-retirement-is-minor-with-lifecycle.md
@@ -48,10 +48,15 @@ deprecation lifecycle, under these conditions:
    config referencing a retired ID warns ("retired in vX.Y, override has
    no effect") but does **not** error under `--strict-config`, which keeps
    meaning "typo or unknown key", not "you once suppressed a rule that
-   later died". This is a precondition, not machinery built today — no
-   retirement is pending, and the fallow pre-1.0 IDs deliberately stay
-   strict errors (they were reclaimed before any 1.0 config could have
-   named them).
+   later died". Strict mode polices mistakes the config author made, not
+   history the tool made: an error on the author's typo is the feature,
+   an error that arrives because the user upgraded is a contract
+   violation dressed as rigor. This is a precondition, not machinery
+   built today — no retirement is pending. The fallow pre-1.0 IDs
+   (CL-0012, CL-0015, CL-0023) deliberately stay strict *errors* — no
+   contract protected 0.x configs — but when the registry is built they
+   join it with a distinct message ("reclaimed pre-1.0, refuted premise,
+   see the changelog; remove this entry") instead of reading as typos.
 
 **Consequences:**
 

--- a/docs/adr/032-rule-retirement-is-minor-with-lifecycle.md
+++ b/docs/adr/032-rule-retirement-is-minor-with-lifecycle.md
@@ -1,0 +1,66 @@
+# ADR-032: Retiring a Refuted Rule Is MINOR, Through the Lifecycle
+
+**Status:** Accepted
+
+**Context:** The draft 1.0 contract made retiring a rule ID a MAJOR. But the
+reason a grounded rule leaves the registry post-1.0 is the reason CL-0012,
+CL-0015 and CL-0023 left it pre-1.0: evidence refutes its premise, or an
+upstream default change makes the flagged configuration a no-op
+([ADR-016](016-runtime-rule-premise-validation.md)'s failure modes). A
+contract that prices that removal at a 2.0 forces the tool to keep emitting
+findings it *knows* describe nothing — the same frozen-error problem
+[ADR-031](031-severity-upgrades-are-minor-with-runway.md) fixed for
+severities, and worse, because here the signal is not under-priced but false.
+
+Mechanically, retirement is the softest change in the catalogue: findings
+stop, so builds only go greener; no pinned setup breaks; machine-output
+consumers see an ID stop appearing, which additive-shape parsing already
+tolerates. The one sharp edge is configuration: a `.compose-lint.yml` that
+references the retired ID. The config layer already warns (not errors) on an
+unknown rule id — the message even anticipates "a retired rule" — but under
+`--strict-config` (#380) that warning becomes an error, which would break
+exactly the pipelines that opted into rigor.
+
+[ADR-030](030-the-policy-is-part-of-the-contract.md)'s asymmetry applies once
+more: shipping 1.0 with retirement-as-MINOR keeps the strict option
+available as a cheap tightening; the reverse migration would cost a 2.0.
+
+**Decision:** Post-1.0, retiring a rule is a **MINOR**, through the full
+deprecation lifecycle, under these conditions:
+
+1. **Evidence, not preference.** Retirement is legal only when the rule's
+   premise is refuted by live measurement or an upstream behavior change —
+   the ADR-016 bar, recorded in an ADR. "Noisy" is not a retirement reason
+   ([ADR-028](028-pre-1.0-rule-id-sweep.md)); prevalence pricing stays out
+   of the registry.
+2. **Announce** — `CHANGELOG.md` under `Deprecated` plus a deprecation
+   banner on the rule's doc page, in the release that announces it. The
+   rule keeps firing through the grace period (its findings are real until
+   the removal ships — or, where the refutation shows the findings were
+   never real, the announcing release may narrow it to nothing and say so).
+3. **Grace** — at least one MINOR between announcement and removal.
+4. **Remove** — findings stop; the ID joins the permanently-fallow set
+   (never reused, [ADR-005](005-rule-id-scheme.md)); the rule's doc page
+   stays as a tombstone stating what refuted it, so `--explain CL-XXXX`
+   and existing links keep resolving.
+5. **Configs must not break — strict mode included.** Before the first
+   post-1.0 retirement, the config layer learns the retired-ID set: a
+   config referencing a retired ID warns ("retired in vX.Y, override has
+   no effect") but does **not** error under `--strict-config`, which keeps
+   meaning "typo or unknown key", not "you once suppressed a rule that
+   later died". This is a precondition, not machinery built today — no
+   retirement is pending, and the fallow pre-1.0 IDs deliberately stay
+   strict errors (they were reclaimed before any 1.0 config could have
+   named them).
+
+**Consequences:**
+
+- `docs/compatibility.md` (rule-ID bullet, lifecycle step 4) and
+  `docs/RELEASING.md` (post-1.0 MAJOR list, cheat sheet) are amended
+  alongside this ADR; the lifecycle's MAJOR-only removal rule now carries
+  two carve-outs (ADR-029 interpreter drops, this one), both
+  evidence-or-calendar-gated rather than discretionary.
+- Coverage loss is the honest cost: a user relying on a retired rule's
+  detection loses it in a MINOR. The lifecycle is the mitigation — the
+  deprecation is announced, warned, and graced — and the evidence bar means
+  what they lose was, by measurement, not protection.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -69,15 +69,22 @@ field, rule, or supported Python version is slated for removal:
 3. **Grace period** — the deprecated surface keeps working for **at least one
    MINOR release** after the announcement.
 4. **Remove** — removal happens only in a **MAJOR** release, listed under
-   `Removed` in `CHANGELOG.md`. One carve-out: a *scheduled* Python
-   interpreter drop ships as a MINOR under the conditions of
-   [ADR-029](adr/029-scheduled-python-drops-are-minor.md).
+   `Removed` in `CHANGELOG.md`. Two carve-outs, both gated on calendar or
+   evidence rather than discretion: a *scheduled* Python interpreter drop
+   ([ADR-029](adr/029-scheduled-python-drops-are-minor.md)) and an
+   evidence-refuted rule retirement
+   ([ADR-032](adr/032-rule-retirement-is-minor-with-lifecycle.md)) ship as
+   MINOR.
 
 Two things are never reused or quietly repurposed:
 
 - **Rule IDs** — `CL-XXXX` IDs are permanent; a retired rule's ID is never
-  reassigned ([ADR-005](adr/005-rule-id-scheme.md)). Retiring a rule is a MAJOR
-  change.
+  reassigned ([ADR-005](adr/005-rule-id-scheme.md)). Retiring a rule is a
+  MINOR, but only through the full deprecation lifecycle and only on
+  evidence that refutes the rule's premise
+  ([ADR-032](adr/032-rule-retirement-is-minor-with-lifecycle.md)) — never
+  on noise or preference. A config referencing a retired ID keeps working,
+  `--strict-config` included.
 - **Exit-code meanings** — `0` / `1` / `2` keep their meanings; adding a new
   non-zero code is a MAJOR change.
 


### PR DESCRIPTION
Follows the ADR-031 reasoning to its sibling case, per review of the 1.0 constraints.

**Stacked on #713** (same MAJOR-list/cheat-sheet regions); retargets when it merges — review the top commit only.

**The rule (ADR-032):** retirement is MINOR only when (1) live evidence refutes the rule's premise (the ADR-016 bar; \"noisy\" stays a non-reason per ADR-028), (2) the full lifecycle runs — announce + doc banner, ≥1 MINOR grace, remove with a tombstone doc page and permanently-fallow ID, and (3) configs referencing the retired ID keep working **including under `--strict-config`** — a precondition the config layer gains before the first such retirement (the existing unknown-id warning already anticipates retired rules; strict mode currently escalates it, which would break exactly the pipelines that opted into rigor). Off-lifecycle retirement stays MAJOR.

**Why MINOR:** removal only turns builds greener; keeping a refuted rule at 2.0-price means knowingly emitting false findings — worse than ADR-031's under-priced signal. And ADR-030 makes this the reversible direction: tightening back to MAJOR later is cheap, the reverse is not.

Honest cost, recorded in the ADR: a user relying on the retired detection loses it in a MINOR — mitigated by the lifecycle, and by the evidence bar meaning what they lose was, by measurement, not protection.