### PR TITLE
Page --explain through a pager on an interactive terminal (ADR-034)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ CRITICAL > HIGH > MEDIUM > LOW. A rule's severity is **derived**, not chosen: it
 
 ## CLI output
 
-Stdout carries data (findings in `check`; future artifacts in operations like `fix` or `completion`). Stderr carries human status and errors. Today's text-mode banner, per-file summary, aggregate summary, and verdict are the exception — gated on `output_format == "text"` in `cli.py` so JSON/SARIF redirects stay clean. When a second stdout-emitting mode lands, decide in that feature's ADR whether to extend the gate or move human-status lines to stderr permanently.
+Stdout carries data (findings in `check`; future artifacts in operations like `fix` or `completion`). Stderr carries human status and errors. Today's text-mode banner, per-file summary, aggregate summary, and verdict are the exception — gated on `output_format == "text"` in `cli.py` so JSON/SARIF redirects stay clean. When a second stdout-emitting mode lands, decide in that feature's ADR whether to extend the gate or move human-status lines to stderr permanently. `--explain` pages through `$PAGER` on a TTY only (ADR-034); piped output is byte-identical to a pagerless run.
 
 ## Config file (`.compose-lint.yml`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`--explain` now pages through a pager on an interactive terminal**
+  ([ADR-034](docs/adr/034-explain-pages-on-a-tty.md)). Rule docs have grown
+  past 100 lines, so a terminal dump scrolled the directive and rationale
+  out of view instantly. On a TTY the doc now goes through `less -RFX`
+  (`PAGER` overrides the command; `--no-pager`, `NO_PAGER`, or `TERM=dumb`
+  disables it; a missing pager binary — e.g. the distroless image under
+  `docker run -t` — falls back to the plain dump). Piped, redirected, and
+  CI output is byte-identical to before: paging engages only when stdout
+  is a TTY.
+
 ## [0.25.0] - 2026-08-26
 
 

--- a/docs/adr/034-explain-pages-on-a-tty.md
+++ b/docs/adr/034-explain-pages-on-a-tty.md
@@ -1,0 +1,43 @@
+# ADR-034: `--explain` Pages Through a Pager on an Interactive Terminal
+
+**Status:** Accepted
+
+**Context:** `--explain CL-XXXX` dumps the rule's full markdown doc to
+stdout. The docs have grown past 100 lines (CL-0001 is 115), so on an
+interactive terminal the top of the doc — the directive and the
+why-it-matters prose, the strongest content — scrolls out of view instantly
+and the reader lands on the tail. The README hero GIF captured this
+faithfully: the recorded `--explain` step shows a single-frame whoosh and
+settles on the ATT&CK table. The GIF is a symptom; the terminal UX is the
+problem.
+
+The constraint is [the CLI output contract](../../AGENTS.md): stdout carries
+data, and `--explain` prints the doc raw — machine consumers pipe it, tests
+byte-compare it, and `fix`/CI never touch a pager.
+
+**Decision:** When stdout is a TTY, `--explain` pipes the doc through a
+pager, exactly the way `git log` does; in every other case the output is
+byte-identical to before. The gate, in order:
+
+- not a TTY → plain dump (pipes, redirects, CI, tests — by construction,
+  not by configuration);
+- `NO_PAGER` set (any non-empty value) → plain dump, mirroring `NO_COLOR`'s
+  contract for color;
+- `TERM` unset or `dumb` → plain dump;
+- `--no-pager` → plain dump;
+- `PAGER` set → that command (split with `shlex`; blank disables), else
+  `less -RFX` (`-F` exits when the doc fits one screen, so short docs never
+  trap the reader; `-X` keeps the tail in scrollback).
+
+A pager that cannot be spawned falls back silently to the plain dump. That
+case is real, not defensive: the published image is distroless, so
+`docker run -t` produces a TTY with no pager binary behind it — the
+fallback is what keeps that invocation working unchanged.
+
+**Consequences:** Non-TTY output is untouched, so the stdout-carries-data
+contract and every existing consumer are unaffected; the tests prove the
+piped bytes identical with and without a pager configured. A human at a
+terminal reads the doc top-down. The change is presentation only and ships
+as MINOR. The paging applies to `--explain` alone — the findings report
+stays unpaged, because a lint run's verdict belongs in the scrollback of
+the command that produced it, not behind a `q`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,6 +26,8 @@ check options:
   --config PATH                Path to config file (default: .compose-lint.yml)
   --strict-config              Treat config diagnostics (unknown rule id or key) as errors, not warnings
   --explain CL-XXXX            Print the full documentation for a single rule
