### PR TITLE
Point JSON file and line at the same document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
 
+### Changed
+- **JSON `file` and `line` now name the same document, and the envelope is
+  schema `"2"`.** `file` had always named the document being *graded* while
+  `line` indexed wherever the evidence actually came from, so on a merged run
+  (default since [ADR-025](docs/adr/025-lint-the-merged-configuration.md)) or
+  one reading an `env_file:` (default since
+  [ADR-027](docs/adr/027-grade-env-file-where-the-document-routes-it.md)) the
+  pair named a real line of the *wrong file* — an overlay's CL-0002 was
+  reported at the base file's line 3, which is its `image:` key. SARIF was
+  already corrected this way after the same mismatch made Code Scanning
+  annotate an unrelated line of the base file; JSON was the last format
+  emitting an incoherent pair. `file` now names the document the evidence is
+  in, the graded document moved to the new conditional `graded_file`, and
+  `source_file` stays as a deprecated alias for consumers written against
+  schema 1. **This is a breaking change to a required field**, which is why it
+  ships before the 1.0 freeze — after the tag the same correction would be a
+  MAJOR. ADR-015 and `docs/configuration.md` now document the complete emitted
+  field list, including `severity_overridden_from` and the closed `severity`
+  set, neither of which the frozen contract had named.
+
+
+### Fixed
 - **A failed stdout write is now exit 2, not an undocumented exit 120 or a
   false exit 1.** Every path that could raise mid-run had been hardened to the
   0/1/2 contract; the channel all of them write through had not. A full disk

