### PR TITLE
Read a quoted .env value that spans lines as one entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CL-0009 `security_opt` normalizer and CL-0010's namespace comparison now do
   too — 35.85s to 90ms. A list is not a value any of those fields can hold, so
   the entry is skipped rather than compared.
+- **A pull request can no longer choose its own lint scope through a quoted
+  `.env` value.** godotenv — and therefore Compose — lets a quoted value span
+  lines, so the physical lines after the opening quote are value *text*, not
+  entries. `_scan` read them as entries, which handed an untrusted contributor
+  the one thing [ADR-026](docs/adr/026-read-the-sibling-env-file.md) §4 forbids:
+  a `COMPOSE_FILE` compose-lint honours and Compose never sees. Three committed
+  files were enough — a `.env` whose value text carries
+  `COMPOSE_FILE=compose.yml:scrub.yml`, and a `scrub.yml` that `!reset`s the
+  dangerous keys — turning a privileged, socket-mounting service from two
+  CRITICAL findings into `✓ PASS` and exit 0, including in the explicit-file
+  form the GitHub Action and the pre-commit hook use. `docker compose config`
+  was never fooled; only compose-lint was. The scanner is now value-aware for
+  both quote styles, with double-quote escapes honoured, and an unterminated
+  quote consumes the rest of the file exactly as Compose does. This is the same
+  failure `_split_env_lines` already closed for `\r`, by the route left open
+  for `\n`.
 
 ## [0.24.0] - 2026-08-24
 

--- a/src/compose_lint/_env_file.py
+++ b/src/compose_lint/_env_file.py
@@ -265,6 +265,76 @@ def _split_env_lines(text: str) -> list[str]:
     return text.split("\n")
 
 
