### PR TITLE
Report a failed stdout write as exit 2, not 120

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A failed stdout write is now exit 2, not an undocumented exit 120 or a
+  false exit 1.** Every path that could raise mid-run had been hardened to the
+  0/1/2 contract; the channel all of them write through had not. A full disk
+  (`> /dev/full`), a reader that closed early (`compose-lint check f.yml |
+  head`) or a descriptor closed at startup (`>&-`) let the error escape
+  `main()`: CPython reported an unraisable error from its own final flush and
+  exited **120** — a code [ADR-006](docs/adr/006-exit-codes.md) does not define
+  and which `docs/compatibility.md` prices at a MAJOR to add — or, when the
+  write failed earlier, exited **1**, which reads as "findings at or above the
+  threshold" on a file that is clean. Piping a clean run into `head` was
+  therefore a red merge gate. Writes now report
+  `Error: could not write output: <reason>` and exit 2, which is what that code
+  already means: compose-lint could not complete the run.
+
 ## [0.24.0] - 2026-08-24
 
 ### Changed

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -509,17 +509,87 @@ def _utf8_stdio() -> None:
             stream.reconfigure(encoding="utf-8")
 
 
-def main(argv: list[str] | None = None) -> NoReturn:
-    """Main entry point for the CLI."""
-    _utf8_stdio()
-    parser = _build_parser()
-    raw = sys.argv[1:] if argv is None else argv
-    args = parser.parse_args(_normalize_argv(raw))
+def _discard_stdout() -> None:
+    """Point stdout at the null device so no further write can fail.
+
+    The interpreter flushes ``sys.stdout`` one last time after ``main``
+    returns, outside any handler this module can install. If the earlier write
+    failed, that flush raises again and CPython reports the unraisable error
+    and exits **120** — overriding whatever code we chose. Replacing the
+    underlying file descriptor is what makes the chosen exit code stick.
+    """
+    with contextlib.suppress(AttributeError, OSError, ValueError):
+        null = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(null, sys.stdout.fileno())
+        os.close(null)
+
+
+def _abort_on_write_failure(exc: OSError) -> NoReturn:
+    """Report a failed stdout write as exit 2 (ADR-006).
+
+    A run whose verdict never reached stdout did not complete, which is
+    exactly what exit 2 means — "compose-lint itself couldn't run" — and is
+    the reason this is not left to the shell convention of dying quietly on
+    ``EPIPE``. Exit 1 is worse than either: it means "findings at or above
+    the threshold", so ``compose-lint check clean.yml | head`` would report a
+    clean file as a failing gate.
+    """
+    _discard_stdout()
+    emit(f"Error: could not write output: {exc.strerror or exc}")
+    sys.exit(2)
+
+
+def _stdout_print(*args: object, **kwargs: Any) -> None:
+    """``print`` to stdout, turning a failed write into the documented exit 2.
+
+    Wrapping the writes themselves — rather than catching ``OSError`` around
+    the whole run — is what keeps the diagnostic honest: only an error raised
+    by writing the report becomes "could not write output". An ``OSError``
+    from anywhere else still surfaces as itself.
+    """
+    try:
+        print(*args, **kwargs)
+    except OSError as exc:
+        _abort_on_write_failure(exc)
+
+
+def _dispatch(args: argparse.Namespace) -> NoReturn:
+    """Route to the subcommand handler; every branch exits."""
     if args.command == "fix":
         _run_fix(args)
     if args.command == "init":
         _run_init(args)
     _run_check(args)
+
+
+def main(argv: list[str] | None = None) -> NoReturn:
+    """Main entry point for the CLI."""
+    _utf8_stdio()
+    if sys.stdout is None:
+        # Started with file descriptor 1 already closed (`compose-lint … >&-`).
+        # CPython leaves `sys.stdout` as None rather than a stream that fails
+        # on write, so this never reaches the handlers below — it surfaces as
+        # an AttributeError from whichever formatter touches stdout first.
+        emit("Error: could not write output: stdout is closed")
+        sys.exit(2)
+    raw = sys.argv[1:] if argv is None else argv
+    try:
+        parser = _build_parser()
+        args = parser.parse_args(_normalize_argv(raw))
+        _dispatch(args)
+    except BrokenPipeError as exc:
+        # Raised by a `print` when the reader closed early (`| head`).
+        _abort_on_write_failure(exc)
+    except SystemExit:
+        # Buffered stdout is not written until it is flushed, so a write
+        # failure surfaces here rather than at the `print` that caused it.
+        # Flush while the exit is in flight so the error can still be turned
+        # into the documented code instead of escaping as an exit 120.
+        try:
+            sys.stdout.flush()
+        except OSError as exc:
+            _abort_on_write_failure(exc)
+        raise
 
 
 def _report_coverage_gaps(
@@ -564,7 +634,7 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
             )
             sys.exit(2)
         try:
