### PR TITLE
Make the tier-summary footnote's string concatenation explicit

### DIFF
--- a/scripts/corpus/run.py
+++ b/scripts/corpus/run.py
@@ -458,9 +458,11 @@ def summarize_tiers(run_dir: Path, results: list[dict], index: dict[str, dict]) 
     if EXCLUDED_FROM_PREVALENCE & set(by_tier):
         lines += [
             "",
-            "\\* excluded from prevalence stats (`run.EXCLUDED_FROM_PREVALENCE`):"
-            " synthetic test inputs and deliberately-vulnerable lab environments"
-            " are corpus members but not real-world deployment intent.",
+            (
+                "\\* excluded from prevalence stats (`run.EXCLUDED_FROM_PREVALENCE`):"
+                " synthetic test inputs and deliberately-vulnerable lab environments"
+                " are corpus members but not real-world deployment intent."
+            ),
         ]
 
     lines += ["", "## Severity distribution per tier", "",


### PR DESCRIPTION
Closes CodeQL alert [#119](https://github.com/tmatens/compose-lint/security/code-scanning/119) (`py/implicit-string-concatenation-in-list`, warning, no security severity) on `scripts/corpus/run.py`.

The three adjacent literals in the `lines += [...]` list are one Markdown footnote line split for width, not a missing comma: the continuation pieces begin with a space and only read as a continuation. Wrapping the group in parentheses is CodeQL's own recommended way to mark the concatenation as deliberate, and it makes the intent obvious to a reader too.

No behaviour change. The rendered `tier_summary.md` is byte-for-byte identical. `scripts/` is outside CI's ruff scope; the changed lines are clean under ruff and the corpus tests pass locally.
