### PR TITLE
Price three bump classes the cheat sheet did not cover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Three bump classes the judgment-call cheat sheet did not price**
+  ([docs/RELEASING.md](docs/RELEASING.md#judgment-call-cheat-sheet)). The
+  sharpest is a rule's **evidence** derivation: it never appears in text output
+  so it reads as an implementation detail, but it is the input to the SARIF
+  `partialFingerprints` digest — the *identity* of a Code Scanning alert
+  ([ADR-024](docs/adr/024-finding-identity-is-not-prose.md)). Change one and
+  every existing alert for that rule closes as "fixed" while the same findings
+  reopen as new, with no field renamed and no shape moved. No document assigned
+  it a bump class; it is a MINOR, announced under `Changed`, and
+  `docs/compatibility.md` gains an *Alert identity* section saying so in
+  user-facing terms. The other two: retiring a rule admitted on *judgment*
+  (new in this release, and previously harder to remove than a grounded rule),
+  and amending the policy itself — ADR-030's
+  clarification/tightening/loosening ladder governs every other row in the
+  table but was only findable in prose elsewhere.
+
+
 - **A test gates the `Development Status` classifier against the major
   version.** `docs/RELEASING.md` says to flip `4 - Beta` to
   `5 - Production/Stable` in the same commit that sets `version = "1.0.0"`, but

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -158,18 +158,54 @@ Once `1.0.0` ships, the contract tightens:
 | Tighten an existing rule (new true positive) | MINOR   | MINOR    |
 | Remove or rename a CLI flag                  | MINOR   | MAJOR    |
 | Retire a rule ID (refuted, via lifecycle)    | MINOR   | MINOR (ADR-032) |
+| Retire a rule admitted on *judgment* (ADR-028 records it as such), via lifecycle | MINOR | MINOR (ADR-032 cond. 1) |
 | Retire a rule ID off-lifecycle               | MINOR   | MAJOR    |
 | Change the default `--fail-on` threshold     | MINOR   | MAJOR    |
 | Drop a Python version on schedule (ADR-029)  | MINOR   | MINOR    |
 | Drop a Python version off-schedule           | MINOR   | MAJOR    |
 | Add a field to JSON/SARIF output             | MINOR   | MINOR    |
 | Remove or rename a JSON/SARIF field          | MINOR   | MAJOR    |
+| Change a rule's **evidence** derivation      | MINOR   | MINOR, announced under `Changed` |
 | Remove or rename a config key                | MINOR   | MAJOR    |
 | Deprecate a flag/key (keep it working)       | PATCH   | MINOR    |
+| Amend this policy — *clarification*          | any     | any      |
+| Amend this policy — *tightening* (promise more) | MINOR | MINOR   |
+| Amend this policy — *loosening* (promise less)  | MINOR | MAJOR   |
 
 When in doubt pre-1.0, pick MINOR. When in doubt post-1.0, pick the
 higher bump — MAJOR costs the maintainer some release ceremony, but a
 too-low bump breaks users who trusted the version contract.
+
+Three rows need a word of explanation, because each was a real gap rather
+than an omission for brevity.
+
+**Evidence.** A rule's `evidence` never appears in text output, so it reads
+like an implementation detail. It is not: it is the input to the SARIF
+`partialFingerprints` digest, which is the *identity* of a Code Scanning
+alert ([ADR-024](adr/024-finding-identity-is-not-prose.md)). Change a
+derivation and every existing alert for that rule closes as "fixed" while
+the same findings reopen as new — a consumer-visible event with no output
+field changed and no test necessarily failing (`tests/test_finding_identity.py`
+pins the derivations for exactly this reason). It is MINOR rather than MAJOR
+because no *shape* changes and nothing breaks: a pinned user is untouched,
+and an unpinned one sees alert churn once. It must be announced under
+`Changed` so that churn is expected rather than mysterious.
+
+**Retire-on-judgment.** The row above it covers a rule whose premise
+evidence *refutes*. A rule [ADR-028](adr/028-pre-1.0-rule-id-sweep.md)
+records as admitted on judgment — a closed set, currently `{CL-0014}` —
+can never meet that bar, because its premise holds and what is thin is its
+grounding. Without its own row such a rule would be *harder* to remove than
+a grounded one, which is backwards.
+
+**Amending this policy.** The ladder comes from
+[ADR-030](adr/030-the-policy-is-part-of-the-contract.md) and governs every
+other row in this table, so leaving it out of the table meant the one rule
+that prices changes to the rules was the one you had to go elsewhere to
+find. Note the asymmetry it creates, which is the reason several 1.0
+decisions were taken early: a loosening is only affordable *before* the
+tag, while the tightening that reverses it stays cheap forever.
+
 
 ### Deprecations
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -60,6 +60,27 @@ build. Every upgrade must still be *derived* — the two-axis model has to
 produce the new number (an axis correction or a declared override), so a
 severity never moves on judgment alone.
 
+### Alert identity
+
+SARIF results carry `partialFingerprints`, which is what GitHub Code Scanning
+uses to decide whether an alert it already has is *this* alert. The digest is
+derived from a finding's `evidence` — the specific construct that tripped the
+rule ([ADR-024](adr/024-finding-identity-is-not-prose.md)) — deliberately, so
+that rewording a message never re-keys an alert and cosmetic edits to a Compose
+file never split one.
+
+The consequence is worth stating plainly, because nothing in the output makes
+it visible: **changing how a rule derives its evidence changes that rule's alert
+identities.** Every existing alert closes as "fixed" and the same findings
+reopen as new. No field is renamed and no shape moves, so a consumer parsing
+JSON or SARIF sees nothing unusual — the churn appears only in the alert list.
+
+That is a **MINOR**, announced under `Changed` in `CHANGELOG.md`. A pinned user
+is untouched; an unpinned one sees the churn once and, because it was
+announced, knows why. `tests/test_finding_identity.py` pins each rule's
+derivation so the change has to be deliberate rather than a side effect of
+tidying a predicate.
+
 ## Deprecation lifecycle
 
 Nothing stable is removed without warning. When a flag, config key, output


### PR DESCRIPTION
`RELEASING.md`'s judgment-call cheat sheet is the single place a maintainer looks to answer *"what bump is this?"*. Three answers were missing from it.

*(This started as a proposal to consolidate the versioning policy into one table. On inspection that table already existed — this is the three rows it was missing, which is a much smaller change and keeps one authoritative location.)*

## 1. Changing a rule's `evidence` derivation — the real gap

`evidence` never appears in text output, so it reads like an implementation detail. It is the input to the SARIF `partialFingerprints` digest, which is the **identity** of a Code Scanning alert ([ADR-024](../blob/main/docs/adr/024-finding-identity-is-not-prose.md)).

Change a derivation and **every existing alert for that rule closes as "fixed" while the same findings reopen as new** — no field renamed, no shape moved, nothing in the output making it visible.

I grepped `compatibility.md`, `RELEASING.md`, ADR-015 and ADR-024: **no document assigned this a bump class.** A consumer-visible contract surface had no price.

It is a **MINOR announced under `Changed`** — MINOR because nothing breaks (a pinned user is untouched, an unpinned one sees churn once), announced because unexplained alert churn is indistinguishable from a bug.

`compatibility.md` gains an **Alert identity** section stating this in user-facing terms, since the cheat sheet is maintainer-facing and this one has a consumer consequence.

## 2. Retiring a rule admitted on judgment

New in this release (#733). The table had "retire refuted, via lifecycle" and "retire off-lifecycle" but not the third case — which left a judgment-admitted rule looking *harder* to remove than a grounded one.

## 3. Amending this policy

ADR-030's clarification / tightening / loosening ladder **governs every other row in the table** — and was only findable in `compatibility.md` prose. So the rule that prices changes to the rules was the one you had to go elsewhere for.

Its asymmetry is also the reason several 1.0 decisions were taken early (#727, #733), which the accompanying note now states explicitly: a loosening is only affordable *before* the tag, while the tightening that reverses it stays cheap forever.

## Not doing

The `docs/adr/README.md` index and the changelog-prose trim were discussed alongside this and are deliberately left out — separate concerns, separate PRs.

Docs only. 2552 tests pass.