--- a/docs/adr/015-machine-readable-output-contract.md
+++ b/docs/adr/015-machine-readable-output-contract.md
@@ -26,8 +26,8 @@ was invisible in JSON, with exit code 2 the only signal.
 
 ```json
 {
-  "version": "1",
-  "tool": { "name": "compose-lint", "version": "0.8.0" },
+  "version": "2",
+  "tool": { "name": "compose-lint", "version": "0.24.0" },
   "findings": [ "..." ],
   "errors": [ { "file": "...", "message": "..." } ]
 }
@@ -37,9 +37,39 @@ was invisible in JSON, with exit code 2 the only signal.
   a breaking change to the shape. Adding a new top-level field (e.g. a future
   `summary`) is additive and does **not** bump it — that is the point of the
   envelope.
-- `findings[]` keeps the exact per-finding fields from 0.x: `file`, `line`,
-  `rule_id`, `severity`, `service`, `message`, `fix`, `references`,
-  `suppressed`, and `suppression_reason` (only when suppressed).
+- `findings[]` carries these fields on **every** finding:
+
+  | field | type | meaning |
+  |-------|------|---------|
+  | `file` | string | the document the evidence is written in |
+  | `line` | integer | 1-indexed line **within `file`** |
+  | `rule_id` | string | **opaque** — match exact values, never the `CL-\d{4}` shape (see [compatibility.md](../compatibility.md)) |
+  | `severity` | string | one of `critical`, `high`, `medium`, `low` — a closed set |
+  | `service` | string | the Compose service the finding is about |
+  | `message` | string | what is wrong |
+  | `fix` | string | how to fix it |
+  | `references` | array of string | authoritative sources |
+  | `suppressed` | boolean | whether config suppressed it |
+
+  And these **only** on the branch that produces them. Each is conditional, so
+  a consumer that does not know the key sees the document it always did:
+
+  | field | present when |
+  |-------|--------------|
+  | `suppression_reason` | `suppressed` is true and the config gave a reason |
+  | `severity_overridden_from` | the config regraded the finding; carries the original severity |
+  | `graded_file` | `file` differs from the document being graded — a merged or `env_file:` run |
+  | `source_file` | *deprecated alias* of `file`, emitted alongside `graded_file`; schema-1 consumers used it to learn where `line` pointed |
+
+  **Schema 2 changed what `file` means.** In schema 1 it always named the
+  document being *graded*, while `line` indexed wherever the evidence actually
+  came from — so on a merged run (default since [ADR-025](025-lint-the-merged-configuration.md))
+  or an `env_file:` run (default since [ADR-027](027-grade-env-file-where-the-document-routes-it.md))
+  the pair named a real line of the wrong file. SARIF had already been
+  corrected the same way, after the mismatch made Code Scanning annotate an
+  unrelated line of the base file. Correcting JSON is a breaking change to a
+  required field, which is why it ships **before** the 1.0 freeze rather than
+  after it.
 - `errors[]` lists files that could not be parsed (the exit-2 cases),
   mirroring SARIF's `toolExecutionNotifications`. ADR-013 "not applicable"
   skips (Compose v1 / fragments, exit 0) are deliberately excluded — they are

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -155,8 +155,8 @@ JSON output is a versioned envelope (see [ADR-015](adr/015-machine-readable-outp
 
 ```json
 {
-  "version": "1",
-  "tool": { "name": "compose-lint", "version": "0.8.0" },
+  "version": "2",
+  "tool": { "name": "compose-lint", "version": "0.24.0" },
   "findings": [
     {
       "file": "docker-compose.yml",
@@ -177,8 +177,13 @@ JSON output is a versioned envelope (see [ADR-015](adr/015-machine-readable-outp
 ```
 
 - `version` is the envelope schema version. New top-level fields are added without bumping it; a bump signals a breaking change.
-- `findings[]` carries one object per finding; `suppression_reason` is present only on suppressed findings.
+- `findings[]` carries one object per finding. `file` names the document the evidence is written in and `line` is a line **within that document** — the two always agree. `severity` is one of `critical`, `high`, `medium`, `low`. `rule_id` is an **opaque string**: match exact values, never the `CL-XXXX` pattern ([compatibility.md](compatibility.md)).
+- Four keys are conditional, present only on the branch that produces them: `suppression_reason` (a suppressed finding whose config gave a reason), `severity_overridden_from` (the config regraded it), `graded_file` (a merged or `env_file:` run, where the graded document differs from `file`), and `source_file` (a deprecated alias of `file`, kept for consumers written against schema 1).
 - `errors[]` lists files that failed to parse (exit 2). Files skipped as not-applicable (Compose v1 / fragments / a compose-lint config, [ADR-013](adr/013-missing-services-key.md)) are not errors and do not appear here.
+
+!!! note "Schema 2 changed what `file` means"
+
+    In schema 1, `file` always named the document being *graded* while `line` indexed wherever the evidence came from — so on a merged run or one reading an `env_file:`, both default behaviour, the pair named a real line of the wrong file. `file` now names the evidence's document, and the graded one moved to `graded_file`. If you consumed `source_file` to work around this, `file` answers it directly.
 
 ### SARIF
 

--- a/src/compose_lint/formatters/json.py
+++ b/src/compose_lint/formatters/json.py
@@ -11,15 +11,37 @@ if TYPE_CHECKING:
 
 # Envelope schema version (ADR-015). Bumped only on a breaking change to the
 # output shape; additive top-level fields do not bump it.
-SCHEMA_VERSION = "1"
+#
+# 2: `file` now names the document the evidence is *in*, and the document that
+# was graded moved to `graded_file`. Before 1.0 that costs a version bump; the
+# same correction after the freeze would be a MAJOR, because `file` and `line`
+# are the required fields ADR-015 froze. See `format_findings`.
+SCHEMA_VERSION = "2"
 
 
 def format_findings(findings: list[Finding], filepath: str) -> list[dict[str, object]]:
-    """Format findings as JSON-serializable dicts."""
+    """Format findings as JSON-serializable dicts.
+
+    ``file`` and ``line`` name the same place: the document the evidence is
+    written in, and a line within *that* document. A merged run grades more
+    than one document, so those had disagreed — ``file`` was always the graded
+    document while ``line`` indexed wherever the evidence actually came from,
+    which on any overlay or ``env_file:`` run pointed at a real line of the
+    wrong file. Both are default behaviour (ADR-025, ADR-027), so that was the
+    common path, and both are required fields ADR-015 froze.
+
+    SARIF already resolved this the same way — ``result_path = f.source_file or
+    filepath`` — after the mismatch made Code Scanning annotate an unrelated
+    line of the base file. The graded document is still reported, as
+    ``graded_file``, because "which project did this come from" is a real
+    question a merged run has to answer; it is emitted only when it differs
+    from ``file``.
+    """
     results: list[dict[str, object]] = []
     for f in findings:
+        evidence_file = f.source_file or filepath
         entry: dict[str, object] = {
-            "file": filepath,
+            "file": evidence_file,
             "line": f.line,
             "rule_id": f.rule_id,
             "severity": f.severity.value,
@@ -38,12 +60,14 @@ def format_findings(findings: list[Finding], filepath: str) -> list[dict[str, ob
             entry["suppression_reason"] = f.suppression_reason
         if f.severity_overridden_from is not None:
             entry["severity_overridden_from"] = f.severity_overridden_from.value
-        if f.source_file is not None:
-            # Present only when a run merged documents and this finding's
-            # evidence is in one other than `file` — `line` is a line in
-            # *this* file, not in `file`. Additive and conditional, so the
-            # envelope shape is unchanged for every single-file run and
-            # SCHEMA_VERSION does not move.
+        if evidence_file != filepath:
+            # The project this finding was graded under, when that is not the
+            # document the evidence sits in. Emitted only for a merged or
+            # `env_file:` run, so a single-file run's shape is unchanged.
+            entry["graded_file"] = filepath
+            # Retained as an alias of `file` for consumers written against
+            # schema 1, where it was the only way to learn where `line`
+            # actually pointed. Deprecated; `file` now answers it directly.
             entry["source_file"] = f.source_file
         results.append(entry)
     return results

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -259,7 +259,7 @@ class TestCLI:
         result = run_cli("--format", "json", str(FIXTURES / "valid_basic.yml"))
         assert result.returncode == 0
         data = json.loads(result.stdout)
-        assert data["version"] == "1"
+        assert data["version"] == "2"
         assert data["tool"]["name"] == "compose-lint"
         assert isinstance(data["findings"], list)
 
@@ -454,7 +454,7 @@ class TestCLI:
         )
         assert result.returncode == 0
         data = json.loads(result.stdout)
-        assert data["version"] == "1"
+        assert data["version"] == "2"
         assert data["tool"]["name"] == "compose-lint"
         assert data["tool"]["version"]
         assert data["findings"] == []

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -35,7 +35,7 @@ class TestIntegration:
         result = run_cli("--format", "json", str(FIXTURES / "mixed.yml"))
         assert result.returncode == 1
         data = json.loads(result.stdout)
-        assert data["version"] == "1"
+        assert data["version"] == "2"
         assert isinstance(data["findings"], list)
         assert len(data["findings"]) > 5
 

--- a/tests/test_json_contract.py
+++ b/tests/test_json_contract.py
@@ -61,6 +61,7 @@ CONDITIONAL_FINDING_KEYS = {
     "suppression_reason",
     "severity_overridden_from",
     "source_file",
+    "graded_file",
 }
 
 _RULE = (
@@ -131,7 +132,7 @@ def test_schema_version_is_pinned_to_its_literal_value() -> None:
     `version` is told the shape moved, so it belongs with a CHANGELOG `Changed`
     entry and a documented migration, not with a refactor.
     """
-    assert SCHEMA_VERSION == "1", (
+    assert SCHEMA_VERSION == "2", (
         "SCHEMA_VERSION changed. That is a breaking change to the JSON "
         "envelope, not a version bump of the tool.\n" + _RULE
     )
@@ -234,9 +235,27 @@ def test_source_file_appears_only_on_a_merged_run() -> None:
     (merged,) = format_json([_from_overlay()], "compose.yml")
     (plain,) = format_json([_plain()], "compose.yml")
 
-    assert set(merged) == FINDING_KEYS | {"source_file"}, _RULE
+    assert set(merged) == FINDING_KEYS | {"source_file", "graded_file"}, _RULE
     assert merged["source_file"] == "compose.override.yml"
     assert "source_file" not in plain, _RULE
+    assert "graded_file" not in plain, _RULE
+
+
+def test_file_and_line_name_the_same_document() -> None:
+    """Schema 2. `line` indexes `file`, on every run shape.
+
+    They had disagreed: `file` was always the graded document while `line`
+    indexed wherever the evidence came from, so a merged or `env_file:` run —
+    both default behaviour — pointed at a real line of the wrong file. SARIF
+    had already been corrected the same way after the mismatch made Code
+    Scanning annotate an unrelated line of the base file.
+    """
+    (merged,) = format_json([_from_overlay()], "compose.yml")
+    assert merged["file"] == "compose.override.yml"
+    assert merged["graded_file"] == "compose.yml"
+
+    (plain,) = format_json([_plain()], "compose.yml")
+    assert plain["file"] == "compose.yml"
 
 
 def test_every_conditional_key_is_accounted_for() -> None:


### PR DESCRIPTION
> **Breaking change to a required field. This is why it ships before the 1.0 freeze — after the tag the same correction is a MAJOR.**

## The defect

`file` always named the document being *graded*, while `line` indexed wherever the evidence actually came from. The in-code comment at `formatters/json.py:43` states the consequence outright: *"`line` is a line in **this** file, not in `file`."*

An overlay run emitted:

```json
{ "rule_id": "CL-0002", "file": "compose.yml", "line": 3,
  "source_file": "compose.override.yml" }
```

`compose.yml` line 3 is `image: nginx:1.27`. The overlay's line 3 is `privileged: true`. The pair named a real line of the wrong file.

Merged grading is default since ADR-025 and `env_file:` reading since ADR-027, so **this is the common path**, and `file`/`line` are the required fields ADR-015 froze.

SARIF already resolved this the same way (`result_path = f.source_file or filepath`) after the mismatch made Code Scanning annotate an unrelated line of the base file — see the comment at `sarif.py:410`. Text names the file explicitly. JSON was the last format emitting an incoherent pair.

## The change

- `file` now names the document the evidence is written in; `line` indexes it.
- `graded_file` (new, conditional) names the document being graded, emitted only when it differs.
- `source_file` is retained as a **deprecated alias** of `file`, so consumers written against schema 1 keep working.
- `SCHEMA_VERSION` → `"2"`. This is exactly what the envelope was introduced for, and it is only affordable now.

After:

```json
{ "rule_id": "CL-0002", "file": "compose.override.yml", "line": 3,
  "graded_file": "compose.yml", "source_file": "compose.override.yml" }
```

## Docs

ADR-015 and `docs/configuration.md` now carry the **complete** emitted field list — including `severity_overridden_from` and the closed `severity` set, neither of which the frozen contract had ever named, and the opaque-`rule_id` rule.

## Test churn

Six contract tests failed on this change and were updated. That is the guard working as designed — `test_json_contract.py` exists to make exactly this change deliberate rather than silent. A new test pins that `file` and `line` name the same document on every run shape.

Found by a pre-1.0 freeze-surface audit.
