### PR TITLE
Let a rule admitted on judgment be withdrawn on judgment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   as the only remedy.
 
 ### Changed
+
+- **A rule admitted on judgment may be withdrawn on judgment**
+  ([ADR-032](docs/adr/032-rule-retirement-is-minor-with-lifecycle.md)
+  condition 1, widened). ADR-032 made retirement MINOR only where evidence
+  refutes the rule's premise. CL-0014's premise *holds* — `docker logs` under
+  `driver: none` really does fail — so that bar could never be met for it, and
+  the thin part is its grounding, which is a different defect. The effect was
+  that a rule the project itself declines to ground was *harder* to remove than
+  one that is grounded and later refuted, which is backwards; dropping it would
+  have cost a MAJOR. The exception reaches only rules
+  [ADR-028](docs/adr/028-pre-1.0-rule-id-sweep.md) records as admitted on
+  judgment — a set closed at the 1.0 sweep, currently `{CL-0014}` — so "evidence,
+  not preference" is unchanged for every rule admitted on evidence. Withdrawal
+  still needs its own ADR and still runs the full deprecation lifecycle. Landed
+  before the tag because the direction only goes one way: admitting this ground
+  later is a loosening and costs a MAJOR, while removing it later is a
+  tightening and costs a MINOR.
+
 - **JSON `file` and `line` now name the same document, and the envelope is
   schema `"2"`.** `file` had always named the document being *graded* while
   `line` indexed wherever the evidence actually came from, so on a merged run

--- a/docs/adr/028-pre-1.0-rule-id-sweep.md
+++ b/docs/adr/028-pre-1.0-rule-id-sweep.md
@@ -255,6 +255,11 @@ options, and the doc states what `noexec` does and does not stop.
   CL-0029; `/dev/shm` and `/dev/hugepages` as `/dev` descendants in CL-0013;
   CL-0014's source-only grounding. Each is a precision or override question on
   a rule that stays, and each is recorded on its row above.
+  CL-0014's is the one with no post-1.0 exit under ADR-032 as first written:
+  its premise *holds*, so the evidence bar can never be met, and the thin
+  part is the grounding. ADR-032 condition 1 was widened before the tag to
+  admit withdrawal-on-judgment for exactly the rules this table records as
+  admitted on judgment — a closed set, currently `{CL-0014}`.
 
 ## Alternatives rejected
 

--- a/docs/adr/032-rule-retirement-is-minor-with-lifecycle.md
+++ b/docs/adr/032-rule-retirement-is-minor-with-lifecycle.md
@@ -33,6 +33,30 @@ deprecation lifecycle, under these conditions:
    the ADR-016 bar, recorded in an ADR. "Noisy" is not a retirement reason
    ([ADR-028](028-pre-1.0-rule-id-sweep.md)); prevalence pricing stays out
    of the registry.
