### PR TITLE
Bump forgejo-smoke pin to 16.0.3; Codeberg GC'd the 16.0.2 manifest

### DIFF
--- a/docs/forgejo.md
+++ b/docs/forgejo.md
@@ -24,4 +24,4 @@ jobs:
         run: compose-lint --fail-on high
 ```
 
-Forgejo has no SARIF UI today — `--format sarif` still produces a valid document, but there's no security-tab equivalent to render it. Verified on Forgejo 16.0.2, runner 13.0.0 — this exact snippet is executed against a live Forgejo weekly by the [forgejo-smoke workflow](https://github.com/tmatens/compose-lint/blob/main/.github/workflows/forgejo-smoke.yml), which fails if this line and the versions it ran on disagree.
+Forgejo has no SARIF UI today — `--format sarif` still produces a valid document, but there's no security-tab equivalent to render it. Verified on Forgejo 16.0.3, runner 13.0.0 — this exact snippet is executed against a live Forgejo weekly by the [forgejo-smoke workflow](https://github.com/tmatens/compose-lint/blob/main/.github/workflows/forgejo-smoke.yml), which fails if this line and the versions it ran on disagree.

--- a/tests/forgejo_smoke/compose-forgejo-smoke.yml
+++ b/tests/forgejo_smoke/compose-forgejo-smoke.yml
@@ -1,20 +1,23 @@
 # Throwaway Forgejo + act_runner stack for the forgejo-smoke workflow
-# (issue #573): scripts/forgejo_smoke.py boots it, executes README's
-# Forgejo Actions snippet against it verbatim, and tears it down. This is
+# (issue #573): scripts/forgejo_smoke.py boots it, executes the
+# docs/forgejo.md Actions snippet against it verbatim, and tears it down. This is
 # harness infrastructure, not a lint fixture — nothing in CI runs
 # compose-lint against this file (it would rightly object to the Docker
 # socket mount the runner needs to spawn job containers).
 #
-# The compose-* filename keeps both images under Renovate's
-# docker-compose manager, so digest bumps arrive automatically and a
-# Forgejo/runner version bump re-runs the harness when it merges (the
-# workflow triggers on pushes touching this file). The versions here are
-# what README's "Verified on ..." line claims: forgejo_smoke.py asserts
-# the claim against the *live* instance, so bumping an image without
-# updating the README fails the run.
+# Renovate does NOT track this file, despite the compose-* filename:
+# config:recommended's :ignoreModulesAndTests preset skips tests/**
+# entirely, so image bumps here are manual (#746). Codeberg deletes a
+# superseded Forgejo patch tag — pinned digest included — within days
+# of the next patch shipping, so bump promptly when a release lands. A
+# version bump re-runs the harness when it merges (the workflow
+# triggers on pushes touching this file). The versions here are what
+# docs/forgejo.md's "Verified on ..." line claims: forgejo_smoke.py
+# asserts the claim against the *live* instance, so bumping an image
+# without updating docs/forgejo.md fails the run.
 services:
   forgejo:
-    image: codeberg.org/forgejo/forgejo:16.0.2@sha256:2fdfe28b5c68f82f49580e227b84e2afb43af0250e0631a54a386ef3b1d9b759
+    image: codeberg.org/forgejo/forgejo:16.0.3@sha256:7c4e1db440be7b2ca685b49d0d7864cdd78e92431f531bf7893659def8200fc5
     environment:
       # Headless install: lock the installer and configure via env.
       FORGEJO__security__INSTALL_LOCK: "true"


### PR DESCRIPTION
Fixes #746 — forgejo-smoke red since the 2026-08-24 scheduled run.

## What

- Bump the harness pin to `codeberg.org/forgejo/forgejo:16.0.3@sha256:7c4e1db4…` and update `docs/forgejo.md`'s "Verified on Forgejo 16.0.3, runner 13.0.0" line in the same change (`forgejo_smoke.py` asserts the pair against the live instance).
- Correct the compose file's header comment: the snippet/verified-on line lives in `docs/forgejo.md` (not README), and the claim that Renovate tracks this file was never true.
- Runner pin `13.0.0@sha256:7fb853…` still resolves — unchanged.

## Verification

- `16.0.2` is gone entirely from Codeberg's registry — tag **and** digest (`manifest unknown`), GC'd after 16.0.3 shipped 2026-08-20.
- The new digest is the OCI **index** digest from the registry's `Docker-Content-Digest` header, verified pullable as `16.0.3@sha256:7c4e1db4…`. (Careless resolution hands you the per-arch digest `sha256:121ff0…`, which fails manifest verification — same manifest-list gotcha the Renovate config documents for Dockerfile pins.)
- The push trigger on `tests/forgejo_smoke/**` runs the full harness on this branch, which is the end-to-end proof.

## Why Renovate never saved us

`config:recommended` includes `:ignoreModulesAndTests`, which ignores `tests/**` wholesale — the Dependency Dashboard's docker-compose section lists only `scripts/demo/docker-compose.yml`, and no Renovate commit has ever touched this file. So the 16.0.3 bump PR that should have opened on the weekly schedule never existed.

Structural follow-up (not in this PR): move the harness compose out of `tests/` so Renovate sees it — un-ignoring `tests/` is wrong, as four fixture compose files there would start getting "fixed". Even then, Codeberg deletes a superseded patch tag within days, so every Forgejo patch release will briefly red the weekly run until the bump merges; a `schedule: at any time` package rule for this file's deps would shrink that window.
