### PR TITLE
Bump the macOS smoke leg to the macos-26 runner

### DIFF
--- a/.github/workflows/os-smoke.yml
+++ b/.github/workflows/os-smoke.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-15, windows-2025]
+        os: [macos-26, windows-2025]
         python-version: ["3.11", "3.13"]
     defaults:
       run:
@@ -106,7 +106,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-15, windows-2025]
+        os: [macos-26, windows-2025]
     defaults:
       run:
         shell: bash

--- a/scripts/eol_watch.py
+++ b/scripts/eol_watch.py
@@ -16,7 +16,7 @@ What it watches, against https://endoflife.date:
   ROADMAP commits to adding one within ~3 months of each October release.
 - **debian**, the Docker runtime base (distroless on Debian, ADR-009).
 - **github-actions-runner-images**, the exact runner labels CI stands on
-  (ubuntu-24.04, and os-smoke's macos-15/windows-2025) — the image
+  (ubuntu-24.04, and os-smoke's macos-26/windows-2025) — the image
   calendar, not the OS calendar, because GitHub retires images first.
 - **docker-engine**, the major the rule premises are grounded on: its EOL
   is the signal to re-ground validate_rule_premises.py on the current
@@ -237,10 +237,10 @@ def build_watches(floor: str) -> list[Watch]:
         ),
         Watch(
             "github-actions-runner-images",
-            "macos-15",
+            "macos-26",
             "os-smoke runner image (macOS leg)",
             anchor_file=".github/workflows/os-smoke.yml",
-            anchor_pattern=r"macos-15",
+            anchor_pattern=r"macos-26",
         ),
         Watch(
             "github-actions-runner-images",


### PR DESCRIPTION
macos-15 is one major release behind, not eleven: Apple renumbered
macOS from 15 to 26 in 2025 (year-based scheme, 16-25 never existed).
macos-26 is GA and is what macos-latest points to today; this stays on
the explicit label per the no-mutable-refs convention, so the migration
happens here as a reviewable bump instead of silently under -latest.

The runner stays Apple Silicon (arm64), so the leg's coverage is
unchanged. Bumping now rather than later also serves #572: the OS legs
promote into gating CI after ~a month green (clock started 2026-08-17),
and doing the runner change mid-window gives macos-26 weeks of green
history before the promotion instead of resetting confidence at the
gate.

Signed-off-by: Todd <tmatens@gmail.com>
