### PR TITLE
Prepare 0.26.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-08-27
+
 ### Added
 
 - **`--explain` now pages through a pager on an interactive terminal**
@@ -3077,7 +3079,8 @@ First public release.
   inputs through `env:` rather than direct `${{ }}` interpolation to prevent
   shell injection.
 
-[Unreleased]: https://github.com/tmatens/compose-lint/compare/v0.25.0...HEAD
+[Unreleased]: https://github.com/tmatens/compose-lint/compare/v0.26.0...HEAD
+[0.26.0]: https://github.com/tmatens/compose-lint/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/tmatens/compose-lint/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/tmatens/compose-lint/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/tmatens/compose-lint/compare/v0.22.0...v0.23.0

--- a/README.md
+++ b/README.md
@@ -45,15 +45,15 @@ uvx compose-lint docker-compose.yml        # or: pipx run compose-lint docker-co
 That resolves the newest release at install time. For a reproducible install (CI, production tooling), pin the version and install the dependency set from the repo's hash-pinned lockfile, which release automation keeps current:
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/tmatens/compose-lint/v0.25.0/requirements.lock
+curl -fsSLO https://raw.githubusercontent.com/tmatens/compose-lint/v0.26.0/requirements.lock
 pip install --require-hashes -r requirements.lock   # dependencies, hash-pinned
-pip install --no-deps compose-lint==0.25.0          # the tool, version-pinned
+pip install --no-deps compose-lint==0.26.0          # the tool, version-pinned
 ```
 
 **Docker** — [composelint/compose-lint](https://hub.docker.com/r/composelint/compose-lint)
 
 ```bash
-docker run --rm -v "$(pwd):/src" composelint/compose-lint:0.25.0
+docker run --rm -v "$(pwd):/src" composelint/compose-lint:0.26.0
 ```
 
 The Docker image is distroless, multi-arch, and runs nonroot — see [Security posture](#security-posture) below for SLSA, Sigstore, and OpenVEX details.
@@ -92,7 +92,7 @@ compose-lint --explain CL-0005
 Docker equivalent:
 
 ```bash
-docker run --rm -v "$(pwd):/src" composelint/compose-lint:0.25.0 docker-compose.prod.yml
+docker run --rm -v "$(pwd):/src" composelint/compose-lint:0.26.0 docker-compose.prod.yml
 ```
 
 ### Compose compatibility
@@ -481,7 +481,7 @@ compose-lint --format sarif docker-compose.yml > results.sarif
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/tmatens/compose-lint
-    rev: v0.25.0
+    rev: v0.26.0
     hooks:
       - id: compose-lint
 ```

--- a/action.yml
+++ b/action.yml
@@ -85,7 +85,7 @@ runs:
         # the package it installs. Release automation keeps DEFAULT_VERSION in
         # step with the release, and CI's "Version strings in sync" job fails
         # if it drifts.
-        DEFAULT_VERSION="0.25.0"
+        DEFAULT_VERSION="0.26.0"
         if [ -z "$CL_VERSION" ]; then
           SPEC="compose-lint==${DEFAULT_VERSION}"
         elif [ "$CL_VERSION" = "latest" ]; then

--- a/docs/forgejo.md
+++ b/docs/forgejo.md
@@ -19,7 +19,7 @@ jobs:
         run: |
           apt-get update -qq
           apt-get install -yqq --no-install-recommends python3-pip
-          pip3 install --break-system-packages --no-cache-dir compose-lint==0.25.0
+          pip3 install --break-system-packages --no-cache-dir compose-lint==0.26.0
       - name: Run compose-lint
         run: compose-lint --fail-on high
 ```

--- a/docs/hardening.md
+++ b/docs/hardening.md
@@ -15,7 +15,7 @@ docker run --rm \
   --cpus 0.5 \
   --pids-limit 256 \
   -v "$(pwd):/src:ro" \
-  composelint/compose-lint:0.25.0
+  composelint/compose-lint:0.26.0
 ```
 
 | Flag | Rule satisfied |
@@ -29,6 +29,6 @@ docker run --rm \
 
 `--network none` and `:ro` on the bind mount are extra hardening — compose-lint never reaches the network and only reads its inputs.
 
-For full supply-chain reproducibility (and to satisfy CL-0004 / CL-0019), replace the version tag with a digest pin: `composelint/compose-lint@sha256:<digest>`. Get the current digest from [Docker Hub](https://hub.docker.com/r/composelint/compose-lint/tags) or with `docker buildx imagetools inspect composelint/compose-lint:0.25.0 --format '{{json .Manifest}}' | jq -r '.digest'`.
+For full supply-chain reproducibility (and to satisfy CL-0004 / CL-0019), replace the version tag with a digest pin: `composelint/compose-lint@sha256:<digest>`. Get the current digest from [Docker Hub](https://hub.docker.com/r/composelint/compose-lint/tags) or with `docker buildx imagetools inspect composelint/compose-lint:0.26.0 --format '{{json .Manifest}}' | jq -r '.digest'`.
 
 A Compose-form equivalent that lints clean across every rule lives in [`tests/compose_files/safe_self_hosted.yml`](https://github.com/tmatens/compose-lint/blob/main/tests/compose_files/safe_self_hosted.yml).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "compose-lint"
-version = "0.25.0"
+version = "0.26.0"
 description = "Security-focused linter for Docker Compose files. Catches dangerous misconfigurations before they reach production — grounded in OWASP and the CIS Docker Benchmark; emits SARIF for GitHub Code Scanning."
 readme = "README.md"
 license = "MIT"

--- a/src/compose_lint/__init__.py
+++ b/src/compose_lint/__init__.py
@@ -1,3 +1,3 @@
 """A security-focused linter for Docker Compose files."""
 
-__version__ = "0.25.0"
+__version__ = "0.26.0"


### PR DESCRIPTION
Automated release prep for `0.26.0`. Review the CHANGELOG entry and version bumps, then squash-merge.

**After this PR merges**, create and push a signed annotated tag from your workstation:

```
git checkout main && git pull --ff-only
git tag -s v0.26.0 -m "compose-lint 0.26.0"
git push origin v0.26.0
```

The tag push triggers `publish.yml`, which runs TestPyPI/Docker smoke tests, waits for your approval on the `release` environment, then publishes PyPI + Docker Hub, creates the GitHub Release, and opens a follow-up PR to bump the `marketplace-smoke` pin.
