### PR TITLE
Stop init emitting a config check refuses, and accept YAML the config file is written in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `scripts/` or the workflows. PyPI metadata is immutable per version, so a
   missed flip would have published 1.0.0 permanently labelled Beta with 1.0.1
   as the only remedy.
+- **`x-` prefixed top-level keys are accepted in `.compose-lint.yml`.** Compose's
+  extension-field convention, already honoured in the documents compose-lint
+  lints. It is the other half of merge-key support — a `<<:` needs an anchor to
+  merge *from*, and the idiomatic place to hold one is a top-level `x-` block,
+  which previously warned and, under `--strict-config`, failed the run. Because
+  `x-` is a deliberate marker it costs no typo detection: a mistyped `rulez:`
+  still warns.
 
 ### Changed
 
@@ -74,6 +81,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Only this case reported success, so the documented Docker recipe
   (`docker run -v "$(pwd):/src" … fix --apply`, where the image runs as UID
   65532) wrote nothing and told a gate it had succeeded.
+- **`compose-lint init` no longer writes a config `check` then refuses.** A
+  service named `no`, `yes`, `on`, `123`, `1.5` or `null` was emitted unquoted:
+  the plain-scalar pattern said the *characters* were safe, but YAML 1.1
+  resolves those *tokens* to booleans, ints and None, and `config.py` requires
+  `exclude_services` keys to be strings. `init` reported success and the next
+  `check` in that directory exited 2 until someone hand-edited the file — the
+  exact failure the emitter's own docstring says it exists to prevent, arriving
+  through the token rather than the characters. A candidate is now emitted
+  unquoted only if PyYAML reloads it as the same string.
+
+- **A `<<:` merge key in `.compose-lint.yml` no longer aborts the run.** The
+  config loader called `construct_object` on every key node and PyYAML has no
+  constructor for the merge tag, so a config using YAML's own merge syntax died
+  with `could not determine a constructor for the tag 'tag:yaml.org,2002:merge'`
+  and named no fix. `parser.py` already skipped the tag for Compose documents,
+  so `<<:` was legal in the file being linted and fatal in the config beside it.
+
+- **`--format json` and `--format sarif` now emit a document for every exit-2
+  path.** "No Compose files found" and a missing `--config` exited before any
+  formatter ran, producing **zero bytes** on stdout — while a missing file, a
+  parse error and a directory argument all produced a full envelope. A `jq`
+  pipeline therefore broke or not depending on which kind of exit 2 it hit, and
+  both silent cases are the commonest CI misconfigurations: the wrong working
+  directory and a typo'd config path.
 
 
 - **Four published claims corrected to match what the tool does.** Under

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -619,6 +619,26 @@ def _report_coverage_gaps(
     return [(filepath, gap) for gap in gaps] if fatal else []
 
 
+def _exit_2_with_envelope(args: argparse.Namespace, message: str) -> NoReturn:
+    """Report a pre-scan failure on the machine channel too, then exit 2.
+
+    These two branches exit before any formatter runs, so `--format json`
+    produced **zero bytes** on stdout for them while every other exit-2 shape
+    — a missing file, a parse error, a directory argument — produced a full
+    envelope. A `jq` pipeline therefore broke or not depending on which kind
+    of exit 2 it hit, and both of these are the commonest CI
+    misconfigurations: the wrong working directory, and a typo'd `--config`.
+    Run-level metadata a consumer can read is what the envelope exists for
+    (ADR-015).
+    """
+    emit(f"Error: {message}")
+    if args.output_format == "json":
+        _stdout_print(json.dumps(build_json_log([], [("", message)]), indent=2))
+    elif args.output_format == "sarif":
+        _stdout_print(json.dumps(build_sarif_log([], [("", message)]), indent=2))
+    sys.exit(2)
+
+
 def _run_check(args: argparse.Namespace) -> NoReturn:
     """Run the `check` operation: lint files and exit with the verdict code."""
     if args.explain is not None:
@@ -648,17 +668,16 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
             args.config, strict=args.strict_config
         )
     except ConfigError as e:
-        emit(f"Error: {e}")
-        sys.exit(2)
+        _exit_2_with_envelope(args, str(e))
 
     selection = _plan(args)
     if not selection.groups:
-        emit(
-            "Error: no Compose files found. Searched for: "
+        _exit_2_with_envelope(
+            args,
+            "no Compose files found. Searched for: "
             "compose.yml, compose.yaml, "
-            "docker-compose.yml, docker-compose.yaml"
+            "docker-compose.yml, docker-compose.yaml",
         )
-        sys.exit(2)
     args.files = [group.primary for group in selection.groups]
     overlay_of = {
         group.primary: list(group.overlays)
@@ -1068,17 +1087,16 @@ def _run_fix(args: argparse.Namespace) -> NoReturn:
             args.config, strict=args.strict_config
         )
     except ConfigError as e:
-        emit(f"Error: {e}")
-        sys.exit(2)
+        _exit_2_with_envelope(args, str(e))
 
     selection = _plan(args)
     if not selection.groups:
-        emit(
-            "Error: no Compose files found. Searched for: "
+        _exit_2_with_envelope(
+            args,
+            "no Compose files found. Searched for: "
             "compose.yml, compose.yaml, "
-            "docker-compose.yml, docker-compose.yaml"
+            "docker-compose.yml, docker-compose.yaml",
         )
-        sys.exit(2)
     args.files = [group.primary for group in selection.groups]
     fix_overlay_of = {
         group.primary: list(group.overlays)

--- a/src/compose_lint/config.py
+++ b/src/compose_lint/config.py
@@ -85,6 +85,15 @@ def _reject_duplicate_config_keys(
 ) -> dict[Any, Any]:
     seen: set[Any] = set()
     for key_node, _value_node in node.value:
+        if key_node.tag == "tag:yaml.org,2002:merge":
+            # The `<<` merge directive, not a data key. `construct_object` has
+            # no constructor for the merge tag, so calling it aborted the whole
+            # run with PyYAML internals — `could not determine a constructor
+            # for the tag 'tag:yaml.org,2002:merge'`, exit 2, naming no fix.
+            # `parser.py` already skips it the same way for Compose documents,
+            # so a `<<:` was legal in the file being linted and fatal in the
+            # config beside it.
+            continue
         key = loader.construct_object(key_node, deep=True)
         try:
             duplicate = key in seen
@@ -129,7 +138,21 @@ def load_config(
         return {}, {}, {}
 
     for key in data:
-        if str(key) not in KNOWN_TOP_LEVEL_KEYS:
+        name = str(key)
+        if name.startswith("x-"):
+            # Compose's extension-field convention, which this project already
+            # honours in the documents it lints (`parser.py`). Tolerated here
+            # because it is the other half of `<<:` support: a merge key needs
+            # an anchor to merge *from*, and the idiomatic place to hold one is
+            # a top-level `x-` block. Warning on that — and erroring under
+            # `--strict-config`, which the docs recommend for CI — would make
+            # the anchor idiom unusable in exactly the pipelines that opted
+            # into rigor.
+            #
+            # It costs no typo detection: `x-` is a deliberate marker, so a
+            # mistyped `rulez:` is still caught. A bare unknown key still warns.
+            continue
+        if name not in KNOWN_TOP_LEVEL_KEYS:
             _warn(
                 f"config: unknown top-level key '{key}' (recognized: "
                 f"{', '.join(sorted(KNOWN_TOP_LEVEL_KEYS))}); it has no effect",

--- a/src/compose_lint/config_emit.py
+++ b/src/compose_lint/config_emit.py
@@ -41,6 +41,32 @@ _SEVERITY_RANK = {
 _PLAIN_SCALAR = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9._-]*\Z")
 
 
+def _round_trips_as_itself(value: str) -> bool:
+    """Whether ``value`` unquoted reloads as the same *string*.
+
+    The pattern above says the characters are safe; it does not say the
+    *token* is. YAML 1.1 resolves a set of bare words and numerals to
+    non-strings, and every one of them matches an identifier-ish pattern:
+    ``no``/``yes``/``on``/``off``/``true``/``false`` become booleans,
+    ``123`` an int, ``1.5`` a float, ``null`` None. Compose service names
+    are unrestricted, so all of these are legal names.
+
+    Emitted unquoted, such a name reloads as a bool or an int, and
+    ``config.py`` requires ``exclude_services`` keys to be strings — so
+    ``init`` wrote a config that ``check`` then refused, exit 2, breaking
+    that directory until someone edited the file by hand. That is the exact
+    failure this module's docstring says it exists to prevent, arriving
+    through the token rather than through the characters.
+
+    Asking PyYAML to reload it is the check that cannot drift: the resolver
+    that decides the type is the same one that will read the file back.
+    """
+    try:
+        return bool(yaml.safe_load(value) == value)
+    except yaml.YAMLError:  # pragma: no cover - the pattern excludes these
+        return False
+
+
 def _scalar(value: str) -> str:
     """Render a string as a YAML scalar, quoting only when necessary.
 
@@ -54,7 +80,7 @@ def _scalar(value: str) -> str:
     Escaping is the kind of thing that is nearly right until it meets the next
     character class; the emitter that owns the format should decide.
     """
-    if _PLAIN_SCALAR.match(value):
+    if _PLAIN_SCALAR.match(value) and _round_trips_as_itself(value):
         return value
     # `default_style='"'` forces the double-quoted form, which is what this
     # emitter wants and which yields a single line with no document markers.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -346,3 +346,64 @@ def test_every_documented_per_rule_key_is_accepted(key: str, tmp_path: Path) -> 
     config = tmp_path / ".compose-lint.yml"
     config.write_text(f"rules:\n  CL-0003:\n    {key}: {values[key]}\n")
     load_config(config)  # must not raise, and must not be an unknown key
+
+
+# --- The config file is YAML, and `<<:` is YAML ----------------------------
+
+
+def test_a_merge_key_is_not_a_data_key(tmp_path: Path) -> None:
+    """`parser.py` already skips the merge tag for Compose documents.
+
+    The config loader called `construct_object` on every key node, and PyYAML
+    has no constructor for the merge tag — so a `<<:` aborted the whole run
+    with `could not determine a constructor for the tag
+    'tag:yaml.org,2002:merge'`, exit 2, naming no fix. A `<<:` was therefore
+    legal in the file being linted and fatal in the config beside it.
+    """
+    config = tmp_path / ".compose-lint.yml"
+    config.write_text(
+        "x-off: &off\n"
+        "  enabled: false\n"
+        "  reason: shared justification\n"
+        "rules:\n"
+        "  CL-0002:\n"
+        "    <<: *off\n",
+        encoding="utf-8",
+    )
+    disabled, _severities, _excluded = load_config(config)
+    assert disabled["CL-0002"] == "shared justification"
+
+
+def test_duplicate_keys_are_still_rejected(tmp_path: Path) -> None:
+    """Guard the guard: skipping the merge tag must not skip the dup check."""
+    config = tmp_path / ".compose-lint.yml"
+    config.write_text(
+        "rules:\n  CL-0002:\n    enabled: false\n  CL-0002:\n    enabled: true\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigError, match="duplicate key"):
+        load_config(config)
+
+
+def test_an_x_prefixed_top_level_key_is_tolerated(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The other half of `<<:` support: an anchor needs somewhere to live.
+
+    Compose's extension-field convention, already honoured in the documents
+    this tool lints. Warning on it — and erroring under `--strict-config` —
+    would make the anchor idiom unusable in exactly the pipelines that opted
+    into rigor.
+    """
+    config = tmp_path / ".compose-lint.yml"
+    config.write_text("x-shared: {a: b}\nrules: {}\n", encoding="utf-8")
+    load_config(config, strict=True)  # must not raise
+    assert "unknown top-level key" not in capsys.readouterr().err
+
+
+def test_a_bare_unknown_top_level_key_still_warns(tmp_path: Path) -> None:
+    """`x-` is a deliberate marker, so tolerating it costs no typo detection."""
+    config = tmp_path / ".compose-lint.yml"
+    config.write_text("rulez: {}\n", encoding="utf-8")
+    with pytest.raises(ConfigError, match="unknown top-level key"):
+        load_config(config, strict=True)

--- a/tests/test_config_emit.py
+++ b/tests/test_config_emit.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
 import yaml
 
 from compose_lint.config_emit import render_config
@@ -82,3 +87,42 @@ class TestRenderConfig:
 
 
 ANY_REASON = "TODO: justify or fix"
+
+
+def test_a_yaml_boolean_service_name_round_trips_through_load_config(
+    tmp_path: Path,
+) -> None:
+    """`init` wrote a config `check` then refused, breaking that directory.
+
+    `_PLAIN_SCALAR` says the *characters* are safe; it did not say the *token*
+    was. YAML 1.1 resolves `no`, `yes`, `on`, `123`, `1.5` and `null` to
+    non-strings, and every one matches an identifier-ish pattern while being a
+    legal Compose service name. Emitted unquoted, such a name reloaded as a
+    bool or an int, and `config.py` requires `exclude_services` keys to be
+    strings — so `init` reported success and `check` exited 2.
+    """
+    import yaml
+
+    from compose_lint.config import load_config
+
+    names = ["no", "yes", "on", "off", "true", "123", "1.5", "null", "web"]
+    findings = [
+        Finding(
+            rule_id="CL-0002",
+            severity=Severity.CRITICAL,
+            service=name,
+            message="m",
+            fix="f",
+            line=1,
+        )
+        for name in names
+    ]
+    config = tmp_path / ".compose-lint.yml"
+    config.write_text(render_config(findings), encoding="utf-8")
+
+    reloaded = yaml.safe_load(config.read_text(encoding="utf-8"))
+    keys = reloaded["rules"]["CL-0002"]["exclude_services"]
+    assert all(isinstance(k, str) for k in keys), f"non-string keys: {keys}"
+    assert set(keys) == set(names)
+
+    load_config(config, strict=True)  # must not raise

--- a/tests/test_json_contract.py
+++ b/tests/test_json_contract.py
@@ -28,15 +28,17 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
-from typing import TYPE_CHECKING
+from pathlib import Path
+
+import pytest
 
 from compose_lint import __version__
 from compose_lint.formatters.json import SCHEMA_VERSION, build_json_log
 from compose_lint.formatters.json import format_findings as format_json
 from compose_lint.models import Finding, Severity
+from tests._cli_env import cli_env
 
-if TYPE_CHECKING:
-    from pathlib import Path
+REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # The frozen surface. Editing either of these constants is the deliberate act
 # the contract exists to require.
@@ -384,3 +386,46 @@ def test_sarif_result_key_set_is_exact(tmp_path: Path) -> None:
     assert any("fixes" in r for r in results), (
         "no result carried `fixes`, so the conditional branch is unpinned"
     )
+
+
+# --- Every exit-2 shape emits the envelope, not just some of them ----------
+
+
+@pytest.mark.parametrize("fmt", ["json", "sarif"])
+@pytest.mark.parametrize("case", ["no-files", "config-missing"])
+def test_a_pre_scan_failure_still_emits_a_machine_document(
+    tmp_path: Path, fmt: str, case: str
+) -> None:
+    """These two exited before any formatter ran, so stdout was empty.
+
+    Every *other* exit-2 shape — a missing file, a parse error, a directory
+    argument — produced a full envelope, so a `jq` pipeline broke or not
+    depending on which kind of exit 2 it hit. Both of these are the commonest
+    CI misconfigurations: the wrong working directory, and a typo'd `--config`.
+    """
+    args = ["check", "--format", fmt]
+    if case == "config-missing":
+        (tmp_path / "docker-compose.yml").write_text(
+            "services:\n  w:\n    image: n:1\n", encoding="utf-8"
+        )
+        args += ["docker-compose.yml", "--config", str(tmp_path / "nope.yml")]
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "compose_lint", *args],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        env=cli_env(PYTHONPATH=str(REPO_ROOT / "src"), NO_COLOR="1"),
+        timeout=180,
+    )
+
+    assert proc.returncode == 2, proc.stderr
+    assert proc.stdout, f"{case}/{fmt} produced no machine output"
+    doc = json.loads(proc.stdout)
+    if fmt == "json":
+        assert doc["version"] == SCHEMA_VERSION
+        assert doc["errors"], "the reason must reach errors[]"
+    else:
+        invocation = doc["runs"][0]["invocations"][0]
+        assert invocation["executionSuccessful"] is False


### PR DESCRIPTION
Three places where the config layer or the machine output disagreed with itself. Each reproduced against `main` first.

## 1. `init` wrote a config that `check` then refused

```console
$ # a Compose file with services named `no` and `"123"`
$ compose-lint init c.yml -o .compose-lint.yml --force
wrote .compose-lint.yml with 12 suppression(s)                      rc=0
$ compose-lint check c.yml --config .compose-lint.yml
Error: exclude_services for 'CL-0002' keys must be service name strings   rc=2
```

`init` reported success, and every later run in that directory failed until someone hand-edited the file.

`_PLAIN_SCALAR` judged the **characters**, not the **token**. YAML 1.1 resolves `no`/`yes`/`on`/`off`/`true`/`false` to booleans, `123` to an int, `1.5` to a float and `null` to None — and every one matches an identifier-ish pattern while being a legal Compose service name. Emitted unquoted, the key reloads as a non-string, and `config.py` requires strings.

This is the failure `config_emit.py`'s own docstring says it exists to prevent (*"a service name carrying a newline produced a config that does not parse — and `init` reported success while writing it"*), arriving through the token instead of the characters.

Fixed by asking PyYAML: emit unquoted only if `safe_load(value) == value`. The resolver that decides the type is the same one that will read the file back, so it cannot drift.

## 2. A `<<:` merge key in the config aborted the run

```console
$ compose-lint check c.yml --config m.yml
Error: Invalid YAML in config file: could not determine a constructor
       for the tag 'tag:yaml.org,2002:merge'                        rc=2
```

PyYAML internals, exit 2, no fix named. `_reject_duplicate_config_keys` called `construct_object` on every key node, and there is no constructor for the merge tag.

`parser.py:294` already skips it for Compose documents — so `<<:` was **legal in the file being linted and fatal in the config beside it**. Now skipped the same way, with the duplicate-key check unchanged (there is a test proving duplicates are still rejected).

## 3. `x-` top-level keys — the other half of merge support

Fixing (2) alone ships half a feature: a `<<:` needs an anchor to merge *from*, and the idiomatic holder is a top-level `x-` block — which warned, and **failed the run under `--strict-config`**, the mode `docs/configuration.md` recommends for CI.

```yaml
x-off: &off
  enabled: false
  reason: shared justification
rules:
  CL-0002:
    <<: *off
```

So `x-` is now tolerated. It is Compose's extension-field convention, already honoured in the documents this tool lints (`parser.py:158`). Because `x-` is a **deliberate marker**, tolerating it costs no typo detection — a mistyped `rulez:` still warns, and there is a test for that.

*Note: I earlier argued against reserving `x-` as speculative future-proofing, and on that reasoning it was rightly dropped. This is a different and concrete justification — a present feature needs it — not the forward-compatibility argument.*

## 4. Two exit-2 paths produced zero bytes of machine output

| exit-2 shape | before | after |
|---|---|---|
| missing file | envelope | envelope |
| parse error | envelope | envelope |
| directory argument | envelope | envelope |
| **no Compose files found** | **0 bytes** | envelope |
| **missing `--config`** | **0 bytes** | envelope |

Both exited before any formatter ran. A `jq` pipeline broke or not depending on which *kind* of exit 2 it hit — and these two are the commonest CI misconfigurations: wrong working directory, typo'd config path. Run-level metadata a consumer can read is what the envelope exists for (ADR-015). SARIF gets the same treatment, with `executionSuccessful: false`.

## Verification

2546 tests pass; `ruff` and `mypy` clean on touched files. (`mypy` reports 7 pre-existing errors in `parser.py` — present on unmodified `main`, unrelated to this PR, and worth a separate look since `CLAUDE.md` says the gate must pass.)

Found by a pre-1.0 freeze-surface audit.