+                               (through a pager on an interactive terminal)
+  --no-pager                   Print --explain output directly, bypassing the pager
   --version                    Show version and exit
 
 fix options:
@@ -47,6 +49,17 @@ init options:
 Color is on when stdout is a terminal. Set `NO_COLOR` to disable it (even on a
 terminal) or `FORCE_COLOR` to force it through a pipe — e.g. into `less -R` or a
 CI log that renders ANSI.
+
+## Pager
+
+`--explain` pages its rule doc through `less -RFX` when stdout is a terminal
+([ADR-034](adr/034-explain-pages-on-a-tty.md)) — `-F` means a doc that fits
+one screen prints and exits with no pager interaction. `PAGER` selects a
+different pager; `--no-pager`, a non-empty `NO_PAGER`, or `TERM=dumb`
+disables paging; a pager binary that isn't installed falls back to a plain
+dump. Piped or redirected output never pages and is byte-identical to the
+pre-pager behavior, so scripts and CI need no changes. The findings report
+itself never pages.
 
 ## End of options
 

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -7,7 +7,9 @@ import contextlib
 import io
 import json
 import os
+import shlex
 import stat
+import subprocess
 import sys
 import tempfile
 from dataclasses import replace
@@ -329,8 +331,19 @@ def _add_check_subparser(
         "--explain",
         metavar="CL-XXXX",
         help=(
-            "print the prose documentation for a single rule and exit. "
+            "print the prose documentation for a single rule and exit, "
+            "through a pager on an interactive terminal. "
             "Cannot be combined with FILE arguments."
+        ),
+    )
+    check.add_argument(
+        "--no-pager",
+        action="store_true",
+        default=False,
+        help=(
+            "print --explain output directly, bypassing the pager it uses "
+            "on interactive terminals. PAGER selects the pager (default: "
+            "less -RFX); NO_PAGER or TERM=dumb also disables it."
         ),
     )
 
@@ -554,6 +567,59 @@ def _stdout_print(*args: object, **kwargs: Any) -> None:
         _abort_on_write_failure(exc)
 
 
+# `less` flags mirror git's defaults: -R passes ANSI color through, -F exits
+# immediately when the doc fits one screen (short docs never trap the reader
+# in a pager), -X skips the alternate screen so the tail stays in scrollback.
+_DEFAULT_PAGER = ("less", "-R", "-F", "-X")
+
+
+def _pager_argv(*, tty: bool) -> list[str] | None:
+    """Resolve the pager command for ``--explain``, or None to print directly.
+
+    Paging is presentation only and engages solely for a human at an
+    interactive terminal, so machine consumers (pipes, redirects, CI) always
+    receive the byte-identical plain dump (ADR-034). ``NO_PAGER`` (any
+    non-empty value) disables it, mirroring ``NO_COLOR``'s contract for
+    color; ``TERM`` unset or ``dumb`` means no terminal worth paging on;
+    ``PAGER`` overrides the default command, and a blank ``PAGER`` disables
+    paging outright.
+    """
+    if not tty:
+        return None
+    if os.environ.get("NO_PAGER"):
+        return None
+    if os.environ.get("TERM", "") in ("", "dumb"):
+        return None
+    pager = os.environ.get("PAGER")
+    if pager is None:
+        return list(_DEFAULT_PAGER)
+    return shlex.split(pager) or None
+
+
+def _page_rule_doc(text: str) -> bool:
+    """Try to display rule prose through a pager; True when it displayed.
+
+    A pager that cannot be spawned is a signal to fall back, not an error:
+    the published image is distroless, so ``docker run -t`` yields a TTY
+    with no pager binary behind it. A viewer quitting before EOF (EPIPE)
+    still counts as displayed.
+    """
+    argv = _pager_argv(tty=sys.stdout.isatty())
+    if argv is None:
+        return False
+    try:
+        proc = subprocess.Popen(argv, stdin=subprocess.PIPE)
+    except OSError:
+        return False
+    stdin = proc.stdin
+    if stdin is not None:
+        with contextlib.suppress(BrokenPipeError, OSError):
+            stdin.write((text + "\n").encode("utf-8"))
+            stdin.close()
+    proc.wait()
+    return True
+
+
 def _dispatch(args: argparse.Namespace) -> NoReturn:
     """Route to the subcommand handler; every branch exits."""
     if args.command == "fix":
