### PR TITLE
Report a crashed rule in JSON and SARIF, not only on stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   page now says. `docs/configuration.md` told users to pass a `--pattern` flag
   that does not exist — globbing is the GitHub Action's `pattern:` input, not a
   CLI flag.
+- **A crashed rule now reports itself in JSON and SARIF, not only on stderr.**
+  A rule that raises is isolated rather than aborting the run
+  ([ADR-006](docs/adr/006-exit-codes.md)), and it already set exit 2 and printed
+  to stderr — but `run_errors` omitted `rule_errors`, so the machine output said
+  nothing. JSON reported `errors: []` and SARIF reported
+  `executionSuccessful: true` while that rule's findings were silently absent
+  from a document the GitHub Action uploads. For Code Scanning that is worse
+  than an omission: a *declared* rule with zero results reads as "every alert
+  for this rule is fixed", so a crash closed the alerts instead of reporting
+  itself. Crashed rules now ride the same structured channel as parse errors and
+  coverage gaps.
 
 - **A failed stdout write is now exit 2, not an undocumented exit 120 or a
   false exit 1.** Every path that could raise mid-run had been hardened to the

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -843,7 +843,17 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
     # `errors[]`, SARIF `toolExecutionNotifications`, exit 2 — but are counted
     # separately in the text verdict, because "could not be parsed" is not what
     # happened and the tool must not report a state that is not true.
-    run_errors = parse_errors + coverage_errors
+    #
+    # A crashed rule rides it too. It already sets exit 2 (below) and prints to
+    # stderr, but it was absent from both machine channels: JSON reported
+    # `errors: []` and SARIF reported `executionSuccessful: true` while that
+    # rule's findings were silently missing from a document a gate uploads.
+    # For Code Scanning that is worse than an omission — a declared rule with
+    # zero results reads as "every alert for this rule is fixed", so a crash
+    # closed the alerts instead of reporting itself. ADR-015 exists so a run
+    # that could not complete says so in the machine output, not only on a
+    # channel a gate does not read.
+    run_errors = parse_errors + coverage_errors + rule_errors
 
     if args.output_format == "text":
         if len(args.files) > 1:
@@ -892,7 +902,7 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
     if has_errors and config_path is None:
         _note_no_config_in_effect()
 
-    if run_errors or rule_errors:
+    if run_errors:  # parse errors, coverage gaps, and crashed rules
         sys.exit(2)
     sys.exit(1 if has_errors else 0)
 

--- a/tests/test_exit_code_contract.py
+++ b/tests/test_exit_code_contract.py
@@ -13,6 +13,7 @@ unguarded. The Compose loader was wrapped; the config loader was not.
 from __future__ import annotations
 
 import contextlib
+import json
 import os
 import subprocess
 import sys
@@ -308,3 +309,68 @@ def test_a_closed_stdout_is_a_clean_error() -> None:
     assert proc.returncode == 2, proc.stderr
     _assert_no_traceback(proc)
     assert "stdout is closed" in proc.stderr
