### PR TITLE
Label the pager's controls in --explain's status prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   disables it; a missing pager binary — e.g. the distroless image under
   `docker run -t` — falls back to the plain dump). Piped, redirected, and
   CI output is byte-identical to before: paging engages only when stdout
-  is a TTY.
+  is a TTY. The default pager labels its controls in the status line
+  (`CL-XXXX · Space next · b back · q quit`) instead of less's bare `:`,
+  and a pager that exits nonzero (busybox `less` rejecting the flags)
+  falls back to the plain dump rather than swallowing the doc.
 
 ## [0.25.0] - 2026-08-26
 

--- a/docs/adr/034-explain-pages-on-a-tty.md
+++ b/docs/adr/034-explain-pages-on-a-tty.md
@@ -27,12 +27,20 @@ byte-identical to before. The gate, in order:
 - `--no-pager` → plain dump;
 - `PAGER` set → that command (split with `shlex`; blank disables), else
   `less -RFX` (`-F` exits when the doc fits one screen, so short docs never
-  trap the reader; `-X` keeps the tail in scrollback).
+  trap the reader; `-X` keeps the tail in scrollback) plus a labeled status
+  prompt — `-Ps"CL-XXXX · Space next · b back · q quit"` — because the
+  pager's controls are pure convention and the bare `:` labels none of
+  them. The prompt rides only on the default pager; a user's own `PAGER`
+  keeps whatever prompt they configured.
 
 A pager that cannot be spawned falls back silently to the plain dump. That
 case is real, not defensive: the published image is distroless, so
 `docker run -t` produces a TTY with no pager binary behind it — the
-fallback is what keeps that invocation working unchanged.
+fallback is what keeps that invocation working unchanged. A pager that
+exits nonzero falls back the same way: busybox's `less` (Alpine) rejects
+`-Ps` with a usage error, and without the rescue that rejection would
+swallow the doc. The cost is bounded — a pager dying nonzero after showing
+content prints the doc twice, never zero times.
 
 **Consequences:** Non-TTY output is untouched, so the stdout-carries-data
 contract and every existing consumer are unaffected; the tests prove the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -54,7 +54,9 @@ CI log that renders ANSI.
 
 `--explain` pages its rule doc through `less -RFX` when stdout is a terminal
 ([ADR-034](adr/034-explain-pages-on-a-tty.md)) — `-F` means a doc that fits
-one screen prints and exits with no pager interaction. `PAGER` selects a
+one screen prints and exits with no pager interaction. The default pager
+labels its controls in the status line (`CL-XXXX · Space next · b back ·
+q quit`) instead of less's bare `:`; a custom `PAGER` keeps its own prompt. `PAGER` selects a
 different pager; `--no-pager`, a non-empty `NO_PAGER`, or `TERM=dumb`
 disables paging; a pager binary that isn't installed falls back to a plain
 dump. Piped or redirected output never pages and is byte-identical to the

--- a/src/compose_lint/cli.py
+++ b/src/compose_lint/cli.py
@@ -24,7 +24,7 @@ from compose_lint._service_env import describe_unread, resolve_env_files
 from compose_lint.config import ConfigError, load_config
 from compose_lint.config_emit import render_config
 from compose_lint.engine import filter_findings, run_rules