-            print(load_rule_doc(args.explain))
+            _stdout_print(load_rule_doc(args.explain))
         except UnknownRuleError:
             emit(f"Error: unknown rule id '{args.explain}' (expected format: CL-XXXX)")
             sys.exit(2)
@@ -604,7 +674,7 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
     # (and on the per-file text prints below) keeps block-buffered stdout from
     # landing after unbuffered stderr when both are captured together (2>&1).
     if args.output_format == "text":
-        print(
+        _stdout_print(
             format_header(
                 args.files,
                 str(config_path) if config_path else None,
@@ -716,8 +786,8 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
                 findings, filepath, verbose=args.verbose, quiet=args.quiet
             )
             if output:
-                print(output, flush=True)
-            print(format_summary(findings, filepath), flush=True)
+                _stdout_print(output, flush=True)
+            _stdout_print(format_summary(findings, filepath), flush=True)
             all_file_findings.append((findings, filepath))
         elif args.output_format == "sarif":
             # Structured SARIF fixes (ADR-014, promoted in 0.11.0): every
@@ -777,13 +847,13 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
 
     if args.output_format == "text":
         if len(args.files) > 1:
-            print()
-            print(
+            _stdout_print()
+            _stdout_print(
                 format_aggregate_summary(
                     all_file_findings, len(parse_errors), len(coverage_errors)
                 )
             )
-        print(
+        _stdout_print(
             format_verdict(
                 all_file_findings,
                 args.fail_on,
@@ -797,7 +867,7 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
         # reject. The formatter already coerces `service` to str, so this guards
         # any future numeric field; the same applies to the SARIF dump below.
         json_log = build_json_log(all_json, run_errors)
-        print(json.dumps(json_log, indent=2, allow_nan=False))
+        _stdout_print(json.dumps(json_log, indent=2, allow_nan=False))
     elif args.output_format == "sarif":
         if len(all_sarif) > MAX_SARIF_RESULTS:
             # The document below reports the truncation itself; record it here
@@ -814,7 +884,7 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
         sarif_log = build_sarif_log(
             all_sarif, run_errors, severity_overrides=severity_overrides
         )
-        print(json.dumps(sarif_log, indent=2, allow_nan=False))
+        _stdout_print(json.dumps(sarif_log, indent=2, allow_nan=False))
 
     # A failing run with no config loaded is the shape of a config that was
     # never found. This is the moment the user asks "why is this failing?",
@@ -1132,7 +1202,7 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
             )
             touched = True
         else:
-            print(
+            _stdout_print(
                 render_file_diff(filepath, text, patched, result.caveats),
                 end="",
                 flush=True,

--- a/tests/test_exit_code_contract.py
+++ b/tests/test_exit_code_contract.py
@@ -16,6 +16,7 @@ import contextlib
 import os
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -205,3 +206,105 @@ def test_init_to_a_directory_is_a_clean_error(tmp_path: Path) -> None:
     assert "not a regular file" in proc.stderr
     assert "hard link" not in proc.stderr
     assert os.path.isdir(out)
+
+
+# --- Writing the report can fail too -------------------------------------
+#
+# Every path above hardened a *computation* that could raise. The channel all
+# of them write through was not: a full disk, a reader that closed early
+# (`| head`), or a closed descriptor let the error escape `main`. CPython
+# reports an unraisable error from its final implicit flush and exits **120**,
+# a code ADR-006 does not define and `docs/compatibility.md` says costs a MAJOR
+# to add -- or, when the write failed before that flush, exit **1**, which
+# reads as "I linted it and it failed" on a file that is clean.
+
+_CLEAN = (
+    "services:\n"
+    "  web:\n"
+    "    image: nginx:1.27\n"
+    "    read_only: true\n"
+    "    security_opt: ['no-new-privileges:true']\n"
+)
+
+
+@pytest.mark.skipif(
+    not os.path.exists("/dev/full"),
+    reason="/dev/full is how a write failure is provoked without filling a disk",
+)
+@pytest.mark.parametrize("fmt", ["text", "json", "sarif"])
+def test_a_full_disk_is_exit_2_not_120(tmp_path: Path, fmt: str) -> None:
+    """The report could not be written, so the run did not complete."""
+    (tmp_path / "docker-compose.yml").write_text(_CLEAN, encoding="utf-8")
+
+    with open("/dev/full", "w", encoding="utf-8") as full:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "compose_lint",
+                "check",
+                "--format",
+                fmt,
+                "docker-compose.yml",
+            ],
+            cwd=tmp_path,
+            stdout=full,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            env=cli_env(PYTHONPATH=str(REPO_ROOT / "src"), NO_COLOR="1"),
+            timeout=180,
+        )
+
+    assert proc.returncode == 2, proc.stderr
+    _assert_no_traceback(proc)
+    assert "could not write output" in proc.stderr
+
+
+@pytest.mark.skipif(os.name != "posix", reason="needs a POSIX pipe reader")
+def test_a_reader_that_closes_early_is_exit_2_not_a_failed_gate() -> None:
+    """`compose-lint check clean.yml | head` must not look like findings.
+
+    Exit 1 means "findings at or above the threshold". Reporting it because
+    the *reader* went away turns every clean file piped into `head` into a red
+    merge gate.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        Path(tmp, "docker-compose.yml").write_text(_CLEAN, encoding="utf-8")
+        proc = subprocess.run(
+            "set -o pipefail; "
+            f"{sys.executable} -m compose_lint check docker-compose.yml "
+            "| head -1 >/dev/null",
+            cwd=tmp,
+            shell=True,
+            executable="/bin/bash",
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            env=cli_env(PYTHONPATH=str(REPO_ROOT / "src"), NO_COLOR="1"),
+            timeout=180,
+        )
+
+    assert proc.returncode == 2, proc.stderr
+    _assert_no_traceback(proc)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="needs `>&-` descriptor closing")
+def test_a_closed_stdout_is_a_clean_error() -> None:
+    """With fd 1 closed at startup CPython leaves `sys.stdout` as None."""
+    with tempfile.TemporaryDirectory() as tmp:
+        Path(tmp, "docker-compose.yml").write_text(_CLEAN, encoding="utf-8")
+        proc = subprocess.run(
+            f"{sys.executable} -m compose_lint check docker-compose.yml >&-",
+            cwd=tmp,
+            shell=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            env=cli_env(PYTHONPATH=str(REPO_ROOT / "src"), NO_COLOR="1"),
+            timeout=180,
+        )
+
+    assert proc.returncode == 2, proc.stderr
+    _assert_no_traceback(proc)
+    assert "stdout is closed" in proc.stderr


### PR DESCRIPTION
Every path that could raise mid-run had already been hardened to the 0/1/2 contract. The channel all of them write through had not.

## The defect

| invocation | before | after |
|---|---|---|
| `check --format json f.yml > /dev/full` | **120** + unraisable-error text | **2** |
| `check f.yml \| head` (pipefail) | **120** + traceback | **2** |
| `check f.yml >&-` | **1** + traceback | **2** |

Two ways this breaks the contract 1.0 is about to freeze:

- **Exit 120 is not a code ADR-006 defines**, and `docs/compatibility.md:93` prices adding a new non-zero exit code at a MAJOR. Tagging 1.0 freezes a code the policy says cannot exist; both honest later fixes (map it, or document it) are MAJOR-shaped.
- **Exit 1 means "findings at or above the threshold."** So `compose-lint check clean.yml | head` reported a clean file as a failing merge gate — verbatim the failure `tests/test_exit_code_contract.py`'s own docstring says must never happen.

## The fix

Stdout writes go through one guarded helper, so *only* an error raised by writing the report becomes `could not write output` — an `OSError` from anywhere else still surfaces as itself. Buffered output is flushed while the exit is in flight, and the descriptor is repointed at the null device so the interpreter's final implicit flush cannot override the chosen code.

`>&-` needed separate handling: with fd 1 closed at startup CPython leaves `sys.stdout` as `None`, so it surfaced as an `AttributeError` from whichever formatter touched stdout first, never reaching an `OSError` handler.

## Verification

Reproduced before and after across text/json/sarif/explain. Exit 0 (clean) and exit 1 (findings) are unchanged. New cases in `tests/test_exit_code_contract.py` cover `/dev/full`, `| head` under `pipefail`, and `>&-`.

Found by a pre-1.0 freeze-surface audit.
