### PR TITLE
Bound what variable substitution produces, not just what it scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   therefore a red merge gate. Writes now report
   `Error: could not write output: <reason>` and exit 2, which is what that code
   already means: compose-lint could not complete the run.
+- **A tiny Compose file can no longer buy an unbounded amount of work.** Two
+  vectors, both reachable from a pull request in the CI merge gate the tool
+  ships as. `MAX_SCAN_LEN` bounds what a pass *scans*; nothing bounded what
+  substitution *produces* — `${A}${A}` is four characters whose result is twice
+  whatever `A` holds, so a ladder of definitions each referencing the one below
+  doubles per rung, and thirty rungs is a **489-byte** `.env` whose expansion
+  exhausts memory. The new `MAX_SUBSTITUTED_LEN` bounds the result as it is
+  built, returning the same "unknowable" answer both call sites already return
+  for a name they cannot resolve. Separately, `str()` on an alias-expanded
+  nested list serializes the DAG as a tree: `security_opt: [*l26]` is **690
+  bytes** on disk and took 35s. `compose_lint._scalar` exists to refuse exactly
+  that and `_caps.iter_cap_add` already applied it to `cap_add`; the CL-0003 /
+  CL-0009 `security_opt` normalizer and CL-0010's namespace comparison now do
+  too — 35.85s to 90ms. A list is not a value any of those fields can hold, so
+  the entry is skipped rather than compared.
 
 ## [0.24.0] - 2026-08-24
 

--- a/src/compose_lint/_env_file.py
+++ b/src/compose_lint/_env_file.py
@@ -91,6 +91,7 @@ import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from compose_lint._limits import MAX_SUBSTITUTED_LEN
 from compose_lint._safe_read import UnsafeFileError, read_text_bounded
 from compose_lint.rules._interpolation import _default_of, _matching_brace
 
@@ -457,11 +458,15 @@ def _expand(value: str, defined: Mapping[str, str]) -> str | None:
     being linted.
     """
     out: list[str] = []
+    produced = 0
     index = 0
     while index < len(value):
+        if produced > MAX_SUBSTITUTED_LEN:
+            return None
         char = value[index]
         if char != "$" or index + 1 >= len(value):
             out.append(char)
+            produced += 1
             index += 1
             continue
         following = value[index + 1]
@@ -472,29 +477,36 @@ def _expand(value: str, defined: Mapping[str, str]) -> str | None:
             # `docker compose config`, which re-escapes a literal dollar on the
             # way out (it prints `a$$b`) so its own output round-trips.
             out.append("$")
+            produced += 1
             index += 2
             continue
         if following == "{":
             close = _matching_brace(value, index + 1)
             if close is None:
                 out.append(char)
+                produced += 1
                 index += 1
                 continue
             substituted = _substitute(value[index + 2 : close], defined)
             if substituted is None:
                 return None
             out.append(substituted)
+            produced += len(substituted)
             index = close + 1
             continue
         name = re.match(r"[A-Za-z_][A-Za-z0-9_]*", value[index + 1 :])
         if name is None:
             out.append(char)
+            produced += 1
             index += 1
             continue
         if name.group() not in defined:
             return None
         out.append(defined[name.group()])
+        produced += len(defined[name.group()])
         index += 1 + len(name.group())
+    if produced > MAX_SUBSTITUTED_LEN:
+        return None
     return "".join(out)
 
 

--- a/src/compose_lint/_limits.py
+++ b/src/compose_lint/_limits.py
@@ -19,3 +19,17 @@ from __future__ import annotations
 # input written to be pathological. Below it, even a quadratic pattern is
 # bounded at a few milliseconds.
 MAX_SCAN_LEN = 8192
+
+# The cap above bounds what is *scanned*; this one bounds what substitution
+# *produces*. They are different quantities: `${A}${A}` is four characters of
+# input whose result is twice whatever `A` holds, so a chain of definitions
+# that each reference the one below doubles per level. Thirty levels of that
+# is a 489-byte `.env` whose expansion is gigabytes — the input cap never
+# fires, because no single value is ever large.
+#
+# Sixteen times MAX_SCAN_LEN: far above any real interpolated value (a scalar
+# larger than MAX_SCAN_LEN is not scanned by the rules anyway), and small
+# enough that reaching it costs nothing. Above it the caller returns the same
+# conservative "unknowable" answer it already returns for a name it cannot
+# resolve.
+MAX_SUBSTITUTED_LEN = MAX_SCAN_LEN * 16

--- a/src/compose_lint/_yaml_edit.py
+++ b/src/compose_lint/_yaml_edit.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from compose_lint._scalar import as_scalar_text
 from compose_lint.models import TextEdit
 
 # security_opt directives that disable a default platform profile — CL-0009's
@@ -38,8 +39,20 @@ def normalize_security_opt(opt: Any) -> str:
     (issue #277 F3) and CL-0003 fires on an already-hardened ``=``-form
     ``no-new-privileges`` (#277 P1). Lower-cases and rewrites only the first
     ``=`` (the key/value separator), leaving any ``=`` inside a value untouched.
+
+    A non-scalar entry normalizes to ``""``. ``str()`` on an alias-expanded
+    nested list serializes the DAG as a tree — ``security_opt: [*l26]`` is 690
+    bytes on disk and took 35s here — which is the allocation
+    :mod:`compose_lint._scalar` exists to refuse, already refused for
+    ``cap_add`` in :func:`_caps.iter_cap_add`. A list is also not a directive
+    Docker accepts, so there is nothing to compare it against; every caller
+    treats an unrecognized value as "not one of ours" and skips it, which is
+    what it would have done with the giant string anyway.
     """