+
+
+# --- A crashed rule must say so in the machine output, not only on stderr ---
+#
+# A rule that raises is isolated rather than aborting the run (ADR-006), and it
+# already set exit 2 and printed to stderr. It was absent from both machine
+# channels: JSON reported `errors: []` and SARIF reported
+# `executionSuccessful: true` while that rule's findings were silently missing.
+# For Code Scanning that is worse than an omission -- a declared rule with zero
+# results reads as "every alert for this rule is fixed", so a crash closed the
+# alerts instead of reporting itself.
+
+_CRASH_HARNESS = """
+import sys
+sys.path.insert(0, {src!r})
+from compose_lint.rules import CL0002_privileged_mode as m
+m.PrivilegedModeRule.check = lambda self, *a, **k: (_ for _ in ()).throw(
+    RuntimeError("simulated predicate bug")
+)
+from compose_lint import cli
+sys.argv = ["compose-lint", "check", "--format", {fmt!r}, {target!r}]
+cli.main()
+"""
+
+
+def _run_with_crashing_rule(
+    tmp_path: Path, fmt: str
+) -> subprocess.CompletedProcess[str]:
+    target = tmp_path / "docker-compose.yml"
+    target.write_text(_PRIVILEGED, encoding="utf-8")
+    harness = tmp_path / "harness.py"
+    harness.write_text(
+        _CRASH_HARNESS.format(src=str(REPO_ROOT / "src"), fmt=fmt, target=str(target)),
+        encoding="utf-8",
+    )
+    return subprocess.run(
+        [sys.executable, str(harness)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        env=cli_env(PYTHONPATH=str(REPO_ROOT / "src"), NO_COLOR="1"),
+        timeout=180,
+    )
+
+
+def test_a_crashed_rule_reaches_the_json_errors_array(tmp_path: Path) -> None:
+    proc = _run_with_crashing_rule(tmp_path, "json")
+    assert proc.returncode == 2, proc.stderr
+    doc = json.loads(proc.stdout)
+    assert doc["errors"], "a crashed rule must not leave errors[] empty"
+    assert any("CL-0002" in e["message"] for e in doc["errors"])
+
+
+def test_a_crashed_rule_makes_sarif_declare_the_run_unsuccessful(
+    tmp_path: Path,
+) -> None:
+    proc = _run_with_crashing_rule(tmp_path, "sarif")
+    assert proc.returncode == 2, proc.stderr
+    invocation = json.loads(proc.stdout)["runs"][0]["invocations"][0]
+    assert invocation["executionSuccessful"] is False, (
+        "SARIF claimed success while a rule's findings were missing"
+    )
+    notifications = invocation.get("toolExecutionNotifications") or []
+    assert any("CL-0002" in n["message"]["text"] for n in notifications)


### PR DESCRIPTION
A rule that raises is isolated rather than aborting the run ([ADR-006](../blob/main/docs/adr/006-exit-codes.md)), and it already set exit 2 and printed to stderr. It reached **neither machine channel**.

`run_errors = parse_errors + coverage_errors` omitted `rule_errors`, which was collected at `cli.py:766` and then consulted only for the exit code.

## Before

Forcing a predicate to raise:

```
exit code                  : 2       correct
stderr                     : "rule CL-0002 failed on service 'web'"   correct

json errors[]              : []      <- empty
CL-0002 in findings        : False   <- CRITICAL silently gone

SARIF executionSuccessful  : True    <- claims success
SARIF notifications        : None
CL-0002 declared in rules  : True
CL-0002 results            : 0
```

## Why this is worse than an omission

`action.yml` uploads that SARIF regardless. **A declared rule with zero results reads to Code Scanning as "every alert for this rule is fixed"** — so a crash didn't just fail to report itself, it closed the existing alerts. The stderr line is on a channel a merge gate does not read.

That is precisely the state ADR-015 exists to prevent: a run that could not complete must say so in the machine output.

## After

```
JSON   exit=2  errors=1  -> "rule CL-0002 failed on service 'web': RuntimeError: ..."
SARIF  exit=2  executionSuccessful=False  notifications=1
```

Crashed rules now ride the same structured channel as parse errors and coverage gaps. The change is one term in an existing expression; `run_errors or rule_errors` in the exit-code condition loses its now-redundant second term.

## Tests

Two regression tests in `tests/test_exit_code_contract.py`, one per format, driving a real subprocess with a deliberately-crashing predicate. They assert `errors[]` is non-empty and that SARIF reports `executionSuccessful: false` with a matching notification.

## Note on scope

`errors[]` remains an undiscriminated bucket — it now carries three conditions (parse failure, coverage gap, crashed rule) under one flat `{file, message}` shape. Adding a `kind` discriminator is additive and deliberately left out of this change.

**Latency, not correctness, is why this was not a 1.0 blocker:** 20 adversarial fixtures produced no document-reachable crash. But when one happens the output document actively lies, and the fix is additive.

Found by a pre-1.0 freeze-surface audit. 2520 tests pass.
