### PR TITLE
Refuse a path that resolves outside the project, not just one that says so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   quote consumes the rest of the file exactly as Compose does. This is the same
   failure `_split_env_lines` already closed for `\r`, by the route left open
   for `\n`.
+- **A committed symlink no longer walks through the project-containment
+  guard.** The guards in `_selection` and `_service_env` are deliberately
+  lexical — whether a path *says* it leaves the project is a fact about the
+  document, identical on every platform
+  ([ADR-023](docs/adr/023-deploy-host-independent-claims.md) §1) — and a
+  symlink says nothing. `probe.env` is spelled like a project-relative file
+  and passes every lexical test while the link beside it points at
+  `/home/runner/.aws/credentials`: exactly the scenario
+  [ADR-027](docs/adr/027-grade-env-file-where-the-document-routes-it.md) §7
+  names and `README.md` promises to refuse. In a pull request that put
+  out-of-project env-key names into CL-0020/CL-0021 findings, and a line of an
+  arbitrary host file into the SARIF uploaded to Code Scanning. A second gate
+  now asks the *filesystem* — after the lexical test, at the moment of
+  resolution — for both `env_file:` targets and `COMPOSE_FILE` entries.
+  Symlinks themselves are still followed; only ones resolving outside the
+  project are refused, with the existing `outside-project` note.
+
+- **A parse error no longer reproduces the line it failed on.** PyYAML renders
+  a snippet of the document under a caret, which reached `errors[].message`,
+  the SARIF `toolExecutionNotifications` uploaded to Code Scanning, and the job
+  log. A syntax error on a line carrying a credential therefore republished the
+  credential. The diagnosis and the line/column position are kept — they say
+  what is wrong and exactly where — and only the quoted bytes are dropped.
 
 ## [0.24.0] - 2026-08-24
 

--- a/src/compose_lint/_safe_read.py
+++ b/src/compose_lint/_safe_read.py
@@ -33,11 +33,40 @@ class UnsafeFileError(OSError):
     """Raised when a path is not a regular file, or is larger than the cap."""
 
 
+class OutsideProjectError(UnsafeFileError):
+    """Raised when a path resolves outside the project it was named from."""
+
+
+def escapes_project(path: Path, project: Path) -> bool:
+    """Whether ``path`` resolves outside ``project`` on *this* filesystem.
+
+    The lexical guards in :mod:`compose_lint._selection` and
+    :mod:`compose_lint._service_env` answer a different question, and
+    deliberately so: whether a path *says* it leaves the project is a fact
+    about the document, identical on every platform (ADR-023 §1). A symlink is
+    not visible in what the path says. ``probe.env`` is spelled like a
+    project-relative file and passes every lexical test, while the committed
+    link beside it points at ``/home/runner/.aws/credentials`` — the scenario
+    ADR-027 §7 names and promises to refuse.
+
+    So this is a *second* gate rather than a replacement: asked at the moment
+    of reading, about this filesystem, after the lexical test has already
+    ruled on the document. Both have to pass.
+    """
+    try:
+        resolved = path.resolve()
+        root = project.resolve()
+    except OSError:  # pragma: no cover - resolution failed; treat as escaping
+        return True
+    return not resolved.is_relative_to(root)
+
+
 def read_text_bounded(
     path: Path,
     *,
     max_bytes: int = MAX_FILE_BYTES,
     newline: str | None = None,
+    within: Path | None = None,
 ) -> str:
     """Read ``path`` as UTF-8, refusing anything that is not a bounded regular file.
 
@@ -65,7 +94,19 @@ def read_text_bounded(
     file read on Windows in 0.18.0. ``O_BINARY`` exists only on Windows, where
     omitting it makes the CRT translate newlines *under* the text layer below,
     silently breaking the ``newline=""`` real-bytes contract.
+
+    ``within`` adds the physical containment gate: the path must *resolve*
+    inside that directory. Symlinks are still followed for the shape check —
+    a symlink to a real Compose file is ordinary — but a link whose target
+    leaves the project is refused with :class:`OutsideProjectError` when the
+    caller names a project. Callers that were pointed at a file by the user
+    (an argv path, ``--config``) pass nothing and are unaffected; callers
+    opening a path *the document named* pass the project directory.
     """
+    if within is not None and escapes_project(path, within):
+        raise OutsideProjectError(
+            f"{path} resolves outside the project directory (refused rather than read)"
+        )
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_BINARY", 0)
     fd = os.open(path, flags)
     try:

--- a/src/compose_lint/_selection.py
+++ b/src/compose_lint/_selection.py
@@ -36,6 +36,7 @@ from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 
 from compose_lint._env_file import ENV_FILENAME, read_env
+from compose_lint._safe_read import escapes_project
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -330,5 +331,13 @@ def _resolve_entry(directory: Path, entry: str) -> str | None:
         return None
     candidate = directory.joinpath(*parts)
     if not candidate.is_file():