-    return str(opt).strip().lower().replace("=", ":", 1)
+    text = as_scalar_text(opt)
+    if text is None:
+        return ""
+    return text.strip().lower().replace("=", ":", 1)
 
 
 # One entry is enough: a run processes one document at a time, and the fix

--- a/src/compose_lint/rules/CL0010_host_namespace.py
+++ b/src/compose_lint/rules/CL0010_host_namespace.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from compose_lint._scalar import as_scalar_text
 from compose_lint.models import Finding, RuleMetadata, Severity
 from compose_lint.rules import BaseRule, register_rule
 
@@ -81,7 +82,15 @@ class HostNamespaceRule(BaseRule):
         lines: dict[str, int],
     ) -> Iterator[Finding]:
         for key, value, cis_ref, desc in _NAMESPACE_CHECKS:
-            if str(service_config.get(key, "")).lower() == value:
+            # `str()` on an alias-expanded nested list serializes the DAG as a
+            # tree, so a few hundred bytes of YAML allocates 2^depth characters
+            # here. A list is also not a value `pid:`/`ipc:`/`network_mode:`
+            # can hold, so there is nothing to compare — skip it, as
+            # `_caps.iter_cap_add` already does for `cap_add`.
+            raw = as_scalar_text(service_config.get(key, ""))
+            if raw is None:
+                continue
+            if raw.lower() == value:
                 yield Finding(
                     rule_id="CL-0010",
                     severity=Severity.HIGH,

--- a/src/compose_lint/rules/_interpolation.py
+++ b/src/compose_lint/rules/_interpolation.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
-from compose_lint._limits import MAX_SCAN_LEN
+from compose_lint._limits import MAX_SCAN_LEN, MAX_SUBSTITUTED_LEN
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -147,14 +147,18 @@ def _resolve_defaults(
         return None
     lookup: Mapping[str, str] = env or {}
     out: list[str] = []
+    produced = 0
     i = 0
     end = len(value)
     while i < end:
+        if produced > MAX_SUBSTITUTED_LEN:
+            return None
         char = value[i]
         if char == "$" and i + 1 < end:
             following = value[i + 1]
             if following == "$":  # escaped literal dollar, not a reference
                 out.append("$$")
+                produced += 2
                 i += 2
                 continue
             if following == "{":
@@ -164,6 +168,7 @@ def _resolve_defaults(
                     supplied = _supplied(interior, lookup)
                     if supplied is not None:
                         out.append(supplied)
+                        produced += len(supplied)
                         i = close + 1
                         continue
                     default = _default_of(interior)
@@ -172,18 +177,24 @@ def _resolve_defaults(
                         if resolved is None:
                             return None
                         out.append(resolved)
+                        produced += len(resolved)
                         i = close + 1
                         continue
                     out.append(value[i : close + 1])  # no default; as written
+                    produced += close + 1 - i
                     i = close + 1
                     continue
             name = _BARE_NAME_RE.match(value, i + 1)
             if name is not None and name.group() in lookup:
                 out.append(lookup[name.group()])
+                produced += len(lookup[name.group()])
                 i = name.end()
                 continue
         out.append(char)
+        produced += 1
         i += 1
+    if produced > MAX_SUBSTITUTED_LEN:
+        return None
     return "".join(out)
 
 

--- a/tests/test_resource_bounds.py
+++ b/tests/test_resource_bounds.py
@@ -23,14 +23,16 @@ from pathlib import Path
 
 import pytest
 
+from compose_lint._limits import MAX_SUBSTITUTED_LEN
 from compose_lint._lines import split_lines
 from compose_lint._safe_read import MAX_FILE_BYTES, UnsafeFileError, read_text_bounded
 from compose_lint._scalar import as_scalar_text
-from compose_lint._yaml_edit import extends_targets
+from compose_lint._yaml_edit import extends_targets, normalize_security_opt
 from compose_lint.config import ConfigError, load_config
 from compose_lint.engine import run_rules
 from compose_lint.formatters.sarif import MAX_SARIF_RESULTS
 from compose_lint.parser import ComposeError, loads
+from compose_lint.rules._interpolation import _resolve_defaults
 from tests._cli_env import cli_env
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -290,3 +292,85 @@ def test_an_ordinary_run_is_not_truncated(tmp_path: Path) -> None:
 def test_a_malformed_document_is_still_a_compose_error() -> None:
     with pytest.raises(ComposeError):
         loads("services:\n  web:\n    image: [\n")
+
+
+# --- Substitution is bounded on what it produces, not just what it scans ---
+#
+# `MAX_SCAN_LEN` bounds the *input* a pass will look at. It never fires here,
+# because no single value is ever large: `${A}${A}` is four characters whose
+# result is twice whatever `A` holds, so a ladder of definitions that each
+# reference the one below doubles per rung. Thirty rungs is a 489-byte `.env`
+# whose expansion is gigabytes.
+
+
+def _doubling_env(rungs: int = 30) -> str:
+    lines = ["K0=AAAA"]
+    lines += [f"K{i}=${{K{i - 1}}}${{K{i - 1}}}" for i in range(1, rungs + 1)]
+    return "\n".join(lines) + "\n"
+
+
+def test_a_tiny_env_cannot_buy_an_unbounded_expansion(tmp_path: Path) -> None:
+    """A 489-byte `.env` used to allocate until the runner died."""
+    env = tmp_path / ".env"
+    env.write_text(_doubling_env(), encoding="utf-8")
+    assert len(env.read_bytes()) < 1024, "the point is that the input is tiny"
+    (tmp_path / "docker-compose.yml").write_text(
+        "services:\n  web:\n    image: nginx:1.27\n    environment:\n      X: ${K30}\n",
+        encoding="utf-8",
+    )
+
+    start = time.monotonic()
+    proc = _run(["check", "docker-compose.yml"], tmp_path, timeout=60)
+    elapsed = time.monotonic() - start
+
+    # The run completes and reports a verdict rather than dying mid-write.
+    assert proc.returncode in (0, 1), proc.stderr
+    assert "MemoryError" not in proc.stderr
+    assert "Traceback" not in proc.stderr, proc.stderr
+    assert elapsed < 30, f"took {elapsed:.1f}s; expansion is unbounded again"
+
+
+def test_the_substitution_cap_returns_the_unknowable_answer() -> None:
+    """Over the cap the value is not knowable, which is already `None`."""
+    over = {"A": "x" * (MAX_SUBSTITUTED_LEN + 1)}
+    assert _resolve_defaults("${A}", env=over) is None
+    # Under it, resolution is unchanged.
+    assert _resolve_defaults("${A:-ok}") == "ok"
+
+
+# --- `str()` on an alias DAG, in the three predicates `_scalar` had missed ---
+
+
+def _alias_ladder(field: str, rungs: int = 26) -> str:
+    lines = ["services:", "  web:", "    image: nginx:1.27", "    x-l0: &l0 [a, b]"]
+    lines += [f"    x-l{i}: &l{i} [*l{i - 1}, *l{i - 1}]" for i in range(1, rungs + 1)]
+    lines.append(f"    {field}: *l{rungs}")
+    return "\n".join(lines) + "\n"
+
+
+@pytest.mark.parametrize("field", ["security_opt", "pid", "ipc", "network_mode"])
+def test_an_alias_dag_is_not_serialized_as_a_tree(tmp_path: Path, field: str) -> None:
+    """`security_opt: [*l26]` is 690 bytes on disk and 2^26 via `str()`.
+
+    `_caps.iter_cap_add` already refused this for `cap_add`; the CL-0003 /
+    CL-0009 normalizer and CL-0010's namespace comparison did not.
+    """
+    target = tmp_path / "docker-compose.yml"
+    target.write_text(_alias_ladder(field), encoding="utf-8")
+    assert len(target.read_bytes()) < 2048, "the point is that the input is tiny"
+
+    start = time.monotonic()
+    proc = _run(["check", "docker-compose.yml"], tmp_path, timeout=60)
+    elapsed = time.monotonic() - start
+
+    assert proc.returncode in (0, 1), proc.stderr
+    assert "Traceback" not in proc.stderr, proc.stderr
+    assert elapsed < 20, f"took {elapsed:.1f}s; the DAG is being expanded again"
+
+
+def test_a_non_scalar_security_opt_normalizes_to_nothing() -> None:
+    """A list is not a directive Docker accepts, so it matches nothing."""
+    assert normalize_security_opt(["seccomp:unconfined"]) == ""
+    assert normalize_security_opt({"a": "b"}) == ""
+    # Scalars are untouched.
+    assert normalize_security_opt("seccomp=unconfined") == "seccomp:unconfined"


### PR DESCRIPTION
Two vectors, both reachable from a pull request in the CI merge gate this tool ships as (the Action, the pre-commit hook, the Docker image).

## (a) Substitution is bounded on input, unbounded on output

`MAX_SCAN_LEN` bounds what a pass *scans*. It never fires here, because no single value is ever large: `${A}${A}` is four characters whose result is twice whatever `A` holds, so a ladder of definitions each referencing the one below doubles per rung.

Thirty rungs is a **489-byte** `.env` whose expansion exhausts memory — `MemoryError` at `_env_file.py`, and under `--format json` **zero bytes on stdout**. Reachable via the ambient `.env` and via `env_file:`, which has no wanted-set filter at all.

New `MAX_SUBSTITUTED_LEN` bounds the result *as it is built* — checking after the join is too late, the allocation has already happened. Over the cap both sites return `None`, the same "unknowable" answer they already return for a name they cannot resolve.

## (b) `str()` on an alias DAG, in three predicates

YAML aliases make a document a DAG; `str()` serializes it as a tree.

| depth | before | after |
|---|---|---|
| `[*l22]` | 1.84 s | — |
| `[*l24]` | 7.41 s | — |
| `[*l26]` (**690 bytes**) | **35.85 s** | **90 ms** |

`compose_lint._scalar` exists precisely to refuse this and `_caps.iter_cap_add` already applied it to `cap_add`. The CL-0003 / CL-0009 `security_opt` normalizer and CL-0010's namespace comparison were missed. A list is not a value any of those fields can hold, so the entry is skipped rather than compared — every caller already treats an unrecognized value that way.

## Note

`(a)` also violated the exit-code contract: a run that completed nothing exited 1, which a gate reads as an ordinary failing lint. That half is fixed independently in #718.

Found by a pre-1.0 freeze-surface audit.
