### PR TITLE
Assert the invariant the broken-pipe test exists for, not a raced exit code

### DIFF
--- a/tests/test_exit_code_contract.py
+++ b/tests/test_exit_code_contract.py
@@ -268,7 +268,18 @@ def test_a_reader_that_closes_early_is_exit_2_not_a_failed_gate() -> None:
 
     Exit 1 means "findings at or above the threshold". Reporting it because
     the *reader* went away turns every clean file piped into `head` into a red
-    merge gate.
+    merge gate. That is the invariant, and it is what this asserts.
+
+    Deliberately **not** asserting exit 2. Whether the writer ever sees
+    ``EPIPE`` is a race: a clean file's report is small, so if the whole of it
+    reaches the pipe buffer before ``head`` exits, every write succeeds and the
+    run ends 0 — which is correct, not a failure. An earlier version of this
+    test pinned 2 and passed on Linux while failing on macOS for exactly that
+    reason. Both 0 and 2 are honest answers; only 1 is a lie, and only 1 turns
+    a clean file into a red gate.
+
+    `/dev/full` above covers the write-failure-becomes-2 path deterministically,
+    which is the half a timing-dependent pipe cannot pin down.
     """
     with tempfile.TemporaryDirectory() as tmp:
         Path(tmp, "docker-compose.yml").write_text(_CLEAN, encoding="utf-8")
@@ -286,7 +297,11 @@ def test_a_reader_that_closes_early_is_exit_2_not_a_failed_gate() -> None:
             timeout=180,
         )
 
-    assert proc.returncode == 2, proc.stderr
+    assert proc.returncode != 1, (
+        "a clean file reported findings because the reader closed early; "
+        f"stderr: {proc.stderr}"
+    )
+    assert proc.returncode in (0, 2), proc.stderr
     _assert_no_traceback(proc)
 
 


### PR DESCRIPTION
`test_a_reader_that_closes_early_is_exit_2_not_a_failed_gate` (added in #718) is timing-dependent. It passes on Linux and **fails on macOS**, and because `ci-ok` aggregates `os-smoke` it is currently blocking every open PR.

```
os-smoke / pytest (macos-15, py3.11)
  assert proc.returncode == 2
  assert 0 == 2
    args='set -o pipefail; python -m compose_lint check docker-compose.yml | head -1 >/dev/null'
    returncode=0
```

My bug, from #718.

## Why it races

The test pinned exit **2**. Whether the writer ever sees `EPIPE` is not deterministic: a clean file's report is small, so if all of it reaches the pipe buffer before `head` exits, every write succeeds and the run ends **0**. That is correct behaviour, not a failure — the race decides which of two honest answers you get.

## The fix

Assert the invariant the test actually exists for.

Exit 1 means *"findings at or above the threshold"*. The failure being prevented is a clean file reporting findings because its **reader** went away — turning `compose-lint check clean.yml | head` into a red merge gate. So:

```python
assert proc.returncode != 1   # the lie
assert proc.returncode in (0, 2)   # both honest
```

Both 0 and 2 are correct answers depending on timing; only 1 is wrong, and only 1 causes the harm the test was written to prevent.

The deterministic half — *a write failure becomes exit 2* — is already covered by the `/dev/full` test directly above, which does not race. Nothing is lost.

## Worth noting

`os-smoke` earned its keep here. `docs/compatibility.md` says macOS and Windows "do not yet gate merges" — via `ci-ok` this one effectively did, and it caught a real portability defect in a test I wrote. That is an argument for the current arrangement, not against it.
