### PR TITLE
Correct four published claims to match what the tool does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Fixed
+
+- **Four published claims corrected to match what the tool does.** Under
+  [ADR-030](docs/adr/030-the-policy-is-part-of-the-contract.md) the policy is
+  part of the frozen contract, so a claim that is wrong at the tag is expensive
+  to walk back later. `docs/ASSURANCE.md` said compose-lint "does not modify
+  its inputs" — `fix --apply` has rewritten files in place since 0.11.0 — and
+  its CWE-22 row said "the tool only *reads* them" and "No path is constructed
+  from untrusted YAML content", when `env_file:` targets and `COMPOSE_FILE`
+  entries are exactly that (ADR-026, ADR-027); the row now describes both path
+  classes and the two containment gates that guard the document-supplied one.
+  `docs/compatibility.md` promised a config naming a retired rule ID "keeps
+  working, `--strict-config` included"; it loads, but the override is reported
+  as an unknown ID and `--strict-config` promotes that to an error, which the
+  page now says. `docs/configuration.md` told users to pass a `--pattern` flag
+  that does not exist — globbing is the GitHub Action's `pattern:` input, not a
+  CLI flag.
+
 - **A failed stdout write is now exit 2, not an undocumented exit 120 or a
   false exit 1.** Every path that could raise mid-run had been hardened to the
   0/1/2 contract; the channel all of them write through had not. A full disk

