### PR TITLE
Split corpus tiers by intent: lab, synthetic, collections

### DIFF
--- a/scripts/corpus/README.md
+++ b/scripts/corpus/README.md
@@ -20,6 +20,24 @@ python scripts/corpus/run.py                # lint everything → runs/<ts>/
 
 If you only edited the curated lists, skip the fetches: `retier.py` then `make_tier_summary.py` regenerates per-tier numbers without re-linting.
 
+## Tiers
+
+`retier.py` is the attribution authority. Seven tiers, in priority order (an entry is only ever promoted upward):
+
+| Tier | What it is | In prevalence stats? |
+| --- | --- | --- |
+| `lab` | Deliberately-vulnerable environments: vulhub CVE reproductions, CTF challenge archives (curated list) | **No** |
+| `synthetic` | Test inputs to compose tooling: any file under a test/fixture/e2e path segment, plus whole tool repos (docker/compose, podman-compose, kompose) | **No** |
+| `canonical` | Curated vendor reference examples (awesome-compose, bitnami, …) | Yes |
+| `selfhosted` | Curated self-hosted app-store templates | Yes |
+| `collections` | Template/recipe collection repos split out of `popular` by size (>= 20 corpus entries from one repo) | Yes |
+| `popular` | Ordinary >= 50★ projects' own compose files | Yes |
+| `longtail` | Stratified code-search sweep of everything else | Yes |
+
+`lab` and `synthetic` outrank the curated tiers on purpose: a test fixture inside a canonical repo is still a test fixture. Examples, templates, and demos are **not** synthetic — they are the copy-paste material the canonical/selfhosted tiers exist to measure; only test *inputs* and lab targets are excluded. The exclusion set itself lives in `run.EXCLUDED_FROM_PREVALENCE` so `tier_summary.md`, `charts.py`, and the report cannot disagree about it.
+
+Why the split exists (measured on run `20260811T044906Z`): synthetic files showed 97.3% with-findings vs 90.6% for plain files, and docker/compose's fixtures alone moved the canonical tier's headline rate from 78.1% to 83.7%; the old blended `popular` tier was bimodal — collection repos at 9.02 findings/file and 6.4% CL-0001 vs ordinary projects at 19.43 and 15.0%; vulhub *diluted* popular (0.7% files-with-CRITICAL, 0% CL-0001) but is excluded on intent, not direction.
+
 ## Charts
 
 `charts.py` renders the report's SVGs into `docs/assets/` from a finished run. It reads the same `results.jsonl` + `index.jsonl` via `run.aggregate_tiers`, so the charts can never disagree with `tier_summary.md`.

--- a/scripts/corpus/fetch_canonical.py
+++ b/scripts/corpus/fetch_canonical.py
@@ -44,8 +44,11 @@ CURATED_REPOS = [
     "jellyfin/jellyfin",
     "grafana/grafana",
     "pi-hole/docker-pi-hole",
-    # Official engine examples
-    "docker/compose",
+    # docker/compose was listed here as "official engine examples" until
+    # the 2026-08-27 corpus analysis showed all 92 of its fetched files
+    # are pkg/e2e and testdata fixtures — test inputs, not examples.
+    # Existing entries are retiered to `synthetic` (retier.SYNTHETIC_REPOS);
+    # it is deliberately no longer fetched as canonical.
 ]
 
 

--- a/scripts/corpus/retier.py
+++ b/scripts/corpus/retier.py
@@ -1,19 +1,50 @@
 #!/usr/bin/env python3
-"""Reattribute index entries to the correct tier by curated-list priority.
+"""Reattribute index entries to the correct tier.
 
