### PR TITLE
Pin three frozen surfaces that no test was holding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,12 @@ jobs:
           # contract, and `precommit-smoke` (gated on this filter) is what
           # guards it. Leaving it out meant a manifest-only edit — exactly
           # the shape of issue #465 — skipped its own smoke test.
-          if match '^(src/|tests/|scripts/|pyproject\.toml$|requirements[.-].*lock$|action\.yml$|\.pre-commit-hooks\.yaml$)'; then
+          # `docs/` is in here because docs are load-bearing, not prose: tests
+          # assert against docs/severity.md's table, docs/rules/*.md front
+          # matter and headings, and the rule-count claims on the README and
+          # mkdocs nav. A docs-only edit could break those and merge green,
+          # reddening main after the gate had passed.
+          if match '^(src/|tests/|scripts/|docs/|README\.md$|mkdocs\.yml$|pyproject\.toml$|requirements[.-].*lock$|action\.yml$|\.pre-commit-hooks\.yaml$)'; then
             code=true
           fi
           if match '^(Dockerfile$|\.dockerignore$|requirements\.lock$|requirements-build\.lock$|pyproject\.toml$|src/)'; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for this rule is fixed", so a crash closed the alerts instead of reporting
   itself. Crashed rules now ride the same structured channel as parse errors and
   coverage gaps.
+- **Contract tests for three frozen surfaces that no test pinned.** Found by
+  mutation: each change below left the entire suite green before this release.
+  Halving `_KNOWN_RULE_KEYS` to `{enabled, reason}` passed — `severity:` and
+  `exclude_services:` would have started warning as unknown keys, and *erroring*
+  under `--strict-config`. Regrading SARIF `security-severity` for HIGH
+  (`7.5`→`3.0`) and MEDIUM (`5.5`→`0.5`) passed, and both drop a full tier in
+  GitHub's bands — the formatter's own comment records that Code Scanning
+  derives an alert's severity column from that number alone. And changing the
+  evidence derivation in CL-0017, CL-0020, CL-0021, CL-0025, CL-0028 or CL-0030
+  passed *whenever the values stayed distinct*: evidence is the SARIF
+  fingerprint, so that silently re-keys every alert, and the existing collision
+  test only catches the degenerate case where values collapse together. Each is
+  now pinned, with a guard-the-guard companion. Separately, `ci.yml`'s path
+  filter now includes `docs/`, `README.md` and `mkdocs.yml`, which are asserted
+  against by tests and could previously break on a docs-only PR that merged
+  green.
 
 - **A failed stdout write is now exit 2, not an undocumented exit 120 or a
   false exit 1.** Every path that could raise mid-run had been hardened to the

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,7 +9,12 @@ import pytest
 if TYPE_CHECKING:
     from pathlib import Path
 
-from compose_lint.config import ConfigError, load_config
+from compose_lint.config import (
+    _KNOWN_RULE_KEYS,
+    KNOWN_TOP_LEVEL_KEYS,
+    ConfigError,
+    load_config,
+)
 from compose_lint.models import Severity
 
 
@@ -294,3 +299,50 @@ class TestExcludeServices:
         config.write_text("rules:\n  CL-0003:\n    exclude_services:\n      - 42\n")
         with pytest.raises(ConfigError, match="service name strings"):
             load_config(config)