-from compose_lint.explain import UnknownRuleError, load_rule_doc
+from compose_lint.explain import UnknownRuleError, load_rule_doc, normalize_rule_id
 from compose_lint.fix import (
     LineOutOfRangeError,
     apply_edits,
@@ -572,8 +572,15 @@ def _stdout_print(*args: object, **kwargs: Any) -> None:
 # in a pager), -X skips the alternate screen so the tail stays in scrollback.
 _DEFAULT_PAGER = ("less", "-R", "-F", "-X")
 
+# Labels for less's otherwise-bare `:` prompt. The pager's controls are pure
+# convention, so the default pager names the ones a reader needs; a user's
+# own PAGER keeps whatever prompt they configured. The text must avoid the
+# characters less expands in prompt strings (`%`, `?`, `:`, `.`, `\`) —
+# rule ids (CL-NNNN) are safe by construction.
+_PAGER_HINTS = "Space next · b back · q quit"
 
-def _pager_argv(*, tty: bool) -> list[str] | None:
+
+def _pager_argv(*, tty: bool, rule_id: str) -> list[str] | None:
     """Resolve the pager command for ``--explain``, or None to print directly.
 
     Paging is presentation only and engages solely for a human at an
@@ -592,19 +599,24 @@ def _pager_argv(*, tty: bool) -> list[str] | None:
         return None
     pager = os.environ.get("PAGER")
     if pager is None:
-        return list(_DEFAULT_PAGER)
+        return [*_DEFAULT_PAGER, f"-Ps{rule_id} · {_PAGER_HINTS}"]
     return shlex.split(pager) or None
 
 
-def _page_rule_doc(text: str) -> bool:
+def _page_rule_doc(text: str, rule_id: str) -> bool:
     """Try to display rule prose through a pager; True when it displayed.
 
     A pager that cannot be spawned is a signal to fall back, not an error:
     the published image is distroless, so ``docker run -t`` yields a TTY
-    with no pager binary behind it. A viewer quitting before EOF (EPIPE)
-    still counts as displayed.
+    with no pager binary behind it. A pager that exits nonzero is treated
+    the same way — busybox's ``less`` rejects flags like ``-Ps`` with a
+    usage error, which would otherwise swallow the doc on Alpine. The cost
+    of that rescue is bounded: a pager that dies nonzero *after* showing
+    content leads to the doc printing twice, never to it printing not at
+    all. A viewer quitting before EOF (EPIPE, then ``q`` → exit 0) still
+    counts as displayed.
     """
-    argv = _pager_argv(tty=sys.stdout.isatty())
+    argv = _pager_argv(tty=sys.stdout.isatty(), rule_id=rule_id)
     if argv is None:
         return False
     try:
@@ -616,8 +628,7 @@ def _page_rule_doc(text: str) -> bool:
         with contextlib.suppress(BrokenPipeError, OSError):
             stdin.write((text + "\n").encode("utf-8"))
             stdin.close()
-    proc.wait()
-    return True
+    return proc.wait() == 0
 
 
 def _dispatch(args: argparse.Namespace) -> NoReturn:
@@ -721,11 +732,12 @@ def _run_check(args: argparse.Namespace) -> NoReturn:
             )
             sys.exit(2)
         try:
-            doc = load_rule_doc(args.explain)
+            canonical = normalize_rule_id(args.explain)
+            doc = load_rule_doc(canonical)
         except UnknownRuleError:
             emit(f"Error: unknown rule id '{args.explain}' (expected format: CL-XXXX)")
             sys.exit(2)
-        if args.no_pager or not _page_rule_doc(doc):
+        if args.no_pager or not _page_rule_doc(doc, canonical):
             _stdout_print(doc)
         sys.exit(0)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,23 +35,37 @@ def run_cli(
     )
 
 
-def run_cli_tty(*args: str, env_extra: dict[str, str]) -> tuple[int, str]:
+def run_cli_tty(
+    *args: str, env_extra: dict[str, str], send_keys: bytes | None = None
+) -> tuple[int, str]:
     """Run the CLI with stdout attached to a pseudo-terminal (POSIX only).
 
     This is what lets the pager tests exercise the real ``isatty()`` branch:
     every other test in this module runs with stdout on a pipe, which is
     exactly the non-TTY path the pager must never engage on.
     """
+    import fcntl
     import pty
+    import termios
 
     master, slave = pty.openpty()
+
+    def make_controlling_tty() -> None:
+        # A real pager reads its keystrokes from /dev/tty, which resolves to
+        # the *controlling* terminal — inheriting the slave as stdio is not
+        # enough. New session + TIOCSCTTY on the inherited slave (fd 0) is
+        # the same dance pty.fork() does.
+        os.setsid()
+        fcntl.ioctl(0, termios.TIOCSCTTY, 0)
+
     try:
         proc = subprocess.Popen(
             [sys.executable, "-m", "compose_lint", *args],
-            stdin=subprocess.DEVNULL,
+            stdin=slave,
             stdout=slave,
             stderr=subprocess.DEVNULL,
             env={**os.environ, **env_extra},
+            preexec_fn=make_controlling_tty,
         )
         os.close(slave)
         chunks = []
@@ -63,6 +77,11 @@ def run_cli_tty(*args: str, env_extra: dict[str, str]) -> tuple[int, str]:
             if not data:
                 break
             chunks.append(data)
+            if send_keys is not None:
+                # One-shot keystroke for an interactive pager (e.g. `q` to
+                # quit less), sent only after the first screen has drawn.
+                os.write(master, send_keys)
+                send_keys = None
         returncode = proc.wait()
     finally:
         os.close(master)
@@ -1033,36 +1052,42 @@ class TestPagerResolution:
     def test_not_a_tty_never_pages(self) -> None:
         from compose_lint.cli import _pager_argv
 
-        assert _pager_argv(tty=False) is None
+        assert _pager_argv(tty=False, rule_id="CL-0003") is None
 
     def test_tty_defaults_to_less(self) -> None:
         from compose_lint.cli import _pager_argv
 
-        assert _pager_argv(tty=True) == ["less", "-R", "-F", "-X"]
+        assert _pager_argv(tty=True, rule_id="CL-0003") == [
+            "less",
+            "-R",
+            "-F",
+            "-X",
+            "-PsCL-0003 · Space next · b back · q quit",
+        ]
 
     def test_no_pager_env_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from compose_lint.cli import _pager_argv
 
         monkeypatch.setenv("NO_PAGER", "1")
-        assert _pager_argv(tty=True) is None
+        assert _pager_argv(tty=True, rule_id="CL-0003") is None
 
     def test_term_dumb_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from compose_lint.cli import _pager_argv
 
         monkeypatch.setenv("TERM", "dumb")
-        assert _pager_argv(tty=True) is None
+        assert _pager_argv(tty=True, rule_id="CL-0003") is None
 
     def test_term_unset_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from compose_lint.cli import _pager_argv
 
         monkeypatch.delenv("TERM")
-        assert _pager_argv(tty=True) is None
+        assert _pager_argv(tty=True, rule_id="CL-0003") is None
 
     def test_blank_pager_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from compose_lint.cli import _pager_argv
 
         monkeypatch.setenv("PAGER", "   ")
-        assert _pager_argv(tty=True) is None
+        assert _pager_argv(tty=True, rule_id="CL-0003") is None
 
     def test_pager_env_overrides_and_splits(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1070,7 +1095,7 @@ class TestPagerResolution:
         from compose_lint.cli import _pager_argv
 
         monkeypatch.setenv("PAGER", "more -d")
-        assert _pager_argv(tty=True) == ["more", "-d"]
+        assert _pager_argv(tty=True, rule_id="CL-0003") == ["more", "-d"]
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="pty is POSIX-only")
@@ -1158,3 +1183,37 @@ class TestExplainPagerOnTTY:
         assert with_pager.returncode == 0
         assert not marker.exists()
         assert with_pager.stdout == plain.stdout
+
+    def test_failing_pager_falls_back_to_plain_dump(self, tmp_path: Path) -> None:
+        # The busybox shape: a pager binary that exists but rejects the
+        # default flags with a usage error (nonzero exit). The doc must
+        # still reach the reader via the plain dump.
+        script = tmp_path / "usage-error-pager.sh"
+        script.write_text("#!/bin/sh\ncat >/dev/null\nexit 1\n")
+        script.chmod(0o755)
+        code, out = run_cli_tty(
+            "--explain",
+            "CL-0003",
+            env_extra={"PAGER": str(script), "TERM": "xterm"},
+        )
+        assert code == 0
+        assert "CL-0003" in out
+        assert "no-new-privileges" in out
+
+    def test_default_less_shows_labeled_prompt(self) -> None:
+        # The real default pager end to end: bare --explain on a TTY with no
+        # PAGER set must open less with the labeled hint prompt, and `q`
+        # must return cleanly. Skipped where less isn't installed.
+        import shutil
+
+        if shutil.which("less") is None:
+            pytest.skip("less not installed")
+        code, out = run_cli_tty(
+            "--explain",
+            "CL-0003",
+            env_extra={"TERM": "xterm"},
+            send_keys=b"q",
+        )
+        assert code == 0
+        assert "CL-0003" in out
+        assert "Space next" in out and "q quit" in out


### PR DESCRIPTION
Follow-up to #749, from the review question "are the pager controls obvious to users?" — they're pure convention, and less's bare `:` labels none of them. Ships with the pager in 0.26.0.

## What

- The default pager argv gains `-Ps"CL-XXXX · Space next · b back · q quit"`: every page of `--explain` now ends in a status line that says how to page and how to leave. Only the *default* pager gets it — a user's own `PAGER` keeps its configured prompt. Hint text avoids all characters less expands in prompts (`%`, `?`, `:`, `.`, `\`).
- **Nonzero pager exit now falls back to the plain dump.** Probed live before writing the code: busybox `less` (Alpine 1.37.0) rejects `-Ps` with a usage error and exits 1 — under the old contract (spawn succeeded → "displayed") that would have silently swallowed the doc on Alpine. Cost is bounded: a pager dying nonzero *after* showing content prints the doc twice, never zero times.
- ADR-034 and the Unreleased CHANGELOG entry amended in place (same unreleased cycle), `docs/cli.md` Pager section updated.

## Testing

- pty harness upgrade: the pty is now the child's **controlling terminal** (`setsid` + `TIOCSCTTY`, the `pty.fork` dance) — a real pager reads keystrokes from `/dev/tty`, so this is what lets a test drive actual `less`.
- New end-to-end: bare `--explain` on a TTY opens real `less`, the labeled prompt is asserted in the pty capture, and a sent `q` returns exit 0 (skips where `less` is absent).
- New end-to-end: the busybox shape — a pager that consumes stdin and exits 1 — still delivers the full doc, exit 0.
- All prior pager tests updated for the new argv/signature; full gates green locally (ruff, ruff format, mypy strict, pytest: 2595 passed).
- Verified live on a real terminal: prompt renders, `q` quits cleanly.

Per Todd: no GIF re-render now — release 0.26.0 first, then rebuild the casts (the hint will appear in the hero automatically once the toolchain's `PAGER` override is dropped in favor of the built-in default).
