### PR TITLE
Allow empty config sections in rules and exclude_services

### DIFF
--- a/src/compose_lint/config.py
+++ b/src/compose_lint/config.py
@@ -240,6 +240,8 @@ def _parse_rules(
     strict: bool = False,
 ) -> tuple[dict[str, str | None], dict[str, Severity], ExcludedServices]:
     """Parse the rules section of a config file."""
+    if rules is None:
+        rules = {}
     if not isinstance(rules, dict):
         raise ConfigError("'rules' must be a mapping")
 
@@ -251,6 +253,8 @@ def _parse_rules(
     for rule_id, rule_config in rules.items():
         rule_id = str(rule_id)
 
+        if rule_config is None:
+            rule_config = {}
         if not isinstance(rule_config, dict):
             raise ConfigError(f"Config for rule '{rule_id}' must be a mapping")
 
@@ -302,6 +306,8 @@ def _parse_exclude_services(rule_id: str, value: Any) -> dict[str, str | None]:
     Accepts either a list of service names (no reasons) or a mapping of
     service name to reason string.
     """
+    if value is None:
+        return {}
     if isinstance(value, list):
         result: dict[str, str | None] = {}
         for item in value:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -102,6 +102,38 @@ class TestLoadConfig:
         assert disabled == {}
         assert overrides == {}
 
+    def test_rules_null_behaves_like_empty_mapping(self, tmp_path: Path) -> None:
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text("rules:\n")
+        disabled, overrides, excluded = load_config(config)
+        assert disabled == {}
+        assert overrides == {}
+        assert excluded == {}
+
+    def test_per_rule_null_config_behaves_like_empty_mapping(
+        self, tmp_path: Path
+    ) -> None:
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text("rules:\n  CL-0001:\n")
+        disabled, overrides, excluded = load_config(config)
+        assert "CL-0001" not in disabled
+        assert "CL-0001" not in overrides
+        assert "CL-0001" not in excluded
+
+    def test_rules_wrong_type_raises(self, tmp_path: Path) -> None:
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text("rules: hello\n")
+        with pytest.raises(ConfigError, match="'rules' must be a mapping"):
+            load_config(config)
+
+    def test_per_rule_wrong_type_raises(self, tmp_path: Path) -> None:
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text("rules:\n  CL-0001: hello\n")
+        with pytest.raises(
+            ConfigError, match="Config for rule 'CL-0001' must be a mapping"
+        ):
+            load_config(config)
+
     def test_config_not_mapping(self, tmp_path: Path) -> None:
         config = tmp_path / ".compose-lint.yml"
         config.write_text("- list\n- items\n")
@@ -287,6 +319,18 @@ class TestExcludeServices:
         config.write_text("rules:\n  CL-0003:\n    enabled: false\n")
         _disabled, _overrides, excluded = load_config(config)
         assert excluded == {}
+
+    def test_exclude_services_null_behaves_like_empty(self, tmp_path: Path) -> None:
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text("rules:\n  CL-0003:\n    exclude_services:\n")
+        _disabled, _overrides, excluded = load_config(config)
+        assert excluded == {"CL-0003": {}}
+
+    def test_exclude_services_wrong_type_raises(self, tmp_path: Path) -> None:
+        config = tmp_path / ".compose-lint.yml"
+        config.write_text("rules:\n  CL-0003:\n    exclude_services: 5\n")
+        with pytest.raises(ConfigError, match="must be a list or mapping"):
+            load_config(config)
 
     def test_invalid_scalar_value(self, tmp_path: Path) -> None:
         config = tmp_path / ".compose-lint.yml"


### PR DESCRIPTION
## Summary

Treat an explicit null value for 'rules', per-rule config, and 'exclude_services' as empty mappings rather than fatal type errors.

## Changes

- src/compose_lint/config.py: handle \None\ for \ules\, per-rule dicts, and \exclude_services\
- tests/test_config.py: add unit tests for null config sections and verify wrong scalar types still raise ConfigError

Fixes #724