-The fetchers dedupe on blob_sha (first-write-wins), so a compose file
-that exists in both a curated registry and a high-star repo may keep
-whichever tier's fetch ran first. That's wrong for analysis: we want
-canonical/selfhosted entries to stay tagged as such even when popular
-swept them up earlier.
+Two jobs, applied as one priority scheme:
+
+1. **Curated-list priority** (original job). The fetchers dedupe on
+   blob_sha (first-write-wins), so a compose file that exists in both a
+   curated registry and a high-star repo may keep whichever tier's fetch
+   ran first. We want canonical/selfhosted entries tagged as such even
+   when another fetch swept them up earlier. The curated lists are
+   imported from the canonical and self-hosted fetchers.
+
+2. **Composition taxonomy** (2026-08-27 corpus analysis). Three kinds of
+   entries were measured to distort per-tier prevalence stats and are
+   attributed to their own tiers:
+
+   - ``lab`` — deliberately-vulnerable environments (vulhub CVE
+     reproductions, CTF challenge archives). Measured: they *dilute*
+     rather than inflate (vulhub: 0.7% files-with-CRITICAL, 0% CL-0001,
+     8.91 findings/file vs the popular tier's 13.29) — but intent, not
+     direction, is the exclusion criterion: a lab target answers no
+     tier's threat-model question.
+   - ``synthetic`` — test *inputs* to compose tooling: files under
+     test/fixture/e2e path segments anywhere, plus whole repos whose
+     compose files exist to exercise a tool (docker/compose e2e
+     fixtures, podman-compose, kompose). Measured: 97.3% with-findings
+     vs 90.6% for plain files — minimal snippets omit every hardening
+     key by construction. docker/compose alone was 27% of the canonical
+     tier and pulled its with-findings rate from 78.1% to 83.7%.
+     Examples/templates/demos are deliberately NOT synthetic: they are
+     copy-paste material, which is exactly the population the canonical
+     and selfhosted tiers exist to measure.
+   - ``collections`` — template/recipe collection repos split out of
+     ``popular`` by file count (>= COLLECTION_MIN_FILES corpus entries
+     from one repo). Measured: the popular tier was bimodal — collection
+     repos averaged 9.02 findings/file with 6.4% CL-0001 while ordinary
+     projects' own compose files averaged 19.43 with 15.0% CL-0001. One
+     blended tier described neither population.
 
 Priority (highest wins):
-    canonical > selfhosted > popular > longtail
+    lab > synthetic > canonical > selfhosted > collections > popular > longtail
 
-This script imports the curated `CURATED_REPOS` lists from the
-canonical and self-hosted fetchers and re-tags any entry whose `repo`
-appears in those lists. Popular and longtail tiers are left alone —
-they're the residual buckets, not curated lists.
+Entries are only ever promoted, never demoted (so a future curated-list
+shrink or threshold change doesn't silently reset a deliberate tag).
+
+Prevalence exclusion for ``lab`` and ``synthetic`` lives in
+``run.EXCLUDED_FROM_PREVALENCE`` — this script only attributes.
 
 Idempotent: rerunning produces no changes.
 """
@@ -21,7 +52,8 @@ from __future__ import annotations
 
 import json
 import sys
-from pathlib import Path
+from collections import Counter
+from pathlib import Path, PurePosixPath
 
 sys.path.insert(0, str(Path(__file__).parent))
 import fetch_canonical  # noqa: E402
@@ -30,7 +62,57 @@ import fetch_selfhosted  # noqa: E402
 INDEX = Path.home() / ".cache" / "compose-lint-corpus" / "index.jsonl"
 
 # Higher number = higher priority. Used to gate downgrades.
-PRIORITY = {"canonical": 4, "selfhosted": 3, "popular": 2, "longtail": 1, "unknown": 0}
+PRIORITY = {
+    "lab": 7,
+    "synthetic": 6,
+    "canonical": 5,
+    "selfhosted": 4,
+    "collections": 3,
+    "popular": 2,
+    "longtail": 1,
+    "unknown": 0,
+}
+
+# Deliberately-vulnerable environments: CVE reproduction stacks and CTF
+# challenge archives. Curated, not pattern-matched — repo names like
+# "TaxHacker" or hackathon projects are ordinary apps and stay put.
+LAB_REPOS = {
+    "vulhub/vulhub",
+    "sajjadium/ctf-archives",
+    "cscosu/buckeyectf-2021",
+    "UrmiaCTF/UCTF-2024",
+    "acisoru/vrnctf-6-kids-writeups",
+    "Team-Drovosec/sasctf-quals-2025",
+}
+
+# Repos whose compose files exist to exercise a compose tool, wholesale.
+# docker/compose was fetched as canonical ("official engine examples")
+# until the 2026-08-27 analysis showed every one of its 92 files is a
+# pkg/e2e or testdata fixture.
+SYNTHETIC_REPOS = {
+    "docker/compose",
+    "containers/podman-compose",
+    "kubernetes/kompose",
+}
+
+# A file whose directory path contains one of these segments is a test
+# input regardless of repo. Matched on exact lowercased path segments
+# (not substrings — "latest/" or "contest/" must not match).
+SYNTHETIC_SEGMENTS = {
+    "test", "tests", "testing", "testdata", "e2e",
+    "fixture", "fixtures", "spec", "specs", "__tests__",
+}
+
+# A repo contributing this many corpus entries is a template/recipe
+# collection, not a project shipping its own compose file. Counted over
+# entries left in popular/collections after lab/synthetic/curated
+# attribution, so the threshold is stable across reruns.
+COLLECTION_MIN_FILES = 20
+
+
+def synthetic_path(path: str) -> bool:
+    parts = PurePosixPath(path).parts[:-1]  # basename is always compose-named
+    return any(seg.lower() in SYNTHETIC_SEGMENTS for seg in parts)
 
 
 def main() -> int:
@@ -48,23 +130,42 @@ def main() -> int:
 
     entries = [json.loads(line) for line in INDEX.open()]
 
-    desired_for: dict[str, str] = {}
-    for repo in selfhosted_repos:
-        desired_for[repo] = "selfhosted"
-    for repo in canonical_repos:  # overwrites selfhosted entries on overlap
-        desired_for[repo] = "canonical"
+    def desired_base(e: dict) -> str | None:
+        if e["repo"] in LAB_REPOS:
+            return "lab"
+        if e["repo"] in SYNTHETIC_REPOS or synthetic_path(e["path"]):
+            return "synthetic"
+        if e["repo"] in canonical_repos:
+            return "canonical"
+        if e["repo"] in selfhosted_repos:
+            return "selfhosted"
+        return None
+
+    base = {id(e): desired_base(e) for e in entries}
+
+    # Collections threshold: count per-repo over entries that remain
+    # popular/collections once lab/synthetic/curated claims are applied.
+    residual = Counter(
+        e["repo"]
+        for e in entries
+        if base[id(e)] is None and e.get("tier") in ("popular", "collections")
+    )
+    collection_repos = {r for r, n in residual.items() if n >= COLLECTION_MIN_FILES}
 
     changed = 0
     by_change: dict[tuple[str, str], int] = {}
     for e in entries:
-        desired = desired_for.get(e["repo"])
+        desired = base[id(e)]
+        in_residual = e.get("tier") in ("popular", "collections")
+        if desired is None and in_residual and e["repo"] in collection_repos:
+            desired = "collections"
         if not desired:
             continue
         current = e.get("tier", "unknown")
         if current == desired:
             continue
         # Only promote, never demote (so a future curated list shrink
-        # doesn't reset a deliberate canonical tag back to popular).
+        # doesn't reset a deliberate tag).
         if PRIORITY[desired] <= PRIORITY[current]:
             continue
         e["tier"] = desired

--- a/scripts/corpus/run.py
+++ b/scripts/corpus/run.py
@@ -340,6 +340,16 @@ def summarize(run_dir: Path, results: list[dict], index: dict[str, dict], starte
     (run_dir / "summary.md").write_text("\n".join(lines))
 
 
+# Tiers whose files are not real-world deployment intent: `synthetic`
+# (test inputs to compose tooling) and `lab` (deliberately-vulnerable
+# environments — vulhub, CTF archives). aggregate_tiers still counts
+# them — they are corpus members and useful parser/fix-gate fuel — but
+# any prevalence claim ("X% of compose files …") must not include them.
+# See retier.py for the attribution rules and the measurements behind
+# them; tier_summary.md and the report's aggregates read this set.
+EXCLUDED_FROM_PREVALENCE = frozenset({"synthetic", "lab"})
+
+
 def aggregate_tiers(
     results: list[dict], index: dict[str, dict]
 ) -> tuple[dict[str, dict], dict[str, str]]:
@@ -417,10 +427,18 @@ def summarize_tiers(run_dir: Path, results: list[dict], index: dict[str, dict]) 
     for tier in sorted(by_tier):
         b = by_tier[tier]
         per_parsed = b["findings"] / b["parsed"] if b["parsed"] else 0
+        mark = "\\*" if tier in EXCLUDED_FROM_PREVALENCE else ""
         lines.append(
-            f"| `{tier}` | {b['total']} | {b['parsed']} | {b['parse_errors']} | "
+            f"| `{tier}`{mark} | {b['total']} | {b['parsed']} | {b['parse_errors']} | "
             f"{b['clean']} | {b['with_findings']} | {b['findings']} | {per_parsed:.2f} |"
         )
+    if EXCLUDED_FROM_PREVALENCE & set(by_tier):
+        lines += [
+            "",
+            "\\* excluded from prevalence stats (`run.EXCLUDED_FROM_PREVALENCE`):"
+            " synthetic test inputs and deliberately-vulnerable lab environments"
+            " are corpus members but not real-world deployment intent.",
+        ]
 
     lines += ["", "## Severity distribution per tier", "",
               "| tier | critical | high | medium | low |",


### PR DESCRIPTION
Draft for review — implements the composition changes from today's corpus analysis. Analysis and all numbers measured against the pinned report run `20260811T044906Z`.

## What it changes

- **`retier.py`** becomes the single attribution authority for a seven-tier scheme: `lab` > `synthetic` > `canonical` > `selfhosted` > `collections` > `popular` > `longtail` (promote-only). `lab`/`synthetic` outrank the curated tiers on purpose — a test fixture inside a canonical repo is still a test fixture.
- **`lab`**: vulhub + five CTF challenge archives (curated list, not name-pattern matching — "TaxHacker" and hackathon apps stay put).
- **`synthetic`**: exact path-segment match on test/tests/testdata/e2e/fixture(s)/spec(s)/\_\_tests\_\_, plus whole tool repos (docker/compose, podman-compose, kompose). Examples/templates/demos are deliberately **not** synthetic — copy-paste material is what canonical/selfhosted exist to measure.
- **`collections`**: split out of `popular` at ≥20 corpus entries per repo, counted over the residual after lab/synthetic/curated claims (stable across reruns).
- **`run.EXCLUDED_FROM_PREVALENCE` = {synthetic, lab}** — one place the summary, charts, and report all read; `tier_summary.md` footnotes it.
- docker/compose removed from the canonical curated fetch list with a comment (all 92 of its files are e2e/testdata fixtures).
- `scripts/corpus/README.md` documents the taxonomy and the measurements behind it.

## Why (measured)

- Synthetic files: 97.3% with-findings vs 90.6% for plain files; docker/compose alone was 27% of canonical and moved its headline from 78.1% → 83.7%.
- Popular was bimodal: collections 9.02 finds/file, 6.4% CL-0001 vs ordinary projects **19.43 finds/file, 15.0% CL-0001**.
- vulhub *dilutes* (0.7% files-with-CRITICAL, 0% CL-0001) — excluded on intent, not direction.

## Re-cut of the pinned run under the new taxonomy

| tier | total | parsed | with findings | finds/file |
|---|---:|---:|---:|---:|
| collections | 1485 | 1472 | 89.1% | 8.85 |
| popular | 1231 | 1216 | **99.6%** | **19.83** |
| longtail | 1070 | 968 | 75.7% | 8.72 |
| selfhosted | 596 | 596 | 100.0% | 9.32 |
| synthetic (excl.) | 476 | 470 | 98.3% | 11.20 |
| lab (excl.) | 310 | 310 | 100.0% | 8.87 |
| canonical | 249 | 247 | 77.7% | 10.43 |

Prevalence-bearing headline becomes **89.9% of 4,499 parsed files** (was 91% blended). The strongest new story: ordinary popular projects' own compose files run ~2× worse than every template tier.

Re-tiering the live index moved 2,271 entries; a second run is a no-op (idempotent).

## Deliberately not in this PR

1. **Report re-cut** — `docs/state-of-compose.md` stays pinned to its archived edition; rewriting its numbers/charts/prose on this taxonomy is a follow-up (the report's own "each edition is a new baseline" rule accommodates it).
2. **Overlay stratum** — `docker-compose.prod.yml` / `*.override.yml` etc. are excluded by the four-filename allowlist today; adding an `overlay` stratum needs a fetch (rate-limit budget), which waits for explicit sign-off.