+        return None
+    # Second gate, on this filesystem rather than on the spelling. The climb
+    # test above is deliberately lexical (ADR-023 §1), and a symlink is
+    # invisible to it: a committed link named like a project-relative document
+    # passes every test above while pointing anywhere on the runner. Selecting
+    # one would let the artifact choose a file outside itself, which is the
+    # traversal ADR-026 §4 requires this function to refuse.
+    if escapes_project(candidate, directory):
         return None
     return str(candidate)

--- a/src/compose_lint/_service_env.py
+++ b/src/compose_lint/_service_env.py
@@ -44,7 +44,11 @@ from compose_lint._env_file import (
     parse_env_file,
     read_env,
 )
-from compose_lint._safe_read import UnsafeFileError, read_text_bounded
+from compose_lint._safe_read import (
+    UnsafeFileError,
+    escapes_project,
+    read_text_bounded,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -205,7 +209,17 @@ def _classify(ref: EnvFileRef, base_dir: Path) -> tuple[Path | None, Unread | No
     segments = _project_relative(ref.path)
     if segments is None:
         return None, Unread.OUTSIDE_PROJECT
-    return base_dir.joinpath(*segments), None
+    candidate = base_dir.joinpath(*segments)
+    # Second gate, and a different question. The segment math above rules on
+    # what the *document* says, identically on every platform (ADR-023 §1); a
+    # symlink says nothing. `probe.env` is spelled like a project-relative
+    # file and passes every lexical test while the committed link beside it
+    # points at `/home/runner/.aws/credentials` — the scenario ADR-027 §7
+    # names and promises to refuse. Asked here, at the moment of resolution,
+    # about this filesystem.
+    if escapes_project(candidate, base_dir):
+        return None, Unread.OUTSIDE_PROJECT
+    return candidate, None
 
 
 def resolve_env_files(

--- a/src/compose_lint/parser.py
+++ b/src/compose_lint/parser.py
@@ -42,6 +42,35 @@ class _LinesKey:
 _LINES = _LinesKey()
 
 
+def _describe_yaml_error(exc: yaml.YAMLError) -> str:
+    """PyYAML's diagnosis, without the source line it quotes.
+
+    ``MarkedYAMLError.__str__`` renders a snippet of the document under a
+    caret. That is genuinely the most useful part of the message for a human
+    fixing their own file, and it is also a verbatim line of a file the run
+    was pointed at — which reaches ``errors[].message`` in JSON, the SARIF
+    ``toolExecutionNotifications`` uploaded to Code Scanning, and the job log.
+    Two shapes make that a disclosure rather than a nicety: a syntax error on a
+    line carrying a credential reproduces the credential, and an ``env_file:``
+    or ``COMPOSE_FILE`` naming a file the document chose makes it a line of
+    *that* file.
+
+    So the diagnosis and the position are kept — they say what is wrong and
+    exactly where — and only the quoted bytes are dropped. The user still has
+    the file open in front of them; a reader of the report does not.
+    """
+    problem = getattr(exc, "problem", None)
+    if problem is None:
+        return str(exc)
+    context = getattr(exc, "context", None)
+    parts = [context, problem] if context else [problem]
+    mark = getattr(exc, "problem_mark", None)
+    if mark is not None:
+        # Marks are 0-indexed; every other line number compose-lint prints is 1-indexed.
+        parts.append(f"at line {mark.line + 1}, column {mark.column + 1}")
+    return ", ".join(parts)
+
+
 class ComposeError(Exception):
     """Raised when a file is not a valid Docker Compose file."""
 
@@ -1249,7 +1278,7 @@ def _loads_full(
         raw_resets = loader._resets
         raw_overrides = loader._overrides
     except yaml.YAMLError as e:
-        raise ComposeError(f"Invalid YAML: {e}") from e
+        raise ComposeError(f"Invalid YAML: {_describe_yaml_error(e)}") from e
     except RecursionError as e:
         # PyYAML's composer is recursive (compose_node -> compose_sequence_node
         # -> compose_node) with no built-in depth limit, so deeply-nested input

--- a/tests/test_output_sanitizing.py
+++ b/tests/test_output_sanitizing.py
@@ -17,6 +17,7 @@ enforces that.
 from __future__ import annotations
 
 import ast
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -24,6 +25,9 @@ from pathlib import Path
 import pytest
 
 from compose_lint._output import sanitize, sanitize_line
+from compose_lint._selection import _resolve_entry
+from compose_lint._service_env import Unread, _classify, env_file_refs
+from compose_lint.parser import ComposeError, loads
 from tests._cli_env import cli_env
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -192,3 +196,77 @@ def test_diff_content_is_escaped_but_structure_survives(
     assert diff.startswith("---")
     assert "\n" in diff
     assert "+++" in diff
+
+
+# --- A symlink is invisible to a lexical containment test ------------------
+#
+# The guards in `_selection` and `_service_env` are deliberately lexical: what
+# a path *says* is a fact about the document, identical on every platform
+# (ADR-023 section 1). A committed symlink says nothing -- `probe.env` passes
+# every lexical test while pointing at `/home/runner/.aws/credentials`, the
+# scenario ADR-027 section 7 names and promises to refuse. So a second gate
+# asks the filesystem, at the moment of resolution.
+
+
+@pytest.mark.skipif(os.name != "posix", reason="needs POSIX symlinks")
+def test_an_env_file_symlink_out_of_the_project_is_refused(tmp_path: Path) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secrets.env").write_text("DB_PASSWORD=hunter2\n", encoding="utf-8")
+
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "leaked.env").symlink_to(outside / "secrets.env")
+    (project / "compose.yml").write_text(
+        "services:\n  web:\n    image: nginx:1.27\n    env_file: leaked.env\n",
+        encoding="utf-8",
+    )
+
+    refs = env_file_refs("leaked.env")
+    path, refusal = _classify(refs[0], project)
+    assert path is None
+    assert refusal is Unread.OUTSIDE_PROJECT
+
+
+@pytest.mark.skipif(os.name != "posix", reason="needs POSIX symlinks")
+def test_an_in_project_symlink_is_still_read(tmp_path: Path) -> None:
+    """The gate refuses escapes, not symlinks."""
+    project = tmp_path / "project"
+    (project / "shared").mkdir(parents=True)
+    (project / "shared" / "real.env").write_text("A=b\n", encoding="utf-8")
+    (project / "app.env").symlink_to(project / "shared" / "real.env")
+
+    path, refusal = _classify(env_file_refs("app.env")[0], project)
+    assert refusal is None
+    assert path is not None
+
+
+@pytest.mark.skipif(os.name != "posix", reason="needs POSIX symlinks")
+def test_a_compose_file_entry_symlink_out_of_the_project_is_refused(
+    tmp_path: Path,
+) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "evil.yml").write_text(
+        "services:\n  x:\n    image: nginx:1.27\n", encoding="utf-8"
+    )
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "linked.yml").symlink_to(outside / "evil.yml")
+
+    assert _resolve_entry(project, "linked.yml") is None
+
+
+# --- A parse error must not quote the line it failed on --------------------
+
+
+def test_a_parse_error_does_not_reproduce_the_line_it_failed_on() -> None:
+    """PyYAML renders a snippet under a caret; that snippet is the document."""
+    with pytest.raises(ComposeError) as excinfo:
+        loads("services:\n  db:\n\tPOSTGRES_PASSWORD: s3cr3t-do-not-leak\n")
+
+    message = str(excinfo.value)
+    assert "s3cr3t-do-not-leak" not in message
+    # The diagnosis and the position survive -- only the quoted bytes go.
+    assert "cannot start any token" in message
+    assert "line 3" in message


### PR DESCRIPTION
A committed symlink walked straight through the project-containment guard.

## The gap

The guards in `_selection` and `_service_env` are lexical **by design** — whether a path *says* it leaves the project is a fact about the document, identical on every platform (ADR-023 §1). A symlink says nothing. `probe.env` is spelled like a project-relative file and passes every lexical test, while the committed link beside it points anywhere on the runner.

That is exactly the scenario ADR-027 §7 names — *"an `env_file: /home/runner/.aws/credentials` added in a pull request"* — and that `README.md:402` promises to refuse: *"a path resolving outside the project directory is refused rather than read."* No ADR carves out symlinks.

Reproduced:
- an `env_file:` symlink out of the project was **read**, and CL-0020 fired with the out-of-project key name reaching the JSON output;
- a `COMPOSE_FILE` entry symlink selected a document outside the project;
- a read-oracle: `env_file:` → `/etc/passwd` reported *"whose lines 1, 2, … 39 could not be read as KEY=value"*, and the file has exactly 39 lines.

## The fix

A **second** gate, not a replacement: after the lexical test has ruled on the document, ask the filesystem whether the path *resolves* inside the project. Both must pass. Applied to `env_file:` targets and `COMPOSE_FILE` entries, reusing the existing `outside-project` refusal and its note.

Symlinks themselves are still followed — a symlink to a real Compose file is ordinary. Verified that an in-project symlink is still read, and that a project reached *through* a symlink still works (both sides are resolved).

## Second half: parse errors quoted the line they failed on

`MarkedYAMLError.__str__` renders a snippet of the document under a caret. That reached `errors[].message`, the SARIF `toolExecutionNotifications` uploaded to Code Scanning, and the job log — so a syntax error on a line carrying a credential **republished the credential**.

The diagnosis and the line/column position are kept; only the quoted bytes are dropped:

```
Invalid YAML: while scanning for the next token, found character '\t'
that cannot start any token, at line 3, column 1
```

## Behaviour change

CL-0020/CL-0021 stop firing on out-of-project `env_file:` targets. That is the documented promise being enforced rather than a new policy, but it is a change in emitted findings and called out here deliberately.

Found by a pre-1.0 freeze-surface audit.