--- a/docs/ASSURANCE.md
+++ b/docs/ASSURANCE.md
@@ -16,8 +16,14 @@ For the vulnerability-reporting process, see [SECURITY.md](../.github/SECURITY.m
 compose-lint is a local static analyzer for Docker Compose files. A user
 runs `compose-lint docker-compose.yml`; the tool reads the file, applies
 a fixed set of rules, prints findings to stdout (text, JSON, or SARIF),
-and exits 0 / 1 / 2. It does not connect to a network, does not modify
-its inputs, and does not run as a daemon.
+and exits 0 / 1 / 2. It does not connect to a network and does not run as
+a daemon.
+
+`check`, `--explain` and `init -o` never modify a Compose file. The one
+subcommand that writes to an input is `fix --apply`, which rewrites the
+file in place via an atomic swap — dry-run is the default, and every apply
+is guarded by a re-parse and a verify-apply pass ([ADR-014](adr/014-fix-remediation.md)).
+`init` also writes, but to `.compose-lint.yml` rather than to an input.
 
 ## Trust boundaries
 
@@ -94,7 +100,7 @@ Common Python-level weakness classes and their mitigations:
 |------------------------------------------------------|------------------------------------------------------------------------------|
 | Unsafe deserialization (CWE-502)                     | `yaml.SafeLoader` everywhere; custom loader asserts subclass at import time. |
 | Command injection / shell-out (CWE-78, CWE-77)       | Product code calls no subprocess, no `os.system`. Bandit enforces.           |
-| Path traversal on input (CWE-22)                     | All file paths are user-supplied targets; the tool only *reads* them. No path is constructed from untrusted YAML content. |
+| Path traversal on input (CWE-22)                     | Two classes of path. **User-supplied targets** (argv, `--config`) are read as given, and written only by `fix --apply` / `init`. **Document-supplied paths** — `env_file:` targets and `COMPOSE_FILE` entries ([ADR-026](adr/026-read-the-sibling-env-file.md), [ADR-027](adr/027-grade-env-file-where-the-document-routes-it.md)) — *are* constructed from untrusted content, and are gated twice: a lexical containment test on what the path says, then a containment test on what it resolves to, so a symlink cannot escape the project. Both are read-only. |
 | Resource exhaustion (CWE-400)                        | Iterative parser traversals; ClusterFuzzLite runs as a continuous gate.     |
 | Type confusion in rule predicates                    | `mypy --strict` on every commit; rules receive plain types only (AGENTS.md). |
 | Logic bug in a rule (false negative or positive)     | Per-rule positive + negative + hardened-but-unusual fixtures; corpus snapshot regression gate; mutation testing on rule predicates via `mutmut`. |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -88,8 +88,13 @@ Two things are never reused or quietly repurposed:
   MINOR, but only through the full deprecation lifecycle and only on
   evidence that refutes the rule's premise
   ([ADR-032](adr/032-rule-retirement-is-minor-with-lifecycle.md)) — never
-  on noise or preference. A config referencing a retired ID keeps working,
-  `--strict-config` included.
+  on noise or preference. A config referencing a retired ID still loads:
+  the override simply has no rule to apply. It is reported the same way a
+  typo'd ID is — `warning: config: unknown rule id 'CL-XXXX'` — which
+  `--strict-config` promotes to an error, so a strict CI pipeline does
+  fail on one. Distinguishing "retired" from "mistyped" needs the retired
+  set to be known to the tool rather than only to its tests; until it is,
+  drop the stale entry or stop passing `--strict-config`.
 - **Exit-code meanings** — `0` / `1` / `2` keep their meanings; adding a new
   non-zero code is a MAJOR change.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,7 @@ compose-lint reads `.compose-lint.yml` from the current working directory by def
 
 ## Which files get linted
 
-Given explicit paths or a `--pattern`, compose-lint lints exactly those. With no arguments it looks in the **current directory only**, for exactly four names:
+Given explicit paths, compose-lint lints exactly those. With no arguments it looks in the **current directory only**, for exactly four names:
 
 ```
 compose.yml   compose.yaml   docker-compose.yml   docker-compose.yaml
@@ -33,7 +33,7 @@ Finding none is an error (exit 2), not a pass — a gate reporting success over 
 
 The asymmetry is intentional. pre-commit hands the hook a filename-filtered list of files you actually changed, so matching broadly is useful and safe. A bare `compose-lint` has no such list and must not guess which of a repository's YAML files are Compose files.
 
-**What this means for you:** if your Compose files are not among the four default names, pass them explicitly (`compose-lint compose.prod.yml`) or use `--pattern`, and configure the GitHub Action's `files:` or `pattern:` input the same way. Otherwise a repository that passes pre-commit can report "no Compose files found" in CI.
+**What this means for you:** if your Compose files are not among the four default names, pass them explicitly (`compose-lint compose.prod.yml`) — the CLI has no glob flag, so expand one in your shell (`compose-lint compose.*.yml`) or let your runner do it. The GitHub Action does take a glob, via its `pattern:` input (`files:` for explicit paths). Otherwise a repository that passes pre-commit can report "no Compose files found" in CI.
 
 `tests/test_discovery_parity.py` holds all three surfaces to this table, so the hook can never become *narrower* than the CLI and the Action's list cannot drift from it.
 


### PR DESCRIPTION
Four claims in the published docs are wrong **today**. [ADR-030](../blob/main/docs/adr/030-the-policy-is-part-of-the-contract.md) makes the compatibility policy part of the frozen contract, so a false claim at the 1.0 tag becomes expensive to walk back — a *loosening* is a MAJOR. Docs only; no code changes.

## 1–2. `ASSURANCE.md` — the OpenSSF assurance artifact

**"does not modify its inputs"** (`ASSURANCE.md:19`, under *What compose-lint is*). `fix --apply` has rewritten files in place since 0.11.0 and is SemVer-covered. The section now says what each subcommand does: `check` / `--explain` / `init -o` never touch a Compose file; `fix --apply` writes via atomic swap, dry-run by default, guarded by re-parse + verify-apply.

**The CWE-22 row** (`ASSURANCE.md:97`) said:

> All file paths are user-supplied targets; the tool only *reads* them. No path is constructed from untrusted YAML content.

Both halves are false. `fix --apply` writes, and `env_file:` targets and `COMPOSE_FILE` entries *are* constructed from untrusted document content — that is the premise of ADR-026 and ADR-027. This is the path-traversal row specifically, so it was claiming a mitigation the tool does not have.

Rewritten to separate the two path classes and state the actual mitigation: document-supplied paths are gated twice, lexically on what the path says and then on what it *resolves* to, so a symlink cannot escape the project (#721).

## 3. `compatibility.md:91` — retired rule IDs

> A config referencing a retired ID keeps working, `--strict-config` included.

Reproduced against `main`:

```console
$ # .compose-lint.yml -> rules: { CL-0012: { enabled: false } }
$ compose-lint check compose.yml --strict-config
Error: config: unknown rule id 'CL-0012'; the override has no effect
rc=2
```

The config loads, but the override is reported as an unknown ID and `--strict-config` promotes that to an error. The page now says so.

**This one is a genuine fork and I took the conservative branch.** The promise is *good* — retiring a rule should not break a pinned user's strict pipeline. Honoring it needs the tool to know its own retired set, which today lives only in `tests/test_rule_surfaces.py:39` as `FALLOW`. That is code, not docs, and is already scoped in #725. If you would rather keep the promise and implement it, say so and this hunk comes out — but shipping 1.0 with the promise false is the one option that costs a MAJOR later.

## 4. `configuration.md:17,36` — a flag that does not exist

```console
$ compose-lint check --pattern '*.yml'
usage: compose-lint [-h] [--version] COMMAND ...
rc=2
```

`pattern:` is a **GitHub Action input**, not a CLI flag — the docs conflated them, in the one section explaining why a repo that passes pre-commit reports "no Compose files found" in CI. Now points users at shell expansion for the CLI and at the Action's `pattern:` / `files:` inputs for the Action.

---

Found by a pre-1.0 freeze-surface audit; each reproduced against `main` before editing. 2518 tests pass.