@@ -655,10 +721,12 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
             )
             sys.exit(2)
         try:
-            _stdout_print(load_rule_doc(args.explain))
+            doc = load_rule_doc(args.explain)
         except UnknownRuleError:
             emit(f"Error: unknown rule id '{args.explain}' (expected format: CL-XXXX)")
             sys.exit(2)
+        if args.no_pager or not _page_rule_doc(doc):
+            _stdout_print(doc)
         sys.exit(0)
 
     config_path = _effective_config_path(args.config)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,9 @@ if TYPE_CHECKING:
 FIXTURES = Path(__file__).parent / "compose_files"
 
 
-def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+def run_cli(
+    *args: str, env_extra: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
     """Run compose-lint CLI as a subprocess."""
     return subprocess.run(
         [sys.executable, "-m", "compose_lint", *args],
@@ -29,7 +31,42 @@ def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
         # The CLI guarantees UTF-8 output; decoding with the locale (cp1252 on
         # Windows) would mojibake the report's non-ASCII characters.
         encoding="utf-8",
+        env={**os.environ, **env_extra} if env_extra is not None else None,
     )
+
+
+def run_cli_tty(*args: str, env_extra: dict[str, str]) -> tuple[int, str]:
+    """Run the CLI with stdout attached to a pseudo-terminal (POSIX only).
+
+    This is what lets the pager tests exercise the real ``isatty()`` branch:
+    every other test in this module runs with stdout on a pipe, which is
+    exactly the non-TTY path the pager must never engage on.
+    """
+    import pty
+
+    master, slave = pty.openpty()
+    try:
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "compose_lint", *args],
+            stdin=subprocess.DEVNULL,
+            stdout=slave,
+            stderr=subprocess.DEVNULL,
+            env={**os.environ, **env_extra},
+        )
+        os.close(slave)
+        chunks = []
+        while True:
+            try:
+                data = os.read(master, 4096)
+            except OSError:  # EIO once the slave side fully closes: EOF
+                break
+            if not data:
+                break
+            chunks.append(data)
+        returncode = proc.wait()
+    finally:
+        os.close(master)
+    return returncode, b"".join(chunks).decode("utf-8", errors="replace")
 
 
 class TestCLI:
@@ -982,3 +1019,142 @@ class TestFixOnlyValidation:
         result = run_cli("fix", "--only", "banana", "--strict-config", str(f))
         assert result.returncode == 2
         assert "names no rule" in result.stderr
