### PR TITLE
Document the CLI behaviours an agent gets wrong, and point agentic setups at the existing gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,24 @@ documents the attack this blocks):
         args: [--fail-on, low, --]
 ```
 
+## Agent-written Compose
+
+If a coding agent writes or edits Compose files in your repo, the two gates
+above already cover it and the agent needs to know nothing: the pre-commit hook
+catches it before the commit, the Action before the merge. Agent-authored
+Compose then gets graded on exactly the same terms as anyone else's, which is
+the cheapest way to make this reliable.
+
+If you are instead driving compose-lint *from* an agent or a script, parse
+`--format json` — a versioned envelope, unlike the text output — and read
+[Automation and agent
+use](https://tmatens.github.io/compose-lint/cli/#automation-and-agent-use).
+It covers the behaviours an agent tends to get wrong: exit 2 means a coverage
+gap or a broken run rather than a lint failure, `fix` is a dry run by default
+and its refusals are deliberate, suppressions live in `.compose-lint.yml` with
+a reason and there is no inline comment syntax, and `--explain CL-XXXX` reads
+the rule docs offline so nothing has to be fetched or guessed.
+
 ## Security posture
 
 compose-lint is built to be safe to depend on:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -75,3 +75,73 @@ the run. compose-lint cannot insert the separator itself: flags after a
 positional (`compose-lint init docker-compose.yml -o ci.yml`) are documented
 and must keep working, so placing `--` is the caller's job. If you set
 `args:` in your pre-commit config, keep `--` last.
+
+## Automation and agent use
+
+Everything below is also true of a shell script; it is written out because a
+coding agent driving compose-lint tends to pattern-match on "linter" and get
+these five wrong. Nothing here enumerates rules — `--explain CL-XXXX` is the
+single source for what a rule means and how to fix it, it reads the rule docs
+shipped inside the wheel, and it needs no network.
+
+**Exit 2 is not "the lint failed".** Exit 1 means findings at or above the
+threshold — that is the failure to act on. Exit 2 means compose-lint could not
+run, *or* could not see the whole stack: an unresolved `include:` or cross-file
+`extends:` means part of the stack was never graded, so the run cannot honestly
+report a verdict. Treating exit 2 as a findings failure invents remediation work
+that does not exist. Either resolve the coverage gap or downgrade it
+deliberately with `--allow-partial-coverage`, which demotes it to a stderr
+warning. `fix` reports gaps and never fails on them; it is not the gate.
+
+**`fix` is a dry run by default, and its refusals are the safety property.**
+A bare `compose-lint fix` prints a diff and writes nothing; `--apply` writes
+in place through an atomic swap, guarded by a re-parse and a verify-apply pass.
+It deliberately refuses regions it cannot rewrite safely — anchors, merge keys,
+`${VAR}` interpolation — and reports findings whose remediation is
+context-dependent (CL-0006 capability lists, CL-0001 socket mounts) as needing
+manual review rather than guessing at a value only the operator can choose.
+That is the contract, not an unfinished fixer: see [the fix design
+contract](fix.md). When `fix` declines a finding, hand-editing the same change
+into place discards the guard that made the decline correct.
+
+Two consequences for an agent reporting on a `fix` run. An edit that alters
+runtime behavior carries a `⚠ behavior-changing` line naming what breaks —
+surface it, because the label *is* the mitigation; nothing else withholds the
+risky fix. And the diff goes to stdout while status goes to stderr, so
+`compose-lint fix file.yml > changes.diff` captures exactly the patch and
+nothing else.
+
+**Suppression has one shape.** Findings are suppressed in `.compose-lint.yml`
+with a `reason`, which flows through to `suppression_reason` in JSON,
+`justification` in SARIF, and after `SUPPRESSED` in text — the suppressed
+finding is still reported, so a suppression stays visible rather than
+disappearing. There are no inline suppression comments, and no comment syntax
+to guess at. `compose-lint init` generates a baseline config from a file's
+current findings, as per-service `exclude_services` entries with placeholder
+reasons to replace. Deleting the offending service to clear a finding is not a
+fix; neither is a global `enabled: false` where the finding is about one
+service.
+
+**Severity is derived, not chosen.** Each rule's severity is what the two-axis
+matrix in [severity.md](severity.md) produces for its cell, under a stated
+attacker baseline and Docker posture. Report the severity the tool emits and
+quote `--explain` for the reasoning; re-ranking a finding because it feels more
+or less urgent in context is exactly the failure mode the model exists to
+prevent. If it genuinely reads wrong, that is an issue worth filing, not a
+number worth adjusting in a report.
+
+**Parse `--format json`, never the text output.** JSON is a versioned envelope
+([ADR-015](adr/015-machine-readable-output-contract.md)): a top-level
+`version`, a `tool` block, `findings`, and `errors` carrying the files that
+failed to parse. New
+top-level fields are additive and do not bump `version`, so a consumer can read
+what it knows and ignore the rest. Text output is for humans and is not a
+contract — its banner, summaries and verdict go to stdout only in text mode, so
+JSON and SARIF redirects stay clean. Piped output is never paged or colored,
+so no flag is needed to make a run scriptable.
+
+Two smaller things worth knowing when assembling a command line
+programmatically: pass `--` before the file paths (see [End of
+options](#end-of-options)) whenever any part of the command comes from
+repository content, and pin a version if the run gates CI, because new and
+tightened rules ship in MINOR releases.


### PR DESCRIPTION
## Summary

Adds an "Automation and agent use" section to `docs/cli.md` covering the five CLI behaviours a coding agent tends to read backwards, and a short README section pointing people wiring an agent at the gates that already cover agent-written Compose.

Docs only — no source, no behaviour change.

## Why

Refs #763 (deliverables 1 and 2 of three; the skill decision stays open, so this does not close it).

An agent writing Compose has no path to compose-lint unless the repo it is working in is already wired. The channels that reach it today do so only by accident of setup, and `AGENTS.md` does not help: it is contributor-facing and excluded from the wheel, so it exists only in a checkout of this repo. An agent working in someone else's repo never sees it.

Separately, the CLI is self-describing enough that `--help` plus `--explain` makes an agent competent in one call — so the gap is not usage, it is five behaviours that "linter" pattern-matching gets wrong:

- **Exit 2 is not a lint failure** — it means the run could not see the whole stack (unresolved `include:` / cross-file `extends:`). An agent mapping non-zero → "fix the findings" invents remediation work that does not exist.
- **`fix` is dry-run by default and its refusals are the safety property** — hand-applying what `fix` declined discards the guard that made the decline correct. Also flags the `⚠ behavior-changing` label as something to surface rather than swallow, since the label *is* the mitigation.
- **Suppression has one shape** — `.compose-lint.yml` with a `reason`; no inline comment syntax to guess at, and deleting the service is not a fix.
- **Severity is derived, not chosen** — quote `--explain`, don't re-rank.
- **`--format json` is the parsing contract** — a versioned envelope (ADR-015); text output is not a contract.

Placed in `cli.md` rather than a new `docs/agents.md`: a second agents file next to the root `AGENTS.md` would be confusing, and `cli.md` already carries the adjacent material — Color, Pager, and End of options, the last of which is itself about a command line assembled from repository content.

## Type of change

- [x] Documentation

## Origin

- [x] Produced primarily by an automated agent

## Checklist

- [x] Commits are signed (GitHub shows **Verified**)
- [x] Commits carry a `Signed-off-by:` trailer
- [x] One logical change per commit; no unrelated changes bundled in
- [x] `pytest` passes locally (2289 passed, 316 skipped); `ruff`/`mypy` unaffected — no `src/` or `tests/` changes
- [x] No AI credit lines in commit messages
- [x] `tests/corpus_snapshot.json.gz` is **not** in this PR

Two deliberate omissions worth a reviewer's eye:

- **No `CHANGELOG.md` entry.** No user-visible behaviour changed, and the closest precedent (#745, README docs) did not add one. Say the word if you'd rather it were listed.
- **`docs/dockerhub-overview.md` not mirrored.** It is a separate condensed file under a 25 KB Docker Hub limit with a different audience; adding this there seemed like the wrong trade. Easy to add if you disagree.

Every rule-specific claim delegates to `--explain`, so the section should not rot as rules change. Each factual claim was checked against the source it describes (`fix.md`, `formatters/json.py`, the exit-code table, `AGENTS.md`) rather than written from memory.

## Breaking changes

None
