### PR TITLE
Make fix --only and the read-only refusal answer consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
+### Added
+
+- **A test gates the `Development Status` classifier against the major
+  version.** `docs/RELEASING.md` says to flip `4 - Beta` to
+  `5 - Production/Stable` in the same commit that sets `version = "1.0.0"`, but
+  nothing enforced it — the classifier was referenced nowhere in `tests/`,
+  `scripts/` or the workflows. PyPI metadata is immutable per version, so a
+  missed flip would have published 1.0.0 permanently labelled Beta with 1.0.1
+  as the only remedy.
+
 ### Changed
 - **JSON `file` and `line` now name the same document, and the envelope is
   schema `"2"`.** `file` had always named the document being *graded* while
@@ -30,6 +40,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Fixed
+
+- **`fix --only` now normalizes case and reports an id that names no rule.**
+  `--only cl-0014` — the correct id, lower-cased — matched nothing, printed
+  "nothing to fix" and exited 0, which is indistinguishable from a clean repo;
+  so did `--only CL-9999` and `--only banana`. A CI remediation step pinned to a
+  typo therefore went green forever. `--explain` already normalized case, so one
+  CLI was answering the same input two different ways. An id that matches no
+  rule is now a `Warning:` naming it, promoted to an error by `--strict-config`
+  — the same treatment an unknown rule id in `.compose-lint.yml` already gets.
+
+- **`fix --apply` on a read-only file is now exit 2, not exit 0.** The three
+  sibling write refusals — a symlink target, a hard link, an unwritable
+  directory — all report exit 2, as does `init --force` on the same predicate.
+  Only this case reported success, so the documented Docker recipe
+  (`docker run -v "$(pwd):/src" … fix --apply`, where the image runs as UID
+  65532) wrote nothing and told a gate it had succeeded.
+
 
 - **Four published claims corrected to match what the tool does.** Under
   [ADR-030](docs/adr/030-the-policy-is-part-of-the-contract.md) the policy is

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -54,6 +54,7 @@ from compose_lint.parser import (
     merge_patched,
     unresolved_mount_sources,
 )
+from compose_lint.rules import get_registered_rules
 
 
 def _severity_type(value: str) -> Severity:
@@ -1018,6 +1019,41 @@ def _merged_reparser(
     return reparse
 
 
+def _validated_only(raw: list[str] | None, *, strict: bool) -> set[str] | None:
+    """Normalize ``--only`` ids and say so when one names no rule.
+
+    ``--only`` took any string. ``--only cl-0014`` — the right id, lower-cased
+    — matched nothing, printed "nothing to fix" and exited 0, which is
+    indistinguishable from a clean repo; so did ``CL-9999`` and ``banana``. A
+    CI remediation step pinned to a typo therefore goes green forever, which
+    is the failure a gate must not have.
+
+    Case is normalized because ``--explain`` already does it, and answering
+    the same input two different ways on one CLI is the inconsistency that
+    gets frozen at 1.0. An id that matches no rule is a diagnostic rather
+    than a hard error, matching how an unknown rule id in the config file is
+    treated — and ``--strict-config`` promotes it the same way.
+    """
+    if not raw:
+        return None
+    known = {cls().metadata.id for cls in get_registered_rules()}
+    resolved: set[str] = set()
+    for value in raw:
+        candidate = value.strip().upper()
+        if candidate in known:
+            resolved.add(candidate)
+            continue
+        message = (
+            f"--only {value!r} names no rule, so it selects nothing "
+            "(check for a typo or a retired rule)"
+        )
+        if strict:
+            emit(f"Error: {message}")
+            sys.exit(2)
+        emit(f"Warning: {message}")
+    return resolved
+
+
 def _run_fix(args: argparse.Namespace) -> NoReturn:
     """Run the `fix` operation (ADR-014).
 
@@ -1050,7 +1086,7 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
         if group.overlays
     }
 
-    only = set(args.only) if args.only else None
+    only = _validated_only(args.only, strict=args.strict_config)
     had_error = False
     # Whether any file had a fix applied or offered — see the note below.
     touched = False
@@ -1186,10 +1222,19 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
 
         if args.apply:
             if _refuses_write(Path(filepath)):
+                # Exit 2, matching the three sibling write refusals — a symlink
+                # target, a hard link, and an unwritable directory all report
+                # the same way, and `init --force` on this same predicate does
+                # too. Reporting exit 0 here meant the documented Docker recipe
+                # (`docker run -v "$(pwd):/src" ... fix --apply`, where the
+                # image runs as UID 65532) wrote nothing and told a gate it had
+                # succeeded.
                 emit(
-                    f"Warning: {filepath}: file is not writable; skipping "
-                    "(make it writable to allow `fix --apply` to modify it)"
+                    f"Error: {filepath}: file is not writable; no changes "
+                    "written (make it writable to allow `fix --apply` to "
+                    "modify it)"
                 )
+                had_error = True
                 continue
             try:
                 _atomic_write(Path(filepath), patched)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -607,15 +607,21 @@ class TestFixSubcommand:
         assert b"\r\n" in raw  # endings preserved
         assert b"\n" not in raw.replace(b"\r\n", b"")  # no lone LF introduced
 
-    def test_apply_skips_read_only_file_with_warning(self, tmp_path: Path) -> None:
+    def test_apply_refuses_read_only_file_with_exit_2(self, tmp_path: Path) -> None:
         # Regression (#515): a chmod 444 file is an explicit "do not modify"
         # signal; os.replace would still swap it in via the writable directory.
+        #
+        # Exit 2, matching the three sibling write refusals — symlink, hard
+        # link, unwritable directory — and `init --force` on the same
+        # predicate. This case reported exit 0, so the documented Docker
+        # recipe (image runs as UID 65532 against a bind-mounted tree) wrote
+        # nothing and told a gate it had succeeded.
         f = tmp_path / "docker-compose.yml"
         f.write_text(_BARE_SERVICE)
         f.chmod(0o444)
         try:
             result = run_cli("fix", "--apply", "--only", "CL-0007", str(f))
-            assert result.returncode == 0
+            assert result.returncode == 2
             assert "not writable" in result.stderr
             assert f.read_text() == _BARE_SERVICE  # unchanged
         finally:
@@ -936,3 +942,49 @@ class TestRuleCrashExitCode:
         err = capsys.readouterr().err
         assert "CL-CRASH" in err
         assert "RuntimeError" in err
+
+
+_FIXABLE_LOGGING = "services:\n  w:\n    image: n:1\n    logging:\n      driver: none\n"
+
+
+class TestFixOnlyValidation:
+    """`--only` took any string, and a wrong one was indistinguishable from clean.
+
+    `--only cl-0014` — the right id, lower-cased — matched nothing, printed
+    "nothing to fix" and exited 0. So did `CL-9999` and `banana`. A CI
+    remediation step pinned to a typo went green forever.
+    """
+
+    def test_a_lowercase_rule_id_is_accepted(self, tmp_path: Path) -> None:
+        """`--explain` already normalizes case; one CLI must not answer twice."""
+        f = tmp_path / "docker-compose.yml"
+        f.write_text(
+            "services:\n  w:\n    image: n:1\n    logging:\n      driver: none\n"
+        )
+        lower = run_cli("fix", "--only", "cl-0014", str(f))
+        upper = run_cli("fix", "--only", "CL-0014", str(f))
+        assert lower.returncode == upper.returncode == 0
+        assert "fix(es) available" in lower.stderr
+        assert "names no rule" not in lower.stderr
+
+    @pytest.mark.parametrize("bad", ["CL-9999", "banana", "CL-00003"])
+    def test_an_id_that_names_no_rule_is_reported(
+        self, tmp_path: Path, bad: str
+    ) -> None:
+        f = tmp_path / "docker-compose.yml"
+        f.write_text(
+            "services:\n  w:\n    image: n:1\n    logging:\n      driver: none\n"
+        )
+        result = run_cli("fix", "--only", bad, str(f))
+        assert "names no rule" in result.stderr
+        assert bad in result.stderr
+
+    def test_strict_config_promotes_it_to_an_error(self, tmp_path: Path) -> None:
+        """Mirrors how an unknown rule id in the config file is treated."""
+        f = tmp_path / "docker-compose.yml"
+        f.write_text(
+            "services:\n  w:\n    image: n:1\n    logging:\n      driver: none\n"
+        )
+        result = run_cli("fix", "--only", "banana", "--strict-config", str(f))
+        assert result.returncode == 2
+        assert "names no rule" in result.stderr

--- a/tests/test_release_layer.py
+++ b/tests/test_release_layer.py
@@ -404,3 +404,37 @@ def test_the_shared_docker_smoke_runs_the_documented_hardened_flags() -> None:
             f"across {docker_runs} `docker run` invocations — every smoke step "
             "runs the fully-hardened flag set documented in README.md"
         )
+
+
+# --- The 1.0 classifier bump has no second chance --------------------------
+
+
+def test_the_development_status_classifier_matches_the_major_version() -> None:
+    """PyPI metadata is immutable per version, so a miss is permanent.
+
+    `docs/RELEASING.md` says to flip `4 - Beta` to `5 - Production/Stable` in
+    the same commit that sets `version = "1.0.0"`. That was prose with nothing
+    enforcing it: nothing in `tests/`, `scripts/` or `.github/workflows/`
+    referenced the classifier, so 1.0.0 could publish permanently labelled
+    Beta and the only remedy would be 1.0.1.
+    """
+    text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    version = re.search(r'^version = "([^"]+)"', text, re.M)
+    assert version, "could not read version from pyproject.toml"
+    major = int(version.group(1).split(".")[0])
+
+    classifiers = re.findall(r'"(Development Status :: [^"]+)"', text)
+    assert len(classifiers) == 1, f"expected one status classifier, got {classifiers}"
+    status = classifiers[0]
+
+    if major >= 1:
+        assert status == "Development Status :: 5 - Production/Stable", (
+            f"version is {version.group(1)} but the classifier is {status!r}. "
+            "PyPI metadata is immutable per version — flip this in the same "
+            "commit that sets the version (docs/RELEASING.md)."
+        )
+    else:
+        assert status == "Development Status :: 4 - Beta", (
+            f"version is {version.group(1)}, so the classifier should still be "
+            f"'4 - Beta', not {status!r}."
+        )


### PR DESCRIPTION
Three places where one CLI answered the same class of input two different ways. Each verified by running the tool.

## 1. `fix --only` accepted any string

```console
$ compose-lint fix --only CL-0014 t.yml   ->  1 fix(es) available    rc=0
$ compose-lint fix --only cl-0014 t.yml   ->  nothing to fix         rc=0   <-- correct id!
$ compose-lint fix --only CL-9999 t.yml   ->  nothing to fix         rc=0
$ compose-lint fix --only banana  t.yml   ->  nothing to fix         rc=0
```

The lowercase case is the sharp one: `cl-0014` **is** the right rule id, and `--explain` already normalizes case — so one CLI answered the same input two ways. All three failures are indistinguishable from a clean repo, so **a CI auto-remediation step pinned to a typo goes green forever**, which is the failure a gate must not have.

Now: case is normalized, and an id matching no rule gets a `Warning:` naming it — promoted to an error by `--strict-config`, exactly how an unknown rule id in `.compose-lint.yml` is already treated.

```console
$ compose-lint fix --only cl-0014 t.yml                    ->  1 fix(es) available   rc=0
$ compose-lint fix --only banana t.yml                     ->  Warning: --only 'banana' names no rule…
$ compose-lint fix --only banana --strict-config t.yml     ->  Error: …                rc=2
```

## 2. `fix --apply` on a read-only file reported success

| refusal | before | after |
|---|---|---|
| read-only file | **0** | **2** |
| unwritable directory | 2 | 2 |
| symlink target | 2 | 2 |
| hard link | 2 | 2 |
| `init --force`, same predicate | 2 | — |

One of five disagreed. It matters because it is the *documented* path: `docs/dockerhub-overview.md` publishes `docker run -v "$(pwd):/src" … fix --apply`, and `Dockerfile:75` runs the image as `USER 65532:65532`. A user following the recipe against a root-owned tree got no changes and a success code.

`tests/test_cli.py::test_apply_skips_read_only_file_with_warning` pinned the old exit 0 and is updated to the new contract — renamed, with the reasoning recorded.

## 3. The 1.0 classifier had no gate

```toml
version = "0.24.0"
"Development Status :: 4 - Beta",
```

`docs/RELEASING.md` says to flip this to `5 - Production/Stable` in the same commit that sets `1.0.0` — prose, with nothing enforcing it. `Development Status` was referenced nowhere in `tests/`, `scripts/` or `.github/workflows/`.

**PyPI metadata is immutable per version.** A missed flip publishes 1.0.0 permanently labelled Beta, with 1.0.1 the only remedy. Now asserted both ways: `major >= 1` requires Production/Stable, `major == 0` requires Beta — so this PR is green today and turns red the moment the version bump lands without its companion.

*(This one is from the release-mechanics group rather than the CLI group; it rides along because it is four lines and has no other natural home.)*

## Verification

2526 tests pass. Found by a pre-1.0 freeze-surface audit; each reproduced against `main` first.