+
+
+# --- The config schema is frozen at 1.0, so its key sets are a contract ------
+#
+# Added after a mutation pass: halving `_KNOWN_RULE_KEYS` to
+# `{enabled, reason}` left the entire suite green. `severity:` and
+# `exclude_services:` would have started warning as unknown keys — and
+# *erroring* under `--strict-config`, which docs/configuration.md recommends
+# for CI — with nothing to catch it. `docs/compatibility.md` freezes
+# ".compose-lint.yml keys and their semantics" at 1.0, so the sets belong
+# under a contract test rather than being implied by the tests that use them.
+
+
+def test_the_top_level_key_set_is_exact() -> None:
+    """Adding a key is a deliberate, documented act (RELEASING.md: MINOR)."""
+    assert frozenset({"rules"}) == KNOWN_TOP_LEVEL_KEYS, (
+        "the .compose-lint.yml top-level key set changed. That is a config "
+        "schema change frozen at 1.0 — document it and update this test."
+    )
+
+
+def test_the_per_rule_key_set_is_exact() -> None:
+    assert (
+        frozenset({"enabled", "reason", "severity", "exclude_services"})
+        == _KNOWN_RULE_KEYS
+    ), (
+        "the per-rule key set changed. Dropping one makes a valid config warn "
+        "as an unknown key, and error under --strict-config."
+    )
+
+
+@pytest.mark.parametrize("key", ["enabled", "reason", "severity", "exclude_services"])
+def test_every_documented_per_rule_key_is_accepted(key: str, tmp_path: Path) -> None:
+    """Guard the guard: the set above must match what the loader really takes.
+
+    A key could be listed as known and still be rejected downstream, which is
+    what the set existing does not by itself prove.
+    """
+    values = {
+        "enabled": "false",
+        "reason": "'because'",
+        "severity": "low",
+        "exclude_services": "{web: 'because'}",
+    }
+    config = tmp_path / ".compose-lint.yml"
+    config.write_text(f"rules:\n  CL-0003:\n    {key}: {values[key]}\n")
+    load_config(config)  # must not raise, and must not be an unknown key

--- a/tests/test_finding_identity.py
+++ b/tests/test_finding_identity.py
@@ -232,6 +232,17 @@ EVIDENCE_CONTRACT = {
     "CL-0024": {"SYS_ADMIN"},
     "CL-0027": {"SYS_PTRACE"},
     "CL-0029": {"SYS_NICE"},
+    # Added after a mutation pass showed these six derived evidence that no
+    # test pinned: changing a derivation while keeping values *distinct* left
+    # the whole suite green, and evidence is the SARIF fingerprint — so every
+    # alert for these rules could be silently re-keyed. The collision test
+    # below catches only the degenerate case where values collapse together.
+    "CL-0017": {"/srv/data:/data:shared"},
+    "CL-0020": {"POSTGRES_PASSWORD"},
+    "CL-0021": {"DATABASE_URL"},
+    "CL-0025": {"/etc"},
+    "CL-0028": {"SYS_TIME"},
+    "CL-0030": {"SYSLOG"},
 }
 
 _CONTRACT_DOC = """
@@ -261,6 +272,18 @@ services:
     security_opt: ["apparmor:unconfined", "seccomp:unconfined"]
     pid: host
     ipc: host
+  # A second service so the six rules added below are exercised without
+  # perturbing anything pinned above: `sink` mounts /etc read-only for
+  # CL-0013, and CL-0025 needs the writable spelling of the same path.
+  sink2:
+    image: x:1
+    environment:
+      POSTGRES_PASSWORD: hunter2
+      DATABASE_URL: "postgres://u:p@db:5432/x"
+    volumes:
+      - /etc:/host-etc-rw
+      - /srv/data:/data:shared
+    cap_add: [SYS_TIME, SYSLOG]
 """
 
 

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 
 from compose_lint.formatters.sarif import (
+    _SECURITY_SEVERITY,
     build_sarif_log,
     format_findings,
 )
@@ -624,3 +625,51 @@ class TestArtifactUri:
         notif = log["runs"][0]["invocations"][0]["toolExecutionNotifications"][0]
         notif_art = notif["locations"][0]["physicalLocation"]["artifactLocation"]
         assert notif_art == {"uri": "stack/compose.yml", "uriBaseId": "SRCROOT"}
