### PR TITLE
Re-cut the State of Compose report on the seven-tier taxonomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 Static-analysis checks for `docker-compose.yml` and `compose.yaml`, covering privileged containers, unpinned images, host-network sharing, sensitive bind mounts, hard-coded credentials, and more. Full rule documentation lives at **[tmatens.github.io/compose-lint](https://tmatens.github.io/compose-lint/)** (the same pages `--explain` prints offline).
 
-In a scan of 5,417 public Docker Compose files on GitHub, **91% of those that parse had at least one security finding.** Nearly all skip basic capability restrictions, 49% run images without a pinned digest, and 64% bind ports to all interfaces. compose-lint catches these in CI before they ship. **[Read the full *State of Docker Compose Security* report →](https://tmatens.github.io/compose-lint/state-of-compose/)**
+In a scan of 5,417 public Docker Compose files on GitHub, **90% of the real-world files that parse had at least one security finding** (test fixtures and deliberately-vulnerable lab environments counted separately). Nearly all skip basic capability restrictions, 48% run images without a pinned digest, and 66% bind ports to all interfaces — and popular projects' own compose files fare worst of all, at 99.6% with findings. compose-lint catches these in CI before they ship. **[Read the full *State of Docker Compose Security* report →](https://tmatens.github.io/compose-lint/state-of-compose/)**
 
 <!-- Demo GIF. Regenerate with scripts/demo/ — see scripts/demo/README.md. -->
 ![compose-lint scanning a docker-compose.yml with two services: under `service: watchtower`, a CRITICAL mounted Docker socket (CL-0001) with a box-drawing underline, fix block and reference URL, above a MEDIUM image pinned to a tag but not a digest (CL-0019); then under `service: db`, a HIGH plaintext credential (CL-0020) with `POSTGRES_PASSWORD: hunter2` underlined — then the FAIL verdict, and `compose-lint --explain CL-0001` reading the offline rule docs in its built-in pager: the title, severity derivation and references hold on the first page, the status line naming the controls — `CL-0001 · Space next · b back · q quit` — then a page-down continues into the doc, prompt still in place.](https://raw.githubusercontent.com/tmatens/compose-lint/main/docs/assets/demo.gif)
@@ -104,8 +104,8 @@ Python 3.11+ is required for the pip install path; the Docker image is self-cont
 ## Adopting on an existing repo
 
 Most established stacks don't start clean — in the [State of Compose
-scan](https://tmatens.github.io/compose-lint/state-of-compose/), 91% of public
-Compose files that parse had at least one finding. You don't have to fix
+scan](https://tmatens.github.io/compose-lint/state-of-compose/), 90% of
+real-world public Compose files that parse had at least one finding. You don't have to fix
 everything before the gate goes in: `compose-lint init` turns a file's current
 findings into a `.compose-lint.yml` baseline you then triage, so the gate can
 go in today without hand-authoring suppressions from the schema:

--- a/docs/assets/findings-by-tier.svg
+++ b/docs/assets/findings-by-tier.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-10T23:51:24.097973</dc:date>
+    <dc:date>2026-08-27T07:48:33.857795</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -41,163 +41,180 @@ z
     <g id="xtick_1">
      <g id="line2d_1"/>
      <g id="text_1">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="103.471906" y="311.157182" transform="rotate(-0 103.471906 311.157182)">canonical</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="95.139184" y="311.157182" transform="rotate(-0 95.139184 311.157182)">canonical</text>
      </g>
     </g>
     <g id="xtick_2">
      <g id="line2d_2"/>
      <g id="text_2">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="227.656338" y="311.157182" transform="rotate(-0 227.656338 311.157182)">popular</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="192.443869" y="311.157182" transform="rotate(-0 192.443869 311.157182)">selfhosted</text>
      </g>
     </g>
     <g id="xtick_3">
      <g id="line2d_3"/>
      <g id="text_3">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="351.840771" y="311.157182" transform="rotate(-0 351.840771 311.157182)">selfhosted</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="289.748555" y="311.157182" transform="rotate(-0 289.748555 311.157182)">collections</text>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_4"/>
      <g id="text_4">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="476.025204" y="311.157182" transform="rotate(-0 476.025204 311.157182)">longtail</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="387.05324" y="311.157182" transform="rotate(-0 387.05324 311.157182)">popular</text>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5"/>
+     <g id="text_5">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="484.357925" y="311.157182" transform="rotate(-0 484.357925 311.157182)">longtail</text>
      </g>
     </g>
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
-     <g id="line2d_5">
+     <g id="line2d_6">
       <path d="M 42.497349 299.298901 
 L 536.99976 299.298901 
-" clip-path="url(#p1abb377194)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pb6d2af3d29)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_6"/>
-     <g id="text_5">
+     <g id="line2d_7"/>
+     <g id="text_6">
       <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.997349" y="303.477612" transform="rotate(-0 38.997349 303.477612)">0</text>
      </g>
     </g>
     <g id="ytick_2">
-     <g id="line2d_7">
+     <g id="line2d_8">
       <path d="M 42.497349 252.586921 
 L 536.99976 252.586921 
-" clip-path="url(#p1abb377194)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pb6d2af3d29)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_8"/>
-     <g id="text_6">
+     <g id="line2d_9"/>
+     <g id="text_7">
       <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.997349" y="256.765632" transform="rotate(-0 38.997349 256.765632)">20</text>
      </g>
     </g>
     <g id="ytick_3">
-     <g id="line2d_9">
+     <g id="line2d_10">
       <path d="M 42.497349 205.874941 
 L 536.99976 205.874941 
-" clip-path="url(#p1abb377194)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pb6d2af3d29)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_10"/>
-     <g id="text_7">
+     <g id="line2d_11"/>
+     <g id="text_8">
       <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.997349" y="210.053652" transform="rotate(-0 38.997349 210.053652)">40</text>
      </g>
     </g>
     <g id="ytick_4">
-     <g id="line2d_11">
+     <g id="line2d_12">
       <path d="M 42.497349 159.162961 
 L 536.99976 159.162961 
-" clip-path="url(#p1abb377194)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pb6d2af3d29)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_12"/>
-     <g id="text_8">
+     <g id="line2d_13"/>
+     <g id="text_9">
       <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.997349" y="163.341672" transform="rotate(-0 38.997349 163.341672)">60</text>
      </g>
     </g>
     <g id="ytick_5">
-     <g id="line2d_13">
+     <g id="line2d_14">
       <path d="M 42.497349 112.450981 
 L 536.99976 112.450981 
-" clip-path="url(#p1abb377194)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pb6d2af3d29)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_14"/>
-     <g id="text_9">
+     <g id="line2d_15"/>
+     <g id="text_10">
       <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.997349" y="116.629692" transform="rotate(-0 38.997349 116.629692)">80</text>
      </g>
     </g>
     <g id="ytick_6">
-     <g id="line2d_15">
+     <g id="line2d_16">
       <path d="M 42.497349 65.739001 
 L 536.99976 65.739001 
-" clip-path="url(#p1abb377194)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pb6d2af3d29)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_16"/>
-     <g id="text_10">
+     <g id="line2d_17"/>
+     <g id="text_11">
       <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.997349" y="69.917712" transform="rotate(-0 38.997349 69.917712)">100</text>
      </g>
     </g>
-    <g id="text_11">
+    <g id="text_12">
      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="11.358521" y="173.176555" transform="rotate(-90 11.358521 173.176555)">Files with ≥1 finding (% of parsed)</text>
     </g>
    </g>
    <g id="patch_3">
     <path d="M 64.974732 299.298901 
-L 141.96908 299.298901 
-L 141.96908 103.871229 
-L 64.974732 103.871229 
+L 125.303637 299.298901 
+L 125.303637 117.746266 
+L 64.974732 117.746266 
 z
-" clip-path="url(#p1abb377194)" style="fill: #2563eb"/>
+" clip-path="url(#pb6d2af3d29)" style="fill: #2563eb"/>
    </g>
    <g id="patch_4">
-    <path d="M 189.159164 299.298901 
-L 266.153512 299.298901 
-L 266.153512 77.497971 
-L 189.159164 77.497971 
+    <path d="M 162.279417 299.298901 
+L 222.608322 299.298901 
+L 222.608322 65.739001 
+L 162.279417 65.739001 
 z
-" clip-path="url(#p1abb377194)" style="fill: #2563eb"/>
+" clip-path="url(#pb6d2af3d29)" style="fill: #b1281f; stroke: #b1281f; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 313.343597 299.298901 
-L 390.337945 299.298901 
-L 390.337945 65.739001 
-L 313.343597 65.739001 
+    <path d="M 259.584102 299.298901 
+L 319.913007 299.298901 
+L 319.913007 91.125946 
+L 259.584102 91.125946 
 z
-" clip-path="url(#p1abb377194)" style="fill: #b1281f; stroke: #b1281f; stroke-linejoin: miter"/>
+" clip-path="url(#pb6d2af3d29)" style="fill: #2563eb"/>
    </g>
    <g id="patch_6">
-    <path d="M 437.528029 299.298901 
-L 514.522378 299.298901 
-L 514.522378 120.533112 
-L 437.528029 120.533112 
+    <path d="M 356.888788 299.298901 
+L 417.217692 299.298901 
+L 417.217692 66.699362 
+L 356.888788 66.699362 
 z
-" clip-path="url(#p1abb377194)" style="fill: #2563eb"/>
+" clip-path="url(#pb6d2af3d29)" style="fill: #2563eb"/>
    </g>
    <g id="patch_7">
+    <path d="M 454.193473 299.298901 
+L 514.522378 299.298901 
+L 514.522378 122.440009 
+L 454.193473 122.440009 
+z
+" clip-path="url(#pb6d2af3d29)" style="fill: #2563eb"/>
+   </g>
+   <g id="patch_8">
     <path d="M 42.497349 299.298901 
 L 42.497349 47.054209 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_8">
+   <g id="patch_9">
     <path d="M 42.497349 299.298901 
 L 536.99976 299.298901 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="text_12">
-    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="103.471906" y="98.425932" transform="rotate(-0 103.471906 98.425932)">83.7%</text>
-   </g>
    <g id="text_13">
-    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="227.656338" y="72.052674" transform="rotate(-0 227.656338 72.052674)">95.0%</text>
+    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="95.139184" y="112.300969" transform="rotate(-0 95.139184 112.300969)">77.7%</text>
    </g>
    <g id="text_14">
-    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="351.840771" y="60.293704" transform="rotate(-0 351.840771 60.293704)">100.0%</text>
+    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="192.443869" y="60.293704" transform="rotate(-0 192.443869 60.293704)">100.0%</text>
    </g>
    <g id="text_15">
-    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="476.025204" y="115.087815" transform="rotate(-0 476.025204 115.087815)">76.5%</text>
+    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="289.748555" y="85.680649" transform="rotate(-0 289.748555 85.680649)">89.1%</text>
    </g>
    <g id="text_16">
-    <text style="font-weight: 700; font-size: 13px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="289.748555" y="35.054209" transform="rotate(-0 289.748555 35.054209)">Every tier ships findings — even the cleanest is 83%</text>
+    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="387.05324" y="61.254065" transform="rotate(-0 387.05324 61.254065)">99.6%</text>
+   </g>
+   <g id="text_17">
+    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="484.357925" y="116.994713" transform="rotate(-0 484.357925 116.994713)">75.7%</text>
+   </g>
+   <g id="text_18">
+    <text style="font-weight: 700; font-size: 13px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="289.748555" y="35.054209" transform="rotate(-0 289.748555 35.054209)">Every tier ships findings — even the cleanest is 76%</text>
    </g>
   </g>
-  <g id="text_17">
-   <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #999999" x="6.48" y="10.83075" transform="rotate(-0 6.48 10.83075)">compose-lint 0.16.0  ·  corpus 20260811T044906Z  ·  n=5,279 parsed</text>
+  <g id="text_19">
+   <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #999999" x="6.48" y="10.83075" transform="rotate(-0 6.48 10.83075)">compose-lint 0.16.0  ·  corpus 20260811T044906Z  ·  n=4,499 parsed, prevalence tiers</text>
   </g>
  </g>
  <defs>
-  <clipPath id="p1abb377194">
+  <clipPath id="pb6d2af3d29">
    <rect x="42.497349" y="47.054209" width="494.502411" height="252.244692"/>
   </clipPath>
  </defs>

--- a/docs/assets/parse-error-rate.svg
+++ b/docs/assets/parse-error-rate.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-10T23:51:24.292774</dc:date>
+    <dc:date>2026-08-27T07:48:34.021673</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -41,163 +41,180 @@ z
     <g id="xtick_1">
      <g id="line2d_1"/>
      <g id="text_1">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="97.336136" y="311.157182" transform="rotate(-0 97.336136 311.157182)">canonical</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="88.88548" y="311.157182" transform="rotate(-0 88.88548 311.157182)">canonical</text>
      </g>
     </g>
     <g id="xtick_2">
      <g id="line2d_2"/>
      <g id="text_2">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="223.278165" y="311.157182" transform="rotate(-0 223.278165 311.157182)">popular</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="187.56733" y="311.157182" transform="rotate(-0 187.56733 311.157182)">selfhosted</text>
      </g>
     </g>
     <g id="xtick_3">
      <g id="line2d_3"/>
      <g id="text_3">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="349.220194" y="311.157182" transform="rotate(-0 349.220194 311.157182)">selfhosted</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="286.24918" y="311.157182" transform="rotate(-0 286.24918 311.157182)">collections</text>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_4"/>
      <g id="text_4">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="475.162224" y="311.157182" transform="rotate(-0 475.162224 311.157182)">longtail</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="384.931029" y="311.157182" transform="rotate(-0 384.931029 311.157182)">popular</text>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5"/>
+     <g id="text_5">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="483.612879" y="311.157182" transform="rotate(-0 483.612879 311.157182)">longtail</text>
      </g>
     </g>
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
-     <g id="line2d_5">
+     <g id="line2d_6">
       <path d="M 35.498599 299.298901 
 L 536.99976 299.298901 
-" clip-path="url(#p1f3969c2e0)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p70ad45af9d)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_6"/>
-     <g id="text_5">
+     <g id="line2d_7"/>
+     <g id="text_6">
       <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="31.998599" y="303.477612" transform="rotate(-0 31.998599 303.477612)">0</text>
      </g>
     </g>
     <g id="ytick_2">
-     <g id="line2d_7">
-      <path d="M 35.498599 254.785131 
-L 536.99976 254.785131 
-" clip-path="url(#p1f3969c2e0)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+     <g id="line2d_8">
+      <path d="M 35.498599 256.96136 
+L 536.99976 256.96136 
+" clip-path="url(#p70ad45af9d)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_8"/>
-     <g id="text_6">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="31.998599" y="258.963842" transform="rotate(-0 31.998599 258.963842)">2</text>
+     <g id="line2d_9"/>
+     <g id="text_7">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="31.998599" y="261.140071" transform="rotate(-0 31.998599 261.140071)">2</text>
      </g>
     </g>
     <g id="ytick_3">
-     <g id="line2d_9">
-      <path d="M 35.498599 210.271362 
-L 536.99976 210.271362 
-" clip-path="url(#p1f3969c2e0)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+     <g id="line2d_10">
+      <path d="M 35.498599 214.62382 
+L 536.99976 214.62382 
+" clip-path="url(#p70ad45af9d)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_10"/>
-     <g id="text_7">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="31.998599" y="214.450073" transform="rotate(-0 31.998599 214.450073)">4</text>
+     <g id="line2d_11"/>
+     <g id="text_8">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="31.998599" y="218.802531" transform="rotate(-0 31.998599 218.802531)">4</text>
      </g>
     </g>
     <g id="ytick_4">
-     <g id="line2d_11">
-      <path d="M 35.498599 165.757593 
-L 536.99976 165.757593 
-" clip-path="url(#p1f3969c2e0)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+     <g id="line2d_12">
+      <path d="M 35.498599 172.286279 
+L 536.99976 172.286279 
+" clip-path="url(#p70ad45af9d)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_12"/>
-     <g id="text_8">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="31.998599" y="169.936304" transform="rotate(-0 31.998599 169.936304)">6</text>
+     <g id="line2d_13"/>
+     <g id="text_9">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="31.998599" y="176.46499" transform="rotate(-0 31.998599 176.46499)">6</text>
      </g>
     </g>
     <g id="ytick_5">
-     <g id="line2d_13">
-      <path d="M 35.498599 121.243824 
-L 536.99976 121.243824 
-" clip-path="url(#p1f3969c2e0)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+     <g id="line2d_14">
+      <path d="M 35.498599 129.948739 
+L 536.99976 129.948739 
+" clip-path="url(#p70ad45af9d)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_14"/>
-     <g id="text_9">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="31.998599" y="125.422535" transform="rotate(-0 31.998599 125.422535)">8</text>
+     <g id="line2d_15"/>
+     <g id="text_10">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="31.998599" y="134.12745" transform="rotate(-0 31.998599 134.12745)">8</text>
      </g>
     </g>
     <g id="ytick_6">
-     <g id="line2d_15">
-      <path d="M 35.498599 76.730055 
-L 536.99976 76.730055 
-" clip-path="url(#p1f3969c2e0)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+     <g id="line2d_16">
+      <path d="M 35.498599 87.611198 
+L 536.99976 87.611198 
+" clip-path="url(#p70ad45af9d)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_16"/>
-     <g id="text_10">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="31.998599" y="80.908766" transform="rotate(-0 31.998599 80.908766)">10</text>
+     <g id="line2d_17"/>
+     <g id="text_11">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="31.998599" y="91.789909" transform="rotate(-0 31.998599 91.789909)">10</text>
      </g>
     </g>
-    <g id="text_11">
+    <g id="text_12">
      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="11.358521" y="173.176555" transform="rotate(-90 11.358521 173.176555)">Files failing to parse as Compose (% of tier)</text>
     </g>
    </g>
    <g id="patch_3">
     <path d="M 58.294107 299.298901 
-L 136.378165 299.298901 
-L 136.378165 286.396359 
-L 58.294107 286.396359 
+L 119.476854 299.298901 
+L 119.476854 282.295872 
+L 58.294107 282.295872 
 z
-" clip-path="url(#p1f3969c2e0)" style="fill: #2563eb"/>
+" clip-path="url(#p70ad45af9d)" style="fill: #2563eb"/>
    </g>
    <g id="patch_4">
-    <path d="M 184.236136 299.298901 
-L 262.320194 299.298901 
-L 262.320194 276.716565 
-L 184.236136 276.716565 
+    <path d="M 156.975956 299.298901 
+L 218.158703 299.298901 
+L 218.158703 299.298901 
+L 156.975956 299.298901 
 z
-" clip-path="url(#p1f3969c2e0)" style="fill: #2563eb"/>
+" clip-path="url(#p70ad45af9d)" style="fill: #2563eb"/>
    </g>
    <g id="patch_5">
-    <path d="M 310.178165 299.298901 
-L 388.262223 299.298901 
-L 388.262223 299.298901 
-L 310.178165 299.298901 
+    <path d="M 255.657806 299.298901 
+L 316.840553 299.298901 
+L 316.840553 280.767317 
+L 255.657806 280.767317 
 z
-" clip-path="url(#p1f3969c2e0)" style="fill: #2563eb"/>
+" clip-path="url(#p70ad45af9d)" style="fill: #2563eb"/>
    </g>
    <g id="patch_6">
-    <path d="M 436.120195 299.298901 
-L 514.204253 299.298901 
-L 514.204253 97.503147 
-L 436.120195 97.503147 
+    <path d="M 354.339656 299.298901 
+L 415.522403 299.298901 
+L 415.522403 273.504298 
+L 354.339656 273.504298 
 z
-" clip-path="url(#p1f3969c2e0)" style="fill: #b1281f; stroke: #b1281f; stroke-linejoin: miter"/>
+" clip-path="url(#p70ad45af9d)" style="fill: #2563eb"/>
    </g>
    <g id="patch_7">
+    <path d="M 453.021506 299.298901 
+L 514.204253 299.298901 
+L 514.204253 97.503147 
+L 453.021506 97.503147 
+z
+" clip-path="url(#p70ad45af9d)" style="fill: #b1281f; stroke: #b1281f; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_8">
     <path d="M 35.498599 299.298901 
 L 35.498599 47.054209 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_8">
+   <g id="patch_9">
     <path d="M 35.498599 299.298901 
 L 536.99976 299.298901 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="text_12">
-    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="97.336136" y="280.415248" transform="rotate(-0 97.336136 280.415248)">0.6%</text>
-   </g>
    <g id="text_13">
-    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="223.278165" y="270.735454" transform="rotate(-0 223.278165 270.735454)">1.0%</text>
+    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="88.88548" y="276.477979" transform="rotate(-0 88.88548 276.477979)">0.8%</text>
    </g>
    <g id="text_14">
-    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="349.220194" y="293.31779" transform="rotate(-0 349.220194 293.31779)">0.0%</text>
+    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="187.56733" y="293.481007" transform="rotate(-0 187.56733 293.481007)">0.0%</text>
    </g>
    <g id="text_15">
-    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="475.162224" y="91.522036" transform="rotate(-0 475.162224 91.522036)">9.1%</text>
+    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="286.24918" y="274.949424" transform="rotate(-0 286.24918 274.949424)">0.9%</text>
    </g>
    <g id="text_16">
+    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="384.931029" y="267.686405" transform="rotate(-0 384.931029 267.686405)">1.2%</text>
+   </g>
+   <g id="text_17">
+    <text style="font-weight: 700; font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="483.612879" y="91.685253" transform="rotate(-0 483.612879 91.685253)">9.5%</text>
+   </g>
+   <g id="text_18">
     <text style="font-weight: 700; font-size: 13px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="286.24918" y="35.054209" transform="rotate(-0 286.24918 35.054209)">Parse failures are a longtail phenomenon</text>
    </g>
   </g>
-  <g id="text_17">
-   <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #999999" x="6.48" y="10.83075" transform="rotate(-0 6.48 10.83075)">compose-lint 0.16.0  ·  corpus 20260811T044906Z  ·  n=5,279 parsed</text>
+  <g id="text_19">
+   <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #999999" x="6.48" y="10.83075" transform="rotate(-0 6.48 10.83075)">compose-lint 0.16.0  ·  corpus 20260811T044906Z  ·  n=4,499 parsed, prevalence tiers</text>
   </g>
  </g>
  <defs>
-  <clipPath id="p1f3969c2e0">
+  <clipPath id="p70ad45af9d">
    <rect x="35.498599" y="47.054209" width="501.501161" height="252.244692"/>
   </clipPath>
  </defs>

--- a/docs/assets/severity-distribution.svg
+++ b/docs/assets/severity-distribution.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-10T23:51:24.253255</dc:date>
+    <dc:date>2026-08-27T07:48:33.986489</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -30,80 +30,80 @@ z
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 34.965011 148.29688 
-L 598.634989 148.29688 
-L 598.634989 38.990209 
-L 34.965011 38.990209 
+    <path d="M 29.238761 148.29688 
+L 604.361239 148.29688 
+L 604.361239 38.990209 
+L 29.238761 38.990209 
 z
 " style="fill: #ffffff"/>
    </g>
    <g id="patch_3">
-    <path d="M 34.965011 126.435546 
-L 42.086783 126.435546 
-L 42.086783 60.851543 
-L 34.965011 60.851543 
+    <path d="M 29.238761 126.435546 
+L 36.593323 126.435546 
+L 36.593323 60.851543 
+L 29.238761 60.851543 
 z
-" clip-path="url(#pcc52f10a7e)" style="fill: #b1281f"/>
+" clip-path="url(#peab0c7b4c6)" style="fill: #b1281f"/>
    </g>
    <g id="patch_4">
-    <path d="M 42.086783 126.435546 
-L 73.723885 126.435546 
-L 73.723885 60.851543 
-L 42.086783 60.851543 
+    <path d="M 36.593323 126.435546 
+L 69.255287 126.435546 
+L 69.255287 60.851543 
+L 36.593323 60.851543 
 z
-" clip-path="url(#pcc52f10a7e)" style="fill: #e06c00"/>
+" clip-path="url(#peab0c7b4c6)" style="fill: #e06c00"/>
    </g>
    <g id="patch_5">
-    <path d="M 73.723885 126.435546 
-L 503.422378 126.435546 
-L 503.422378 60.851543 
-L 73.723885 60.851543 
+    <path d="M 69.255287 126.435546 
+L 507.563639 126.435546 
+L 507.563639 60.851543 
+L 69.255287 60.851543 
 z
-" clip-path="url(#pcc52f10a7e)" style="fill: #e0a800"/>
+" clip-path="url(#peab0c7b4c6)" style="fill: #e0a800"/>
    </g>
    <g id="patch_6">
-    <path d="M 503.422378 126.435546 
-L 598.634989 126.435546 
-L 598.634989 60.851543 
-L 503.422378 60.851543 
+    <path d="M 507.563639 126.435546 
+L 604.361239 126.435546 
+L 604.361239 60.851543 
+L 507.563639 60.851543 
 z
-" clip-path="url(#pcc52f10a7e)" style="fill: #8a8a8a"/>
+" clip-path="url(#peab0c7b4c6)" style="fill: #8a8a8a"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1"/>
      <g id="text_1">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="34.965011" y="160.154302" transform="rotate(-0 34.965011 160.154302)">0</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="29.238761" y="160.154302" transform="rotate(-0 29.238761 160.154302)">0</text>
      </g>
     </g>
     <g id="xtick_2">
      <g id="line2d_2"/>
      <g id="text_2">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="147.699007" y="160.154302" transform="rotate(-0 147.699007 160.154302)">20</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="144.263257" y="160.154302" transform="rotate(-0 144.263257 160.154302)">20</text>
      </g>
     </g>
     <g id="xtick_3">
      <g id="line2d_3"/>
      <g id="text_3">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="260.433002" y="160.154302" transform="rotate(-0 260.433002 160.154302)">40</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="259.287752" y="160.154302" transform="rotate(-0 259.287752 160.154302)">40</text>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_4"/>
      <g id="text_4">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="373.166998" y="160.154302" transform="rotate(-0 373.166998 160.154302)">60</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="374.312248" y="160.154302" transform="rotate(-0 374.312248 160.154302)">60</text>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_5"/>
      <g id="text_5">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="485.900993" y="160.154302" transform="rotate(-0 485.900993 160.154302)">80</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="489.336743" y="160.154302" transform="rotate(-0 489.336743 160.154302)">80</text>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_6"/>
      <g id="text_6">
-      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="598.634989" y="160.154302" transform="rotate(-0 598.634989 160.154302)">100</text>
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="604.361239" y="160.154302" transform="rotate(-0 604.361239 160.154302)">100</text>
      </g>
     </g>
     <g id="text_7">
@@ -112,84 +112,84 @@ z
    </g>
    <g id="matplotlib.axis_2"/>
    <g id="patch_7">
-    <path d="M 34.965011 148.29688 
-L 34.965011 38.990209 
+    <path d="M 29.238761 148.29688 
+L 29.238761 38.990209 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_8">
-    <path d="M 34.965011 148.29688 
-L 598.634989 148.29688 
+    <path d="M 29.238761 148.29688 
+L 604.361239 148.29688 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_8">
-    <text style="font-weight: 700; font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #ffffff" transform="translate(43.572521 90.240224)">HIGH</text>
-    <text style="font-weight: 700; font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #ffffff" transform="translate(44.038146 102.242177)">5.6%</text>
+    <text style="font-weight: 700; font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #ffffff" transform="translate(38.591493 90.240224)">HIGH</text>
+    <text style="font-weight: 700; font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #ffffff" transform="translate(39.057118 102.242177)">5.7%</text>
    </g>
    <g id="text_9">
-    <text style="font-weight: 700; font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #ffffff" transform="translate(265.13485 90.240224)">MEDIUM</text>
-    <text style="font-weight: 700; font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #ffffff" transform="translate(271.227038 102.242177)">76.2%</text>
+    <text style="font-weight: 700; font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #ffffff" transform="translate(264.971182 90.240224)">MEDIUM</text>
+    <text style="font-weight: 700; font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #ffffff" transform="translate(271.063369 102.242177)">76.2%</text>
    </g>
    <g id="text_10">
-    <text style="font-weight: 700; font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #ffffff" transform="translate(538.255246 90.240224)">LOW</text>
-    <text style="font-weight: 700; font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #ffffff" transform="translate(533.68259 102.242177)">16.9%</text>
+    <text style="font-weight: 700; font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #ffffff" transform="translate(543.189001 90.240224)">LOW</text>
+    <text style="font-weight: 700; font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; fill: #ffffff" transform="translate(538.616345 102.242177)">16.8%</text>
    </g>
    <g id="text_11">
     <text style="font-weight: 700; font-size: 13px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="316.8" y="26.990209" transform="rotate(-0 316.8 26.990209)">Findings by severity — MEDIUM hardening misses dominate</text>
    </g>
    <g id="legend_1">
     <g id="patch_9">
-     <path d="M 24.757734 201.492809 
-L 42.757734 201.492809 
-L 42.757734 195.192809 
-L 24.757734 195.192809 
+     <path d="M 27.620859 201.492809 
+L 45.620859 201.492809 
+L 45.620859 195.192809 
+L 27.620859 195.192809 
 z
 " style="fill: #b1281f; stroke: #b1281f; stroke-linejoin: miter"/>
     </g>
     <g id="text_12">
-     <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="49.957734" y="201.492809" transform="rotate(-0 49.957734 201.492809)">CRITICAL — 780 (1.3%)</text>
+     <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="52.820859" y="201.492809" transform="rotate(-0 52.820859 201.492809)">CRITICAL — 687 (1.3%)</text>
     </g>
     <g id="patch_10">
-     <path d="M 173.405391 201.492809 
-L 191.405391 201.492809 
-L 191.405391 195.192809 
-L 173.405391 195.192809 
+     <path d="M 176.268516 201.492809 
+L 194.268516 201.492809 
+L 194.268516 195.192809 
+L 176.268516 195.192809 
 z
 " style="fill: #e06c00; stroke: #e06c00; stroke-linejoin: miter"/>
     </g>
     <g id="text_13">
-     <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="198.605391" y="201.492809" transform="rotate(-0 198.605391 201.492809)">HIGH — 3,465 (5.6%)</text>
+     <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="201.468516" y="201.492809" transform="rotate(-0 201.468516 201.492809)">HIGH — 3,051 (5.7%)</text>
     </g>
     <g id="patch_11">
-     <path d="M 313.003828 201.492809 
-L 331.003828 201.492809 
-L 331.003828 195.192809 
-L 313.003828 195.192809 
+     <path d="M 315.866953 201.492809 
+L 333.866953 201.492809 
+L 333.866953 195.192809 
+L 315.866953 195.192809 
 z
 " style="fill: #e0a800; stroke: #e0a800; stroke-linejoin: miter"/>
     </g>
     <g id="text_14">
-     <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="338.203828" y="201.492809" transform="rotate(-0 338.203828 201.492809)">MEDIUM — 47,062 (76.2%)</text>
+     <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="341.066953" y="201.492809" transform="rotate(-0 341.066953 201.492809)">MEDIUM — 40,943 (76.2%)</text>
     </g>
     <g id="patch_12">
-     <path d="M 478.278984 201.492809 
-L 496.278984 201.492809 
-L 496.278984 195.192809 
-L 478.278984 195.192809 
+     <path d="M 481.142109 201.492809 
+L 499.142109 201.492809 
+L 499.142109 195.192809 
+L 481.142109 195.192809 
 z
 " style="fill: #8a8a8a; stroke: #8a8a8a; stroke-linejoin: miter"/>
     </g>
     <g id="text_15">
-     <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="503.478984" y="201.492809" transform="rotate(-0 503.478984 201.492809)">LOW — 10,428 (16.9%)</text>
+     <text style="font-size: 9px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="506.342109" y="201.492809" transform="rotate(-0 506.342109 201.492809)">LOW — 9,042 (16.8%)</text>
     </g>
    </g>
   </g>
   <g id="text_16">
-   <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #999999" x="7.6032" y="9.10275" transform="rotate(-0 7.6032 9.10275)">compose-lint 0.16.0  ·  corpus 20260811T044906Z  ·  n=5,279 parsed</text>
+   <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #999999" x="7.6032" y="9.10275" transform="rotate(-0 7.6032 9.10275)">compose-lint 0.16.0  ·  corpus 20260811T044906Z  ·  n=4,499 parsed, prevalence tiers</text>
   </g>
  </g>
  <defs>
-  <clipPath id="pcc52f10a7e">
-   <rect x="34.965011" y="38.990209" width="563.669977" height="109.306671"/>
+  <clipPath id="peab0c7b4c6">
+   <rect x="29.238761" y="38.990209" width="575.122478" height="109.306671"/>
   </clipPath>
  </defs>
 </svg>

--- a/docs/assets/top-findings.svg
+++ b/docs/assets/top-findings.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-10T23:51:24.174777</dc:date>
+    <dc:date>2026-08-27T07:48:33.920698</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -42,7 +42,7 @@ z
      <g id="line2d_1">
       <path d="M 438.561334 356.298901 
 L 438.561334 52.094209 
-" clip-path="url(#p715f299a09)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2423bfd136)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_2"/>
      <g id="text_1">
@@ -53,7 +53,7 @@ L 438.561334 52.094209
      <g id="line2d_3">
       <path d="M 474.869394 356.298901 
 L 474.869394 52.094209 
-" clip-path="url(#p715f299a09)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2423bfd136)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_4"/>
      <g id="text_2">
@@ -64,7 +64,7 @@ L 474.869394 52.094209
      <g id="line2d_5">
       <path d="M 511.177454 356.298901 
 L 511.177454 52.094209 
-" clip-path="url(#p715f299a09)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2423bfd136)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_6"/>
      <g id="text_3">
@@ -75,7 +75,7 @@ L 511.177454 52.094209
      <g id="line2d_7">
       <path d="M 547.485515 356.298901 
 L 547.485515 52.094209 
-" clip-path="url(#p715f299a09)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2423bfd136)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8"/>
      <g id="text_4">
@@ -86,7 +86,7 @@ L 547.485515 52.094209
      <g id="line2d_9">
       <path d="M 583.793575 356.298901 
 L 583.793575 52.094209 
-" clip-path="url(#p715f299a09)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2423bfd136)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10"/>
      <g id="text_5">
@@ -97,7 +97,7 @@ L 583.793575 52.094209
      <g id="line2d_11">
       <path d="M 620.101635 356.298901 
 L 620.101635 52.094209 
-" clip-path="url(#p715f299a09)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2423bfd136)" style="fill: none; stroke: #e6e6e6; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12"/>
      <g id="text_6">
@@ -172,83 +172,83 @@ L 620.101635 52.094209
    </g>
    <g id="patch_3">
     <path d="M 438.561334 342.471415 
-L 445.232828 342.471415 
-L 445.232828 319.895927 
+L 446.308775 342.471415 
+L 446.308775 319.895927 
 L 438.561334 319.895927 
 z
-" clip-path="url(#p715f299a09)" style="fill: #e06c00"/>
+" clip-path="url(#p2423bfd136)" style="fill: #e06c00"/>
    </g>
    <g id="patch_4">
     <path d="M 438.561334 314.252055 
-L 452.282603 314.252055 
-L 452.282603 291.676568 
+L 453.410596 314.252055 
+L 453.410596 291.676568 
 L 438.561334 291.676568 
 z
-" clip-path="url(#p715f299a09)" style="fill: #b1281f"/>
+" clip-path="url(#p2423bfd136)" style="fill: #b1281f"/>
    </g>
    <g id="patch_5">
     <path d="M 438.561334 286.032696 
-L 474.394824 286.032696 
-L 474.394824 263.457209 
+L 475.442382 286.032696 
+L 475.442382 263.457209 
 L 438.561334 263.457209 
 z
-" clip-path="url(#p715f299a09)" style="fill: #e06c00"/>
+" clip-path="url(#p2423bfd136)" style="fill: #e06c00"/>
    </g>
    <g id="patch_6">
     <path d="M 438.561334 257.813337 
-L 521.817456 257.813337 
-L 521.817456 235.23785 
+L 523.500728 257.813337 
+L 523.500728 235.23785 
 L 438.561334 235.23785 
 z
-" clip-path="url(#p715f299a09)" style="fill: #e0a800"/>
+" clip-path="url(#p2423bfd136)" style="fill: #e0a800"/>
    </g>
    <g id="patch_7">
     <path d="M 438.561334 229.593978 
-L 527.801167 229.593978 
-L 527.801167 207.018491 
+L 525.034076 229.593978 
+L 525.034076 207.018491 
 L 438.561334 207.018491 
 z
-" clip-path="url(#p715f299a09)" style="fill: #e0a800"/>
+" clip-path="url(#p2423bfd136)" style="fill: #e0a800"/>
    </g>
    <g id="patch_8">
     <path d="M 438.561334 201.374619 
-L 555.346873 201.374619 
-L 555.346873 178.799131 
+L 557.395783 201.374619 
+L 557.395783 178.799131 
 L 438.561334 178.799131 
 z
-" clip-path="url(#p715f299a09)" style="fill: #e0a800"/>
+" clip-path="url(#p2423bfd136)" style="fill: #e0a800"/>
    </g>
    <g id="patch_9">
     <path d="M 438.561334 173.15526 
-L 600.946881 173.15526 
-L 600.946881 150.579772 
+L 597.989147 173.15526 
+L 597.989147 150.579772 
 L 438.561334 150.579772 
 z
-" clip-path="url(#p715f299a09)" style="fill: #e0a800"/>
+" clip-path="url(#p2423bfd136)" style="fill: #e0a800"/>
    </g>
    <g id="patch_10">
     <path d="M 438.561334 144.9359 
-L 601.153216 144.9359 
-L 601.153216 122.360413 
+L 598.311957 144.9359 
+L 598.311957 122.360413 
 L 438.561334 122.360413 
 z
-" clip-path="url(#p715f299a09)" style="fill: #e0a800"/>
+" clip-path="url(#p2423bfd136)" style="fill: #e0a800"/>
    </g>
    <g id="patch_11">
     <path d="M 438.561334 116.716541 
-L 603.216564 116.716541 
-L 603.216564 94.141054 
+L 600.65233 116.716541 
+L 600.65233 94.141054 
 L 438.561334 94.141054 
 z
-" clip-path="url(#p715f299a09)" style="fill: #e0a800"/>
+" clip-path="url(#p2423bfd136)" style="fill: #e0a800"/>
    </g>
    <g id="patch_12">
     <path d="M 438.561334 88.497182 
-L 603.319732 88.497182 
-L 603.319732 65.921695 
+L 600.894437 88.497182 
+L 600.894437 65.921695 
 L 438.561334 65.921695 
 z
-" clip-path="url(#p715f299a09)" style="fill: #8a8a8a"/>
+" clip-path="url(#p2423bfd136)" style="fill: #8a8a8a"/>
    </g>
    <g id="patch_13">
     <path d="M 438.561334 356.298901 
@@ -261,34 +261,34 @@ L 620.101635 356.298901
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_18">
-    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="446.68515" y="333.781327" transform="rotate(-0 446.68515 333.781327)">4%</text>
+    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="447.761097" y="333.781327" transform="rotate(-0 447.761097 333.781327)">4%</text>
    </g>
    <g id="text_19">
-    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="453.734925" y="305.561968" transform="rotate(-0 453.734925 305.561968)">8%</text>
+    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="454.862918" y="305.561968" transform="rotate(-0 454.862918 305.561968)">8%</text>
    </g>
    <g id="text_20">
-    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="475.847146" y="277.342609" transform="rotate(-0 475.847146 277.342609)">20%</text>
+    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="476.894704" y="277.342609" transform="rotate(-0 476.894704 277.342609)">20%</text>
    </g>
    <g id="text_21">
-    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="523.269778" y="249.12325" transform="rotate(-0 523.269778 249.12325)">46%</text>
+    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="524.95305" y="249.12325" transform="rotate(-0 524.95305 249.12325)">47%</text>
    </g>
    <g id="text_22">
-    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="529.25349" y="220.903891" transform="rotate(-0 529.25349 220.903891)">49%</text>
+    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="526.486398" y="220.903891" transform="rotate(-0 526.486398 220.903891)">48%</text>
    </g>
    <g id="text_23">
-    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="556.799196" y="192.684531" transform="rotate(-0 556.799196 192.684531)">64%</text>
+    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="558.848105" y="192.684531" transform="rotate(-0 558.848105 192.684531)">65%</text>
    </g>
    <g id="text_24">
-    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="602.399203" y="164.465172" transform="rotate(-0 602.399203 164.465172)">89%</text>
+    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="599.441469" y="164.465172" transform="rotate(-0 599.441469 164.465172)">88%</text>
    </g>
    <g id="text_25">
-    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="602.605538" y="136.245813" transform="rotate(-0 602.605538 136.245813)">90%</text>
+    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="599.764279" y="136.245813" transform="rotate(-0 599.764279 136.245813)">88%</text>
    </g>
    <g id="text_26">
-    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="604.668887" y="108.026454" transform="rotate(-0 604.668887 108.026454)">91%</text>
+    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="602.104652" y="108.026454" transform="rotate(-0 602.104652 108.026454)">89%</text>
    </g>
    <g id="text_27">
-    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="604.772054" y="79.807095" transform="rotate(-0 604.772054 79.807095)">91%</text>
+    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="602.34676" y="79.807095" transform="rotate(-0 602.34676 79.807095)">89%</text>
    </g>
    <g id="text_28">
     <text style="font-weight: 700; font-size: 13px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="529.331484" y="40.094209" transform="rotate(-0 529.331484 40.094209)">Most common findings across the corpus</text>
@@ -344,11 +344,11 @@ z
    </g>
   </g>
   <g id="text_34">
-   <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #999999" x="7.6032" y="11.91075" transform="rotate(-0 7.6032 11.91075)">compose-lint 0.16.0  ·  corpus 20260811T044906Z  ·  n=5,279 parsed</text>
+   <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #999999" x="7.6032" y="11.91075" transform="rotate(-0 7.6032 11.91075)">compose-lint 0.16.0  ·  corpus 20260811T044906Z  ·  n=4,499 parsed, prevalence tiers</text>
   </g>
  </g>
  <defs>
-  <clipPath id="p715f299a09">
+  <clipPath id="p2423bfd136">
    <rect x="438.561334" y="52.094209" width="181.540301" height="304.204692"/>
   </clipPath>
  </defs>

--- a/docs/state-of-compose.md
+++ b/docs/state-of-compose.md
@@ -4,17 +4,20 @@
 >
 > Pinned to **compose-lint 0.16.0** and corpus run **`20260811T044906Z`** (5,417 files, 2026-08-11).
 >
+> **Revised 2026-08-27 — same measurement, re-cut attribution.** The snapshot, the lint run, and the tool version are unchanged; what changed is how files are attributed to tiers. A composition analysis split the corpus into seven tiers: test *inputs* to compose tooling (`synthetic`, 476 files — docker/compose e2e fixtures and the like) and deliberately-vulnerable lab environments (`lab`, 310 files — vulhub, CTF archives) are now excluded from every prevalence claim, and template-collection repos (`collections`, 1,485 files) are split out of `popular`. Every figure below is a re-partition of the same underlying results — unlike a new edition, the pre- and post-revision figures are mappable 1:1. The headline moved from 91% to 89.9%; the largest correction is to the `popular` tier, which previously blended two populations with a 2× security gap.
+>
 > **This edition is a new baseline, not a refresh of the previous one.** The 6,444-file corpus the 0.7.0 edition was pinned to no longer exists, and it cannot be rebuilt: its `longtail` tier was a stratified GitHub code-search sweep, and GitHub does not reproduce that sweep. The rule set changed underneath it as well. Two variables moved at once, so **no delta across the two editions is measurable, and none is presented here** — figures from the 0.7.0 edition are not repeated as like-for-like comparisons, because they were not measured the same way. The snapshot behind this edition is archived rather than left in a cache directory, so the discontinuity does not happen twice, and refreshes measured against it can carry a delta callout.
 
 The first published empirical study of security misconfigurations in real-world Docker Compose files at corpus scale.
 
 ## TL;DR
 
-- **91% of public Docker Compose files** that successfully parse ship with at least one security finding (4,816 of 5,279 parsed files, from a 5,417-file corpus).
-- **Even canonical vendor examples are not clean.** The canonical tier — the awesome-compose / bitnami / grafana / vaultwarden examples people copy-paste — averages 9.95 findings per file, and 83.7% of those files carry at least one.
-- **The same four rules lead every tier:** filesystem not read-only, no capability restrictions, no resource limits, privilege escalation not blocked. Each fires on 89–91% of parsed files, and their order barely changes between vendor examples and the longtail.
-- **9.1% of longtail files fail to parse as a v2/v3 Compose file at all** — almost entirely shape errors (someone wrote `services` as a string-valued mapping instead of a service-mapping), not malformed YAML. We treat the parse-error population as a finding, not a discard.
-- **Every one of the 25 rules fires on real files.** None is dead, and there were zero crashes and zero timeouts across 5,279 linted files.
+- **90% of real-world public Docker Compose files** that successfully parse ship with at least one security finding (4,044 of 4,499 parsed files across the five prevalence tiers of a 5,417-file corpus; test fixtures and lab environments are counted separately).
+- **Popular projects' own compose files are the worst population in the corpus.** With template collections, test fixtures, and vuln-lab repos split out, the `popular` tier — ordinary ≥50★ projects' own service definitions — runs **99.6% with findings at 19.8 findings per file**, roughly twice any template tier, and 16.4% of them mount a host control socket.
+- **Even canonical vendor examples are not clean.** The canonical tier — the awesome-compose / bitnami / grafana / vaultwarden examples people copy-paste — averages 10.4 findings per file, and 77.7% of those files carry at least one.
+- **The same four rules lead every tier:** filesystem not read-only, no capability restrictions, no resource limits, privilege escalation not blocked. Each fires on 88–89% of parsed files, and their order barely changes between vendor examples and the longtail.
+- **9.5% of longtail files fail to parse as a v2/v3 Compose file at all** — almost entirely shape errors (someone wrote `services` as a string-valued mapping instead of a service-mapping), not malformed YAML. We treat the parse-error population as a finding, not a discard.
+- **Every one of the 25 rules fires on real files.** None is dead — even with the synthetic and lab tiers excluded, all 25 fire in the prevalence tiers — and there were zero crashes and zero timeouts across all 5,279 linted files.
 
 The framing is descriptive, not inferential. Read [§ What this study does NOT claim](#what-this-study-does-not-claim) before citing any number from this report.
 
@@ -24,14 +27,19 @@ The framing is descriptive, not inferential. Read [§ What this study does NOT c
 
 The corpus lives outside the repo at `~/.cache/compose-lint-corpus/`. Each unique compose file is stored by content hash; an index file maps content hash → source repo, path, blob SHA, and tier. The fetch + lint pipeline is in [`scripts/corpus/`](https://github.com/tmatens/compose-lint/tree/main/scripts/corpus). All numbers in this report come from corpus run `20260811T044906Z` (2026-08-11).
 
-The corpus is divided into four tiers, each with a distinct threat-model framing:
+The corpus is divided into seven tiers, each with a distinct framing. Five carry prevalence claims; two are excluded from them (marked ✗) — they are corpus members and useful lint fuel, but not real-world deployment intent. The attribution rules and the measurements behind the split live in [`scripts/corpus/README.md`](https://github.com/tmatens/compose-lint/blob/main/scripts/corpus/README.md#tiers) and `scripts/corpus/retier.py`.
 
-| Tier | Files | What it represents |
-| --- | ---: | --- |
-| `canonical` | 345 | Official upstream examples (awesome-compose, bitnami, docker/compose, grafana, vaultwarden, …). *Do the examples people copy-paste ship insecure defaults?* |
-| `popular` | 3,351 | High-star (≥50) GitHub repos with a Compose file pushed in the last two years. *What does production-adjacent code look like?* |
-| `selfhosted` | 596 | Curated app-store / template-registry repos (CasaOS-AppStore, runtipi-appstore, Compose-Examples, dockge, …). Distinct threat model from `popular`: home-LAN deployments, not cloud. |
-| `longtail` | 1,125 | Stratified GitHub-code-search sweep across anchor terms × filenames × size buckets — the low-visibility mass of ordinary repos (a homelab, a tutorial follow-along, a half-finished side project), as opposed to the curated, high-attention head the other three tiers represent. The name is the "long tail" of GitHub *by repo attention*, not a distribution tail in the statistical sense. *What does the median compose file in the wild look like?* |
+| Tier | Files | Prevalence | What it represents |
+| --- | ---: | :---: | --- |
+| `canonical` | 249 | ✓ | Official upstream examples (awesome-compose, bitnami, grafana, vaultwarden, …). *Do the examples people copy-paste ship insecure defaults?* |
+| `selfhosted` | 596 | ✓ | Curated app-store / template-registry repos (CasaOS-AppStore, runtipi-appstore, Compose-Examples, dockge, …). Distinct threat model: home-LAN deployments, not cloud. |
+| `collections` | 1,485 | ✓ | Template/recipe collection repos (≥20 corpus entries from one repo — vimagick/dockerfiles, laradock, ScaleTail, …): curated example libraries that happened to clear the popular tier's star bar. |
+| `popular` | 1,231 | ✓ | Ordinary high-star (≥50) projects' **own** compose files, pushed in the last two years. *What does production-adjacent code look like?* |
+| `longtail` | 1,070 | ✓ | Stratified GitHub-code-search sweep across anchor terms × filenames × size buckets — the low-visibility mass of ordinary repos (a homelab, a tutorial follow-along, a half-finished side project), as opposed to the curated, high-attention head. The name is the "long tail" of GitHub *by repo attention*, not a distribution tail in the statistical sense. *What does the median compose file in the wild look like?* |
+| `synthetic` | 476 | ✗ | Test *inputs* to compose tooling: files under test/fixture/e2e path segments anywhere, plus whole tool repos (docker/compose, podman-compose, kompose). Minimal snippets that omit every hardening key by construction (98.3% with findings). |
+| `lab` | 310 | ✗ | Deliberately-vulnerable environments: vulhub CVE reproductions, CTF challenge archives. Measured, they *dilute* rather than inflate (0.7% of files carry a CRITICAL; none mounts a control socket) — excluded on intent, not direction. |
+
+Examples, templates, and demos are deliberately **not** synthetic: copy-paste material is exactly the population the `canonical`, `selfhosted`, and `collections` tiers exist to measure. Only test inputs and lab targets are excluded.
 
 Tier sizes are a property of the sweep that built this snapshot, not a designed allocation, and they differ from the previous edition's. The `longtail` tier in particular is whatever the code-search sweep returned on the day it ran — which is exactly why it does not reproduce.
 
@@ -49,35 +57,35 @@ For ranking rules by overall impact within a tier we use a doubled weighting: **
 
 ## Findings overview
 
-Across the 5,279 successfully-parsed files:
+Across the 4,499 successfully-parsed files in the five prevalence tiers:
 
 | Metric | Value |
 | --- | ---: |
-| Files with ≥1 finding | 4,816 (91.2%) |
-| Files clean | 463 (8.8%) |
-| Total findings | 61,735 |
-| Findings per file (mean) | 11.7 |
+| Files with ≥1 finding | 4,044 (89.9%) |
+| Files clean | 455 (10.1%) |
+| Total findings | 53,723 |
+| Findings per file (mean) | 11.9 |
 | Findings per file (median) | 7 |
 | Findings per file (max) | 323 |
 
-Severity distribution across the 61,735 findings:
+Severity distribution across the 53,723 findings:
 
 | Severity | Count | Share |
 | --- | ---: | ---: |
-| CRITICAL | 780 | 1.3% |
-| HIGH | 3,465 | 5.6% |
-| MEDIUM | 47,062 | 76.2% |
-| LOW | 10,428 | 16.9% |
+| CRITICAL | 687 | 1.3% |
+| HIGH | 3,051 | 5.7% |
+| MEDIUM | 40,943 | 76.2% |
+| LOW | 9,042 | 16.8% |
 
-![Stacked bar of findings by severity across all 61,735 findings: MEDIUM 76.2% (47,062), LOW 16.9% (10,428), HIGH 5.6% (3,465), CRITICAL 1.3% (780).](assets/severity-distribution.svg)
+![Stacked bar of findings by severity across all 53,723 findings: MEDIUM 76.2% (40,943), LOW 16.8% (9,042), HIGH 5.7% (3,051), CRITICAL 1.3% (687).](assets/severity-distribution.svg)
 
-The MEDIUM-heavy distribution is a property of compose-lint's rule design, not of the corpus: the hardening misses that fire on nearly every file — capability restrictions, no-new-privileges, resource limits — sit at MEDIUM, so a near-universal rule contributes tens of thousands of findings to one tier. CRITICAL findings are rarer, because they require something acutely dangerous like a mounted control socket, but they are not marginal: **10.5% of parsed files (554 of 5,279) carry at least one CRITICAL finding**, and 7.6% carry a mounted host control socket specifically.
+The MEDIUM-heavy distribution is a property of compose-lint's rule design, not of the corpus: the hardening misses that fire on nearly every file — capability restrictions, no-new-privileges, resource limits — sit at MEDIUM, so a near-universal rule contributes tens of thousands of findings to one tier. CRITICAL findings are rarer, because they require something acutely dangerous like a mounted control socket, but they are not marginal: **11.0% of parsed files (497 of 4,499) carry at least one CRITICAL finding**, and 8.2% carry a mounted host control socket specifically.
 
-Broadening to HIGH-or-above, **32.4% of parsed files (1,710) carry at least one finding rated HIGH or CRITICAL.** Roughly a third of public Compose files contain something the model rates as an active dangerous grant rather than a missing flag.
+Broadening to HIGH-or-above, **34.2% of parsed files (1,540) carry at least one finding rated HIGH or CRITICAL.** Roughly a third of public Compose files contain something the model rates as an active dangerous grant rather than a missing flag.
 
 If you remember a much larger HIGH-or-above share from the previous edition, that is a rule-model difference, not a change in what people write — the derived model moved several near-universal rules off HIGH, most consequentially the published-port rule. It cannot be quantified as a delta, because the corpus changed at the same time.
 
-**LOW is one rule.** The 10,428 LOW findings (16.9%) look like a substantial tier and are almost entirely a single rule: [CL-0007](rules/CL-0007.md) (filesystem not read-only) accounts for 10,405 of them, or 99.8%. The remaining 23 come from [CL-0014](rules/CL-0014.md) (logging driver disabled, 15), [CL-0022](rules/CL-0022.md) (tmpfs re-enables exec/suid/dev, 5), and [CL-0017](rules/CL-0017.md) (shared mount propagation, 3) — rules that fire only when a file *explicitly* opts out of a default, a deliberate and uncommon act rather than an omission. Read the LOW tier as "almost every file omits `read_only: true`", not as a broad population of small problems.
+**LOW is one rule.** The 9,042 LOW findings (16.8%) look like a substantial tier and are almost entirely a single rule: [CL-0007](rules/CL-0007.md) (filesystem not read-only) accounts for 9,020 of them, or 99.8%. The remaining 22 come from [CL-0014](rules/CL-0014.md) (logging driver disabled, 14), [CL-0022](rules/CL-0022.md) (tmpfs re-enables exec/suid/dev, 5), and [CL-0017](rules/CL-0017.md) (shared mount propagation, 3) — rules that fire only when a file *explicitly* opts out of a default, a deliberate and uncommon act rather than an omission. Read the LOW tier as "almost every file omits `read_only: true`", not as a broad population of small problems.
 
 ## Per-tier breakdown
 
@@ -87,46 +95,51 @@ Tier-level rates differ enough that aggregate "X% of compose files have finding 
 
 | Tier | Total | Parsed | With findings | Clean | Rate (of parsed) | Findings per parsed file |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| `canonical` | 345 | 343 | 287 | 56 | 83.7% | 9.95 |
-| `popular` | 3,351 | 3,317 | 3,150 | 167 | 95.0% | 13.29 |
+| `canonical` | 249 | 247 | 192 | 55 | 77.7% | 10.43 |
 | `selfhosted` | 596 | 596 | 596 | 0 | **100.0%** | 9.32 |
-| `longtail` | 1,125 | 1,023 | 783 | 240 | 76.5% | 8.50 |
+| `collections` | 1,485 | 1,472 | 1,312 | 160 | 89.1% | 8.85 |
+| `popular` | 1,231 | 1,216 | 1,211 | 5 | **99.6%** | **19.83** |
+| `longtail` | 1,070 | 968 | 733 | 235 | 75.7% | 8.72 |
 
-![Bar chart of the share of parsed files with at least one finding, by tier: canonical 83.7%, popular 95.0%, selfhosted 100.0%, longtail 76.5%.](assets/findings-by-tier.svg)
+![Bar chart of the share of parsed files with at least one finding, by tier: canonical 77.7%, selfhosted 100.0%, collections 89.1%, popular 99.6%, longtail 75.7%.](assets/findings-by-tier.svg)
+
+The excluded tiers, for transparency: `synthetic` 470 parsed, 98.3% with findings, 11.20 per file (minimal fixtures omit every hardening key by construction — including them would inflate every rate above); `lab` 310 parsed, 100% with findings, 8.87 per file.
 
 Notable observations:
 
-- **Every `selfhosted` file has at least one finding.** The app-store templates ship with optimistic defaults — they target a home-LAN audience and frequently expose ports on `0.0.0.0`, run as root, mount large host paths, and skip the hardening flags. The fact that 100% of these files trigger compose-lint is the central finding of this tier.
-- **Popular repos are not noticeably better than the longtail.** With ≥50 stars and recent activity as the inclusion criteria, the `popular` tier averages *more* findings per file than the longtail — 13.29 against 8.50. Higher visibility doesn't translate to hardening discipline.
-- **Canonical is the cleanest tier and still 84% with findings.** The vendor examples that READMEs tell users to copy-paste are not hardening exemplars — they're configuration demos. That's the gap this report is documenting.
+- **Ordinary projects' own compose files are the worst population in the corpus — by a factor of two.** Only 5 of 1,216 parsed `popular` files are clean, and the tier averages 19.83 findings per file against 8.5–10.4 for every template tier. The pre-revision blend (95.0% at 13.29) understated this: three fifths of the old tier was template collections at 8.85 findings per file, and averaging the two populations described neither. When someone writes a compose file *for their own service* rather than as an example for others, hardening is essentially absent.
+- **Every `selfhosted` file has at least one finding.** The app-store templates ship with optimistic defaults — they target a home-LAN audience and frequently expose ports on `0.0.0.0`, run as root, mount large host paths, and skip the hardening flags. The fact that 100% of these files trigger compose-lint remains the central finding of this tier.
+- **Canonical is the cleanest curated tier and still 78% with findings.** The vendor examples that READMEs tell users to copy-paste are not hardening exemplars — they're configuration demos. That's the gap this report is documenting. (The pre-revision 83.7% was partly an artifact: 27% of the old tier was docker/compose's e2e fixtures, now attributed to `synthetic`.)
+- **Collections sit between the curated head and the longtail** — 89.1% at 8.85 findings per file: better-groomed than random files, no more hardened than app-store templates.
 
 ### Severity distribution per tier
 
 | Tier | CRITICAL | HIGH | MEDIUM | LOW |
 | --- | ---: | ---: | ---: | ---: |
-| `canonical` | 23 | 212 | 2,591 | 587 |
-| `popular` | 624 | 2,499 | 33,550 | 7,396 |
+| `canonical` | 23 | 212 | 1,925 | 417 |
 | `selfhosted` | 67 | 318 | 4,287 | 885 |
-| `longtail` | 66 | 436 | 6,634 | 1,560 |
+| `collections` | 192 | 794 | 9,887 | 2,158 |
+| `popular` | 339 | 1,295 | 18,410 | 4,075 |
+| `longtail` | 66 | 432 | 6,434 | 1,507 |
 
-CRITICAL findings are concentrated in `popular` (624 of 780, 80% of all CRITICAL findings in the corpus) — though `popular` is also the largest tier, so the concentration partly tracks tier size. Normalising to the share of each tier's parsed files carrying a mounted host control socket ([CL-0001](rules/CL-0001.md), the dominant CRITICAL rule) separates the two: `popular` 9.9%, `selfhosted` 5.2%, `canonical` 4.4%, `longtail` 2.3%. The production-adjacent tier really does mount the control socket most often, roughly four times as often as the longtail.
+CRITICAL findings concentrate in `popular` (339 of 687, 49% of all CRITICAL findings in the prevalence tiers, from 27% of the parsed files). Normalising to the share of each tier's parsed files carrying a mounted host control socket ([CL-0001](rules/CL-0001.md), the dominant CRITICAL rule) makes the gap starker: `popular` **16.4%**, `collections` 6.7%, `canonical` 6.1%, `selfhosted` 5.2%, `longtail` 2.5%. Ordinary projects mount the control socket six and a half times as often as the longtail and two and a half times as often as any template tier — the pre-revision blend reported 9.9% for this population.
 
 ## Top findings
 
 Ten rules account for 98% of all findings. They cluster into three groups: hardening defaults that nobody flips, supply-chain shortcuts, and acute privilege grants.
 
-![Horizontal bar chart of the ten most common rules by share of parsed files affected, coloured by severity: CL-0007 read_only 91% (LOW), CL-0006 cap_drop ALL 91% (MEDIUM), CL-0026 No resource limits 90% (MEDIUM), CL-0003 no-new-privileges 89% (MEDIUM), CL-0005 Ports published on 0.0.0.0 64% (MEDIUM), CL-0019 Image tags without digest pins 49% (MEDIUM), CL-0004 Unpinned image tags 46% (MEDIUM), CL-0020 Credential-shaped environment keys 20% (HIGH), CL-0001 Host control socket exposed 8% (CRITICAL), CL-0011 Strong host-adjacent capabilities 4% (HIGH).](assets/top-findings.svg)
+![Horizontal bar chart of the ten most common rules by share of parsed files affected, coloured by severity: CL-0007 read_only 89% (LOW), CL-0006 cap_drop ALL 89% (MEDIUM), CL-0026 No resource limits 88% (MEDIUM), CL-0003 no-new-privileges 88% (MEDIUM), CL-0005 Ports published on 0.0.0.0 66% (MEDIUM), CL-0019 Image tags without digest pins 48% (MEDIUM), CL-0004 Unpinned image tags 47% (MEDIUM), CL-0020 Credential-shaped environment keys 20% (HIGH), CL-0001 Host control socket exposed 8% (CRITICAL), CL-0011 Strong host-adjacent capabilities 4% (HIGH).](assets/top-findings.svg)
 
 ### Hardening defaults (the bulk of the findings)
 
-These four rules fire on roughly 90% of every parsed file in the corpus:
+These four rules fire on roughly 90% of every parsed file in the prevalence tiers:
 
 | Rule | Severity | Files affected | Share of parsed |
 | --- | --- | ---: | ---: |
-| [CL-0007](rules/CL-0007.md) Filesystem not read-only | LOW | 4,791 | 90.8% |
-| [CL-0006](rules/CL-0006.md) No capability restrictions | MEDIUM | 4,788 | 90.7% |
-| [CL-0026](rules/CL-0026.md) No resource limits | MEDIUM | 4,728 | 89.6% |
-| [CL-0003](rules/CL-0003.md) Privilege escalation not blocked | MEDIUM | 4,722 | 89.4% |
+| [CL-0007](rules/CL-0007.md) Filesystem not read-only | LOW | 4,023 | 89.4% |
+| [CL-0006](rules/CL-0006.md) No capability restrictions | MEDIUM | 4,017 | 89.3% |
+| [CL-0026](rules/CL-0026.md) No resource limits | MEDIUM | 3,959 | 88.0% |
+| [CL-0003](rules/CL-0003.md) Privilege escalation not blocked | MEDIUM | 3,951 | 87.8% |
 
 Each is a *missing hardening flag* rather than an active misuse — the file isn't doing something dangerous, it's failing to opt into a defense-in-depth control, which is why the derived model rates them MEDIUM or LOW rather than HIGH. The fact that each fires on ~90% of files is the central observation of the report: the Compose hardening set (`read_only: true`, `cap_drop: [ALL]`, `security_opt: [no-new-privileges:true]`, and a `deploy.resources.limits` block) is essentially never set.
 
@@ -136,59 +149,60 @@ The four move together. They are not four independent habits but one: a service 
 
 | Rule | Severity | Files affected | Share of parsed |
 | --- | --- | ---: | ---: |
-| [CL-0005](rules/CL-0005.md) Ports bound to all interfaces | MEDIUM | 3,396 | 64.3% |
-| [CL-0019](rules/CL-0019.md) Image tag without digest | MEDIUM | 2,595 | 49.2% |
-| [CL-0004](rules/CL-0004.md) Image not pinned to version | MEDIUM | 2,421 | 45.9% |
+| [CL-0005](rules/CL-0005.md) Ports bound to all interfaces | MEDIUM | 2,945 | 65.5% |
+| [CL-0019](rules/CL-0019.md) Image tag without digest | MEDIUM | 2,143 | 47.6% |
+| [CL-0004](rules/CL-0004.md) Image not pinned to version | MEDIUM | 2,105 | 46.8% |
 
-Nearly two thirds of all parsed files publish at least one port to `0.0.0.0`. The image-pinning pair (CL-0019 + CL-0004) shows that ~49% of files don't pin a digest and ~46% don't even pin a tag — `latest` is still the de facto default in published examples.
+Nearly two thirds of all parsed files publish at least one port to `0.0.0.0`. The image-pinning pair (CL-0019 + CL-0004) shows that ~48% of files don't pin a digest and ~47% don't even pin a tag — `latest` is still the de facto default in published examples.
 
 ### Acute privilege grants
 
 | Rule | Severity | Files affected | Share of parsed |
 | --- | --- | ---: | ---: |
-| [CL-0020](rules/CL-0020.md) Credential-shaped env key with literal value | HIGH | 1,042 | 19.7% |
-| [CL-0001](rules/CL-0001.md) Host control socket exposed | CRITICAL | 399 | 7.6% |
-| [CL-0011](rules/CL-0011.md) Strong host-adjacent capability added | HIGH | 194 | 3.7% |
-| [CL-0021](rules/CL-0021.md) Credential embedded in connection-string env value | HIGH | 152 | 2.9% |
-| [CL-0008](rules/CL-0008.md) Host network mode | HIGH | 137 | 2.6% |
-| [CL-0013](rules/CL-0013.md) Sensitive host path exposed | HIGH | 126 | 2.4% |
-| [CL-0002](rules/CL-0002.md) Privileged mode enabled | CRITICAL | 121 | 2.3% |
-| [CL-0024](rules/CL-0024.md) Host-code-execution capability added | CRITICAL | 66 | 1.3% |
-| [CL-0025](rules/CL-0025.md) Root-equivalent host path mounted writable | CRITICAL | 30 | 0.6% |
+| [CL-0020](rules/CL-0020.md) Credential-shaped env key with literal value | HIGH | 914 | 20.3% |
+| [CL-0001](rules/CL-0001.md) Host control socket exposed | CRITICAL | 368 | 8.2% |
+| [CL-0011](rules/CL-0011.md) Strong host-adjacent capability added | HIGH | 192 | 4.3% |
+| [CL-0021](rules/CL-0021.md) Credential embedded in connection-string env value | HIGH | 144 | 3.2% |
+| [CL-0008](rules/CL-0008.md) Host network mode | HIGH | 131 | 2.9% |
+| [CL-0013](rules/CL-0013.md) Sensitive host path exposed | HIGH | 108 | 2.4% |
+| [CL-0002](rules/CL-0002.md) Privileged mode enabled | CRITICAL | 108 | 2.4% |
+| [CL-0024](rules/CL-0024.md) Host-code-execution capability added | CRITICAL | 49 | 1.1% |
+| [CL-0025](rules/CL-0025.md) Root-equivalent host path mounted writable | CRITICAL | 30 | 0.7% |
 
 These are the rules where a finding indicates an *active* dangerous configuration, not a missing flag. Two observations:
 
-- **Plaintext credentials are the most common acute finding by a wide margin.** CL-0020 fires on 19.7% of parsed files — roughly one in five commits a literal value to an environment variable that looks like a credential (e.g. `DB_PASSWORD: hunter2`). Adding CL-0021's connection-string variant, better than one in five public Compose files carries a credential in cleartext.
-- **The container-escape rules are rare but not negligible.** A mounted host control socket (CL-0001, 7.6%) and `privileged: true` (CL-0002, 2.3%) each grant root-equivalent host access. Together with the capability and host-path rules, they are what lifts the CRITICAL-carrying share to 10.5% of parsed files.
+- **Plaintext credentials are the most common acute finding by a wide margin.** CL-0020 fires on 20.3% of parsed files — roughly one in five commits a literal value to an environment variable that looks like a credential (e.g. `DB_PASSWORD: hunter2`). Adding CL-0021's connection-string variant, better than one in five public Compose files carries a credential in cleartext.
+- **The container-escape rules are rare but not negligible.** A mounted host control socket (CL-0001, 8.2%) and `privileged: true` (CL-0002, 2.4%) each grant root-equivalent host access. Together with the capability and host-path rules, they are what lifts the CRITICAL-carrying share to 11.0% of parsed files.
 
-The remaining rules each fire on under 1.5% of files: [CL-0018](rules/CL-0018.md) explicit root user (1.3%), [CL-0009](rules/CL-0009.md) security profile disabled (1.1%), [CL-0010](rules/CL-0010.md) host namespace sharing (0.5%), [CL-0027](rules/CL-0027.md) bounded-grant capability (0.2%), [CL-0014](rules/CL-0014.md) logging driver disabled (0.2%), [CL-0016](rules/CL-0016.md) dangerous host device (0.1%), [CL-0022](rules/CL-0022.md) tmpfs re-enables exec/suid/dev (0.1%), [CL-0017](rules/CL-0017.md) shared mount propagation (0.1%), and [CL-0028](rules/CL-0028.md) host-reaching capability (one file). A rule at this rate is not dead — it is specific, and the corpus is large enough to find its handful of real instances.
+The remaining rules each fire on at most 1.5% of files: [CL-0018](rules/CL-0018.md) explicit root user (1.5%), [CL-0009](rules/CL-0009.md) security profile disabled (0.9%), [CL-0010](rules/CL-0010.md) host namespace sharing (0.5%), [CL-0027](rules/CL-0027.md) bounded-grant capability (0.3%), [CL-0014](rules/CL-0014.md) logging driver disabled (0.2%), [CL-0016](rules/CL-0016.md) dangerous host device (0.1%), [CL-0022](rules/CL-0022.md) tmpfs re-enables exec/suid/dev (0.1%), [CL-0017](rules/CL-0017.md) shared mount propagation (0.1%), and [CL-0028](rules/CL-0028.md) host-reaching capability (one file). A rule at this rate is not dead — it is specific, and the corpus is large enough to find its handful of real instances.
 
 ## Parse errors as a finding
 
-138 of 5,417 files (2.5%) did not lint as a v2 or v3 Compose file. The dominant class is shape errors — files that don't match the Compose schema's expected structure — not malformed YAML.
+132 of the 4,631 prevalence-tier files (2.9%) did not lint as a v2 or v3 Compose file (the excluded tiers add 6 more, all in `synthetic`). The dominant class is shape errors — files that don't match the Compose schema's expected structure — not malformed YAML.
 
 | Class | Count | Description |
 | --- | ---: | --- |
 | `services-not-mapping` | 55 | The top-level `services` key is something other than a mapping (commonly a list or a scalar) |
 | `service-not-mapping` | 32 | A specific service is a scalar instead of a mapping (e.g., `db: "postgres:14"`) |
-| `invalid-yaml` | 24 | YAML scanner / parser error |
+| `invalid-yaml` | 23 | YAML scanner / parser error |
 | `empty-file` | 8 | File parsed to nothing |
-| `top-level-not-mapping` | 7 | Root document is a list or scalar |
-| `other` | 7 | Not a parse failure — all seven are files using `include:`, which compose-lint declines to lint because it does not resolve included files (see below) |
+| `other` | 5 | Not a parse failure — all five are files using `include:`, which compose-lint declines to lint because it does not resolve included files (see below) |
 | `missing-services-key` | 5 | No `services:` at the top level (likely an `extends:`-only fragment or an old v1 file) |
+| `top-level-not-mapping` | 4 | Root document is a list or scalar |
 
-**Seven of the 138 are not errors.** They are `include:` files, which compose-lint deliberately refuses rather than lints: the services live in other files it does not resolve, so linting what is written would report a misleading clean result. They land in the same exit-2 population as genuine parse failures and are counted here for completeness; the real parse-failure count is 131 (2.4%).
+**Five of the 132 are not errors.** They are `include:` files, which compose-lint deliberately refuses rather than lints: the services live in other files it does not resolve, so linting what is written would report a misleading clean result. They land in the same exit-2 population as genuine parse failures and are counted here for completeness; the real parse-failure count is 127 (2.7%).
 
 The per-tier rate is the load-bearing number:
 
 | Tier | Parse-error rate | Dominant class |
 | --- | ---: | --- |
-| `canonical` | 0.6% | invalid-yaml |
-| `popular` | 1.0% | invalid-yaml |
+| `canonical` | 0.8% | invalid-yaml |
 | `selfhosted` | 0.0% | — |
-| `longtail` | **9.1%** | shape errors (53% + 30%) |
+| `collections` | 0.9% | invalid-yaml |
+| `popular` | 1.2% | invalid-yaml |
+| `longtail` | **9.5%** | shape errors (53% + 30%) |
 
-![Bar chart of parse-error rate by tier: canonical 0.6%, popular 1.0%, selfhosted 0.0%, longtail 9.1%.](assets/parse-error-rate.svg)
+![Bar chart of parse-error rate by tier: canonical 0.8%, selfhosted 0.0%, collections 0.9%, popular 1.2%, longtail 9.5%.](assets/parse-error-rate.svg)
 
 Longtail's parse-error tail isn't malformed YAML. It's people writing `services` as a string-valued mapping, the way a `package.json` `dependencies` block works. A reader skimming a Compose tutorial sees `nginx: image: nginx:1.25` and writes `nginx: nginx:1.25` instead. The parse error here is itself a security-relevant finding: a Compose file that doesn't parse with a real Compose engine isn't deployed by that engine, so these files are documentation, copy-paste fragments, or first-attempts — none of which are getting linted before they ship.
 
@@ -214,7 +228,8 @@ Read this section before citing any number from the report. The corpus is a desc
 
 - **GitHub-only.** No GitLab, Codeberg, Gitea, Bitbucket, Docker Hub README snippets, package-manager fragments, blog-post YAML blocks, or Stack Overflow answers. The longtail tier is a stratified sweep of GitHub's code search; see [`scripts/corpus/README.md`](https://github.com/tmatens/compose-lint/blob/main/scripts/corpus/README.md#longtail-sampling-methodology) for the exact query design and the four biases it inherits.
 - **Filename-pinned.** Files saved under non-standard names (`stack.yml`, `web.compose.yml`, etc.) are missed. The four canonical filenames cover the documented Compose Specification names but not every project's conventions.
-- **No statistical inference.** This is descriptive sampling for prevalence estimation. There are no hypothesis tests, no confidence intervals, no population estimates, and no claims about the "average" Compose file outside the four named tiers (`canonical`, `popular`, `selfhosted`, `longtail`). Tier counts are reported as observed; treat them as descriptive of the corpus, not extrapolated to all of GitHub.
+- **No statistical inference.** This is descriptive sampling for prevalence estimation. There are no hypothesis tests, no confidence intervals, no population estimates, and no claims about the "average" Compose file outside the five prevalence tiers (`canonical`, `selfhosted`, `collections`, `popular`, `longtail`). Tier counts are reported as observed; treat them as descriptive of the corpus, not extrapolated to all of GitHub.
+- **Exclusions are intent judgments.** The `synthetic` and `lab` tiers are excluded from prevalence claims by attribution rules (path segments, curated repo lists, a file-count threshold — see `scripts/corpus/retier.py`). The rules are deterministic and published, but the line they draw — "test input" vs "example", "lab" vs "demo" — is a judgment. Both excluded tiers' numbers are reported alongside the others so a reader who draws the line elsewhere can re-blend.
 - **Snapshot in time.** Each report version pins to a single corpus run and a single compose-lint version. The published numbers do not move when a new rule lands; a refresh ships a new version with its own run.
 - **Editions are not a time series.** This edition is a new baseline: the corpus behind the previous one is gone and unrebuildable, and the rule set changed at the same time, so the two cannot be differenced. Do not read successive editions of this report as a trend unless the edition explicitly states that it was measured against the same archived snapshot as its predecessor.
 
@@ -240,14 +255,20 @@ python -m venv .venv && .venv/bin/pip install -e .
 mkdir -p ~/.cache/compose-lint-corpus
 tar -xzf compose-lint-corpus-5417-20260811.tar.gz -C ~/.cache/compose-lint-corpus
 
+# The 2026-08-27 revision's tier attribution and prevalence exclusion
+# live in scripts/corpus/ on current main — the v0.16.0 checkout has the
+# old four-tier pipeline, and the archived snapshot's index predates the
+# re-cut. Lint with the pinned v0.16.0 binary, but run the corpus
+# scripts (retier.py, run.py, charts.py) from a main worktree:
+git worktree add ../cl-main main
+python ../cl-main/scripts/corpus/retier.py
+
 # Lint the corpus and write summary.md + tier_summary.md.
-# COMPOSE_LINT_BIN defaults to <repo>/.venv/bin/compose-lint; set it
-# explicitly if your interpreter lives anywhere else.
-COMPOSE_LINT_BIN=$PWD/.venv/bin/compose-lint python scripts/corpus/run.py
+COMPOSE_LINT_BIN=$PWD/.venv/bin/compose-lint python ../cl-main/scripts/corpus/run.py
 
 # Re-render the charts in this report (matplotlib is a maintainer-only extra)
 pip install -e '.[corpus]'
-python scripts/corpus/charts.py latest
+python ../cl-main/scripts/corpus/charts.py latest
 ```
 
 The snapshot archive is not committed to the repo — it is 5,417 third-party files, the same reason the corpus itself isn't committed. It is held by the maintainers and identified by the sha256 above; open an issue on the tracker if you want a copy to verify a number in this report against.
@@ -256,4 +277,4 @@ To build a *new* corpus from public GitHub instead — a different sample, not t
 
 The output lands in `~/.cache/compose-lint-corpus/runs/<UTC-timestamp>/`. The `summary.md` and `tier_summary.md` files there are the source artifacts every table in this report is built from; `charts.py` reads the same per-tier aggregation, so the figures in `docs/assets/` can never disagree with the tables. A run that reports thousands of *crashes* is almost always a `COMPOSE_LINT_BIN` that does not exist — the harness buckets a missing binary as a per-file crash rather than a startup failure. Check the first few results before letting a full run proceed.
 
-**Why re-fetching does not reproduce this corpus.** Three of the four tiers are enumerable from fixed sources and re-fetch closely. The `longtail` tier is not: it is a stratified GitHub code-search sweep, and GitHub's code search neither offers a random-document primitive nor returns a stable result set for the same queries over time. A re-fetch produces *a* longtail tier, not *this* one. That is why the 6,444-file corpus behind the 0.7.0 edition could not be rebuilt once its cache was lost, and why this edition's 5,417-file snapshot is archived as a file rather than trusted to a cache directory. Refreshes measured against the archived snapshot isolate rule-set changes from corpus drift and can legitimately carry a delta; a refresh against a fresh sweep cannot.
+**Why re-fetching does not reproduce this corpus.** The curated tiers are enumerable from fixed sources and re-fetch closely, and the tiers derived by re-attribution (`collections`, `synthetic`, `lab`) are deterministic given an index. The `longtail` tier is neither: it is a stratified GitHub code-search sweep, and GitHub's code search neither offers a random-document primitive nor returns a stable result set for the same queries over time. A re-fetch produces *a* longtail tier, not *this* one. That is why the 6,444-file corpus behind the 0.7.0 edition could not be rebuilt once its cache was lost, and why this edition's 5,417-file snapshot is archived as a file rather than trusted to a cache directory. Refreshes measured against the archived snapshot isolate rule-set changes from corpus drift and can legitimately carry a delta; a refresh against a fresh sweep cannot.

--- a/scripts/corpus/charts.py
+++ b/scripts/corpus/charts.py
@@ -46,16 +46,24 @@ from matplotlib.patches import Patch  # noqa: E402
 
 sys.path.insert(0, str(Path(__file__).parent))
 from make_tier_summary import resolve_run  # noqa: E402
-from run import aggregate_tiers, get_cl_version, load_index  # noqa: E402
+from run import (  # noqa: E402
+    EXCLUDED_FROM_PREVALENCE,
+    aggregate_tiers,
+    get_cl_version,
+    load_index,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 RULES_DIR = REPO_ROOT / "docs" / "rules"
 ASSETS = REPO_ROOT / "docs" / "assets"            # SVGs embedded in the report
 PNG_ASSETS = REPO_ROOT / "docs" / "publishing" / "assets"  # PNGs for blog upload
 
-# Tier order is the report's order (cleanest -> noisiest framing), not
-# alphabetical, so charts read the same way the prose does.
-TIER_ORDER = ("canonical", "popular", "selfhosted", "longtail")
+# Tier order is the report's order (curated head -> longtail), not
+# alphabetical, so charts read the same way the prose does. Excluded
+# (non-prevalence) tiers never reach the chart functions: main() filters
+# `by_tier` through run.EXCLUDED_FROM_PREVALENCE once, so every
+# aggregation and provenance line below is prevalence-bearing only.
+TIER_ORDER = ("canonical", "selfhosted", "collections", "popular", "longtail")
 SEVERITY_ORDER = ("critical", "high", "medium", "low")
 
 # Severity palette: a warm red->amber ramp plus neutral grey for LOW. Chosen
@@ -121,7 +129,8 @@ def _run_version(run_dir: Path) -> str:
 
 def _provenance(by_tier: dict[str, dict], run_dir: Path) -> str:
     parsed = sum(b["parsed"] for b in by_tier.values())
-    return f"compose-lint {_run_version(run_dir)}  ·  corpus {run_dir.name}  ·  n={parsed:,} parsed"
+    return (f"compose-lint {_run_version(run_dir)}  ·  corpus {run_dir.name}"
+            f"  ·  n={parsed:,} parsed, prevalence tiers")
 
 
 def _caption(fig: plt.Figure, text: str) -> None:
@@ -151,7 +160,7 @@ def chart_findings_by_tier(by_tier: dict[str, dict], run_dir: Path) -> tuple[plt
 
     ax.set_ylim(0, 108)
     ax.set_ylabel("Files with ≥1 finding (% of parsed)")
-    ax.set_title("Every tier ships findings — even the cleanest is 83%")
+    ax.set_title(f"Every tier ships findings — even the cleanest is {min(pct):.0f}%")
     ax.set_axisbelow(True)
     ax.yaxis.grid(True, color=GRID)
     ax.tick_params(length=0)
@@ -325,6 +334,9 @@ def main(argv: list[str]) -> int:
     _style()
     results = [json.loads(line) for line in results_path.open()]
     by_tier, rule_severity = aggregate_tiers(results, load_index())
+    # Prevalence claims only: synthetic test inputs and lab environments
+    # are corpus members but not real-world deployment intent (retier.py).
+    by_tier = {t: b for t, b in by_tier.items() if t not in EXCLUDED_FROM_PREVALENCE}
 
     if cover:
         # Blog cover banner only -> PNG in docs/publishing/assets/.


### PR DESCRIPTION
Same snapshot, same run (20260811T044906Z), same tool (0.16.0) — only
tier attribution changed (#757), so unlike an edition change every
figure maps 1:1 onto its predecessor. A revision note at the top says
exactly that.

The prevalence headline moves 91% -> 89.9% (4,044 of 4,499 parsed
files across the five prevalence tiers; synthetic test inputs and lab
environments now reported separately, and shown alongside so a reader
who draws the intent line elsewhere can re-blend). The load-bearing
correction is the popular tier: ordinary projects' own compose files
run 99.6% with findings at 19.83 per file and mount a host control
socket in 16.4% of files — the old blend reported 95.0% / 13.29 / 9.9%
for a population that was three-fifths template collections. Canonical
drops 83.7% -> 77.7% with docker/compose's e2e fixtures out of it;
both pre-revision figures stay in the prose, labeled as artifacts.

charts.py now filters through run.EXCLUDED_FROM_PREVALENCE once in
main() — every chart and provenance caption is prevalence-bearing only
— and the four report SVGs are re-rendered (five tiers, n=4,499). The
hardcoded 'cleanest is 83%' title derives from the data now.

README's two quoted claims move with the report (90% real-world, 48%
digest, 66% ports, plus the popular-tier stat). docs/publishing/ is
deliberately untouched: the teaser and its PNGs are frozen at the
2026-05-22 dev.to publication (still the 0.7.0 edition), and its
images are hot-linked by the live post — regenerating them would
change the published post's charts under its prose. Refreshing that is
a re-publication decision, not a side effect.

The reproducibility recipe gains the retier step, run from a main
worktree, since the archived snapshot's index and the v0.16.0 tag both
predate the taxonomy.

Signed-off-by: Todd <tmatens@gmail.com>
