### PR TITLE
Grade a writable bind of the host's executable tree under CL-0025 (#737)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **CL-0025 now grades a writable bind of the host's executable tree**
+  ([#737](https://github.com/tmatens/compose-lint/issues/737)). `/usr/bin`,
+  `/usr/sbin`, `/usr/local/bin`, `/usr/local/sbin`, `/bin` and `/sbin` are
+  matched by descent — `/usr/bin/docker:/usr/bin/docker`, the corpus idiom for
+  driving the host's CLI, counts — and bare `/usr` is matched exactly, the
+  `/var/lib` mechanism: it is root-equivalent for what it *contains*, and by
+  descent it would also have priced `/usr/src`, `/usr/share/zoneinfo` and
+  site-packages as host root (6 of the 27 writable `/usr`-family binds in the
+  corpus, 22%). Both spellings are listed because matching is lexical on what
+  the document wrote, while Docker resolves the merged-`/usr` symlink at mount
+  time. Measured on two hosts at Docker defaults, unprivileged: each member
+  accepted a write through an rw bind and refused it through an ro bind, and a
+  root-owned `755` file planted through `-v /usr` into `/usr/local/bin` — ahead
+  of `/usr/bin` on root's `PATH`, so nothing need be overwritten — was on the
+  host afterwards. New premise check `_cl0025_exec_tree` plants, observes from
+  a second container, and removes it. Same cell as `/etc`: Direct × Host,
+  CRITICAL, no override. On the corpus this is 20 new CRITICAL findings.
+
+  Two boundaries recorded rather than guessed: a **read-only** bind of the
+  executable tree is exempt from CL-0013 as well — every file in it is
+  world-readable by design, so `:ro` discloses nothing (the timezone-file shape,
+  one tier up); and the **library tree** (`/usr/lib`, `/lib/modules`) is
+  deferred to an ADR, because by descent it would sweep `/usr/lib/python3` and
+  the standard `/lib/modules` bind of every VPN workload, and the corpus holds
+  nothing else to shape a narrower match on.
+
 - **Three bump classes the judgment-call cheat sheet did not price**
   ([docs/RELEASING.md](docs/RELEASING.md#judgment-call-cheat-sheet)). The
   sharpest is a rule's **evidence** derivation: it never appears in text output

--- a/docs/rules/CL-0013.md
+++ b/docs/rules/CL-0013.md
@@ -25,7 +25,7 @@ boundary rather than host root:
 - `/dev` — the entire host device tree, in either mode. The device *nodes* become visible but stay unusable — a bind is not `devices:`, see below. The inert character devices `/dev/null`, `/dev/zero`, `/dev/full`, `/dev/random` and `/dev/urandom` are excluded: they disclose no host state and grant no access
 - `/home` itself, or a single user's home directory (`/home/alice`) — the whole tree, with credentials, source code and shell history, in either mode
 - a credential directory inside a home directory — `.ssh`, `.docker`, `.aws`, `.kube`, `.gnupg`, and anything below them — in either mode
-- **read-only** mounts of the root-equivalent paths `/etc`, `/proc`, `/boot`, `/root`, `/var/lib/docker`, `/var/lib/containerd` and `/var/lib` — the same paths *writable* are [CL-0025](CL-0025.md) at CRITICAL
+- **read-only** mounts of the root-equivalent paths `/etc`, `/proc`, `/boot`, `/root`, `/var/lib/docker`, `/var/lib/containerd` and `/var/lib` — the same paths *writable* are [CL-0025](CL-0025.md) at CRITICAL. CL-0025's executable-tree members (`/usr`, `/usr/bin`, `/usr/local/bin`, `/bin`, `/sbin`) are **not** graded here read-only: they are world-readable by design, so `:ro` discloses nothing and the grant is write-only
 - a **writable** `/etc/localtime` or `/etc/timezone` — see the timezone exception below
 
 Subpaths (e.g., `/etc/passwd`, `/root/.ssh`) are also flagged. Both short syntax (`/etc:/host-etc`) and long syntax (`source: /etc, target: /host-etc`) are checked. The long syntax is recognized whether `type: bind` is set explicitly or omitted — Compose treats absolute-path sources as bind mounts either way. Named volumes are not flagged.

--- a/docs/rules/CL-0025.md
+++ b/docs/rules/CL-0025.md
@@ -10,7 +10,7 @@
 - **Qualifier/modifier:** none — this is write access, so the `read-only` qualifier that puts the same paths in [CL-0013](CL-0013.md) does not apply
 - **Derived:** Direct × Host = CRITICAL
 - **Shipped:** CRITICAL
-- **Evidence:** `_cl0025_core_pattern` in `scripts/validate_rule_premises.py` — a read-write `/proc` bind arrives writable at default capabilities where the container's own `/proc/sys` is read-only, so `core_pattern` can be repointed. The check writes back the value it read, leaving the host's setting unchanged. The other members are classic direct-root primitives (`cron.d`, `ld.so.preload`, `authorized_keys`, the initramfs)
+- **Evidence:** `_cl0025_core_pattern` and `_cl0025_exec_tree` in `scripts/validate_rule_premises.py`. The first: a read-write `/proc` bind arrives writable at default capabilities where the container's own `/proc/sys` is read-only, so `core_pattern` can be repointed (the check writes back the value it read, leaving the host's setting unchanged). The second: a container given only `-v /usr` plants a root-owned executable in `/usr/local/bin` that a second container sees through its own bind, while the same write through a read-only bind is refused (the check removes the file). The other members are classic direct-root primitives (`cron.d`, `ld.so.preload`, `authorized_keys`, the initramfs)
 
 ## What it detects
 
@@ -25,14 +25,34 @@ A **writable** bind mount of a host path where write access is host root:
 | `/var/lib/containerd` | the containerd snapshot trees holding every container's filesystem — on Docker 29 with the containerd snapshotter, that is where the layers live |
 | `/var/lib` | `/var/lib/docker` and `/var/lib/containerd` inside it, and with them every other container's filesystem. **Matched exactly** — see below |
 | `/proc` | `core_pattern` — the host runs a program of the attacker's choosing, as root, on the next crash |
+| `/usr/bin`, `/usr/sbin`, `/usr/local/bin`, `/usr/local/sbin`, `/bin`, `/sbin` | root's `PATH` — a binary planted or replaced here runs as root on the next cron job, login or unit start. Nothing need be overwritten: `/usr/local/bin` precedes `/usr/bin` on root's `PATH`, so a planted name shadows the real one |
+| `/usr` | the executable tree above, by containment. **Matched exactly** — see below |
 
-Every path above is matched by descent — `/etc/passwd` and `/var/lib/docker/volumes`
-count — **except `/var/lib`, which is matched only as an exact mount.** It is
-root-equivalent because of what it *contains*, not because of what lies below it:
-`-v /var/lib` reaches the container store, while `-v /var/lib/mysql` reaches a
-database's own data directory and nothing else. Descent would have priced every
-stateful service's normal, correct configuration — `/var/lib/mysql`,
-`/var/lib/postgresql/data`, `/var/lib/grafana` — as host root.
+Every path above is matched by descent — `/etc/passwd`, `/var/lib/docker/volumes`
+and `/usr/bin/docker` count — **except `/var/lib` and `/usr`, which are matched
+only as an exact mount.** Each is root-equivalent because of what it *contains*,
+not because of what lies below it: `-v /var/lib` reaches the container store,
+while `-v /var/lib/mysql` reaches a database's own data directory and nothing
+else; `-v /usr` reaches `/usr/local/bin`, while `-v /usr/src` or
+`/usr/share/zoneinfo` reaches kernel headers or timezone data that root never
+executes. Descent would have priced every stateful service's normal, correct
+configuration — `/var/lib/mysql`, `/var/lib/postgresql/data`, `/var/lib/grafana`
+— as host root, and measured over the corpus 6 of the 27 writable `/usr`-family
+binds (22%) were application data of that kind.
+
+The executable tree is listed under **both** spellings. On a merged-`/usr` host
+`/bin` is a symlink to `usr/bin` and Docker resolves it at mount time, but this
+rule matches what the document wrote, so `/bin:/bin` and `/usr/bin:/usr/bin`
+each need their own entry. Which spelling a distro uses varies, and both are
+graded the same.
+
+**The library tree is deferred, not claimed.** `/usr/lib` and `/lib/modules`
+carry a comparable grant — systemd units, `ld.so` libraries, loadable kernel
+modules — but by descent they would also claim `/usr/lib/python3`,
+`/usr/lib/node_modules` and the standard `/lib/modules` bind every VPN and
+kernel-module workload uses (7 corpus services, all of that shape). The corpus
+holds no other `/usr/lib` bind to shape a narrower match on, so the disposition
+is recorded here pending an ADR rather than left as an omission.
 
 A whole-root mount (`/`) is **not** listed here: it contains the daemon control
 socket, so it is host root in either mode — not only when writable — and
@@ -51,7 +71,10 @@ flagging it failed the default gate on otherwise-hardened files (issue #509).
 
 **Read-only mounts of these paths are not this rule.** They fall through to
 [CL-0013](CL-0013.md) at HIGH, where the finding is disclosure rather than
-takeover. That is the whole distinction between the two rules.
+takeover. That is the whole distinction between the two rules. The one exception
+is the executable tree: every file in `/usr/bin` is world-readable by design, so
+a read-only bind of it discloses nothing and is exempt from CL-0013 as well —
+its grant is write-only, the same shape as the timezone files one tier down.
 
 ## Why it matters
 
@@ -67,6 +90,15 @@ Docker 29.1.3.
 `/var/lib/docker` is the other under-rated one: it is not host root directly,
 but it is every other container's filesystem, so a write there escapes into a
 neighbour the next time it starts.
+
+The executable tree is the one people bind without thinking, usually as a
+single file — `/usr/bin/docker:/usr/bin/docker` so a container can drive the
+host's CLI. Writable, that is the host's `docker` binary, replaceable by the
+container. Measured on two hosts (Docker 29.1.3 with AppArmor; 29.7.2 without),
+unprivileged and at default capabilities: a writable bind of each member
+accepted a write, the read-only bind of the same path refused it, and a
+root-owned `755` file planted through `-v /usr` into `/usr/local/bin` was on the
+host afterwards, ahead of `/usr/bin` on root's `PATH`.
 
 ## Fix
 

--- a/scripts/validate_rule_premises.py
+++ b/scripts/validate_rule_premises.py
@@ -592,6 +592,7 @@ def _t_ipc_lock() -> tuple[bool, str]:
 # from the scheduler and the lease-break path not being namespaced, and is
 # recorded as reasoned in the rule's Evidence line.
 
+
 def _cl0029_sys_nice() -> tuple[bool, str]:
     """SCHED_FIFO — real-time priority on the host's CPUs — needs SYS_NICE.
 
@@ -976,6 +977,46 @@ def _cl0025_core_pattern() -> tuple[bool, str]:
     return ok, f"rw /proc bind={bound!r}, container's own /proc={default!r}"
 
 
+def _cl0025_exec_tree() -> tuple[bool, str]:
+    """An rw ``/usr`` bind lets a container plant a root-owned executable on
+    root's PATH; the ro bind of the same path refuses the write.
+
+    The planted file is observed from a *second* container through its own
+    bind of ``/usr/local/bin`` -- host state, not the writer's view of it --
+    and removed by the writer afterwards, so the host is left as found. The
+    name is unique to this check; a leftover from an aborted run is removed
+    before the write so it cannot fake the observation.
+    """
+    probe = "cl0025-exec-tree-probe"
+    plant = (
+        f"rm -f /hostusr/local/bin/{probe}; "
+        f'printf "#!/bin/sh\\necho probe\\n" > /hostusr/local/bin/{probe} '
+        f"2>/dev/null && chmod 755 /hostusr/local/bin/{probe} && echo WROTE "
+        "|| echo REFUSED"
+    )
+    _, rw = _run(["-v", "/usr:/hostusr"], ["sh", "-c", plant])
+    _, seen = _run(
+        ["-v", "/usr/local/bin:/y:ro"],
+        ["sh", "-c", f"test -x /y/{probe} && stat -c %U /y/{probe} || echo ABSENT"],
+    )
+    _run(["-v", "/usr:/hostusr"], ["rm", "-f", f"/hostusr/local/bin/{probe}"])
+    _, ro = _run(
+        ["-v", "/usr:/hostusr:ro"],
+        [
+            "sh",
+            "-c",
+            f"echo x > /hostusr/local/bin/{probe} 2>/dev/null "
+            "&& echo WROTE || echo REFUSED",
+        ],
+    )
+    ok = rw == "WROTE" and seen == "root" and ro == "REFUSED"
+    return (
+        ok,
+        f"rw /usr bind={rw!r}, owner seen by a second container={seen!r}, "
+        f"ro bind={ro!r}",
+    )
+
+
 def _cl0026() -> tuple[bool, str]:
     """Memory and CPU are both unbounded by default; a limit bounds them.
 
@@ -1036,9 +1077,13 @@ def _t_dac_read_search() -> tuple[bool, str]:
     what the capability grants is this: reading a file the workload uid is
     otherwise refused.
     """
-    probe = "echo secret > /tmp/s; chmod 000 /tmp/s; chown 65534:65534 /tmp/s; cat /tmp/s"
+    probe = (
+        "echo secret > /tmp/s; chmod 000 /tmp/s; chown 65534:65534 /tmp/s; cat /tmp/s"
+    )
     _, denied = _run(["--cap-drop", "ALL"], ["sh", "-c", probe])
-    _, allowed = _run(["--cap-drop", "ALL", "--cap-add", "DAC_READ_SEARCH"], ["sh", "-c", probe])
+    _, allowed = _run(
+        ["--cap-drop", "ALL", "--cap-add", "DAC_READ_SEARCH"], ["sh", "-c", probe]
+    )
     ok = "secret" not in denied and allowed.strip() == "secret"
     return ok, f"without={denied!r}; with={allowed!r}"
 
@@ -1047,8 +1092,8 @@ _PERF_PROBE = (
     "import ctypes,struct,os,sys\n"
     "libc=ctypes.CDLL('libc.so.6',use_errno=True)\n"
     "b=bytearray(128)\n"
-    "struct.pack_into('<I',b,0,1)\n"      # PERF_TYPE_SOFTWARE
-    "struct.pack_into('<I',b,4,128)\n"    # attr size
+    "struct.pack_into('<I',b,0,1)\n"  # PERF_TYPE_SOFTWARE
+    "struct.pack_into('<I',b,4,128)\n"  # attr size
     "a=(ctypes.c_char*128).from_buffer(b)\n"
     "ctypes.set_errno(0)\n"
     # pid=-1, cpu=0 -> system-wide, kernel samples included
@@ -1201,6 +1246,11 @@ CHECKS: list[tuple[str, str, Callable[[], tuple[bool | None, str]]]] = [
         "CL-0025",
         "premise: rw /proc bind makes core_pattern writable",
         _cl0025_core_pattern,
+    ),
+    (
+        "CL-0025",
+        "premise: rw /usr bind plants a root-owned executable on root's PATH",
+        _cl0025_exec_tree,
     ),
     ("CL-0026", "premise: memory and cpu are unbounded by default", _cl0026),
     ("CL-0027", "premise: SYS_PTRACE traces a different-uid process", _t_sys_ptrace),

--- a/src/compose_lint/rules/CL0013_sensitive_mount.py
+++ b/src/compose_lint/rules/CL0013_sensitive_mount.py
@@ -13,7 +13,10 @@ from compose_lint.rules._mounts import (
     normalize_host_path,
 )
 from compose_lint.rules.CL0001_docker_socket import claims_host_path
-from compose_lint.rules.CL0025_writable_host_root import match_root_equivalent
+from compose_lint.rules.CL0025_writable_host_root import (
+    EXEC_TREE_PATHS,
+    match_root_equivalent,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -238,6 +241,12 @@ class SensitiveMountRule(BaseRule):
                         "timezone configuration"
                     )
                 elif mount.read_only:
+                    if matched in EXEC_TREE_PATHS:
+                        # The executable tree is world-readable by design, so a
+                        # read-only bind of it discloses nothing; its grant is
+                        # write-only and CL-0025's. Same shape as the timezone
+                        # exemption above.
+                        continue
                     # A read-only mount of a root-equivalent path is disclosure
                     # rather than takeover, so it lands here instead of CL-0025.
                     reason = (

--- a/src/compose_lint/rules/CL0025_writable_host_root.py
+++ b/src/compose_lint/rules/CL0025_writable_host_root.py
@@ -64,6 +64,29 @@ REFERENCES = [OWASP_REF, CIS_REF]
 # Either way /var/lib/docker keeps its grant; /var/lib/containerd is the part
 # that had no owner.
 #
+# The executable tree (#737). Root's PATH on every mainstream distro is some
+# ordering of /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin, so a
+# file planted in any of these runs as root the next time root -- cron, a login
+# shell, a systemd unit -- calls that name. No existing binary need be
+# overwritten: a name planted in /usr/local/bin shadows the same name in
+# /usr/bin. Measured on two hosts (Docker 29.1.3 with AppArmor; 29.7.2 without),
+# unprivileged, default capabilities: a writable bind of each member accepted a
+# write and a read-only bind refused it, and a 755 root-owned file planted
+# through `-v /usr` was visible to a second container and on the host.
+#
+# Both the /usr/... and the bare /bin, /sbin spellings are listed. On a
+# merged-usr host they are the same directories, but Docker resolves the symlink
+# at mount time while this rule matches what the *document* wrote, so a prefix
+# on one spelling cannot cover the other.
+#
+# The library tree is deliberately *not* here. /usr/lib and /lib/modules carry a
+# comparable grant (systemd units, ld.so libraries, loadable modules), but by
+# descent they would also sweep /usr/lib/python3, /usr/lib/node_modules and
+# every VPN workload's standard /lib/modules bind -- the /var/lib containment
+# failure again -- and the corpus holds no bind of /usr/lib other than modules
+# to shape a narrower match on. Recorded here as deferred, pending an ADR, so
+# it is a disposition rather than an omission.
+#
 ROOT_EQUIVALENT_PATHS: tuple[str, ...] = (
     "/etc",
     "/root",
@@ -71,6 +94,28 @@ ROOT_EQUIVALENT_PATHS: tuple[str, ...] = (
     "/var/lib/docker",
     "/var/lib/containerd",
     "/proc",
+    "/usr/bin",
+    "/usr/sbin",
+    "/usr/local/bin",
+    "/usr/local/sbin",
+    "/bin",
+    "/sbin",
+)
+
+# The executable tree is root-equivalent *only* writable. Read-only it discloses
+# nothing -- every file in it is world-readable by design -- so unlike the
+# other members a `:ro` mount of one of these is not CL-0013's disclosure
+# finding either. Same shape as the timezone exemption, one tier up.
+EXEC_TREE_PATHS: frozenset[str] = frozenset(
+    {
+        "/usr",
+        "/usr/bin",
+        "/usr/sbin",
+        "/usr/local/bin",
+        "/usr/local/sbin",
+        "/bin",
+        "/sbin",
+    }
 )
 
 # "/var/lib" is root-equivalent because of what it *contains* — /var/lib/docker
@@ -86,7 +131,12 @@ ROOT_EQUIVALENT_PATHS: tuple[str, ...] = (
 # The general fix is an ancestor-aware matcher, which also has to re-settle the
 # CL-0001 boundary ("/" and "/var" contain the control socket) and is therefore
 # a larger change than this member warrants.
-ROOT_EQUIVALENT_EXACT_PATHS: tuple[str, ...] = ("/var/lib",)
+#
+# "/usr" is the same shape: root-equivalent because it *contains* the exec
+# directories above, while by descent it would also claim /usr/src, /usr/share
+# and the Python site-packages -- measured over the corpus, 6 of the 27 writable
+# /usr-family binds (22%) were that kind of application data.
+ROOT_EQUIVALENT_EXACT_PATHS: tuple[str, ...] = ("/var/lib", "/usr")
 
 
 def match_root_equivalent(host_path: str) -> str | None:
@@ -111,6 +161,13 @@ _GRANTS: dict[str, str] = {
     "only this mount read and modified a neighbour's files",
     "/proc": "core_pattern — the host's core-dump handler runs a program of the "
     "attacker's choosing, as root, on the next crash",
+    **dict.fromkeys(
+        ("/usr/bin", "/usr/sbin", "/usr/local/bin", "/usr/local/sbin", "/bin", "/sbin"),
+        "root's PATH — a planted or replaced binary runs as root on the next "
+        "cron job, login or unit start",
+    ),
+    "/usr": "the executable tree inside it (/usr/bin, /usr/sbin, /usr/local/bin) "
+    "— a planted binary runs as root on the next cron job, login or unit start",
 }
 
 
@@ -125,10 +182,12 @@ class WritableHostRootMountRule(BaseRule):
             name="Root-equivalent host path mounted writable",
             description=(
                 "A writable bind mount of /etc, /root, /boot, /proc, the "
-                "container store (/var/lib/docker, /var/lib/containerd) or "
-                "/var/lib itself gives a container host root through ordinary "
-                "file writes — no exploit and no technique required. (A "
-                "whole-root mount is CL-0001's, which owns it in either mode.)"
+                "container store (/var/lib/docker, /var/lib/containerd), "
+                "/var/lib itself, or the executable tree (/usr, /usr/bin, "
+                "/usr/local/bin, /bin, /sbin) gives a container host root "
+                "through ordinary file writes — no exploit and no technique "
+                "required. (A whole-root mount is CL-0001's, which owns it in "
+                "either mode.)"
             ),
             severity=Severity.CRITICAL,
             references=REFERENCES,

--- a/tests/test_CL0013.py
+++ b/tests/test_CL0013.py
@@ -334,3 +334,36 @@ class TestTildeShapeClaims:
         # See the parser's ~user note: Compose never resolves another
         # account's home, so no claim can be honest.
         assert self._check("~someone/.ssh:/keys") == []
+
+
+class TestExecTreeReadOnly:
+    """A read-only bind of the executable tree is not a disclosure.
+
+    Every file under /usr/bin is world-readable by design, so ``:ro`` grants
+    nothing to read that the image could not ship -- the grant is write-only
+    and CL-0025's. Same shape as the timezone exemption, one tier up: routing
+    it here would report "discloses host configuration and credentials" about
+    a directory holding neither.
+    """
+
+    def setup_method(self) -> None:
+        self.rule = SensitiveMountRule()
+
+    def _findings(self, mount: str) -> list:
+        data, lines = loads(
+            f"services:\n  svc:\n    image: x\n    volumes:\n      - {mount}\n"
+        )
+        return list(self.rule.check("svc", data["services"]["svc"], data, lines))
+
+    def test_read_only_exec_tree_is_exempt(self) -> None:
+        for path in ("/usr", "/usr/bin", "/usr/local/bin", "/bin", "/sbin"):
+            assert self._findings(f"{path}:/x:ro") == [], path
+        assert self._findings("/usr/bin/docker:/usr/bin/docker:ro") == []
+
+    def test_writable_exec_tree_is_cl0025s_not_this_rule(self) -> None:
+        assert self._findings("/usr/bin:/x") == []
+
+    def test_read_only_etc_still_discloses(self) -> None:
+        # The exemption is the exec tree only; the other members keep their
+        # read-only disclosure finding here.
+        assert len(self._findings("/etc:/x:ro")) == 1

--- a/tests/test_CL0025.py
+++ b/tests/test_CL0025.py
@@ -194,3 +194,65 @@ class TestVarLibAncestor:
     def test_a_sibling_of_the_store_is_not_claimed(self) -> None:
         # /var/log is not under /var/lib; the entry must not widen to /var.
         assert self._findings("/var/log:/x") == []
+
+
+class TestExecTree:
+    """A writable bind of the executable tree is host root (#737).
+
+    Measured on two hosts (Docker 29.1.3 with AppArmor, 29.7.2 without),
+    unprivileged and at default capabilities: every member accepted a write
+    through an rw bind and refused it through an ro bind, and a 755 root-owned
+    file planted through ``-v /usr`` was on the host afterwards. Root's PATH
+    puts /usr/local/bin ahead of /usr/bin, so nothing need be overwritten.
+    """
+
+    def setup_method(self) -> None:
+        self.rule = WritableHostRootMountRule()
+
+    def _findings(self, mount: str) -> list:
+        data, lines = loads(
+            f"services:\n  svc:\n    image: x\n    volumes:\n      - {mount}\n"
+        )
+        return list(self.rule.check("svc", data["services"]["svc"], data, lines))
+
+    def test_each_exec_dir_writable_is_critical(self) -> None:
+        for path in (
+            "/usr/bin",
+            "/usr/sbin",
+            "/usr/local/bin",
+            "/usr/local/sbin",
+            "/bin",
+            "/sbin",
+        ):
+            findings = self._findings(f"{path}:/x")
+            assert len(findings) == 1, path
+            assert findings[0].severity is Severity.CRITICAL
+            assert "PATH" in findings[0].message
+
+    def test_a_single_binary_is_covered_by_descent(self) -> None:
+        # The corpus idiom: /usr/bin/docker or /usr/bin/rclone bound rw so a
+        # container can call the host's binary. Writable, it can replace it.
+        assert len(self._findings("/usr/bin/docker:/usr/bin/docker")) == 1
+
+    def test_bare_usr_is_critical_and_names_the_exec_tree(self) -> None:
+        findings = self._findings("/usr:/hostusr")
+        assert len(findings) == 1
+        assert "/usr/local/bin" in findings[0].message
+
+    def test_usr_application_data_is_not_claimed(self) -> None:
+        # Bare /usr is an exact match, so what lies below it outside the exec
+        # directories -- kernel headers, zoneinfo, an app's own share dir --
+        # is not priced as host root.
+        for path in ("/usr/src", "/usr/share/kubearmor", "/usr/share/zoneinfo"):
+            assert self._findings(f"{path}:/x") == [], path
+
+    def test_read_only_is_not_this_rule(self) -> None:
+        for path in ("/usr", "/usr/bin", "/bin"):
+            assert self._findings(f"{path}:/x:ro") == [], path
+
+    def test_library_tree_is_deferred_not_claimed(self) -> None:
+        # /usr/lib and /lib/modules carry a comparable grant but would sweep
+        # site-packages and every VPN workload's modules bind; deferred to an
+        # ADR rather than added by descent.
+        assert self._findings("/usr/lib:/x") == []
+        assert self._findings("/lib/modules:/lib/modules") == []

--- a/tests/test_rule_membership.py
+++ b/tests/test_rule_membership.py
@@ -142,6 +142,15 @@ class TestMountOwnership:
             "/var/lib/docker",
             "/var/lib/containerd",
             "/proc",
+            # The executable tree (#737): a file planted on root's PATH runs
+            # as root. Both spellings, because matching is on what the
+            # document wrote, not on what the merged-usr symlink resolves to.
+            "/usr/bin",
+            "/usr/sbin",
+            "/usr/local/bin",
+            "/usr/local/sbin",
+            "/bin",
+            "/sbin",
         }
 
     def test_var_lib_is_matched_exactly_not_by_descent(self) -> None:
@@ -150,8 +159,9 @@ class TestMountOwnership:
         # different sets: /var/lib/mysql contains neither /var/lib/docker nor
         # /var/lib/containerd. Matching it by descent priced every stateful
         # service's own data directory as host root (24 of 25 corpus hits).
-        assert set(ROOT_EQUIVALENT_EXACT_PATHS) == {"/var/lib"}
+        assert set(ROOT_EQUIVALENT_EXACT_PATHS) == {"/var/lib", "/usr"}
         assert "/var/lib" not in ROOT_EQUIVALENT_PATHS
+        assert "/usr" not in ROOT_EQUIVALENT_PATHS
 
         # The behaviour the split exists to produce.
         assert match_root_equivalent("/var/lib") == "/var/lib"
@@ -163,6 +173,28 @@ class TestMountOwnership:
             "/var/lib/postgresql/data",
             "/var/lib/grafana",
             "/var/lib/redis",
+        ):
+            assert match_root_equivalent(benign) is None, benign
+
+    def test_usr_is_matched_exactly_not_by_descent(self) -> None:
+        # Same containment shape as /var/lib: /usr is root-equivalent because
+        # it holds the exec directories, but by descent it would also claim
+        # /usr/src, /usr/share and site-packages -- 6 of the 27 writable
+        # /usr-family binds in the corpus (22%), none on root's PATH.
+        assert match_root_equivalent("/usr") == "/usr"
+        for exec_dir in ("/usr/bin", "/usr/sbin", "/usr/local/bin", "/bin", "/sbin"):
+            assert match_root_equivalent(exec_dir) == exec_dir
+            assert match_root_equivalent(exec_dir + "/docker") == exec_dir
+        for benign in (
+            "/usr/src",
+            "/usr/src/app",
+            "/usr/share/zoneinfo",
+            "/usr/share/kubearmor",
+            "/usr/local/lib/python3.9/dist-packages",
+            # The library tree is deferred, not claimed -- see the rule's
+            # ROOT_EQUIVALENT_PATHS comment and the CL-0025 page.
+            "/usr/lib",
+            "/lib/modules",
         ):
             assert match_root_equivalent(benign) is None, benign
 


### PR DESCRIPTION
Closes #737.

**What:** CL-0025 gains the executable tree — `/usr/bin`, `/usr/sbin`, `/usr/local/bin`, `/usr/local/sbin`, `/bin`, `/sbin` by descent; bare `/usr` exact (the `/var/lib` mechanism). A read-only bind of these is exempt from CL-0013 too (world-readable by design — the grant is write-only). `/usr/lib` and `/lib/modules` are recorded as deferred pending an ADR.

**Evidence:** measured on two hosts (Docker 29.1.3 with AppArmor; 29.7.2 without), unprivileged, default caps — every member `WROTE` rw / `REFUSED` ro; a root-owned 755 file planted through `-v /usr` into `/usr/local/bin` was on the host afterwards. New premise check `_cl0025_exec_tree`, run live locally: `(True, "rw /usr bind='WROTE', owner seen by a second container='root', ro bind='REFUSED'")`.

**Corpus:** `/usr` 25 binds (20 rw / 5 ro); naive descent would have flagged 6 application-data paths (22%); with this shape: 20 new CRITICAL findings, 0 false positives on the measured set.

**Severity:** same cell as `/etc` — Direct × Host = CRITICAL, no override; derivation on the rule page.

`pytest`: 2566 passed. `ruff`, `mypy` clean on touched files.