+
+
+class TestPagerResolution:
+    """Unit tests for the --explain pager decision (ADR-034)."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_pager_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NO_PAGER", raising=False)
+        monkeypatch.delenv("PAGER", raising=False)
+        monkeypatch.setenv("TERM", "xterm-256color")
+
+    def test_not_a_tty_never_pages(self) -> None:
+        from compose_lint.cli import _pager_argv
+
+        assert _pager_argv(tty=False) is None
+
+    def test_tty_defaults_to_less(self) -> None:
+        from compose_lint.cli import _pager_argv
+
+        assert _pager_argv(tty=True) == ["less", "-R", "-F", "-X"]
+
+    def test_no_pager_env_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from compose_lint.cli import _pager_argv
+
+        monkeypatch.setenv("NO_PAGER", "1")
+        assert _pager_argv(tty=True) is None
+
+    def test_term_dumb_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from compose_lint.cli import _pager_argv
+
+        monkeypatch.setenv("TERM", "dumb")
+        assert _pager_argv(tty=True) is None
+
+    def test_term_unset_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from compose_lint.cli import _pager_argv
+
+        monkeypatch.delenv("TERM")
+        assert _pager_argv(tty=True) is None
+
+    def test_blank_pager_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from compose_lint.cli import _pager_argv
+
+        monkeypatch.setenv("PAGER", "   ")
+        assert _pager_argv(tty=True) is None
+
+    def test_pager_env_overrides_and_splits(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from compose_lint.cli import _pager_argv
+
+        monkeypatch.setenv("PAGER", "more -d")
+        assert _pager_argv(tty=True) == ["more", "-d"]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="pty is POSIX-only")
+class TestExplainPagerOnTTY:
+    """End-to-end pager behavior on a real pseudo-terminal (ADR-034).
+
+    The fake pager leaves a marker file when it runs, so each test can
+    assert not just what reached the screen but whether a pager was in the
+    loop at all.
+    """
+
+    @pytest.fixture
+    def fake_pager(self, tmp_path: Path) -> tuple[str, Path]:
+        marker = tmp_path / "pager-ran"
+        script = tmp_path / "fake-pager.sh"
+        script.write_text(f"#!/bin/sh\ntouch {marker}\nexec cat\n")
+        script.chmod(0o755)
+        return str(script), marker
+
+    def test_pager_engages_on_tty(self, fake_pager: tuple[str, Path]) -> None:
+        script, marker = fake_pager
+        code, out = run_cli_tty(
+            "--explain", "CL-0003", env_extra={"PAGER": script, "TERM": "xterm"}
+        )
+        assert code == 0
+        assert marker.exists()
+        assert "CL-0003" in out
+        assert "no-new-privileges" in out
+
+    def test_missing_pager_falls_back_to_plain_dump(self) -> None:
+        # The distroless-image-under-`docker run -t` shape: a TTY with no
+        # pager binary behind it must degrade to today's raw dump, exit 0.
+        code, out = run_cli_tty(
+            "--explain",
+            "CL-0003",
+            env_extra={"PAGER": "compose-lint-no-such-pager", "TERM": "xterm"},
+        )
+        assert code == 0
+        assert "CL-0003" in out
+        assert "no-new-privileges" in out
+
+    def test_no_pager_flag_bypasses(self, fake_pager: tuple[str, Path]) -> None:
+        script, marker = fake_pager
+        code, out = run_cli_tty(
+            "--explain",
+            "CL-0003",
+            "--no-pager",
+            env_extra={"PAGER": script, "TERM": "xterm"},
+        )
+        assert code == 0
+        assert not marker.exists()
+        assert "CL-0003" in out
+
+    def test_no_pager_env_bypasses(self, fake_pager: tuple[str, Path]) -> None:
+        script, marker = fake_pager
+        code, out = run_cli_tty(
+            "--explain",
+            "CL-0003",
+            env_extra={"PAGER": script, "TERM": "xterm", "NO_PAGER": "1"},
+        )
+        assert code == 0
+        assert not marker.exists()
+        assert "CL-0003" in out
+
+    def test_term_dumb_bypasses(self, fake_pager: tuple[str, Path]) -> None:
+        script, marker = fake_pager
+        code, out = run_cli_tty(
+            "--explain", "CL-0003", env_extra={"PAGER": script, "TERM": "dumb"}
+        )
+        assert code == 0
+        assert not marker.exists()
+        assert "CL-0003" in out
+
+    def test_piped_output_is_byte_identical_and_unpaged(
+        self, fake_pager: tuple[str, Path]
+    ) -> None:
+        # The CI / pipeline contract: with stdout on a pipe, PAGER must be
+        # ignored entirely and the bytes must match a run with no pager
+        # configured at all.
+        script, marker = fake_pager
+        with_pager = run_cli(
+            "--explain", "CL-0003", env_extra={"PAGER": script, "TERM": "xterm"}
+        )
+        plain = run_cli("--explain", "CL-0003", env_extra={"NO_PAGER": "1"})
+        assert with_pager.returncode == 0
+        assert not marker.exists()
+        assert with_pager.stdout == plain.stdout


### PR DESCRIPTION
Implements the pager discussed while reviewing the README hero GIF: `--explain`'s rule docs have grown past 100 lines (CL-0001 is 115), so on a terminal the directive and why-it-matters prose scroll out of view instantly and the reader lands on the ATT&CK-table tail. The GIF records that faithfully — the terminal UX is the underlying problem; this fixes it, and makes the eventual GIF re-render show the doc top-down.

## What

- On an interactive terminal, `--explain` pipes the doc through `less -RFX`, git-style (`-F`: a doc that fits one screen prints and exits with no pager interaction). New [ADR-034](docs/adr/034-explain-pages-on-a-tty.md) records the decision.
- Escape hatches: `PAGER` selects the command (shlex-split; blank disables), `--no-pager` flag, non-empty `NO_PAGER` (mirroring `NO_COLOR`'s contract), `TERM` unset or `dumb`.
- A pager that cannot be spawned falls back silently to the plain dump. That case is real: the published image is distroless, so `docker run -t` yields a TTY with no pager binary behind it.
- Findings output stays unpaged deliberately — a lint verdict belongs in scrollback.
- Docs: `docs/cli.md` (options block + new Pager section), CHANGELOG Unreleased (MINOR), AGENTS.md CLI-output contract note.

## Zero impact on CI/CD, pipes, and containers — by construction

Paging engages only when stdout is a TTY, so pipes, redirects, GitHub Actions, and the test suite (which runs the CLI with `capture_output`) see byte-identical output. Exit codes unchanged.

## Testing

- **Unit**: the full decision table on `_pager_argv` (non-TTY, default `less -RFX`, `NO_PAGER`, `TERM=dumb`/unset, blank `PAGER`, `PAGER` with args shlex-split).
- **End-to-end on a real pseudo-terminal** (POSIX-only, skipped on the Windows os-smoke leg): a marker-file fake pager proves the pager engages on a TTY; a nonexistent pager binary proves the silent fallback (exit 0, full doc); `--no-pager`, `NO_PAGER`, and `TERM=dumb` each proven to bypass (marker absent); and piped output with `PAGER` set is asserted byte-identical to a pagerless run.
- **Live against the built distroless image** (local daemon, Docker 29.7.2): `docker run -t --rm <img> --explain CL-0003` → full 99-line doc, exit 0 (spawn-failure fallback); same without `-t` → byte-identical output. Also verified interactively on a pty with `PAGER='head -3'` that the pager genuinely controls presentation (exactly 3 lines emitted, top of the doc first).
- **Cross-distro probes** (live containers): Alpine's busybox `less` (1.37.0) pages correctly under `-R -F -X` — `-F`/`-R` honored, unknown `-X` tolerated and ignored (exit 0); `debian:trixie-slim` ships no `less` at all, which lands on the verified spawn-failure fallback. Windows consoles set no `TERM`, so paging is disabled there by the existing gate (plain dump, as today); Git Bash sets `TERM` and ships `less`, so it pages.
- Full gates green locally: ruff check, ruff format, mypy strict, pytest (2593 passed, 10 skipped).
