### PR TITLE
Use the fixture constant these tests defined but inlined

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -958,9 +958,7 @@ class TestFixOnlyValidation:
     def test_a_lowercase_rule_id_is_accepted(self, tmp_path: Path) -> None:
         """`--explain` already normalizes case; one CLI must not answer twice."""
         f = tmp_path / "docker-compose.yml"
-        f.write_text(
-            "services:\n  w:\n    image: n:1\n    logging:\n      driver: none\n"
-        )
+        f.write_text(_FIXABLE_LOGGING)
         lower = run_cli("fix", "--only", "cl-0014", str(f))
         upper = run_cli("fix", "--only", "CL-0014", str(f))
         assert lower.returncode == upper.returncode == 0
@@ -972,9 +970,7 @@ class TestFixOnlyValidation:
         self, tmp_path: Path, bad: str
     ) -> None:
         f = tmp_path / "docker-compose.yml"
-        f.write_text(
-            "services:\n  w:\n    image: n:1\n    logging:\n      driver: none\n"
-        )
+        f.write_text(_FIXABLE_LOGGING)
         result = run_cli("fix", "--only", bad, str(f))
         assert "names no rule" in result.stderr
         assert bad in result.stderr
@@ -982,9 +978,7 @@ class TestFixOnlyValidation:
     def test_strict_config_promotes_it_to_an_error(self, tmp_path: Path) -> None:
         """Mirrors how an unknown rule id in the config file is treated."""
         f = tmp_path / "docker-compose.yml"
-        f.write_text(
-            "services:\n  w:\n    image: n:1\n    logging:\n      driver: none\n"
-        )
+        f.write_text(_FIXABLE_LOGGING)
         result = run_cli("fix", "--only", "banana", "--strict-config", str(f))
         assert result.returncode == 2
         assert "names no rule" in result.stderr


### PR DESCRIPTION
`_FIXABLE_LOGGING` landed in #731 as the shared fixture for `TestFixOnlyValidation`, but each of the three tests below it wrote the same literal inline, so the constant was never read. CodeQL flagged it as [`py/unused-global-variable` alert #118](https://github.com/tmatens/compose-lint/security/code-scanning/118) — a true positive, and the finding is the dead constant rather than the duplication.

Point the three `f.write_text(...)` calls at the constant. Test-only, no behavior change and nothing version-visible, so no CHANGELOG entry.

Found during 0.25.0 release preflight (Step 0 alert sweep); it was the only open alert and it is unmatched by `docs/security-exceptions.md`. Fixing it forward rather than recording a fixable defect as an exception.

Local: `ruff check`/`ruff format --check` clean, `pytest tests/test_cli.py` 80 passed.