+
+   **One narrow exception: a rule admitted on judgment may leave on
+   judgment.** [ADR-028](028-pre-1.0-rule-id-sweep.md) records exactly one
+   such rule — CL-0014, "the one rule in the set retained on judgment rather
+   than on the grounding bar", kept over a pre-1.0 audit's recommendation to
+   drop it. Its premise *holds*, so the evidence bar above can never be met;
+   what is thin is its grounding, which is a different defect and one the
+   evidence bar does not speak to. Without this clause a rule the project
+   itself declines to ground is harder to remove than one that is grounded
+   and later refuted, which is backwards.
+
+   The exception is deliberately not a general escape hatch. It reaches only
+   a rule whose ADR-028 row records it as retained on judgment — a closed
+   set, fixed at the 1.0 sweep, currently `{CL-0014}`. A grounded rule still
+   needs refutation, so "evidence, not preference" is unchanged for every
+   rule that was admitted on evidence. Withdrawal on this ground still needs
+   an ADR stating why the judgment changed, and still runs the full
+   lifecycle below.
+
+   Included **before** 1.0 because the direction only goes one way:
+   admitting this ground later is a loosening and costs a MAJOR, while
+   removing it later — deciding judgment is not enough after all — is a
+   tightening and costs a MINOR. The same asymmetry the Context above
+   applies to retirement itself.
 2. **Announce** — `CHANGELOG.md` under `Deprecated` plus a deprecation
    banner on the rule's doc page, in the release that announces it. The
    rule keeps firing through the grace period (its findings are real until

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -88,7 +88,12 @@ Two things are never reused or quietly repurposed:
   MINOR, but only through the full deprecation lifecycle and only on
   evidence that refutes the rule's premise
   ([ADR-032](adr/032-rule-retirement-is-minor-with-lifecycle.md)) — never
-  on noise or preference. A config referencing a retired ID still loads:
+  on noise or preference. One narrow exception: a rule that
+  [ADR-028](adr/028-pre-1.0-rule-id-sweep.md) records as admitted on
+  *judgment* rather than on the grounding bar may be withdrawn on judgment,
+  through the same lifecycle and with its own ADR. That set was closed at
+  the 1.0 sweep and is currently `{CL-0014}`; every rule admitted on
+  evidence still needs refutation. A config referencing a retired ID still loads:
   the override simply has no rule to apply. It is reported the same way a
   typo'd ID is — `warning: config: unknown rule id 'CL-XXXX'` — which
   `--strict-config` promotes to an error, so a strict CI pipeline does


### PR DESCRIPTION
> **Policy change. Lands before 1.0 because the direction only goes one way.**

## The gap

ADR-032 made retirement MINOR under condition 1: *"Retirement is legal only when the rule's premise is refuted by live measurement or an upstream behavior change."*

CL-0014's premise **holds**. ADR-028 says so explicitly — `docker logs` under `driver: none` returns `configured logging driver does not support reading`. So the evidence bar can never be met for it. What is thin is its *grounding*: it is, in ADR-028's words, *"the one rule in the set retained on judgment rather than on the grounding bar"*, kept over a pre-1.0 audit's recommendation to drop it.

The result is backwards: **a rule the project itself declines to ground was harder to remove than one that is grounded and later refuted.** Dropping CL-0014 post-1.0 would have cost a MAJOR.

ADR-028's watch-item note recorded CL-0014's grounding as an open question but did not notice it had no affordable exit.

## The change

Condition 1 gains one narrow exception: a rule **admitted on judgment may be withdrawn on judgment**.

Scoped so it cannot become a general escape hatch:

- it reaches only rules whose **ADR-028 row records them as retained on judgment** — a closed set, fixed at the 1.0 sweep, currently `{CL-0014}`
- a grounded rule still needs refutation, so *"evidence, not preference"* is unchanged for every rule admitted on evidence
- withdrawal still needs its own ADR stating why the judgment changed
- withdrawal still runs the full deprecation lifecycle: announce, one MINOR of grace, tombstone doc page, ID permanently fallow

## Why now and not later

The asymmetry ADR-032's own Context already applies to retirement:

> shipping 1.0 with retirement-as-MINOR keeps the strict option available as a cheap tightening; the reverse migration would cost a 2.0.

Same shape here. **Admitting this ground after 1.0 is a loosening — a MAJOR. Removing it after 1.0 — deciding judgment is not enough after all — is a tightening, a MINOR.** So the option is only purchasable now, and it is cheap to give back.

This does not commit anyone to retiring CL-0014. The maintainer's call to keep it stands and is untouched; this only means that call can be revisited later at MINOR cost instead of being frozen by the tag.

## Touched

- `docs/adr/032-…md` — condition 1 amended, with the scoping and the timing argument
- `docs/compatibility.md` — the user-facing promise updated to match, per ADR-030
- `docs/adr/028-…md` — watch-item note records that CL-0014 was the case with no exit, and that this closed it

Docs only. 2537 tests pass.