+def _closing_quote(value: str, quote: str) -> bool:
+    """Whether ``value`` — which opens with ``quote`` — also closes it.
+
+    A backslash escapes the next character inside a double-quoted value, so
+    ``"a\\"b"`` is one value rather than two. Single quotes take no escapes
+    (godotenv, and Compose 5.4.0, treat the body as literal), so the first
+    ``'`` closes it.
+    """
+    index = 1
+    while index < len(value):
+        char = value[index]
+        if quote == '"' and char == "\\":
+            index += 2
+            continue
+        if char == quote:
+            return True
+        index += 1
+    return False
+
+
+def _join_multiline_values(lines: list[str]) -> list[tuple[int, str]]:
+    """Group physical lines into entries, honouring values that span lines.
+
+    godotenv — and therefore Compose — lets a quoted value contain newlines,
+    so the physical lines after the opening quote are *value text*, not
+    entries. Reading them as entries is the scope-smuggling hole ADR-026 §4
+    exists to close, arriving by the one route :func:`_split_env_lines` left
+    open. A ``.env`` carrying::
+
+        NOTE="release notes:
+        COMPOSE_FILE=compose.yml:scrub.yml
+        end"
+
+    sets only ``NOTE``; Compose never sees a ``COMPOSE_FILE``. compose-lint
+    did, so a pull request could add a document that ``!reset``s the dangerous
+    keys and select it into its own lint — turning two CRITICAL findings into
+    a green gate (verified against ``docker compose config`` 5.4.0).
+
+    Returns ``(line_number, text)`` pairs where ``text`` may contain newlines.
+    An unterminated quote consumes the rest of the file, which is what Compose
+    does with one too.
+    """
+    grouped: list[tuple[int, str]] = []
+    index = 0
+    total = len(lines)
+    while index < total:
+        number = index + 1
+        line = lines[index]
+        stripped = _EXPORT_RE.sub("", line.strip())
+        _key, separator, value = stripped.partition("=")
+        value = value.strip()
+        quote = value[:1]
+        if separator and quote in ('"', "'") and not _closing_quote(value, quote):
+            buffer = [line]
+            index += 1
+            while index < total:
+                buffer.append(lines[index])
+                # The continuation closes when this line carries the quote,
+                # scanned with the same escape rules as the opening line.
+                if _closing_quote(quote + lines[index], quote):
+                    break
+                index += 1
+            grouped.append((number, "\n".join(buffer)))
+            index += 1
+            continue
+        grouped.append((number, line))
+        index += 1
+    return grouped
+
+
 def _scan(text: str, *, raw: bool = False) -> tuple[list[_Entry], list[int]]:
     """Split text into entries as written, plus the lines that are not entries.
 
@@ -277,7 +347,13 @@ def _scan(text: str, *, raw: bool = False) -> tuple[list[_Entry], list[int]]:
     skipped: list[int] = []
     # `\ufeff` is a BOM on the first line; Compose tolerates one (verified), and
     # left in place it would become part of the first key.
-    for number, line in enumerate(_split_env_lines(text.lstrip("\ufeff")), start=1):
+    physical = _split_env_lines(text.lstrip("\ufeff"))
+    # `format: raw` is a different grammar with no quoting at all, so a value
+    # never spans lines there and each physical line is its own entry.
+    numbered = (
+        list(enumerate(physical, start=1)) if raw else _join_multiline_values(physical)
+    )
+    for number, line in numbered:
         stripped = line.strip()
         if not stripped or stripped.startswith("#"):
             continue

--- a/tests/test_env_file.py
+++ b/tests/test_env_file.py
@@ -369,3 +369,59 @@ class TestReadEnvFile:
     def test_a_directory_is_none(self, tmp_path: Path) -> None:
         (tmp_path / "app.env").mkdir()
         assert read_env_file(tmp_path / "app.env") is None
+
+
+# --- A quoted value may span lines, and its lines are not entries ---------
+#
+# godotenv -- and therefore Compose -- lets a quoted value contain newlines.
+# Reading the physical lines after the opening quote as entries is the
+# scope-smuggling hole ADR-026 section 4 exists to close, arriving by the one
+# route `_split_env_lines` left open: a `.env` whose *value text* contains a
+# `COMPOSE_FILE=` line offered compose-lint a document set Compose never sees.
+
+_SMUGGLED = 'NOTE="release notes:\nCOMPOSE_FILE=compose.yml:scrub.yml\nend"\n'
+
+
+def test_a_compose_file_inside_a_quoted_value_is_not_an_entry() -> None:
+    parsed = parse_env(_SMUGGLED, wanted=None)
+    assert "COMPOSE_FILE" not in parsed.values
+    assert "COMPOSE_FILE" not in parsed.unresolved
+    assert (
+        parsed.values["NOTE"]
+        == "release notes:\nCOMPOSE_FILE=compose.yml:scrub.yml\nend"
+    )
+
+
+def test_a_single_quoted_value_spans_lines_too() -> None:
+    parsed = parse_env("NOTE='a\nCOMPOSE_FILE=evil.yml\nend'\nK=v\n", wanted=None)
+    assert "COMPOSE_FILE" not in parsed.values
+    assert parsed.values["K"] == "v"
+
+
+def test_an_entry_after_a_multiline_value_is_still_read() -> None:
+    """The scanner must resume, not swallow the rest of the file."""
+    parsed = parse_env(_SMUGGLED + "AFTER=yes\n", wanted=None)
+    assert parsed.values["AFTER"] == "yes"
+
+
+def test_an_escaped_quote_does_not_close_a_double_quoted_value() -> None:
+    parsed = parse_env('A="a\\"b"\nB=v\n', wanted=None)
+    assert parsed.values["B"] == "v"
+
+
+def test_a_single_quoted_value_takes_no_escapes() -> None:
+    """godotenv treats a single-quoted body as literal, so the first quote closes."""
+    parsed = parse_env("A='a\\'\nB=v\n", wanted=None)
+    assert parsed.values["B"] == "v"
+
+
+def test_an_unterminated_quote_consumes_the_rest_of_the_file() -> None:
+    """Which is what Compose does with one too."""
+    parsed = parse_env('A="never closed\nB=v\n', wanted=None)
+    assert "B" not in parsed.values
+
+
+def test_a_single_line_quoted_value_is_unchanged() -> None:
+    parsed = parse_env('A="one line"\nB="v # keep"\n', wanted=None)
+    assert parsed.values["A"] == "one line"
+    assert parsed.values["B"] == "v # keep"


### PR DESCRIPTION
**A pull request could choose its own lint scope.** Three committed files turned a privileged, socket-mounting service from two CRITICAL findings into `✓ PASS` and exit 0.

## The attack

```
# .env
NOTE="release notes:
COMPOSE_FILE=compose.yml:scrub.yml
end"

# scrub.yml
services: {web: {privileged: !reset null, volumes: !reset null}}
```

```console
$ compose-lint check compose.yml        # the Action's own argv form
compose.yml: 4 medium, 1 low
✓ PASS  ·  threshold: high                        rc=0

# control — same tree, COMPOSE_FILE line deleted from .env
CRITICAL  CL-0002  Service runs in privileged mode…
CRITICAL  CL-0001  Docker runtime socket mounted…   rc=1
```

`docker compose config` (5.4.0) renders `privileged: true` and the socket mount. Line 2 is *value text*; Compose never sets `COMPOSE_FILE`. Only compose-lint was fooled. Bare discovery was worse — the same trick selected an unrelated decoy outright.

## Why it happened

godotenv — and therefore Compose — lets a quoted value span lines. `_split_env_lines` is `text.split("\n")` and `_entry` decided quoting per line, so the physical lines after the opening quote were read as entries.

This is the failure ADR-026 §4 exists to prevent: *"a gate must not let the artifact under inspection define its own scope … an untrusted contributor could shrink a CI gate's scope by adding one file."* `_split_env_lines`'s own docstring names this exact attack for the `\r` route it closed — it was left open for `\n` inside quotes.

§4's add-only rule does **not** rescue the explicit-file form, because the added document `!reset`s the dangerous keys rather than adding to them.

## The fix

The scanner is value-aware for both quote styles, with double-quote escapes honoured (`"a\"b"` is one value) and single-quoted bodies literal, matching godotenv. An unterminated quote consumes the rest of the file, which is what Compose does with one too. `format: raw` is untouched — it has no quoting, so no value spans lines there.

Verified: seven quoting cases round-trip correctly, the smuggled key never reaches `_selection.COMPOSE_FILE_KEYS`, and the scanner resumes afterwards rather than swallowing the file.

Found by a pre-1.0 freeze-surface audit.