+
+
+# --- security-severity is the only severity GitHub reads --------------------
+#
+# Added after a mutation pass: regrading HIGH 7.5 -> 3.0 and MEDIUM 5.5 -> 0.5
+# left the whole suite green, and both drop a full tier in GitHub's bands
+# (>=9.0 critical, 7.0-8.9 high, 4.0-6.9 medium, 0.1-3.9 low). The formatter's
+# own comment records that Code Scanning derives an alert's severity column
+# from *this* number, citing issue #279 S-b where an override showed the wrong
+# severity — that bug was found and fixed, and the numbers were never pinned.
+
+
+def test_security_severity_numbers_are_pinned() -> None:
+    """Each tier sits in its documented GitHub band."""
+    assert _SECURITY_SEVERITY == {
+        Severity.CRITICAL: "9.5",
+        Severity.HIGH: "7.5",
+        Severity.MEDIUM: "5.5",
+        Severity.LOW: "2.0",
+    }, (
+        "security-severity changed. GitHub Code Scanning derives the alert's "
+        "severity column from this number alone, so a change here silently "
+        "regrades every existing alert."
+    )
+
+
+@pytest.mark.parametrize(
+    ("severity", "low", "high"),
+    [
+        (Severity.CRITICAL, 9.0, 10.0),
+        (Severity.HIGH, 7.0, 8.9),
+        (Severity.MEDIUM, 4.0, 6.9),
+        (Severity.LOW, 0.1, 3.9),
+    ],
+)
+def test_each_tier_lands_in_its_github_band(
+    severity: Severity, low: float, high: float
+) -> None:
+    """Guard the guard: pinning the literals says nothing about the bands.
+
+    A future edit could keep all four values distinct and still move HIGH into
+    the medium band, which is the failure mode that matters to a consumer.
+    """
+    value = float(_SECURITY_SEVERITY[severity])
+    assert low <= value <= high, (
+        f"{severity.value} maps to {value}, outside GitHub's "
+        f"{low}-{high} band for that tier"
+    )


### PR DESCRIPTION
Three surfaces that 1.0 freezes had **no test holding them**. Each mutation below left the entire suite green before this PR — that is how they were found, by mutation rather than review.

Tests only, plus one CI path filter. No behaviour change.

## 1. Config key sets

```python
_KNOWN_RULE_KEYS = frozenset({"enabled", "reason"})   # halved
```
→ **2518 passed.**

`severity:` and `exclude_services:` would have started warning as unknown per-rule keys — and *erroring* under `--strict-config`, which `docs/configuration.md:146` recommends for CI. A user's valid config breaks and nothing notices. `docs/compatibility.md` freezes ".compose-lint.yml keys and their semantics" at 1.0.

## 2. SARIF `security-severity`

```python
Severity.HIGH: "3.0",     # was 7.5
Severity.MEDIUM: "0.5",   # was 5.5
```
→ **2518 passed.**

Both drop a full tier in GitHub's bands (`>=9.0` critical, `7.0-8.9` high, `4.0-6.9` medium, `0.1-3.9` low). Pointed, because `sarif.py:274` already documents that *"GitHub Code Scanning derives an alert's severity column from the rule's `security-severity`"* and cites issue #279 S-b — a bug where exactly this showed the wrong severity. That bug was found and fixed; the numbers were never pinned.

## 3. Evidence derivations — the interesting one

The audit claimed the six unpinned rules could be mutated "all at once" with the suite green. **That is not quite right, and the correction matters.** Collapsing every evidence value to a constant *is* caught — by `test_no_two_findings_in_one_document_share_a_fingerprint`, on collision.

But mutate them so the values stay **distinct** and merely different:

```python
evidence="x" + str(<original>)
```
→ **2518 passed.**

So evidence *uniqueness* was pinned; evidence *value* was not. Since evidence is the SARIF fingerprint, a derivation change in CL-0017, CL-0020, CL-0021, CL-0025, CL-0028 or CL-0030 silently re-keys every alert — every existing alert closes as fixed, every finding reopens as new — with CI green. The collision test gave partial cover that reads like full cover.

All six now join `EVIDENCE_CONTRACT`. They are exercised by a **second fixture service** rather than by extending `sink`, because `sink` mounts `/etc` read-only for CL-0013 and CL-0025 needs the writable spelling — adding it to the same service would have perturbed evidence already pinned.

## Guard-the-guard

Each pin has a companion, because asserting a literal says nothing about whether it still *means* the right thing:

- every documented per-rule key is round-tripped through `load_config` — a key can be listed as known and still be rejected downstream
- each severity tier is asserted to land **inside its GitHub band**, so a future edit cannot keep four distinct values while moving HIGH into the medium band

## 4. `ci.yml` path filter

`docs/`, `README.md` and `mkdocs.yml` are now in the `code` filter. Tests assert against `docs/severity.md`'s table, the rule pages, and the rule-count claims — so a docs-only PR could break them, merge green, and redden `main` after the gate had passed.

## Verification

Every mutation above was re-applied after the pins were added, and each is now caught. 2535 tests pass.

Found by a pre-1.0 freeze-surface audit.
